### PR TITLE
feat: add SoulForge session import and integration guide

### DIFF
--- a/examples/soulforge_setup.md
+++ b/examples/soulforge_setup.md
@@ -1,0 +1,238 @@
+# SoulForge + MemPalace Integration
+
+[SoulForge](https://github.com/proxysoul/soulforge) is an AI coding agent with a live code intelligence system called the [Soul Map](https://github.com/proxysoul/soulforge/blob/main/docs/repo-map.md). MemPalace adds persistent memory across sessions.
+
+- **[Soul Map](https://github.com/proxysoul/soulforge/blob/main/docs/repo-map.md)** = what is the code right now
+- **[MemPalace](https://github.com/milla-jovovich/mempalace)** = what happened and why
+
+## Quick Start
+
+### 1. Install MemPalace
+
+```bash
+pip install mempalace
+mempalace init ~/projects/my-app
+```
+
+### 2. Mine your SoulForge sessions
+
+SoulForge stores sessions per project at `<project>/.soulforge/sessions/`. Each session is a folder with `meta.json` and `messages.jsonl`.
+
+```bash
+# Mine sessions from a project
+mempalace mine ~/projects/my-app/.soulforge/sessions/ --mode convos --wing my-app
+
+# Preview first
+mempalace mine ~/projects/my-app/.soulforge/sessions/ --mode convos --wing my-app --dry-run
+```
+
+The normalizer auto-detects SoulForge JSONL and extracts:
+- **User prompts** verbatim
+- **Assistant responses** verbatim
+- **Tool calls** as one-line summaries (e.g. `[read: src/config.ts]`)
+- **Reasoning** with `[reasoning]` prefix
+- **Plans** as step labels
+
+System messages and raw tool output are excluded.
+
+### 3. Search your history
+
+```bash
+mempalace search "why did we switch to Postgres"
+mempalace search "auth migration" --wing my-app
+mempalace search "connection pool timeout" --wing my-app
+```
+
+### 4. Connect as MCP server
+
+Add MemPalace to your SoulForge [MCP config](https://github.com/proxysoul/soulforge/blob/main/docs/mcp.md) (`~/.soulforge/config.json` or `<project>/.soulforge/config.json`):
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "mempalace",
+      "command": "uvx",
+      "args": ["--from", "mempalace", "python", "-m", "mempalace.mcp_server"]
+    }
+  ]
+}
+```
+
+If you installed mempalace globally (`pip install mempalace`), you can use `"command": "python"` and `"args": ["-m", "mempalace.mcp_server"]` instead.
+
+Your agent can then call `mempalace_search` during sessions to recall past decisions. See the [MCP tools reference](https://github.com/milla-jovovich/mempalace#mcp-server) for the full list.
+
+## Automatic Memory via Compaction
+
+This is the main integration point. SoulForge has a [compaction system](https://github.com/proxysoul/soulforge/blob/main/docs/compaction.md) that manages context window pressure. When the context gets full, it compacts older messages into a structured summary. With MemPalace connected as an MCP server, that summary is automatically saved to the palace.
+
+### How compaction v2 works
+
+SoulForge's compaction v2 builds a structured working state incrementally as the conversation happens. Every tool call, every edit, every decision is extracted in real-time into typed slots:
+
+| Slot | What it captures |
+|---|---|
+| **Task** | The original user request |
+| **User Requirements** | Follow-up constraints and clarifications |
+| **Plan** | Active implementation steps and their status |
+| **Files Touched** | Every file read/edited/created, with action summaries |
+| **Key Decisions** | Architecture choices, tradeoffs, approach selections |
+| **Discoveries** | Things learned about the codebase during the session |
+| **Errors & Failures** | What went wrong and how it was resolved |
+| **Tool Results** | Condensed output from shell commands, tests, searches |
+| **Assistant Notes** | Key reasoning from the agent's responses |
+
+This extraction happens at tool-call time, before output gets truncated, so it sees the full data. When compaction triggers (default: 70% context usage), the working state is serialized into a structured markdown summary.
+
+### What MemPalace receives
+
+When a `mempalace` MCP server is connected, SoulForge calls `mempalace_add_drawer` with the serialized compaction state right before it resets. The content looks like:
+
+```markdown
+## Task
+Refactor the auth module to support OAuth2
+
+## User Requirements
+- Must be backwards compatible with existing JWT tokens
+- Add refresh token rotation
+
+## Files Touched
+- `src/auth/oauth.ts`: created (142 lines)
+- `src/auth/jwt.ts`: edited: added refreshToken field
+- `src/middleware/auth.ts`: edited: added OAuth2 flow
+
+## Key Decisions
+- Chose PKCE over implicit flow for security
+- Kept JWT as fallback during migration period
+
+## Errors & Failures
+- project: test src/auth/oauth.test.ts failed: missing mock for token endpoint
+```
+
+This is filed into the palace with `wing` set to the project name and `room` set to `compaction`. Every compaction event becomes a searchable drawer.
+
+### Why this matters
+
+Long sessions compact multiple times. Each compaction captures a snapshot of what happened in that chunk of work. Over weeks and months, the palace accumulates a structured history of every significant coding session:
+
+```bash
+# Six months later
+mempalace search "OAuth2 migration decisions" --wing my-app
+# → finds the compaction drawer with the exact tradeoffs and file changes
+
+mempalace search "auth test failures" --wing my-app
+# → finds what broke and how it was fixed
+```
+
+The combination is:
+- **Soul Map** gives the agent live code structure (rebuilt after every edit, lives within a session)
+- **Compaction v2** extracts structured context from the conversation in real-time, at zero cost (rule-based, no LLM calls)
+- **MemPalace** persists that structured context across sessions via the palace and knowledge graph
+
+No manual `mempalace mine` needed when the MCP server is connected. Compaction handles it automatically.
+
+### Knowledge Graph Integration
+
+Beyond the drawer, SoulForge also files structured facts from the working state into MemPalace's [knowledge graph](https://github.com/milla-jovovich/mempalace#knowledge-graph) as typed triples:
+
+| Working state slot | Knowledge graph triple |
+|---|---|
+| Decisions | `project → decided → "PKCE over implicit flow"` |
+| Discoveries | `project → discovered → "connection pool causes timeouts"` |
+| Failures | `project → failed → "OAuth mock missing in tests"` |
+
+These triples have temporal validity (`valid_from` timestamps), so you can query what was true at any point:
+
+```bash
+# What decisions have we made on this project?
+# → mempalace_kg_query returns a timeline of every decision with dates
+
+# What was true in January?
+# → mempalace_kg_query with as_of="2026-01-20" filters to that point in time
+```
+
+MemPalace's contradiction detection also kicks in. If a new compaction files a decision that conflicts with a previous one, it flags it.
+
+### Agent Diary
+
+At each compaction, SoulForge writes a diary entry for the `forge` agent summarising the task, decisions, discoveries, failures, and files touched. The diary uses MemPalace's [AAAK-style format](https://github.com/milla-jovovich/mempalace#aaak-compression) for compact storage.
+
+Over time, the forge agent builds a persistent journal of everything it has worked on. Future sessions can read the diary to pick up context:
+
+```
+TASK:Refactor auth module for OAuth2|DECISIONS:PKCE over implicit|JWT fallback during migration|FILES:src/auth/oauth.ts|src/auth/jwt.ts|src/middleware/auth.ts
+```
+
+### Wake-up Context
+
+On the first message of each session, SoulForge fetches MemPalace's L0+L1 wake-up context (~170 tokens) for the current project. This gives the agent immediate awareness of project history before the user says anything.
+
+The wake-up context includes critical facts, team info, and recent decisions from the palace. It's injected as a system message and costs almost nothing since it's included in the cached system prompt prefix.
+
+## Compaction v2: Zero-Cost Extraction
+
+Worth noting: SoulForge's compaction v2 extraction is entirely rule-based. No LLM calls are made to extract decisions, files, or failures from the conversation. The extractor runs inline at tool-call time using pattern matching:
+
+- `extractFromToolCall` tracks file reads/edits/creates from tool args
+- `extractFromToolResult` captures errors, search results, test output
+- `extractFromUserMessage` captures the task and follow-up requirements
+- `extractFromAssistantMessage` extracts substantive sentences (filters filler like "Let me check...")
+
+An optional cheap LLM gap-fill pass runs only when the working state has fewer than 15 slots (early in a conversation). For most sessions, compaction is pure extraction with zero API cost.
+
+This means the MemPalace integration adds zero token overhead. The structured data that flows into the palace was already being computed for compaction. MemPalace just persists it.
+
+## Session Mining (Manual)
+
+For sessions that already happened (before you connected MemPalace), or if you prefer batch processing over live MCP:
+
+```bash
+mempalace mine ~/projects/my-app/.soulforge/sessions/ --mode convos --wing my-app
+```
+
+This mines the raw JSONL transcripts. The compaction integration above is preferred for new sessions since it saves the already-structured working state rather than re-parsing raw messages.
+
+## Session Format
+
+SoulForge sessions are JSONL (`messages.jsonl`), one message per line:
+
+```jsonl
+{"id":"msg-1","role":"user","content":"Refactor the auth module","timestamp":1712500000000}
+{"id":"msg-2","role":"assistant","content":"","timestamp":1712500005000,"durationMs":3200,"segments":[{"type":"text","content":"I'll split it into two files."},{"type":"tools","toolCallIds":["tc-1"]},{"type":"text","content":"Done."}],"toolCalls":[{"id":"tc-1","name":"edit_file","args":{"path":"src/auth.ts"},"result":{"success":true,"output":"..."}}]}
+```
+
+Both flat messages (`content` only) and the segments-based format (text, tool calls, reasoning, plans) are supported.
+
+## What Gets Mined
+
+| Element | Included | How |
+|---|---|---|
+| User messages | ✓ | Verbatim |
+| Assistant text | ✓ | Verbatim |
+| Tool calls | ✓ | `[tool_name: key_arg]` |
+| Reasoning | ✓ | `[reasoning]` prefix, truncated to 500 chars |
+| Plans | ✓ | `[plan] Step 1; Step 2; ...` |
+| System prompts | ✗ | Excluded |
+| Raw tool output | ✗ | Excluded |
+| Images | ✗ | N/A |
+
+## MemPalace Features Used
+
+| Feature | How SoulForge uses it |
+|---|---|
+| **Palace drawers** | Compaction summaries filed per project wing |
+| **Knowledge graph** | Decisions, discoveries, failures as temporal triples |
+| **Contradiction detection** | Flags conflicting decisions across compactions |
+| **Agent diary** | Forge agent writes session summaries in AAAK format |
+| **Wake-up context** | L0+L1 injected as system message on first prompt |
+| **Semantic search** | Agent calls `mempalace_search` during sessions |
+| **Wing/room structure** | Wing = project name, room = compaction / auto-detected |
+
+## Tips
+
+- Connect MemPalace as an MCP server and let compaction handle memory automatically.
+- For older sessions, run `mempalace mine` as a one-time backfill.
+- Use `--wing my-app` to keep projects separate.
+- Add `--extract general` to auto-classify into decisions, preferences, milestones, and problems.
+- Run `mempalace wake-up --wing my-app` before a new session for a ~170 token context summary.

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -7,6 +7,7 @@ Supported:
     - Claude.ai JSON export
     - ChatGPT conversations.json
     - Claude Code JSONL
+    - SoulForge JSONL sessions
     - Slack JSON export
     - Plain text (pass through for paragraph chunking)
 
@@ -55,6 +56,10 @@ def _try_normalize_json(content: str) -> Optional[str]:
     if normalized:
         return normalized
 
+    normalized = _try_soulforge_jsonl(content)
+    if normalized:
+        return normalized
+
     try:
         data = json.loads(content)
     except json.JSONDecodeError:
@@ -92,6 +97,118 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
     if len(messages) >= 2:
         return _messages_to_transcript(messages)
     return None
+
+
+def _try_soulforge_jsonl(content: str) -> Optional[str]:
+    """SoulForge JSONL sessions.
+
+    SoulForge (https://github.com/proxysoul/soulforge) stores sessions as
+    messages.jsonl — one JSON object per line with the shape:
+        {"role": "user"|"assistant"|"system", "content": "...", ...}
+
+    Assistant messages may contain tool calls in a ``toolCalls`` array and
+    interleaved ``segments`` (text, tools, reasoning, plan).  We extract
+    the human-readable text and summarise tool activity so the palace
+    captures *what happened* without the raw tool output noise.
+    """
+    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    if len(lines) < 2:
+        return None
+
+    messages = []
+    is_soulforge = False
+
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        role = entry.get("role", "")
+        if role not in ("user", "assistant", "system"):
+            continue
+
+        # Detect SoulForge by its unique fields
+        if not is_soulforge:
+            if any(k in entry for k in ("segments", "toolCalls", "durationMs", "isSteering")):
+                is_soulforge = True
+
+        # Skip system messages unless they were shown inline
+        if role == "system" and not entry.get("showInChat"):
+            continue
+
+        text = _extract_soulforge_text(entry)
+        if not text:
+            continue
+
+        mapped_role = "user" if role == "user" else "assistant"
+        messages.append((mapped_role, text))
+
+    if not is_soulforge:
+        return None
+    if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    return None
+
+
+def _extract_soulforge_text(entry: dict) -> str:
+    """Extract human-readable text from a SoulForge ChatMessage.
+
+    Handles both the segments-based format (interleaved text/tool/reasoning)
+    and the flat content + toolCalls fallback.
+    """
+    parts = []
+
+    segments = entry.get("segments")
+    if segments and isinstance(segments, list):
+        tool_calls = {tc["id"]: tc for tc in (entry.get("toolCalls") or []) if "id" in tc}
+        for seg in segments:
+            seg_type = seg.get("type", "")
+            if seg_type == "text":
+                text = seg.get("content", "").strip()
+                if text:
+                    parts.append(text)
+            elif seg_type == "tools":
+                # Summarise tool calls as one-liners instead of dumping raw output
+                for tc_id in seg.get("toolCallIds", []):
+                    tc = tool_calls.get(tc_id)
+                    if tc:
+                        parts.append(_summarise_tool_call(tc))
+            elif seg_type == "reasoning":
+                text = seg.get("content", "").strip()
+                if text:
+                    parts.append(f"[reasoning] {text[:500]}")
+            elif seg_type == "plan":
+                plan = seg.get("plan", {})
+                steps = plan.get("steps", [])
+                if steps:
+                    step_labels = [s.get("label", "") for s in steps[:10]]
+                    parts.append("[plan] " + "; ".join(step_labels))
+    else:
+        # Flat format fallback
+        content = entry.get("content", "").strip()
+        if content:
+            parts.append(content)
+        for tc in entry.get("toolCalls") or []:
+            parts.append(_summarise_tool_call(tc))
+
+    return "\n".join(parts).strip()
+
+
+def _summarise_tool_call(tc: dict) -> str:
+    """One-line summary of a tool call: name + key args."""
+    name = tc.get("name", "tool")
+    args = tc.get("args", {})
+    # Pick the most informative arg (file path, pattern, command, query)
+    for key in ("path", "file", "pattern", "command", "query", "symbol"):
+        val = args.get(key)
+        if val and isinstance(val, str):
+            short = val if len(val) <= 80 else val[:77] + "..."
+            return f"[{name}: {short}]"
+    # Fallback: just the tool name
+    return f"[{name}]"
 
 
 def _try_claude_ai_json(data) -> Optional[str]:

--- a/tests/test_soulforge.py
+++ b/tests/test_soulforge.py
@@ -1,0 +1,174 @@
+"""Tests for SoulForge JSONL session import.
+
+Uses real SoulForge ChatMessage schema: {id, role, content, timestamp,
+toolCalls?, segments?, durationMs?, showInChat?, isSteering?}.
+"""
+
+import json
+import os
+import tempfile
+
+from mempalace.normalize import normalize
+
+
+def _write_jsonl(lines):
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
+    for obj in lines:
+        f.write(json.dumps(obj) + "\n")
+    f.close()
+    return f.name
+
+
+def _msg(role, content, **kw):
+    return {"id": f"msg-{id(content)}", "role": role, "content": content, "timestamp": 0, **kw}
+
+
+def test_full_session():
+    """Realistic multi-turn session with every segment type and edge case."""
+    path = _write_jsonl(
+        [
+            _msg("system", "You are Forge."),
+            _msg("user", "Refactor auth to support OAuth2"),
+            _msg(
+                "assistant",
+                "",
+                durationMs=4200,
+                segments=[
+                    {"type": "reasoning", "content": "Need to check existing auth first."},
+                    {"type": "text", "content": "I'll read the current auth module."},
+                    {"type": "tools", "toolCallIds": ["tc-1", "tc-2"]},
+                    {"type": "text", "content": "Found the JWT impl. Here's my plan."},
+                    {
+                        "type": "plan",
+                        "plan": {
+                            "steps": [
+                                {"id": "s1", "label": "Add OAuth2 provider", "status": "done"},
+                                {"id": "s2", "label": "Keep JWT fallback", "status": "pending"},
+                            ]
+                        },
+                    },
+                ],
+                toolCalls=[
+                    {"id": "tc-1", "name": "read", "args": {"path": "src/auth/jwt.ts"}},
+                    {"id": "tc-2", "name": "soul_grep", "args": {"pattern": "authenticate"}},
+                ],
+            ),
+            _msg("user", "Use PKCE flow", isSteering=True),
+            _msg("system", "Context compacted.", showInChat=True),
+            _msg("assistant", "Switching to PKCE.", durationMs=800),
+        ]
+    )
+    result = normalize(path)
+
+    assert "You are Forge" not in result
+    assert "Context compacted." in result
+    assert "> Refactor auth to support OAuth2" in result
+    assert "Use PKCE flow" in result
+    assert "I'll read the current auth module." in result
+    assert "[read: src/auth/jwt.ts]" in result
+    assert "[soul_grep: authenticate]" in result
+    assert "[reasoning]" in result
+    assert "[plan] Add OAuth2 provider; Keep JWT fallback" in result
+    assert "Switching to PKCE." in result
+
+    os.unlink(path)
+
+
+def test_malformed_lines_and_missing_tool_refs():
+    """Broken JSON lines skipped; missing toolCallId refs don't crash."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
+    f.write(json.dumps(_msg("user", "Go")) + "\n")
+    f.write("NOT JSON\n")
+    f.write('truncated {"role":\n')
+    f.write(
+        json.dumps(
+            _msg(
+                "assistant",
+                "",
+                durationMs=100,
+                segments=[
+                    {"type": "tools", "toolCallIds": ["tc-1", "tc-GHOST"]},
+                    {"type": "text", "content": "Done."},
+                ],
+                toolCalls=[{"id": "tc-1", "name": "read", "args": {"path": "a.ts"}}],
+            )
+        )
+        + "\n"
+    )
+    f.close()
+    result = normalize(f.name)
+    assert "[read: a.ts]" in result
+    assert "Done." in result
+    os.unlink(f.name)
+
+
+def test_empty_segments_falls_back_to_flat():
+    """segments=[] uses content + toolCalls fallback."""
+    path = _write_jsonl(
+        [
+            _msg("user", "Search"),
+            _msg(
+                "assistant",
+                "Found 3 matches.",
+                segments=[],
+                toolCalls=[{"id": "tc-1", "name": "soul_grep", "args": {"pattern": "auth"}}],
+                durationMs=100,
+            ),
+        ]
+    )
+    result = normalize(path)
+    assert "Found 3 matches." in result
+    assert "[soul_grep: auth]" in result
+    os.unlink(path)
+
+
+def test_tool_summary_priority_truncation_fallback():
+    """path preferred; long values truncated; no informative arg shows name only."""
+    long_path = "src/deeply/nested/" + "x" * 80 + "/file.ts"
+    path = _write_jsonl(
+        [
+            _msg("user", "Go"),
+            _msg(
+                "assistant",
+                "",
+                durationMs=100,
+                segments=[{"type": "tools", "toolCallIds": ["tc-1", "tc-2", "tc-3"]}],
+                toolCalls=[
+                    {
+                        "id": "tc-1",
+                        "name": "edit_file",
+                        "args": {"path": "src/main.ts", "pattern": "ignored"},
+                    },
+                    {"id": "tc-2", "name": "read", "args": {"path": long_path}},
+                    {"id": "tc-3", "name": "list_dir", "args": {"depth": 2}},
+                ],
+            ),
+        ]
+    )
+    result = normalize(path)
+    assert "[edit_file: src/main.ts]" in result
+    assert long_path not in result
+    assert "[list_dir]" in result
+    os.unlink(path)
+
+
+def test_reasoning_truncated_at_500():
+    """Reasoning over 500 chars is cut."""
+    path = _write_jsonl(
+        [
+            _msg("user", "Think"),
+            _msg(
+                "assistant",
+                "",
+                durationMs=100,
+                segments=[
+                    {"type": "reasoning", "content": "x" * 800},
+                    {"type": "text", "content": "Done."},
+                ],
+            ),
+        ]
+    )
+    result = normalize(path)
+    reasoning_line = [line for line in result.split("\n") if "[reasoning]" in line][0]
+    assert len(reasoning_line) <= 512
+    os.unlink(path)


### PR DESCRIPTION
Adds SoulForge JSONL session normalizer to the conversation import pipeline and a full integration guide.

## What this adds

**mempalace/normalize.py** - SoulForge session parser. Auto-detects via unique fields (`segments`, `toolCalls`, `durationMs`). Extracts readable text from both flat and segments-based messages. Summarises tool calls as one-liners. Skips system messages unless shown in chat.

**tests/test_soulforge.py** - 5 tests covering full session extraction, malformed input, missing tool refs, empty segments fallback, truncation.

**examples/soulforge_setup.md** - Integration guide: session mining, MCP server config, compaction v2 auto-save, knowledge graph, agent diary.

## How it works

SoulForge stores coding sessions as `messages.jsonl` (one ChatMessage per line). Users can mine them with:

```bash
mempalace mine ~/projects/my-app/.soulforge/sessions/ --mode convos --wing my-app
```

When MemPalace is connected as an MCP server, SoulForge's compaction v2 also saves structured state directly to the palace at zero extra cost: drawers, knowledge graph triples (decisions/discoveries/failures), and agent diary entries. See the [SoulForge integration commit](https://github.com/proxysoul/soulforge/commit/bfe78cc).

## Checklist

- [x] `pytest tests/ -v` passes (14/14, zero regressions)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] 100-char line limit
- [x] No new dependencies
- [x] Conventional commit

Closes #2