### PR TITLE
refactor: consolidate split known-names config loading

### DIFF
--- a/mempalace/split_mega_files.py
+++ b/mempalace/split_mega_files.py
@@ -34,20 +34,39 @@ LUMI_DIR = Path(os.environ.get("MEMPALACE_SOURCE_DIR", str(HOME / "Desktop/trans
 # People we know about (for name detection in content)
 # Loaded from ~/.mempalace/known_names.json if it exists, otherwise generic fallback.
 _KNOWN_NAMES_PATH = HOME / ".mempalace" / "known_names.json"
+_FALLBACK_KNOWN_PEOPLE = ["Alice", "Ben", "Riley", "Max", "Sam", "Devon", "Jordan"]
+_KNOWN_NAMES_CACHE = None
+
+
+def _load_known_names_config(force_reload: bool = False):
+    """Load and cache the optional known-names config file."""
+    global _KNOWN_NAMES_CACHE
+
+    if force_reload:
+        _KNOWN_NAMES_CACHE = None
+
+    if _KNOWN_NAMES_CACHE is not None:
+        return _KNOWN_NAMES_CACHE
+
+    if _KNOWN_NAMES_PATH.exists():
+        try:
+            _KNOWN_NAMES_CACHE = json.loads(_KNOWN_NAMES_PATH.read_text())
+            return _KNOWN_NAMES_CACHE
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    _KNOWN_NAMES_CACHE = None
+    return None
 
 
 def _load_known_people() -> list:
     """Load known names from config file, falling back to a generic list."""
-    if _KNOWN_NAMES_PATH.exists():
-        try:
-            data = json.loads(_KNOWN_NAMES_PATH.read_text())
-            if isinstance(data, list):
-                return data
-            return data.get("names", [])
-        except (json.JSONDecodeError, OSError):
-            pass
-    # Generic fallback — override by creating ~/.mempalace/known_names.json
-    return ["Alice", "Ben", "Riley", "Max", "Sam", "Devon", "Jordan"]
+    data = _load_known_names_config()
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return data.get("names", [])
+    return list(_FALLBACK_KNOWN_PEOPLE)
 
 
 KNOWN_PEOPLE = _load_known_people()
@@ -55,13 +74,9 @@ KNOWN_PEOPLE = _load_known_people()
 
 def _load_username_map() -> dict:
     """Load username-to-name mapping from config file."""
-    if _KNOWN_NAMES_PATH.exists():
-        try:
-            data = json.loads(_KNOWN_NAMES_PATH.read_text())
-            if isinstance(data, dict):
-                return data.get("username_map", {})
-        except (json.JSONDecodeError, OSError):
-            pass
+    data = _load_known_names_config()
+    if isinstance(data, dict):
+        return data.get("username_map", {})
     return {}
 
 

--- a/tests/test_split_mega_files.py
+++ b/tests/test_split_mega_files.py
@@ -1,0 +1,48 @@
+import json
+
+from mempalace import split_mega_files as smf
+
+
+def test_load_known_people_falls_back_when_config_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(smf, "_KNOWN_NAMES_PATH", tmp_path / "missing.json")
+    smf._KNOWN_NAMES_CACHE = None
+
+    assert smf._load_known_people() == smf._FALLBACK_KNOWN_PEOPLE
+    assert smf._load_username_map() == {}
+
+
+def test_load_known_people_from_list_config(monkeypatch, tmp_path):
+    config_path = tmp_path / "known_names.json"
+    config_path.write_text(json.dumps(["Alice", "Ben"]))
+    monkeypatch.setattr(smf, "_KNOWN_NAMES_PATH", config_path)
+    smf._KNOWN_NAMES_CACHE = None
+
+    assert smf._load_known_people() == ["Alice", "Ben"]
+    assert smf._load_username_map() == {}
+
+
+def test_load_known_people_from_dict_config(monkeypatch, tmp_path):
+    config_path = tmp_path / "known_names.json"
+    config_path.write_text(json.dumps({"names": ["Alice"], "username_map": {"jdoe": "John"}}))
+    monkeypatch.setattr(smf, "_KNOWN_NAMES_PATH", config_path)
+    smf._KNOWN_NAMES_CACHE = None
+
+    assert smf._load_known_people() == ["Alice"]
+    assert smf._load_username_map() == {"jdoe": "John"}
+
+
+def test_extract_people_uses_username_map(monkeypatch, tmp_path):
+    config_path = tmp_path / "known_names.json"
+    config_path.write_text(json.dumps({"names": ["Alice"], "username_map": {"jdoe": "John"}}))
+    monkeypatch.setattr(smf, "_KNOWN_NAMES_PATH", config_path)
+    monkeypatch.setattr(smf, "KNOWN_PEOPLE", ["Alice"])
+    smf._KNOWN_NAMES_CACHE = None
+
+    people = smf.extract_people(["Working in /Users/jdoe/project\n"])
+    assert "John" in people
+
+
+def test_extract_people_detects_names_from_content(monkeypatch):
+    monkeypatch.setattr(smf, "KNOWN_PEOPLE", ["Alice", "Ben"])
+    people = smf.extract_people(["> Alice reviewed the change with Ben\n"])
+    assert people == ["Alice", "Ben"]


### PR DESCRIPTION
## Summary
- add a single cached loader for 
- derive known people and username mappings from that shared parsed config
- add focused tests for missing, list-shaped, and dict-shaped configs plus people extraction behavior

## Why
 previously re-read and re-parsed the same config file in multiple helpers, which duplicated logic and made the utility harder to reason about.

## Validation
- source /Users/jamescane/git/mempalace/.venv/bin/activate
- cd /Users/jamescane/git/mempalace-worktrees/split-known-names
- PYTHONPATH=. pytest -q
