### PR TITLE
fix: unify package and MCP version reporting

### DIFF
--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -1,7 +1,6 @@
 """MemPalace — Give your AI a memory. No API key required."""
 
-__version__ = "2.0.0"
-
 from .cli import main
+from .version import __version__
 
 __all__ = ["main", "__version__"]

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -24,6 +24,7 @@ import hashlib
 from datetime import datetime
 
 from .config import MempalaceConfig
+from .version import __version__
 from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
 import chromadb
@@ -700,7 +701,7 @@ def handle_request(request):
             "result": {
                 "protocolVersion": "2024-11-05",
                 "capabilities": {"tools": {}},
-                "serverInfo": {"name": "mempalace", "version": "2.0.0"},
+                "serverInfo": {"name": "mempalace", "version": __version__},
             },
         }
     elif method == "notifications/initialized":

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,0 +1,3 @@
+"""Single source of truth for the MemPalace package version."""
+
+__version__ = "3.0.0"

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,22 @@
+import re
+from pathlib import Path
+
+from mempalace import __version__
+from mempalace.mcp_server import handle_request
+
+
+def _expected_version() -> str:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    assert match is not None, "Could not find project version in pyproject.toml"
+    return match.group(1)
+
+
+def test_package_version_matches_pyproject():
+    assert __version__ == _expected_version()
+
+
+def test_mcp_initialize_reports_package_version():
+    response = handle_request({"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+    assert response["result"]["serverInfo"]["version"] == _expected_version()


### PR DESCRIPTION
## Summary
- move the package version to a single shared module
- make MCP initialization report that same version
- add regression tests to keep package and MCP version strings aligned with pyproject metadata

## Why
The repo currently reports mixed versions across runtime surfaces, which makes releases and bug reports harder to trust.

## Validation
- 
