### PR TITLE
docs: align MCP setup examples with shipped server

### DIFF
--- a/examples/mcp_setup.md
+++ b/examples/mcp_setup.md
@@ -5,20 +5,22 @@
 Run the MCP server:
 
 ```bash
-python mcp_server.py
+python -m mempalace.mcp_server
 ```
 
-Or add to Claude Code:
+Or add it to Claude Code:
 
 ```bash
-claude mcp add mempal -- python /path/to/mempalace/mcp_server.py
+claude mcp add mempalace -- python -m mempalace.mcp_server
 ```
 
 ## Available Tools
 
-- **mempal_status** — palace stats (wings, rooms, drawer counts)
-- **mempal_search** — semantic search across all memories
-- **mempal_list_wings** — list all projects in the palace
+The server exposes the full MemPalace MCP toolset. Common entry points include:
+
+- **mempalace_status** — palace stats (wings, rooms, drawer counts)
+- **mempalace_search** — semantic search across all memories
+- **mempalace_list_wings** — list all projects in the palace
 
 ## Usage in Claude Code
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2,7 +2,7 @@
 """
 MemPalace MCP Server — read/write palace access for Claude Code
 ================================================================
-Install: claude mcp add mempalace -- python /path/to/mcp_server.py
+Install: claude mcp add mempalace -- python -m mempalace.mcp_server
 
 Tools (read):
   mempalace_status          — total drawers, wing/room breakdown


### PR DESCRIPTION
## Summary
- update the MCP setup example to use the package module entry point
- align the documented Claude command with the main README
- fix tool names in the example from  to 

## Why
The previous example drifted from the actual server entry point and tool names, which could make a correct MCP setup look broken.

## Validation
- source /Users/jamescane/git/mempalace/.venv/bin/activate
- cd /Users/jamescane/git/mempalace-worktrees/mcp-docs
- PYTHONPATH=. python - <<'PY'
from mempalace.mcp_server import handle_request
init = handle_request({jsonrpc:2.0,id:1,method:initialize})
listing = handle_request({jsonrpc:2.0,id:2,method:tools/list})
assert init[result][serverInfo][name] == mempalace
assert mempalace_status in [tool[name] for tool in listing[result][tools]]
PY
