### PR TITLE
fix: narrow bare except Exception to specific types where safe

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -301,7 +301,7 @@ def mine_convos(
         # Normalize format
         try:
             content = normalize(str(filepath))
-        except Exception:
+        except (OSError, ValueError):
             continue
 
         if not content or len(content.strip()) < MIN_CHUNK_SIZE:

--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -660,7 +660,7 @@ def detect_entities(file_paths: list, max_files: int = 10) -> dict:
             all_text.append(content)
             all_lines.extend(content.splitlines())
             files_read += 1
-        except Exception:
+        except OSError:
             continue
 
     combined_text = "\n".join(all_text)

--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -256,7 +256,7 @@ def _wikipedia_lookup(word: str) -> dict:
                 "note": "not found in Wikipedia — likely a proper noun or unusual name",
             }
         return {"inferred_type": "unknown", "confidence": 0.0, "wiki_summary": None}
-    except Exception:
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, KeyError):
         return {"inferred_type": "unknown", "confidence": 0.0, "wiki_summary": None}
 
 

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -248,7 +248,7 @@ def process_file(
 
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")
-    except Exception:
+    except OSError:
         return 0
 
     content = content.strip()

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -27,7 +27,7 @@ def normalize(filepath: str) -> str:
     try:
         with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             content = f.read()
-    except Exception as e:
+    except OSError as e:
         raise IOError(f"Could not read {filepath}: {e}")
 
     if not content.strip():
@@ -213,7 +213,7 @@ def _messages_to_transcript(messages: list, spellcheck: bool = True) -> str:
             from mempalace.spellcheck import spellcheck_user_text
 
             _fix = spellcheck_user_text
-        except Exception:
+        except ImportError:
             _fix = None
     else:
         _fix = None


### PR DESCRIPTION
## Summary
Replace broad `except Exception` with specific exception types in 6 sites where the expected failure mode is well-defined:

- **`normalize.py`**: `OSError` for file read, `ImportError` for optional spellcheck import
- **`miner.py`**: `OSError` for `filepath.read_text()`
- **`entity_detector.py`**: `OSError` for file read in scan loop
- **`convo_miner.py`**: `(OSError, ValueError)` for `normalize()` which reads and parses files
- **`entity_registry.py`**: `(URLError, OSError, JSONDecodeError, KeyError)` for Wikipedia lookup fallback

### What's NOT changed (and why)
- **ChromaDB sites (~30)**: `chromadb.errors` defines `NotFoundError`, `DuplicateIDError`, `InvalidDimensionException`, etc. (verified from [source](https://github.com/chroma-core/chroma/blob/main/chromadb/errors.py)). Narrowing those sites requires importing from `chromadb.errors` and validating across supported versions (>=0.4.0) — left for a follow-up.
- **MCP server handlers**: Intentionally broad for resilience — must return error messages to clients, not crash.
- **`file_already_mined` checks**: Return `False` on any error is correct resilience behavior.

## Changes
5 files changed, 6 lines modified. Each `except Exception` replaced with the narrowest type(s) that cover the actual failure modes.

## Test plan
- [x] `ruff check` passes clean on all 5 files
- [x] `ruff format --check` already formatted
- [x] `python3 -m py_compile` compiles OK for all 5 files
- [x] Pyright reports 0 new diagnostics
- [x] Exception types verified: `OSError` covers all file I/O, `ImportError` covers optional imports, `urllib.error.URLError` covers network failures