### PR TITLE
feat: add OpenAI Codex CLI JSONL normalizer

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -55,6 +55,10 @@ def _try_normalize_json(content: str) -> Optional[str]:
     if normalized:
         return normalized
 
+    normalized = _try_codex_jsonl(content)
+    if normalized:
+        return normalized
+
     try:
         data = json.loads(content)
     except json.JSONDecodeError:
@@ -88,6 +92,31 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
         elif msg_type == "assistant":
             text = _extract_content(message.get("content", ""))
             if text:
+                messages.append(("assistant", text))
+    if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    return None
+
+
+def _try_codex_jsonl(content: str) -> Optional[str]:
+    """OpenAI Codex CLI sessions."""
+    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    messages = []
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        rec_type = entry.get("type", "")
+        payload = entry.get("payload", {})
+        if rec_type == "response_item" and payload.get("type") == "message":
+            role = payload.get("role", "")
+            text = _extract_content(payload.get("content", ""))
+            if role in ("user", "human") and text:
+                messages.append(("user", text))
+            elif role in ("assistant", "ai") and text:
                 messages.append(("assistant", text))
     if len(messages) >= 2:
         return _messages_to_transcript(messages)


### PR DESCRIPTION
**What this does**

Adds support for parsing OpenAI Codex CLI session files (JSONL format stored at `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`).

**How it works**

Codex uses a different structure than Claude Code:
- Each line has `{type: "response_item", payload: {type: "message", role: "user"|"assistant", content: [...]}}`
- This extracts `role` from `payload.role` and content from `payload.content`

Matches the existing Claude Code parser structure — same line-by-line JSONL approach, same content extraction, same transcript output format.

**Why it matters**

Users accumulate hundreds of Codex sessions locally (each containing real conversations, decisions, and debugging sessions). This lets mempalace mine all of them directly.

**Testing**

- Tested against actual Codex session files from `~/.codex/sessions/`
- No regressions to existing Claude Code, ChatGPT, or Slack parsers