### PR TITLE
fix: security hardening — shell injection, SSL bypass, error leaks, read-only MCP mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ venv/
 
 # ChromaDB local data
 *.sqlite3-journal
+
+# Sensitive local data
+entities.json
+known_names.json
+identity.txt
+*.sqlite3
+*.db

--- a/benchmarks/convomem_bench.py
+++ b/benchmarks/convomem_bench.py
@@ -25,7 +25,6 @@ import os
 import sys
 import json
 import shutil
-import ssl
 import tempfile
 import argparse
 import urllib.request
@@ -34,9 +33,6 @@ from collections import defaultdict
 from datetime import datetime
 
 import chromadb
-
-# Bypass SSL for restricted environments
-ssl._create_default_https_context = ssl._create_unverified_context
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -2861,33 +2861,10 @@ def llm_rerank(
 
 
 def _load_api_key(key_arg):
-    """Load API key from --llm-key arg, env var, or ~/.config/lu/keys.json."""
+    """Load API key from --llm-key arg or ANTHROPIC_API_KEY env var."""
     if key_arg:
         return key_arg
-    env_key = os.environ.get("ANTHROPIC_API_KEY", "")
-    if env_key:
-        return env_key
-    keys_path = os.path.expanduser("~/.config/lu/keys.json")
-    if os.path.exists(keys_path):
-        try:
-            with open(keys_path) as f:
-                keys = json.load(f)
-            # Flat string keys
-            for name in ("lu_key", "anthropic_milla", "anthropic_claude_code_main"):
-                val = keys.get(name, "")
-                if isinstance(val, str) and val.startswith("sk-ant-"):
-                    return val
-            # Nested dict: keys["anthropic"]["lu_key"]
-            for section in ("anthropic", "anthropic_milla", "anthropic_claude_code_main"):
-                sec = keys.get(section, {})
-                if isinstance(sec, dict):
-                    for subkey in ("lu_key", "key", "api_key"):
-                        val = sec.get(subkey, "")
-                        if isinstance(val, str) and val.startswith("sk-ant-"):
-                            return val
-        except Exception:
-            pass
-    return ""
+    return os.environ.get("ANTHROPIC_API_KEY", "")
 
 
 # =============================================================================
@@ -2970,8 +2947,7 @@ def run_benchmark(
         if not api_key:
             print(
                 "ERROR: --llm-rerank / --mode diary requires an API key. "
-                "Set ANTHROPIC_API_KEY, use --llm-key, "
-                "or store in ~/.config/lu/keys.json as 'lu_key'."
+                "Set ANTHROPIC_API_KEY or use --llm-key."
             )
             sys.exit(1)
 
@@ -3290,8 +3266,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--llm-key",
         default="",
-        help="Anthropic API key for LLM re-ranking. Falls back to ANTHROPIC_API_KEY "
-        "env var or ~/.config/lu/keys.json 'lu_key' field if not provided.",
+        help="Anthropic API key for LLM re-ranking. Falls back to ANTHROPIC_API_KEY env var if not provided.",
     )
     parser.add_argument(
         "--llm-model",


### PR DESCRIPTION
## Summary                                                                                                                                                                      
                                                                                                                                                                                  
  Security hardening across 6 files, addressing findings from a full codebase audit.                                                                                              
                                                                                                                                                                                  
  - **Shell injection** (`hooks/mempal_save_hook.sh`): `$TRANSCRIPT_PATH` was string-interpolated directly into an inline Python script — a path containing a single quote could  
  inject arbitrary code. Fixed by passing it via env var. `$SESSION_ID` sanitized with `tr` before use as a filename component to prevent path traversal.                         
  - **SSL bypass** (`benchmarks/convomem_bench.py`): `ssl._create_unverified_context` was globally disabling certificate verification, enabling MITM on all HTTPS connections   
  including API key transmission. Removed.                                                                                                                                        
  - **Personal credential names** (`benchmarks/longmemeval_bench.py`): Hardcoded personal key names (`lu_key`, `anthropic_milla`, `anthropic_claude_code_main`) and a personal    
  config path (`~/.config/lu/keys.json`) were published in the repo. Simplified `_load_api_key()` to use only the standard `ANTHROPIC_API_KEY` env var.                       
  - **Internal path leakage** (`mempalace/mcp_server.py`): `str(e)` was returned directly in MCP responses, exposing internal file paths. Replaced with generic messages; real    
  errors still logged server-side.                                                                                                                                              
  - **Read-only MCP mode** (`mempalace/mcp_server.py`): Added `--read-only` flag that blocks all write tools (`mempalace_add_drawer`, `mempalace_kg_add`, `mempalace_diary_write`)
   at the dispatch layer, mitigating memory poisoning from untrusted MCP clients.                                                                                                 
  - **MD5 collision risk** (`mempalace/mcp_server.py`, `mempalace/knowledge_graph.py`): MD5 truncated to 16 hex chars was used for ID generation — collisions could cause silent  
  data overwrites. Replaced with `uuid4`.                                                                                                                                       
  - **`.gitignore` gaps**: Added `entities.json`, `known_names.json`, `identity.txt`, `*.sqlite3`, `*.db` to prevent personal data files from being accidentally committed.       
                                                                                                                                                                                
  ## Test plan                                                                                                                                                                    
                                                                                                                                                                                
  - [x] All 9 existing tests pass (`pytest tests/ -v`)                                                                                                                            
  - [x] Python syntax verified on all changed files                                                                                                                               
  - [x] No new dependencies (uuid, argparse are stdlib)