### PR TITLE
feat: add OpenCode SQLite session database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ mempalace init ~/projects/myapp
 
 # Mine your data
 mempalace mine ~/projects/myapp                    # projects — code, docs, notes
-mempalace mine ~/chats/ --mode convos              # convos — Claude, ChatGPT, Slack exports
+mempalace mine ~/chats/ --mode convos              # convos — Claude, ChatGPT, Slack, OpenCode exports
 mempalace mine ~/chats/ --mode convos --extract general  # general — classifies into decisions, milestones, problems
 
 # Search anything you've ever discussed
@@ -611,7 +611,7 @@ Plain text. Becomes Layer 0 — loaded every session.
 |------|------|
 | `cli.py` | CLI entry point |
 | `config.py` | Configuration loading and defaults |
-| `normalize.py` | Converts 5 chat formats to standard transcript |
+| `normalize.py` | Converts 6 chat formats to standard transcript |
 | `mcp_server.py` | MCP server — 19 tools, AAAK auto-teach, memory protocol |
 | `miner.py` | Project file ingest |
 | `convo_miner.py` | Conversation ingest — chunks by exchange pair |

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -8,7 +8,7 @@ The Python package that powers MemPalace. All modules, all logic.
 |--------|-------------|
 | `cli.py` | CLI entry point — routes to mine, search, init, compress, wake-up |
 | `config.py` | Configuration loading — `~/.mempalace/config.json`, env vars, defaults |
-| `normalize.py` | Converts 5 chat formats (Claude Code JSONL, Claude.ai JSON, ChatGPT JSON, Slack JSON, plain text) to standard transcript format |
+| `normalize.py` | Converts 6 chat formats (Claude Code JSONL, Claude.ai JSON, ChatGPT JSON, OpenCode SQLite, Slack JSON, plain text) to standard transcript format |
 | `miner.py` | Project file ingest — scans directories, chunks by paragraph, stores to ChromaDB |
 | `convo_miner.py` | Conversation ingest — chunks by exchange pair (Q+A), detects rooms from content |
 | `searcher.py` | Semantic search via ChromaDB vectors — filters by wing/room, returns verbatim + scores |

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -367,7 +367,7 @@ def main():
 
     # mine
     p_mine = sub.add_parser("mine", help="Mine files into the palace")
-    p_mine.add_argument("dir", help="Directory to mine")
+    p_mine.add_argument("dir", help="Directory (or .db file) to mine")
     p_mine.add_argument(
         "--mode",
         choices=["projects", "convos"],

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 
 import chromadb
 
-from .normalize import normalize
+from .normalize import normalize, normalize_opencode_sessions
 
 
 # File types that might contain conversations
@@ -26,7 +26,11 @@ CONVO_EXTENSIONS = {
     ".md",
     ".json",
     ".jsonl",
+    ".db",
+    ".sqlite3",
+    ".sqlite",
 }
+
 
 SKIP_DIRS = {
     ".git",
@@ -270,6 +274,35 @@ def mine_convos(
     """
 
     convo_path = Path(convo_dir).expanduser().resolve()
+    if convo_path.is_file() and convo_path.suffix in (".db", ".sqlite3", ".sqlite"):
+        import tempfile
+
+        sessions = normalize_opencode_sessions(str(convo_path))
+        with tempfile.TemporaryDirectory(prefix="mempalace_oc_") as tmpdir:
+            # Write each session as a .txt grouped by project subdirs
+            for s in sessions:
+                proj = s.get("project", "")
+                name = (
+                    Path(proj).name.lower().replace(" ", "_").replace("-", "_")
+                    if proj and proj != "/"
+                    else "opencode_general"
+                )
+                subdir = Path(tmpdir) / name
+                subdir.mkdir(exist_ok=True)
+                (subdir / f"{name}_{s['session_id']}.txt").write_text(s["transcript"])
+            for subdir in sorted(Path(tmpdir).iterdir()):
+                if subdir.is_dir():
+                    mine_convos(
+                        str(subdir),
+                        palace_path,
+                        wing=wing or subdir.name,
+                        agent=agent,
+                        limit=limit,
+                        dry_run=dry_run,
+                        extract_mode=extract_mode,
+                    )
+        return
+
     if not wing:
         wing = convo_path.name.lower().replace(" ", "_").replace("-", "_")
 

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -8,6 +8,7 @@ Supported:
     - ChatGPT conversations.json
     - Claude Code JSONL
     - OpenAI Codex CLI JSONL
+    - OpenCode SQLite (message + part tables)
     - Slack JSON export
     - Plain text (pass through for paragraph chunking)
 
@@ -16,8 +17,9 @@ No API key. No internet. Everything local.
 
 import json
 import os
+import sqlite3
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Tuple
 
 
 def normalize(filepath: str) -> str:
@@ -39,8 +41,12 @@ def normalize(filepath: str) -> str:
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
         return content
 
-    # Try JSON normalization
+    # Try SQLite normalization (OpenCode)
     ext = Path(filepath).suffix.lower()
+    if ext in (".db", ".sqlite3", ".sqlite"):
+        return _normalize_opencode_sqlite(filepath)
+
+    # Try JSON normalization
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
         if normalized:
@@ -145,6 +151,104 @@ def _try_codex_jsonl(content: str) -> Optional[str]:
     if len(messages) >= 2 and has_session_meta:
         return _messages_to_transcript(messages)
     return None
+
+
+def _normalize_opencode_sqlite(filepath: str) -> str:
+    """Normalize all sessions from an OpenCode SQLite database into one transcript."""
+    sessions = normalize_opencode_sessions(filepath)
+    if not sessions:
+        return ""
+    return "\n\n".join(s["transcript"] for s in sessions)
+
+
+def _extract_opencode_messages(
+    conn: sqlite3.Connection, session_id: str = None
+) -> List[Tuple[str, str]]:
+    """Extract (role, text) pairs, skipping tool calls and empty parts."""
+    query = """
+        SELECT
+            json_extract(m.data, '$.role') as role,
+            json_extract(p.data, '$.type') as part_type,
+            json_extract(p.data, '$.text') as text
+        FROM message m
+        JOIN part p ON p.message_id = m.id
+    """
+    params = []
+    if session_id:
+        query += " WHERE m.session_id = ?"
+        params.append(session_id)
+    query += " ORDER BY m.time_created, p.time_created"
+
+    messages = []
+    for role, part_type, text in conn.execute(query, params).fetchall():
+        if part_type != "text" or not text or not text.strip():
+            continue
+        # Skip tool-result echo lines that opencode injects as user parts
+        if text.strip().startswith("Called the ") and " tool with the following input" in text:
+            continue
+        if text.strip().startswith("<path>") and "<type>file</type>" in text:
+            continue
+
+        clean = text.strip()
+        if not clean:
+            continue
+
+        # Merge consecutive same-role messages
+        if messages and messages[-1][0] == role:
+            prev_role, prev_text = messages[-1]
+            messages[-1] = (prev_role, prev_text + "\n\n" + clean)
+        else:
+            messages.append((role if role == "user" else "assistant", clean))
+
+    return messages
+
+
+def normalize_opencode_sessions(db_path: str) -> List[dict]:
+    """Extract per-session transcripts from an OpenCode SQLite database."""
+    try:
+        conn = sqlite3.connect(db_path)
+        tables = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+    except Exception as e:
+        raise IOError(f"Could not read SQLite database: {db_path}: {e}")
+
+    if not {"session", "message", "part"}.issubset(tables):
+        conn.close()
+        raise IOError(f"Not a recognized OpenCode database (missing tables): {db_path}")
+
+    try:
+        conn.execute("SELECT json_extract('{}', '$')")
+    except Exception:
+        conn.close()
+        raise IOError("SQLite json_extract not available — upgrade SQLite or Python")
+    sessions = conn.execute("""
+        SELECT s.id, s.title, s.directory,
+               datetime(s.time_created/1000, 'unixepoch') as created
+        FROM session s
+        ORDER BY s.time_created
+    """).fetchall()
+
+    results = []
+    for sid, title, directory, created in sessions:
+        messages = _extract_opencode_messages(conn, session_id=sid)
+        if len(messages) < 2:  # skip cancelled sessions
+            continue
+        transcript = _messages_to_transcript(messages)
+        if transcript.strip():
+            results.append(
+                {
+                    "session_id": sid,
+                    "title": title or "",
+                    "project": directory or "",
+                    "created": created or "",
+                    "transcript": transcript,
+                }
+            )
+
+    conn.close()
+    return results
 
 
 def _try_claude_ai_json(data) -> Optional[str]:

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -203,16 +203,33 @@ def _extract_opencode_messages(
     return messages
 
 
-def normalize_opencode_sessions(db_path: str) -> List[dict]:
+#List of known opencode db paths
+OPENCODE_DB_PATHS = [
+    "~/.local/share/opencode/opencode.db",
+    "~/.opencode/opencode.db",
+]
+
+
+def _resolve_opencode_db(db_path: str | None = None) -> str:
+    candidates = [db_path] if db_path else OPENCODE_DB_PATHS
+    for p in candidates:
+        expanded = Path(p).expanduser()
+        if expanded.is_file():
+            return str(expanded)
+    raise IOError(f"No OpenCode database found (searched {candidates})")
+
+
+def normalize_opencode_sessions(db_path: str | None = None) -> List[dict]:
     """Extract per-session transcripts from an OpenCode SQLite database."""
+    resolved = _resolve_opencode_db(db_path)
     try:
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(resolved)
         tables = {
             r[0]
             for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
         }
     except Exception as e:
-        raise IOError(f"Could not read SQLite database: {db_path}: {e}")
+        raise IOError(f"Could not read SQLite database: {resolved}: {e}")
 
     if not {"session", "message", "part"}.issubset(tables):
         conn.close()

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,5 +1,6 @@
 import os
 import json
+import sqlite3
 import tempfile
 from mempalace.normalize import normalize
 
@@ -28,4 +29,33 @@ def test_empty():
     f.close()
     result = normalize(f.name)
     assert result.strip() == ""
+    os.unlink(f.name)
+
+
+def test_opencode_sqlite():
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.executescript("""
+        CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT, name TEXT,
+            time_created INT, time_updated INT, sandboxes TEXT DEFAULT '[]');
+        CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, slug TEXT DEFAULT '',
+            directory TEXT DEFAULT '/', title TEXT DEFAULT '', version TEXT DEFAULT '1',
+            time_created INT, time_updated INT);
+        CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT,
+            time_created INT, time_updated INT, data TEXT);
+        CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+            time_created INT, time_updated INT, data TEXT);
+        INSERT INTO project VALUES ('p1','/home/user/app','app',0,0,'[]');
+        INSERT INTO session VALUES ('s1','p1','','/','test','1',0,0);
+        INSERT INTO message VALUES ('m1','s1',1,1,'{"role":"user"}');
+        INSERT INTO part VALUES ('t1','m1','s1',1,1,'{"type":"text","text":"Why Clerk over Auth0?"}');
+        INSERT INTO message VALUES ('m2','s1',2,2,'{"role":"assistant"}');
+        INSERT INTO part VALUES ('t2','m2','s1',2,2,'{"type":"text","text":"Better DX and lower pricing."}');
+    """)
+    conn.commit()
+    conn.close()
+    result = normalize(f.name)
+    assert "> Why Clerk" in result
+    assert "Better DX" in result
     os.unlink(f.name)

--- a/uv.lock
+++ b/uv.lock
@@ -966,6 +966,13 @@ dependencies = [
     { name = "pyyaml" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "ruff" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -976,8 +983,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "chromadb", specifier = ">=0.4.0,<1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
 ]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Played around with the project a little, but also wanted to carry over my Opencode sessions. The patch should hopefully be as minimal as possible.

Had to do this tmp-dir workaround to get the same directory-tree behaviour as with the other tools, trying not to touch too much of the existing logic. So it uses the dir-column in the DB to create a tmp-dir structure.
The table:

```
   session table (SQLite)
   ┌──────────┬─────────────────────┐
   │ id       │ directory           │
   ├──────────┼─────────────────────┤
   │ ses_a1b2 │ /home/user/frontend │
   │ ses_c3d4 │ /home/user/frontend │
   │ ses_e5f6 │ /home/user/backend  │
   │ ses_g7h8 │ /home/user/my-infra │
   └──────────┴─────────────────────┘
   ```
   becomes
   ```
   mempalace_oc_*/
   ├── frontend/
   │   ├── frontend_ses_a1b2.txt
   │   └── frontend_ses_c3d4.txt
   ├── backend/
   │   └── backend_ses_e5f6.txt
   └── my_infra/
       └── my_infra_ses_g7h8.txt
 ```
 
 which is then  handled the same way how claude-code/chatgpt/etc. ingestion works. 
 
 ---

Ingest should work via:

```bash
mempalace mine ~/.local/share/opencode/opencode.db --mode convos
```

Tests + Lint should be clean