### PR TITLE
refactor: unify init onboarding prompt handling

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -38,7 +38,18 @@ def cmd_init(args):
     import json
     from pathlib import Path
     from .entity_detector import scan_for_detection, detect_entities, confirm_entities
+    from .onboarding import run_onboarding
+    from .prompts import stdin_is_interactive
     from .room_detector_local import detect_rooms_local
+
+    MempalaceConfig().init()
+
+    should_run_onboarding = args.onboarding
+    if should_run_onboarding == "auto":
+        should_run_onboarding = stdin_is_interactive() and not getattr(args, "yes", False)
+
+    if should_run_onboarding:
+        run_onboarding(directory=args.dir)
 
     # Pass 1: auto-detect people and projects from file content
     print(f"\n  Scanning for entities in: {args.dir}")
@@ -60,7 +71,6 @@ def cmd_init(args):
 
     # Pass 2: detect rooms from folder structure
     detect_rooms_local(project_dir=args.dir)
-    MempalaceConfig().init()
 
 
 def cmd_mine(args):
@@ -276,6 +286,21 @@ def main():
     p_init.add_argument("dir", help="Project directory to set up")
     p_init.add_argument(
         "--yes", action="store_true", help="Auto-accept all detected entities (non-interactive)"
+    )
+    p_init.add_argument(
+        "--onboarding",
+        dest="onboarding",
+        action="store_const",
+        const=True,
+        default="auto",
+        help="Run the guided onboarding flow before entity and room detection",
+    )
+    p_init.add_argument(
+        "--no-onboarding",
+        dest="onboarding",
+        action="store_const",
+        const=False,
+        help="Skip guided onboarding even in interactive terminals",
     )
 
     # mine

--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -20,6 +20,8 @@ import os
 from pathlib import Path
 from collections import defaultdict
 
+from .prompts import prompt_text
+
 
 # ==================== SIGNAL PATTERNS ====================
 
@@ -750,7 +752,7 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
     print("    [add]    Add missing people or projects")
     print()
 
-    choice = input("  Your choice [enter/edit/add]: ").strip().lower()
+    choice = prompt_text("  Your choice [enter/edit/add]: ").lower()
 
     confirmed_people = [e["name"] for e in detected["people"]]
     confirmed_projects = [e["name"] for e in detected["projects"]]
@@ -760,7 +762,7 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
         if detected["uncertain"]:
             print("\n  Uncertain entities — classify each:")
             for e in detected["uncertain"]:
-                ans = input(f"    {e['name']} — (p)erson, (r)roject, or (s)kip? ").strip().lower()
+                ans = prompt_text(f"    {e['name']} — (p)erson, (r)roject, or (s)kip? ").lower()
                 if ans == "p":
                     confirmed_people.append(e["name"])
                 elif ans == "r":
@@ -768,28 +770,28 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
 
         # Remove wrong people
         print(f"\n  Current people: {', '.join(confirmed_people) or '(none)'}")
-        remove = input(
+        remove = prompt_text(
             "  Numbers to REMOVE from people (comma-separated, or enter to skip): "
-        ).strip()
+        )
         if remove:
             to_remove = {int(x.strip()) - 1 for x in remove.split(",") if x.strip().isdigit()}
             confirmed_people = [p for i, p in enumerate(confirmed_people) if i not in to_remove]
 
         # Remove wrong projects
         print(f"\n  Current projects: {', '.join(confirmed_projects) or '(none)'}")
-        remove = input(
+        remove = prompt_text(
             "  Numbers to REMOVE from projects (comma-separated, or enter to skip): "
-        ).strip()
+        )
         if remove:
             to_remove = {int(x.strip()) - 1 for x in remove.split(",") if x.strip().isdigit()}
             confirmed_projects = [p for i, p in enumerate(confirmed_projects) if i not in to_remove]
 
-    if choice == "add" or input("\n  Add any missing? [y/N]: ").strip().lower() == "y":
+    if choice == "add" or prompt_text("\n  Add any missing? [y/N]: ").lower() == "y":
         while True:
-            name = input("  Name (or enter to stop): ").strip()
+            name = prompt_text("  Name (or enter to stop): ")
             if not name:
                 break
-            kind = input(f"  Is '{name}' a (p)erson or (r)roject? ").strip().lower()
+            kind = prompt_text(f"  Is '{name}' a (p)erson or (r)roject? ").lower()
             if kind == "p":
                 confirmed_people.append(name)
             elif kind == "r":

--- a/mempalace/onboarding.py
+++ b/mempalace/onboarding.py
@@ -19,6 +19,7 @@ Usage:
 from pathlib import Path
 from mempalace.entity_registry import EntityRegistry
 from mempalace.entity_detector import detect_entities, scan_for_detection
+from mempalace.prompts import prompt_text, prompt_yes_no
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -67,17 +68,15 @@ def _header(text):
 
 
 def _ask(prompt, default=None):
-    if default:
-        val = input(f"  {prompt} [{default}]: ").strip()
-        return val if val else default
-    return input(f"  {prompt}: ").strip()
+    formatted = f"  {prompt} [{default}]: " if default is not None else f"  {prompt}: "
+    return prompt_text(formatted, default=default or "")
 
 
 def _yn(prompt, default="y"):
-    val = input(f"  {prompt} [{'Y/n' if default == 'y' else 'y/N'}]: ").strip().lower()
-    if not val:
-        return default == "y"
-    return val.startswith("y")
+    return prompt_yes_no(
+        f"  {prompt} [{'Y/n' if default == 'y' else 'y/N'}]: ",
+        default=default,
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -102,7 +101,7 @@ def _ask_mode() -> str:
     print()
 
     while True:
-        choice = input("  Your choice [1/2/3]: ").strip()
+        choice = prompt_text("  Your choice [1/2/3]: ")
         if choice == "1":
             return "work"
         elif choice == "2":
@@ -132,7 +131,7 @@ def _ask_people(mode: str) -> tuple[list, dict]:
   Type 'done' when finished.
 """)
         while True:
-            entry = input("  Person: ").strip()
+            entry = prompt_text("  Person: ")
             if entry.lower() in ("done", ""):
                 break
             parts = [p.strip() for p in entry.split(",", 1)]
@@ -140,7 +139,7 @@ def _ask_people(mode: str) -> tuple[list, dict]:
             relationship = parts[1] if len(parts) > 1 else ""
             if name:
                 # Ask about nicknames
-                nick = input(f"  Nickname for {name}? (or enter to skip): ").strip()
+                nick = prompt_text(f"  Nickname for {name}? (or enter to skip): ")
                 if nick:
                     aliases[nick] = name
                 people.append({"name": name, "relationship": relationship, "context": "personal"})
@@ -155,7 +154,7 @@ def _ask_people(mode: str) -> tuple[list, dict]:
   Type 'done' when finished.
 """)
         while True:
-            entry = input("  Person: ").strip()
+            entry = prompt_text("  Person: ")
             if entry.lower() in ("done", ""):
                 break
             parts = [p.strip() for p in entry.split(",", 1)]
@@ -185,7 +184,7 @@ def _ask_projects(mode: str) -> list:
 """)
     projects = []
     while True:
-        proj = input("  Project: ").strip()
+        proj = prompt_text("  Project: ")
         if proj.lower() in ("done", ""):
             break
         if proj:
@@ -209,7 +208,7 @@ def _ask_wings(mode: str) -> list:
 
   Press enter to keep these, or type your own comma-separated list.
 """)
-    custom = input("  Wings: ").strip()
+    custom = prompt_text("  Wings: ")
     if custom:
         return [w.strip() for w in custom.split(",") if w.strip()]
     return defaults
@@ -398,17 +397,16 @@ def run_onboarding(
             print()
             if _yn("  Add any of these to your registry?"):
                 for e in detected:
-                    ans = input(f"    {e['name']} — (p)erson, (s)kip? ").strip().lower()
+                    ans = prompt_text(f"    {e['name']} — (p)erson, (s)kip? ").lower()
                     if ans == "p":
-                        rel = input(f"    Relationship/role for {e['name']}? ").strip()
+                        rel = prompt_text(f"    Relationship/role for {e['name']}? ")
                         ctx = (
                             "personal"
                             if mode == "personal"
                             else (
                                 "work"
                                 if mode == "work"
-                                else input("    Context — (p)ersonal or (w)ork? ")
-                                .strip()
+                                else prompt_text("    Context — (p)ersonal or (w)ork? ")
                                 .lower()
                                 .replace("w", "work")
                                 .replace("p", "personal")

--- a/mempalace/prompts.py
+++ b/mempalace/prompts.py
@@ -1,0 +1,27 @@
+"""Shared prompt helpers for interactive and non-interactive CLI flows."""
+
+import sys
+
+
+def prompt_text(prompt: str, default: str = "") -> str:
+    try:
+        raw = input(prompt).strip()
+    except EOFError:
+        fallback = default or "accept"
+        print(f"\n  No interactive input available — defaulting to: {fallback}")
+        return default
+    return raw or default
+
+
+def prompt_yes_no(prompt: str, default: str = "y") -> bool:
+    answer = prompt_text(prompt, default=default).lower()
+    if not answer:
+        return default == "y"
+    return answer.startswith("y")
+
+
+def stdin_is_interactive() -> bool:
+    try:
+        return sys.stdin.isatty()
+    except Exception:
+        return False

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -15,6 +15,8 @@ import yaml
 from pathlib import Path
 from collections import defaultdict
 
+from .prompts import prompt_text
+
 # Common room patterns — detected from folder names and filenames
 # Format: {folder_keyword: room_name}
 FOLDER_ROOM_MAP = {
@@ -224,7 +226,7 @@ def get_user_approval(rooms: list) -> list:
     print("    [add]    Add a room manually")
     print()
 
-    choice = input("  Your choice [enter/edit/add]: ").strip().lower()
+    choice = prompt_text("  Your choice [enter/edit/add]: ").lower()
 
     if choice in ("", "y", "yes"):
         return rooms
@@ -233,19 +235,17 @@ def get_user_approval(rooms: list) -> list:
         print("\n  Current rooms:")
         for i, room in enumerate(rooms):
             print(f"    {i + 1}. {room['name']} — {room['description']}")
-        remove = input("\n  Room numbers to REMOVE (comma-separated, or enter to skip): ").strip()
+        remove = prompt_text("\n  Room numbers to REMOVE (comma-separated, or enter to skip): ")
         if remove:
             to_remove = {int(x.strip()) - 1 for x in remove.split(",") if x.strip().isdigit()}
             rooms = [r for i, r in enumerate(rooms) if i not in to_remove]
 
-    if choice == "add" or input("\n  Add any missing rooms? [y/N]: ").strip().lower() == "y":
+    if choice == "add" or prompt_text("\n  Add any missing rooms? [y/N]: ").lower() == "y":
         while True:
-            new_name = (
-                input("  New room name (or enter to stop): ").strip().lower().replace(" ", "_")
-            )
+            new_name = prompt_text("  New room name (or enter to stop): ").lower().replace(" ", "_")
             if not new_name:
                 break
-            new_desc = input(f"  Description for '{new_name}': ").strip()
+            new_desc = prompt_text(f"  Description for '{new_name}': ")
             rooms.append({"name": new_name, "description": new_desc, "keywords": [new_name]})
             print(f"  Added: {new_name}")
 

--- a/tests/test_init_onboarding.py
+++ b/tests/test_init_onboarding.py
@@ -1,0 +1,74 @@
+import argparse
+import builtins
+from pathlib import Path
+
+from mempalace.cli import cmd_init
+from mempalace.entity_detector import confirm_entities
+from mempalace.prompts import prompt_text
+from mempalace.room_detector_local import get_user_approval
+
+
+def test_prompt_text_returns_default_on_eof(monkeypatch):
+    def raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", raise_eof)
+    assert prompt_text("prompt", default="fallback") == "fallback"
+
+
+def test_room_approval_defaults_to_accept_on_eof(monkeypatch):
+    rooms = [{"name": "src", "description": "Files from src/", "keywords": ["src"]}]
+
+    def raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", raise_eof)
+    assert get_user_approval(rooms) == rooms
+
+
+def test_entity_confirmation_defaults_to_accept_on_eof(monkeypatch):
+    detected = {
+        "people": [{"name": "Alice", "confidence": 1.0, "source": "test", "signals": []}],
+        "projects": [{"name": "MemPalace", "confidence": 1.0, "source": "test", "signals": []}],
+        "uncertain": [],
+    }
+
+    def raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", raise_eof)
+    confirmed = confirm_entities(detected)
+    assert confirmed == {"people": ["Alice"], "projects": ["MemPalace"]}
+
+
+def test_cmd_init_runs_onboarding_in_interactive_auto_mode(monkeypatch, tmp_path):
+    called = []
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    monkeypatch.setattr("mempalace.cli.MempalaceConfig.init", lambda self: None)
+    monkeypatch.setattr("mempalace.prompts.stdin_is_interactive", lambda: True)
+    monkeypatch.setattr("mempalace.onboarding.run_onboarding", lambda directory: called.append(directory))
+    monkeypatch.setattr("mempalace.entity_detector.scan_for_detection", lambda directory: [])
+    monkeypatch.setattr("mempalace.room_detector_local.detect_rooms_local", lambda project_dir: None)
+
+    args = argparse.Namespace(dir=str(project_dir), yes=False, onboarding="auto")
+    cmd_init(args)
+
+    assert called == [str(project_dir)]
+
+
+def test_cmd_init_skips_onboarding_when_disabled(monkeypatch, tmp_path):
+    called = []
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    monkeypatch.setattr("mempalace.cli.MempalaceConfig.init", lambda self: None)
+    monkeypatch.setattr("mempalace.onboarding.run_onboarding", lambda directory: called.append(directory))
+    monkeypatch.setattr("mempalace.entity_detector.scan_for_detection", lambda directory: [])
+    monkeypatch.setattr("mempalace.room_detector_local.detect_rooms_local", lambda project_dir: None)
+
+    args = argparse.Namespace(dir=str(project_dir), yes=True, onboarding=False)
+    cmd_init(args)
+
+    assert called == []


### PR DESCRIPTION
## Summary
- add shared prompt helpers for interactive and non-interactive CLI flows
- make onboarding, entity confirmation, and room approval use the same safe prompt behavior
- let  run guided onboarding in interactive mode, with  and  overrides
- add regression tests for EOF-safe prompts and init onboarding behavior

## Why
The repo already had a guided onboarding flow, but it was orphaned from the main init path and still used duplicated raw prompt handling.

## Validation
- source /Users/jamescane/git/mempalace/.venv/bin/activate
- cd /Users/jamescane/git/mempalace-worktrees/init-onboarding
- PYTHONPATH=. pytest -q
