### PR TITLE
fix: close chroma clients after ingest

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -209,9 +209,7 @@ def detect_convo_room(content: str) -> str:
 # =============================================================================
 
 
-def get_collection(palace_path: str):
-    os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
+def get_collection(client):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
@@ -284,7 +282,13 @@ def mine_convos(
         print("  DRY RUN — nothing will be filed")
     print(f"{'─' * 55}\n")
 
-    collection = get_collection(palace_path) if not dry_run else None
+    client = None
+    if dry_run:
+        collection = None
+    else:
+        os.makedirs(palace_path, exist_ok=True)
+        client = chromadb.PersistentClient(path=palace_path)
+        collection = get_collection(client)
 
     total_drawers = 0
     files_skipped = 0
@@ -379,6 +383,9 @@ def mine_convos(
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
 
     print(f"\n{'=' * 55}")
+    if client is not None:
+        client.close()
+
     print("  Done.")
     print(f"  Files processed: {len(files) - files_skipped}")
     print(f"  Files skipped (already filed): {files_skipped}")

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -180,9 +180,7 @@ def chunk_text(content: str, source_file: str) -> list:
 # =============================================================================
 
 
-def get_collection(palace_path: str):
-    os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
+def get_collection(client):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
@@ -343,10 +341,13 @@ def mine(
         print("  DRY RUN — nothing will be filed")
     print(f"{'─' * 55}\n")
 
-    if not dry_run:
-        collection = get_collection(palace_path)
-    else:
+    client = None
+    if dry_run:
         collection = None
+    else:
+        os.makedirs(palace_path, exist_ok=True)
+        client = chromadb.PersistentClient(path=palace_path)
+        collection = get_collection(client)
 
     total_drawers = 0
     files_skipped = 0
@@ -372,6 +373,9 @@ def mine(
                 print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
 
     print(f"\n{'=' * 55}")
+    if client is not None:
+        client.close()
+
     print("  Done.")
     print(f"  Files processed: {len(files) - files_skipped}")
     print(f"  Files skipped (already filed): {files_skipped}")
@@ -393,14 +397,13 @@ def status(palace_path: str):
     try:
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")
+        r = col.get(limit=10000, include=["metadatas"])
+        metas = r["metadatas"]
+        client.close()
     except Exception:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
-
-    # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -15,12 +15,12 @@ def test_convo_mining():
     palace_path = os.path.join(tmpdir, "palace")
     mine_convos(tmpdir, palace_path, wing="test_convos")
 
-    client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_collection("mempalace_drawers")
-    assert col.count() >= 2
+    with chromadb.PersistentClient(path=palace_path) as client:
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() >= 2
 
-    # Verify search works
-    results = col.query(query_texts=["memory persistence"], n_results=1)
-    assert len(results["documents"][0]) > 0
+        # Verify search works
+        results = col.query(query_texts=["memory persistence"], n_results=1)
+        assert len(results["documents"][0]) > 0
 
     shutil.rmtree(tmpdir)

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -29,8 +29,8 @@ def test_project_mining():
     mine(tmpdir, palace_path)
 
     # Verify
-    client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_collection("mempalace_drawers")
-    assert col.count() > 0
+    with chromadb.PersistentClient(path=palace_path) as client:
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() > 0
 
     shutil.rmtree(tmpdir)


### PR DESCRIPTION
## Summary
Fixes a Windows file-lock issue in the ingest paths by closing Chroma PersistentClient instances after mining completes.

## Proof of bug
Before this change, local Windows runs failed in two ways:

1. pytest tests -v failed in:
   - 	ests/test_miner.py
   - 	ests/test_convo_miner.py

   Both failures were PermissionError during shutil.rmtree(...) because Chroma files in the temp palace directory were still open.

2. A direct repro outside the test suite also failed:
   - create a temp project
   - call mempalace.miner.mine(...)
   - immediately call shutil.rmtree(tmpdir)

   That still raised PermissionError, which showed the leak was in the runtime ingest path, not only in the tests.

## What changed
- mempalace/miner.py
  - keep the Chroma client alive during ingest
  - close it after mining completes
- mempalace/convo_miner.py
  - keep the Chroma client alive during conversation ingest
  - close it after ingest completes
- 	ests/test_miner.py
- 	ests/test_convo_miner.py
  - close verification clients with context managers before temp-dir cleanup

## Proof of fix
- pytest tests -v now passes locally: 9 passed
- the direct Windows repro can now delete the temp palace directory immediately after mine() returns

## Notes
This PR stays scoped to the confirmed Chroma client lifecycle bug in the ingest paths. It does not change retrieval behavior or collection naming behavior.