### PR TITLE
fix: remove dead code and duplicate set items in entity_registry.py

### DIFF
--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -44,7 +44,6 @@ COMMON_ENGLISH_WORDS = {
     "chance",
     "chase",
     "hunter",
-    "hunter",
     "dash",
     "flash",
     "star",
@@ -78,8 +77,6 @@ COMMON_ENGLISH_WORDS = {
     "january",
     "february",
     "march",
-    "april",
-    "june",
     "july",
     "august",
     "september",
@@ -597,7 +594,6 @@ class EntityRegistry:
         Returns list of canonical names found.
         """
         found = []
-        query.lower()
 
         for canonical, info in self.people.items():
             names_to_check = [canonical] + info.get("aliases", [])


### PR DESCRIPTION
## Summary
- Remove discarded `query.lower()` call in `extract_people_from_query()` — Python strings are immutable, so the result was always thrown away. The `re.IGNORECASE` flag already handles case-insensitive matching.
- Remove 3 duplicate literals in `COMMON_ENGLISH_WORDS` set: `"hunter"` (consecutive dup), `"april"` and `"june"` (in both names and months sections). Flagged by ruff B033.

## Changes
4 lines deleted, 0 added. No behavior change — the dead call was a no-op and sets auto-deduplicate at runtime.

## Test plan
- [x] `ruff check mempalace/entity_registry.py` passes clean
- [x] `ruff format --check mempalace/entity_registry.py` passes clean
- [x] `python3 -m py_compile mempalace/entity_registry.py` compiles OK
- [x] Verified via Context7 Python docs: strings are immutable, `.lower()` returns new string