### PR TITLE
fix: modernize ChromaDB API — get_or_create_collection + upsert

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -212,10 +212,7 @@ def detect_convo_room(content: str) -> str:
 def get_collection(palace_path: str):
     os.makedirs(palace_path, exist_ok=True)
     client = chromadb.PersistentClient(path=palace_path)
-    try:
-        return client.get_collection("mempalace_drawers")
-    except Exception:
-        return client.create_collection("mempalace_drawers")
+    return client.get_or_create_collection("mempalace_drawers")
 
 
 def file_already_mined(collection, source_file: str) -> bool:
@@ -353,27 +350,23 @@ def mine_convos(
             if extract_mode == "general":
                 room_counts[chunk_room] += 1
             drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.md5((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:16]}"
-            try:
-                collection.add(
-                    documents=[chunk["content"]],
-                    ids=[drawer_id],
-                    metadatas=[
-                        {
-                            "wing": wing,
-                            "room": chunk_room,
-                            "source_file": source_file,
-                            "chunk_index": chunk["chunk_index"],
-                            "added_by": agent,
-                            "filed_at": datetime.now().isoformat(),
-                            "ingest_mode": "convos",
-                            "extract_mode": extract_mode,
-                        }
-                    ],
-                )
-                drawers_added += 1
-            except Exception as e:
-                if "already exists" not in str(e).lower():
-                    raise
+            collection.upsert(
+                documents=[chunk["content"]],
+                ids=[drawer_id],
+                metadatas=[
+                    {
+                        "wing": wing,
+                        "room": chunk_room,
+                        "source_file": source_file,
+                        "chunk_index": chunk["chunk_index"],
+                        "added_by": agent,
+                        "filed_at": datetime.now().isoformat(),
+                        "ingest_mode": "convos",
+                        "extract_mode": extract_mode,
+                    }
+                ],
+            )
+            drawers_added += 1
 
         total_drawers += drawers_added
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -183,10 +183,7 @@ def chunk_text(content: str, source_file: str) -> list:
 def get_collection(palace_path: str):
     os.makedirs(palace_path, exist_ok=True)
     client = chromadb.PersistentClient(path=palace_path)
-    try:
-        return client.get_collection("mempalace_drawers")
-    except Exception:
-        return client.create_collection("mempalace_drawers")
+    return client.get_or_create_collection("mempalace_drawers")
 
 
 def file_already_mined(collection, source_file: str) -> bool:
@@ -203,26 +200,21 @@ def add_drawer(
 ):
     """Add one drawer to the palace."""
     drawer_id = f"drawer_{wing}_{room}_{hashlib.md5((source_file + str(chunk_index)).encode()).hexdigest()[:16]}"
-    try:
-        collection.add(
-            documents=[content],
-            ids=[drawer_id],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "source_file": source_file,
-                    "chunk_index": chunk_index,
-                    "added_by": agent,
-                    "filed_at": datetime.now().isoformat(),
-                }
-            ],
-        )
-        return True
-    except Exception as e:
-        if "already exists" in str(e).lower() or "duplicate" in str(e).lower():
-            return False
-        raise
+    collection.upsert(
+        documents=[content],
+        ids=[drawer_id],
+        metadatas=[
+            {
+                "wing": wing,
+                "room": room,
+                "source_file": source_file,
+                "chunk_index": chunk_index,
+                "added_by": agent,
+                "filed_at": datetime.now().isoformat(),
+            }
+        ],
+    )
+    return True
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Replace `try: get_collection` / `except: create_collection` with `get_or_create_collection()` in both `miner.py` and `convo_miner.py`. Single atomic call, no broad `except Exception` needed.
- Replace `collection.add()` with `collection.upsert()` for idempotent writes. Removes try/except handling for "already exists" errors — upsert inserts new records and updates existing ones gracefully.
- Both APIs recommended by [ChromaDB docs](https://docs.trychroma.com/docs/overview/getting-started) and available since v0.4.0 (project requires `>=0.4.0`).

## Changes
2 files changed, 34 insertions, 49 deletions. Net reduction of 15 lines of error-handling boilerplate.

## Test plan
- [x] `ruff check mempalace/miner.py mempalace/convo_miner.py` passes clean
- [x] `ruff format --check mempalace/miner.py mempalace/convo_miner.py` already formatted
- [x] `python3 -m py_compile mempalace/miner.py` compiles OK
- [x] `python3 -m py_compile mempalace/convo_miner.py` compiles OK
- [x] API signatures validated against ChromaDB docs via Context7
- [x] `chromadb>=0.4.0` in pyproject.toml confirms both APIs are available