### PR TITLE
fix: handle Windows file-lock errors in test cleanup

### DIFF
--- a/benchmarks/convomem_bench.py
+++ b/benchmarks/convomem_bench.py
@@ -331,7 +331,11 @@ if __name__ == "__main__":
         default="raw",
         help="Retrieval mode",
     )
-    parser.add_argument("--cache-dir", default="/tmp/convomem_cache", help="Cache directory")
+    parser.add_argument(
+        "--cache-dir",
+        default=str(Path(tempfile.gettempdir()) / "convomem_cache"),
+        help="Cache directory",
+    )
     parser.add_argument("--out", default=None, help="Output JSON file")
     args = parser.parse_args()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,32 +1,64 @@
 import os
 import json
+import shutil
 import tempfile
 from mempalace.config import MempalaceConfig
 
 
+def _force_rmtree(path):
+    """Remove a temp directory, handling Windows file-lock issues."""
+
+    def _onerror(func, fpath, exc_info):
+        import stat
+
+        try:
+            os.chmod(fpath, stat.S_IWRITE)
+            func(fpath)
+        except OSError:
+            pass  # temp dir will be cleaned up by OS eventually
+
+    shutil.rmtree(path, onerror=_onerror)
+
+
 def test_default_config():
-    cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
-    assert "palace" in cfg.palace_path
-    assert cfg.collection_name == "mempalace_drawers"
+    tmpdir = tempfile.mkdtemp()
+    try:
+        cfg = MempalaceConfig(config_dir=tmpdir)
+        assert "palace" in cfg.palace_path
+        assert cfg.collection_name == "mempalace_drawers"
+    finally:
+        _force_rmtree(tmpdir)
 
 
 def test_config_from_file():
     tmpdir = tempfile.mkdtemp()
-    with open(os.path.join(tmpdir, "config.json"), "w") as f:
-        json.dump({"palace_path": "/custom/palace"}, f)
-    cfg = MempalaceConfig(config_dir=tmpdir)
-    assert cfg.palace_path == "/custom/palace"
+    try:
+        with open(os.path.join(tmpdir, "config.json"), "w") as f:
+            json.dump({"palace_path": "/custom/palace"}, f)
+        cfg = MempalaceConfig(config_dir=tmpdir)
+        assert cfg.palace_path == "/custom/palace"
+    finally:
+        _force_rmtree(tmpdir)
 
 
 def test_env_override():
-    os.environ["MEMPALACE_PALACE_PATH"] = "/env/palace"
-    cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
-    assert cfg.palace_path == "/env/palace"
-    del os.environ["MEMPALACE_PALACE_PATH"]
+    old_val = os.environ.get("MEMPALACE_PALACE_PATH")
+    try:
+        os.environ["MEMPALACE_PALACE_PATH"] = "/env/palace"
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        assert cfg.palace_path == "/env/palace"
+    finally:
+        if old_val is None:
+            os.environ.pop("MEMPALACE_PALACE_PATH", None)
+        else:
+            os.environ["MEMPALACE_PALACE_PATH"] = old_val
 
 
 def test_init():
     tmpdir = tempfile.mkdtemp()
-    cfg = MempalaceConfig(config_dir=tmpdir)
-    cfg.init()
-    assert os.path.exists(os.path.join(tmpdir, "config.json"))
+    try:
+        cfg = MempalaceConfig(config_dir=tmpdir)
+        cfg.init()
+        assert os.path.exists(os.path.join(tmpdir, "config.json"))
+    finally:
+        _force_rmtree(tmpdir)

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -8,15 +8,18 @@ from mempalace.convo_miner import mine_convos
 
 def _force_rmtree(path):
     """Remove a temp directory, handling Windows file-lock issues from ChromaDB."""
+
     def _onerror(func, fpath, exc_info):
         # On Windows, ChromaDB's HNSW/SQLite files may still be locked
         # even after deleting references. Best-effort removal.
         import stat
+
         try:
             os.chmod(fpath, stat.S_IWRITE)
             func(fpath)
         except OSError:
             pass  # temp dir will be cleaned up by OS eventually
+
     shutil.rmtree(path, onerror=_onerror)
 
 

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -9,15 +9,18 @@ from mempalace.miner import mine
 
 def _force_rmtree(path):
     """Remove a temp directory, handling Windows file-lock issues from ChromaDB."""
+
     def _onerror(func, fpath, exc_info):
         # On Windows, ChromaDB's HNSW/SQLite files may still be locked
         # even after deleting references. Best-effort removal.
         import stat
+
         try:
             os.chmod(fpath, stat.S_IWRITE)
             func(fpath)
         except OSError:
             pass  # temp dir will be cleaned up by OS eventually
+
     shutil.rmtree(path, onerror=_onerror)
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes `PermissionError: [WinError 32]` on Windows when running `pytest tests/ -v`. Two tests (`test_convo_mining`, `test_project_mining`) fail during temp directory cleanup because ChromaDB's `PersistentClient` holds file locks on HNSW data files (`data_level0.bin`, etc.) even after all assertions pass.

**The fix:**
- Delete ChromaDB client/collection references and call `gc.collect()` before `shutil.rmtree`, releasing most file handles
- Use `shutil.rmtree(onerror=...)` to gracefully handle any files still locked by the process, letting the OS clean temp dirs on its own schedule
- Remove unused `sys` imports flagged by ruff

All actual test logic is unchanged — this only affects cleanup.

## How to test

```bash
# On Windows (Python 3.9+)
pip install -e ".[dev]"
pytest tests/ -v
```

Before this fix: 2 FAILED, 7 passed (PermissionError on rmtree)
After this fix: 9 passed

Also works on Linux/macOS (gc.collect + onerror are no-ops when there are no file locks).

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)