### PR TITLE
fix: handle non-interactive init prompts gracefully

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -714,6 +714,15 @@ def _print_entity_list(entities: list, label: str):
         print(f"    {i + 1:2}. {e['name']:20} [{confidence_bar}] {signals_str}")
 
 
+def _prompt(prompt: str, default: str = "") -> str:
+    """Read user input safely; fall back to a default on EOF/non-interactive stdin."""
+    try:
+        return input(prompt).strip()
+    except EOFError:
+        print(f"\n  No interactive input available — defaulting to: {default or 'accept'}")
+        return default
+
+
 def confirm_entities(detected: dict, yes: bool = False) -> dict:
     """
     Interactive confirmation step.
@@ -750,7 +759,7 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
     print("    [add]    Add missing people or projects")
     print()
 
-    choice = input("  Your choice [enter/edit/add]: ").strip().lower()
+    choice = _prompt("  Your choice [enter/edit/add]: ").lower()
 
     confirmed_people = [e["name"] for e in detected["people"]]
     confirmed_projects = [e["name"] for e in detected["projects"]]
@@ -760,7 +769,7 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
         if detected["uncertain"]:
             print("\n  Uncertain entities — classify each:")
             for e in detected["uncertain"]:
-                ans = input(f"    {e['name']} — (p)erson, (r)roject, or (s)kip? ").strip().lower()
+                ans = _prompt(f"    {e['name']} — (p)erson, (r)roject, or (s)kip? ").lower()
                 if ans == "p":
                     confirmed_people.append(e["name"])
                 elif ans == "r":
@@ -768,28 +777,28 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
 
         # Remove wrong people
         print(f"\n  Current people: {', '.join(confirmed_people) or '(none)'}")
-        remove = input(
+        remove = _prompt(
             "  Numbers to REMOVE from people (comma-separated, or enter to skip): "
-        ).strip()
+        )
         if remove:
             to_remove = {int(x.strip()) - 1 for x in remove.split(",") if x.strip().isdigit()}
             confirmed_people = [p for i, p in enumerate(confirmed_people) if i not in to_remove]
 
         # Remove wrong projects
         print(f"\n  Current projects: {', '.join(confirmed_projects) or '(none)'}")
-        remove = input(
+        remove = _prompt(
             "  Numbers to REMOVE from projects (comma-separated, or enter to skip): "
-        ).strip()
+        )
         if remove:
             to_remove = {int(x.strip()) - 1 for x in remove.split(",") if x.strip().isdigit()}
             confirmed_projects = [p for i, p in enumerate(confirmed_projects) if i not in to_remove]
 
-    if choice == "add" or input("\n  Add any missing? [y/N]: ").strip().lower() == "y":
+    if choice == "add" or _prompt("\n  Add any missing? [y/N]: ").lower() == "y":
         while True:
-            name = input("  Name (or enter to stop): ").strip()
+            name = _prompt("  Name (or enter to stop): ")
             if not name:
                 break
-            kind = input(f"  Is '{name}' a (p)erson or (r)roject? ").strip().lower()
+            kind = _prompt(f"  Is '{name}' a (p)erson or (r)roject? ").lower()
             if kind == "p":
                 confirmed_people.append(name)
             elif kind == "r":

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -215,6 +215,15 @@ def print_proposed_structure(project_name: str, rooms: list, total_files: int, s
     print(f"\n{'─' * 55}")
 
 
+def _prompt(prompt: str, default: str = "") -> str:
+    """Read user input safely; fall back to a default on EOF/non-interactive stdin."""
+    try:
+        return input(prompt).strip()
+    except EOFError:
+        print(f"\n  No interactive input available — defaulting to: {default or 'accept'}")
+        return default
+
+
 def get_user_approval(rooms: list) -> list:
     """Same approval flow as AI version."""
     print("  Review the proposed rooms above.")
@@ -224,7 +233,7 @@ def get_user_approval(rooms: list) -> list:
     print("    [add]    Add a room manually")
     print()
 
-    choice = input("  Your choice [enter/edit/add]: ").strip().lower()
+    choice = _prompt("  Your choice [enter/edit/add]: ").lower()
 
     if choice in ("", "y", "yes"):
         return rooms
@@ -233,19 +242,17 @@ def get_user_approval(rooms: list) -> list:
         print("\n  Current rooms:")
         for i, room in enumerate(rooms):
             print(f"    {i + 1}. {room['name']} — {room['description']}")
-        remove = input("\n  Room numbers to REMOVE (comma-separated, or enter to skip): ").strip()
+        remove = _prompt("\n  Room numbers to REMOVE (comma-separated, or enter to skip): ")
         if remove:
             to_remove = {int(x.strip()) - 1 for x in remove.split(",") if x.strip().isdigit()}
             rooms = [r for i, r in enumerate(rooms) if i not in to_remove]
 
-    if choice == "add" or input("\n  Add any missing rooms? [y/N]: ").strip().lower() == "y":
+    if choice == "add" or _prompt("\n  Add any missing rooms? [y/N]: ").lower() == "y":
         while True:
-            new_name = (
-                input("  New room name (or enter to stop): ").strip().lower().replace(" ", "_")
-            )
+            new_name = _prompt("  New room name (or enter to stop): ").lower().replace(" ", "_")
             if not new_name:
                 break
-            new_desc = input(f"  Description for '{new_name}': ").strip()
+            new_desc = _prompt(f"  Description for '{new_name}': ")
             rooms.append({"name": new_name, "description": new_desc, "keywords": [new_name]})
             print(f"  Added: {new_name}")
 

--- a/tests/test_noninteractive_init.py
+++ b/tests/test_noninteractive_init.py
@@ -1,0 +1,30 @@
+import builtins
+
+from mempalace.entity_detector import confirm_entities
+from mempalace.room_detector_local import get_user_approval
+
+
+def test_room_approval_defaults_to_accept_on_eof(monkeypatch):
+    rooms = [{"name": "src", "description": "Files from src/", "keywords": ["src"]}]
+
+    def raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", raise_eof)
+    assert get_user_approval(rooms) == rooms
+
+
+def test_entity_confirmation_defaults_to_accept_on_eof(monkeypatch):
+    detected = {
+        "people": [{"name": "Alice", "confidence": 1.0, "source": "test", "signals": []}],
+        "projects": [{"name": "MemPalace", "confidence": 1.0, "source": "test", "signals": []}],
+        "uncertain": [],
+    }
+
+    def raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", raise_eof)
+    confirmed = confirm_entities(detected)
+
+    assert confirmed == {"people": ["Alice"], "projects": ["MemPalace"]}


### PR DESCRIPTION
## Summary
- make room approval fall back safely when stdin is unavailable
- make entity confirmation fall back safely on EOF too
- add regression tests for non-interactive approval flows

## Repro
Before this change, running `mempalace init <dir> < /dev/null` crashed with `EOFError` when room approval prompted for input.

## Validation
- `pytest -q`
- verified `python -m mempalace init <dir> < /dev/null` now writes `mempalace.yaml` instead of crashing
