### PR TITLE
refactor: centralize storage access across search and layers

### DIFF
--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -21,9 +21,8 @@ import sys
 from pathlib import Path
 from collections import defaultdict
 
-import chromadb
-
 from .config import MempalaceConfig
+from .storage import get_collection, get_drawers, query_drawers
 
 
 # ---------------------------------------------------------------------------
@@ -91,20 +90,13 @@ class Layer1:
     def generate(self) -> str:
         """Pull top drawers from ChromaDB and format as compact L1 text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            results = get_drawers(
+                palace_path=self.palace_path,
+                wing=self.wing,
+                include=["documents", "metadatas"],
+            )
         except Exception:
             return "## L1 — No palace found. Run: mempalace mine <dir>"
-
-        # Fetch all drawers (with optional wing filter)
-        kwargs = {"include": ["documents", "metadatas"]}
-        if self.wing:
-            kwargs["where"] = {"wing": self.wing}
-
-        try:
-            results = col.get(**kwargs)
-        except Exception:
-            return "## L1 — No drawers found."
 
         docs = results.get("documents", [])
         metas = results.get("metadatas", [])
@@ -187,25 +179,13 @@ class Layer2:
     def retrieve(self, wing: str = None, room: str = None, n_results: int = 10) -> str:
         """Retrieve drawers filtered by wing and/or room."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
-        except Exception:
-            return "No palace found."
-
-        where = {}
-        if wing and room:
-            where = {"$and": [{"wing": wing}, {"room": room}]}
-        elif wing:
-            where = {"wing": wing}
-        elif room:
-            where = {"room": room}
-
-        kwargs = {"include": ["documents", "metadatas"], "limit": n_results}
-        if where:
-            kwargs["where"] = where
-
-        try:
-            results = col.get(**kwargs)
+            results = get_drawers(
+                palace_path=self.palace_path,
+                wing=wing,
+                room=room,
+                limit=n_results,
+                include=["documents", "metadatas"],
+            )
         except Exception as e:
             return f"Retrieval error: {e}"
 
@@ -251,51 +231,30 @@ class Layer3:
     def search(self, query: str, wing: str = None, room: str = None, n_results: int = 5) -> str:
         """Semantic search, returns compact result text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
-        except Exception:
-            return "No palace found."
-
-        where = {}
-        if wing and room:
-            where = {"$and": [{"wing": wing}, {"room": room}]}
-        elif wing:
-            where = {"wing": wing}
-        elif room:
-            where = {"room": room}
-
-        kwargs = {
-            "query_texts": [query],
-            "n_results": n_results,
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            kwargs["where"] = where
-
-        try:
-            results = col.query(**kwargs)
+            hits = query_drawers(
+                query=query,
+                palace_path=self.palace_path,
+                wing=wing,
+                room=room,
+                n_results=n_results,
+            )
         except Exception as e:
             return f"Search error: {e}"
 
-        docs = results["documents"][0]
-        metas = results["metadatas"][0]
-        dists = results["distances"][0]
-
-        if not docs:
+        if not hits:
             return "No results found."
 
         lines = [f'## L3 — SEARCH RESULTS for "{query}"']
-        for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
-            similarity = round(1 - dist, 3)
-            wing_name = meta.get("wing", "?")
-            room_name = meta.get("room", "?")
-            source = Path(meta.get("source_file", "")).name if meta.get("source_file") else ""
+        for i, hit in enumerate(hits, 1):
+            wing_name = hit["wing"]
+            room_name = hit["room"]
+            source = hit["source_file"]
 
-            snippet = doc.strip().replace("\n", " ")
+            snippet = hit["text"].strip().replace("\n", " ")
             if len(snippet) > 300:
                 snippet = snippet[:297] + "..."
 
-            lines.append(f"  [{i}] {wing_name}/{room_name} (sim={similarity})")
+            lines.append(f"  [{i}] {wing_name}/{room_name} (sim={hit['similarity']})")
             lines.append(f"      {snippet}")
             if source:
                 lines.append(f"      src: {source}")
@@ -307,49 +266,16 @@ class Layer3:
     ) -> list:
         """Return raw dicts instead of formatted text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
-        except Exception:
-            return []
-
-        where = {}
-        if wing and room:
-            where = {"$and": [{"wing": wing}, {"room": room}]}
-        elif wing:
-            where = {"wing": wing}
-        elif room:
-            where = {"room": room}
-
-        kwargs = {
-            "query_texts": [query],
-            "n_results": n_results,
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            kwargs["where"] = where
-
-        try:
-            results = col.query(**kwargs)
-        except Exception:
-            return []
-
-        hits = []
-        for doc, meta, dist in zip(
-            results["documents"][0],
-            results["metadatas"][0],
-            results["distances"][0],
-        ):
-            hits.append(
-                {
-                    "text": doc,
-                    "wing": meta.get("wing", "unknown"),
-                    "room": meta.get("room", "unknown"),
-                    "source_file": Path(meta.get("source_file", "?")).name,
-                    "similarity": round(1 - dist, 3),
-                    "metadata": meta,
-                }
+            get_collection(palace_path=self.palace_path)
+            return query_drawers(
+                query=query,
+                palace_path=self.palace_path,
+                wing=wing,
+                room=room,
+                n_results=n_results,
             )
-        return hits
+        except Exception:
+            return []
 
 
 # ---------------------------------------------------------------------------

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -14,7 +14,8 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-import chromadb
+from .storage import get_collection, get_drawers, summarize_taxonomy
+
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -180,13 +181,9 @@ def chunk_text(content: str, source_file: str) -> list:
 # =============================================================================
 
 
-def get_collection(palace_path: str):
+def get_or_create_collection(palace_path: str):
     os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
-    try:
-        return client.get_collection("mempalace_drawers")
-    except Exception:
-        return client.create_collection("mempalace_drawers")
+    return get_collection(palace_path=palace_path, create=True)
 
 
 def file_already_mined(collection, source_file: str) -> bool:
@@ -344,7 +341,7 @@ def mine(
     print(f"{'─' * 55}\n")
 
     if not dry_run:
-        collection = get_collection(palace_path)
+        collection = get_or_create_collection(palace_path)
     else:
         collection = None
 
@@ -391,20 +388,13 @@ def mine(
 def status(palace_path: str):
     """Show what's been filed in the palace."""
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        metas = get_drawers(palace_path=palace_path, limit=10000, include=["metadatas"])["metadatas"]
     except Exception:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
-
-    wing_rooms = defaultdict(lambda: defaultdict(int))
-    for m in metas:
-        wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
+    wing_rooms = summarize_taxonomy(metadatas=metas)
 
     print(f"\n{'=' * 55}")
     print(f"  MemPalace Status — {len(metas)} drawers")

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -7,9 +7,8 @@ Returns verbatim text — the actual words, never summaries.
 """
 
 import sys
-from pathlib import Path
 
-import chromadb
+from .storage import get_collection, query_drawers
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
@@ -18,42 +17,25 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     Optionally filter by wing (project) or room (aspect).
     """
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        get_collection(palace_path=palace_path)
     except Exception:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         sys.exit(1)
 
-    # Build where filter
-    where = {}
-    if wing and room:
-        where = {"$and": [{"wing": wing}, {"room": room}]}
-    elif wing:
-        where = {"wing": wing}
-    elif room:
-        where = {"room": room}
-
     try:
-        kwargs = {
-            "query_texts": [query],
-            "n_results": n_results,
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            kwargs["where"] = where
-
-        results = col.query(**kwargs)
-
+        hits = query_drawers(
+            query=query,
+            palace_path=palace_path,
+            wing=wing,
+            room=room,
+            n_results=n_results,
+        )
     except Exception as e:
         print(f"\n  Search error: {e}")
         sys.exit(1)
 
-    docs = results["documents"][0]
-    metas = results["metadatas"][0]
-    dists = results["distances"][0]
-
-    if not docs:
+    if not hits:
         print(f'\n  No results found for: "{query}"')
         return
 
@@ -65,18 +47,17 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print(f"  Room: {room}")
     print(f"{'=' * 60}\n")
 
-    for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
-        similarity = round(1 - dist, 3)
-        source = Path(meta.get("source_file", "?")).name
-        wing_name = meta.get("wing", "?")
-        room_name = meta.get("room", "?")
+    for i, hit in enumerate(hits, 1):
+        source = hit["source_file"]
+        wing_name = hit["wing"]
+        room_name = hit["room"]
 
         print(f"  [{i}] {wing_name} / {room_name}")
         print(f"      Source: {source}")
-        print(f"      Match:  {similarity}")
+        print(f"      Match:  {hit['similarity']}")
         print()
         # Print the verbatim text, indented
-        for line in doc.strip().split("\n"):
+        for line in hit["text"].strip().split("\n"):
             print(f"      {line}")
         print()
         print(f"  {'─' * 56}")
@@ -92,48 +73,15 @@ def search_memories(
     Used by the MCP server and other callers that need data.
     """
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
-    except Exception as e:
-        return {"error": f"No palace found at {palace_path}: {e}"}
-
-    # Build where filter
-    where = {}
-    if wing and room:
-        where = {"$and": [{"wing": wing}, {"room": room}]}
-    elif wing:
-        where = {"wing": wing}
-    elif room:
-        where = {"room": room}
-
-    try:
-        kwargs = {
-            "query_texts": [query],
-            "n_results": n_results,
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            kwargs["where"] = where
-
-        results = col.query(**kwargs)
+        hits = query_drawers(
+            query=query,
+            palace_path=palace_path,
+            wing=wing,
+            room=room,
+            n_results=n_results,
+        )
     except Exception as e:
         return {"error": f"Search error: {e}"}
-
-    docs = results["documents"][0]
-    metas = results["metadatas"][0]
-    dists = results["distances"][0]
-
-    hits = []
-    for doc, meta, dist in zip(docs, metas, dists):
-        hits.append(
-            {
-                "text": doc,
-                "wing": meta.get("wing", "unknown"),
-                "room": meta.get("room", "unknown"),
-                "source_file": Path(meta.get("source_file", "?")).name,
-                "similarity": round(1 - dist, 3),
-            }
-        )
 
     return {
         "query": query,

--- a/mempalace/storage.py
+++ b/mempalace/storage.py
@@ -1,0 +1,103 @@
+"""Shared ChromaDB access helpers for MemPalace."""
+
+from pathlib import Path
+from typing import Optional
+
+import chromadb
+
+from .config import MempalaceConfig
+
+
+class PalaceNotFoundError(RuntimeError):
+    """Raised when the configured palace or collection does not exist."""
+
+
+def get_collection(
+    palace_path: Optional[str] = None,
+    collection_name: Optional[str] = None,
+    create: bool = False,
+):
+    cfg = MempalaceConfig()
+    resolved_palace_path = palace_path or cfg.palace_path
+    resolved_collection_name = collection_name or cfg.collection_name
+
+    client = chromadb.PersistentClient(path=resolved_palace_path)
+    if create:
+        return client.get_or_create_collection(resolved_collection_name)
+    return client.get_collection(resolved_collection_name)
+
+
+def build_where(wing: Optional[str] = None, room: Optional[str] = None):
+    if wing and room:
+        return {"$and": [{"wing": wing}, {"room": room}]}
+    if wing:
+        return {"wing": wing}
+    if room:
+        return {"room": room}
+    return None
+
+
+def query_drawers(
+    query: str,
+    palace_path: Optional[str] = None,
+    collection_name: Optional[str] = None,
+    wing: Optional[str] = None,
+    room: Optional[str] = None,
+    n_results: int = 5,
+):
+    col = get_collection(palace_path=palace_path, collection_name=collection_name)
+    kwargs = {
+        "query_texts": [query],
+        "n_results": n_results,
+        "include": ["documents", "metadatas", "distances"],
+    }
+    where = build_where(wing=wing, room=room)
+    if where:
+        kwargs["where"] = where
+
+    results = col.query(**kwargs)
+    docs = results["documents"][0]
+    metas = results["metadatas"][0]
+    dists = results["distances"][0]
+
+    hits = []
+    for doc, meta, dist in zip(docs, metas, dists):
+        hits.append(
+            {
+                "text": doc,
+                "wing": meta.get("wing", "unknown"),
+                "room": meta.get("room", "unknown"),
+                "source_file": Path(meta.get("source_file", "?")).name,
+                "similarity": round(1 - dist, 3),
+                "metadata": meta,
+            }
+        )
+    return hits
+
+
+def get_drawers(
+    palace_path: Optional[str] = None,
+    collection_name: Optional[str] = None,
+    wing: Optional[str] = None,
+    room: Optional[str] = None,
+    limit: Optional[int] = None,
+    include=None,
+):
+    col = get_collection(palace_path=palace_path, collection_name=collection_name)
+    kwargs = {"include": include or ["documents", "metadatas"]}
+    if limit is not None:
+        kwargs["limit"] = limit
+    where = build_where(wing=wing, room=room)
+    if where:
+        kwargs["where"] = where
+    return col.get(**kwargs)
+
+
+def summarize_taxonomy(metadatas: list):
+    taxonomy = {}
+    for meta in metadatas:
+        wing = meta.get("wing", "unknown")
+        room = meta.get("room", "unknown")
+        taxonomy.setdefault(wing, {})
+        taxonomy[wing][room] = taxonomy[wing].get(room, 0) + 1
+    return taxonomy

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,64 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from mempalace.layers import Layer3
+from mempalace.miner import mine
+from mempalace.searcher import search_memories
+from mempalace.storage import build_where, get_collection
+
+
+def test_build_where_variants():
+    assert build_where() is None
+    assert build_where(wing="alpha") == {"wing": "alpha"}
+    assert build_where(room="backend") == {"room": "backend"}
+    assert build_where(wing="alpha", room="backend") == {
+        "$and": [{"wing": "alpha"}, {"room": "backend"}]
+    }
+
+
+def test_configured_collection_name_is_used_across_mine_and_search(monkeypatch):
+    tmpdir = tempfile.mkdtemp()
+    home = os.path.join(tmpdir, "home")
+    os.makedirs(os.path.join(home, ".mempalace"), exist_ok=True)
+
+    config = {
+        "palace_path": os.path.join(tmpdir, "palace-from-config"),
+        "collection_name": "custom_drawers",
+    }
+    with open(os.path.join(home, ".mempalace", "config.json"), "w") as f:
+        json.dump(config, f)
+
+    monkeypatch.setenv("HOME", home)
+
+    project_dir = os.path.join(tmpdir, "project")
+    os.makedirs(os.path.join(project_dir, "backend"), exist_ok=True)
+    with open(os.path.join(project_dir, "backend", "app.py"), "w") as f:
+        f.write("def main():\n    return 'memory palace'\n" * 20)
+    with open(os.path.join(project_dir, "mempalace.yaml"), "w") as f:
+        yaml.dump(
+            {
+                "wing": "test_project",
+                "rooms": [
+                    {"name": "backend", "description": "Backend code"},
+                    {"name": "general", "description": "General"},
+                ],
+            },
+            f,
+        )
+
+    palace_path = os.path.join(tmpdir, "custom-palace")
+    mine(project_dir, palace_path)
+
+    custom_collection = get_collection(palace_path=palace_path)
+    assert custom_collection.count() > 0
+
+    results = search_memories("memory palace", palace_path=palace_path)
+    assert results["results"]
+
+    layer_results = Layer3(palace_path=palace_path).search_raw("memory palace")
+    assert layer_results
+    assert layer_results[0]["source_file"] == Path(results["results"][0]["source_file"]).name


### PR DESCRIPTION
## Summary
- add a shared storage module for collection access, filters, and semantic queries
- make miner, searcher, and layers use the configured collection name consistently
- add regression coverage for custom collection names and shared filter construction

## Why
The repo previously mixed config-aware and hardcoded collection access, which could split reads and writes across different Chroma collections.

## Validation
- source /Users/jamescane/git/mempalace/.venv/bin/activate
- cd /Users/jamescane/git/mempalace-worktrees/storage-refactor
- PYTHONPATH=. pytest -q
