### PR TITLE
fix: add explicit Optional[T] annotations for all None-defaulted params

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -17,6 +17,8 @@ from collections import defaultdict
 
 import chromadb
 
+from typing import Optional
+
 from .normalize import normalize
 
 
@@ -252,7 +254,7 @@ def scan_convos(convo_dir: str) -> list:
 def mine_convos(
     convo_dir: str,
     palace_path: str,
-    wing: str = None,
+    wing: Optional[str] = None,
     agent: str = "mempalace",
     limit: int = 0,
     dry_run: bool = False,

--- a/mempalace/dialect.py
+++ b/mempalace/dialect.py
@@ -311,7 +311,9 @@ class Dialect:
         dialect.generate_layer1("zettels/", output="LAYER1.aaak")
     """
 
-    def __init__(self, entities: Dict[str, str] = None, skip_names: List[str] = None):
+    def __init__(
+        self, entities: Optional[Dict[str, str]] = None, skip_names: Optional[List[str]] = None
+    ):
         """
         Args:
             entities: Mapping of full names -> short codes.
@@ -536,7 +538,7 @@ class Dialect:
                     break
         return found
 
-    def compress(self, text: str, metadata: dict = None) -> str:
+    def compress(self, text: str, metadata: Optional[dict] = None) -> str:
         """
         Compress plain text into AAAK Dialect format.
 
@@ -752,7 +754,7 @@ class Dialect:
 
     # === FILE-BASED COMPRESSION ===
 
-    def compress_file(self, zettel_json_path: str, output_path: str = None) -> str:
+    def compress_file(self, zettel_json_path: str, output_path: Optional[str] = None) -> str:
         """Read a zettel JSON file and compress it to AAAK Dialect."""
         with open(zettel_json_path, "r") as f:
             data = json.load(f)
@@ -762,7 +764,7 @@ class Dialect:
                 f.write(dialect)
         return dialect
 
-    def compress_all(self, zettel_dir: str, output_path: str = None) -> str:
+    def compress_all(self, zettel_dir: str, output_path: Optional[str] = None) -> str:
         """Compress ALL zettel files into a single AAAK Dialect file."""
         all_dialect = []
         for fname in sorted(os.listdir(zettel_dir)):
@@ -784,8 +786,8 @@ class Dialect:
     def generate_layer1(
         self,
         zettel_dir: str,
-        output_path: str = None,
-        identity_sections: Dict[str, List[str]] = None,
+        output_path: Optional[str] = None,
+        identity_sections: Optional[Dict[str, List[str]]] = None,
         weight_threshold: float = 0.85,
     ) -> str:
         """

--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -345,7 +345,7 @@ class EntityRegistry:
 
     # ── Seed from onboarding ─────────────────────────────────────────────────
 
-    def seed(self, mode: str, people: list, projects: list, aliases: dict = None):
+    def seed(self, mode: str, people: list, projects: list, aliases: Optional[dict] = None):
         """
         Seed the registry from onboarding data.
 

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -41,13 +41,14 @@ import os
 import sqlite3
 from datetime import date, datetime
 from pathlib import Path
+from typing import Optional
 
 
 DEFAULT_KG_PATH = os.path.expanduser("~/.mempalace/knowledge_graph.sqlite3")
 
 
 class KnowledgeGraph:
-    def __init__(self, db_path: str = None):
+    def __init__(self, db_path: Optional[str] = None):
         self.db_path = db_path or DEFAULT_KG_PATH
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
@@ -94,7 +95,9 @@ class KnowledgeGraph:
 
     # ── Write operations ──────────────────────────────────────────────────
 
-    def add_entity(self, name: str, entity_type: str = "unknown", properties: dict = None):
+    def add_entity(
+        self, name: str, entity_type: str = "unknown", properties: Optional[dict] = None
+    ):
         """Add or update an entity node."""
         eid = self._entity_id(name)
         props = json.dumps(properties or {})
@@ -112,11 +115,11 @@ class KnowledgeGraph:
         subject: str,
         predicate: str,
         obj: str,
-        valid_from: str = None,
-        valid_to: str = None,
+        valid_from: Optional[str] = None,
+        valid_to: Optional[str] = None,
         confidence: float = 1.0,
-        source_closet: str = None,
-        source_file: str = None,
+        source_closet: Optional[str] = None,
+        source_file: Optional[str] = None,
     ):
         """
         Add a relationship triple: subject → predicate → object.
@@ -166,7 +169,7 @@ class KnowledgeGraph:
         conn.close()
         return triple_id
 
-    def invalidate(self, subject: str, predicate: str, obj: str, ended: str = None):
+    def invalidate(self, subject: str, predicate: str, obj: str, ended: Optional[str] = None):
         """Mark a relationship as no longer valid (set valid_to date)."""
         sub_id = self._entity_id(subject)
         obj_id = self._entity_id(obj)
@@ -183,7 +186,7 @@ class KnowledgeGraph:
 
     # ── Query operations ──────────────────────────────────────────────────
 
-    def query_entity(self, name: str, as_of: str = None, direction: str = "outgoing"):
+    def query_entity(self, name: str, as_of: Optional[str] = None, direction: str = "outgoing"):
         """
         Get all relationships for an entity.
 
@@ -240,7 +243,7 @@ class KnowledgeGraph:
         conn.close()
         return results
 
-    def query_relationship(self, predicate: str, as_of: str = None):
+    def query_relationship(self, predicate: str, as_of: Optional[str] = None):
         """Get all triples with a given relationship type."""
         pred = predicate.lower().replace(" ", "_")
         conn = self._conn()
@@ -271,7 +274,7 @@ class KnowledgeGraph:
         conn.close()
         return results
 
-    def timeline(self, entity_name: str = None):
+    def timeline(self, entity_name: Optional[str] = None):
         """Get all facts in chronological order, optionally filtered by entity."""
         conn = self._conn()
         if entity_name:

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -25,6 +25,8 @@ import chromadb
 
 from .config import MempalaceConfig
 
+from typing import Optional
+
 
 # ---------------------------------------------------------------------------
 # Layer 0 — Identity
@@ -43,7 +45,7 @@ class Layer0:
         Project: A journaling app that helps people process emotions.
     """
 
-    def __init__(self, identity_path: str = None):
+    def __init__(self, identity_path: Optional[str] = None):
         if identity_path is None:
             identity_path = os.path.expanduser("~/.mempalace/identity.txt")
         self.path = identity_path
@@ -83,7 +85,7 @@ class Layer1:
     MAX_DRAWERS = 15  # at most 15 moments in wake-up
     MAX_CHARS = 3200  # hard cap on total L1 text (~800 tokens)
 
-    def __init__(self, palace_path: str = None, wing: str = None):
+    def __init__(self, palace_path: Optional[str] = None, wing: Optional[str] = None):
         cfg = MempalaceConfig()
         self.palace_path = palace_path or cfg.palace_path
         self.wing = wing
@@ -180,11 +182,13 @@ class Layer2:
     Queries ChromaDB with a wing/room filter.
     """
 
-    def __init__(self, palace_path: str = None):
+    def __init__(self, palace_path: Optional[str] = None):
         cfg = MempalaceConfig()
         self.palace_path = palace_path or cfg.palace_path
 
-    def retrieve(self, wing: str = None, room: str = None, n_results: int = 10) -> str:
+    def retrieve(
+        self, wing: Optional[str] = None, room: Optional[str] = None, n_results: int = 10
+    ) -> str:
         """Retrieve drawers filtered by wing and/or room."""
         try:
             client = chromadb.PersistentClient(path=self.palace_path)
@@ -244,11 +248,13 @@ class Layer3:
     Reuses searcher.py logic against mempalace_drawers.
     """
 
-    def __init__(self, palace_path: str = None):
+    def __init__(self, palace_path: Optional[str] = None):
         cfg = MempalaceConfig()
         self.palace_path = palace_path or cfg.palace_path
 
-    def search(self, query: str, wing: str = None, room: str = None, n_results: int = 5) -> str:
+    def search(
+        self, query: str, wing: Optional[str] = None, room: Optional[str] = None, n_results: int = 5
+    ) -> str:
         """Semantic search, returns compact result text."""
         try:
             client = chromadb.PersistentClient(path=self.palace_path)
@@ -303,7 +309,7 @@ class Layer3:
         return "\n".join(lines)
 
     def search_raw(
-        self, query: str, wing: str = None, room: str = None, n_results: int = 5
+        self, query: str, wing: Optional[str] = None, room: Optional[str] = None, n_results: int = 5
     ) -> list:
         """Return raw dicts instead of formatted text."""
         try:
@@ -367,7 +373,7 @@ class MemoryStack:
         print(stack.search("pricing change"))  # L3 deep search
     """
 
-    def __init__(self, palace_path: str = None, identity_path: str = None):
+    def __init__(self, palace_path: Optional[str] = None, identity_path: Optional[str] = None):
         cfg = MempalaceConfig()
         self.palace_path = palace_path or cfg.palace_path
         self.identity_path = identity_path or os.path.expanduser("~/.mempalace/identity.txt")
@@ -377,7 +383,7 @@ class MemoryStack:
         self.l2 = Layer2(self.palace_path)
         self.l3 = Layer3(self.palace_path)
 
-    def wake_up(self, wing: str = None) -> str:
+    def wake_up(self, wing: Optional[str] = None) -> str:
         """
         Generate wake-up text: L0 (identity) + L1 (essential story).
         Typically ~600-900 tokens. Inject into system prompt or first message.
@@ -398,11 +404,15 @@ class MemoryStack:
 
         return "\n".join(parts)
 
-    def recall(self, wing: str = None, room: str = None, n_results: int = 10) -> str:
+    def recall(
+        self, wing: Optional[str] = None, room: Optional[str] = None, n_results: int = 10
+    ) -> str:
         """On-demand L2 retrieval filtered by wing/room."""
         return self.l2.retrieve(wing=wing, room=room, n_results=n_results)
 
-    def search(self, query: str, wing: str = None, room: str = None, n_results: int = 5) -> str:
+    def search(
+        self, query: str, wing: Optional[str] = None, room: Optional[str] = None, n_results: int = 5
+    ) -> str:
         """Deep L3 semantic search."""
         return self.l3.search(query, wing=wing, room=room, n_results=n_results)
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -28,6 +28,8 @@ from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
 import chromadb
 
+from typing import Optional
+
 from .knowledge_graph import KnowledgeGraph
 
 _kg = KnowledgeGraph()
@@ -134,7 +136,7 @@ def tool_list_wings():
     return {"wings": wings}
 
 
-def tool_list_rooms(wing: str = None):
+def tool_list_rooms(wing: Optional[str] = None):
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -170,7 +172,7 @@ def tool_get_taxonomy():
     return {"taxonomy": taxonomy}
 
 
-def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+def tool_search(query: str, limit: int = 5, wing: Optional[str] = None, room: Optional[str] = None):
     return search_memories(
         query,
         palace_path=_config.palace_path,
@@ -228,7 +230,7 @@ def tool_traverse_graph(start_room: str, max_hops: int = 2):
     return traverse(start_room, col=col, max_hops=max_hops)
 
 
-def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
+def tool_find_tunnels(wing_a: Optional[str] = None, wing_b: Optional[str] = None):
     """Find rooms that bridge two wings — the hallways connecting domains."""
     col = _get_collection()
     if not col:
@@ -248,7 +250,7 @@ def tool_graph_stats():
 
 
 def tool_add_drawer(
-    wing: str, room: str, content: str, source_file: str = None, added_by: str = "mcp"
+    wing: str, room: str, content: str, source_file: Optional[str] = None, added_by: str = "mcp"
 ):
     """File verbatim content into a wing/room. Checks for duplicates first."""
     col = _get_collection(create=True)
@@ -306,14 +308,18 @@ def tool_delete_drawer(drawer_id: str):
 # ==================== KNOWLEDGE GRAPH ====================
 
 
-def tool_kg_query(entity: str, as_of: str = None, direction: str = "both"):
+def tool_kg_query(entity: str, as_of: Optional[str] = None, direction: str = "both"):
     """Query the knowledge graph for an entity's relationships."""
     results = _kg.query_entity(entity, as_of=as_of, direction=direction)
     return {"entity": entity, "as_of": as_of, "facts": results, "count": len(results)}
 
 
 def tool_kg_add(
-    subject: str, predicate: str, object: str, valid_from: str = None, source_closet: str = None
+    subject: str,
+    predicate: str,
+    object: str,
+    valid_from: Optional[str] = None,
+    source_closet: Optional[str] = None,
 ):
     """Add a relationship to the knowledge graph."""
     triple_id = _kg.add_triple(
@@ -322,7 +328,7 @@ def tool_kg_add(
     return {"success": True, "triple_id": triple_id, "fact": f"{subject} → {predicate} → {object}"}
 
 
-def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = None):
+def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: Optional[str] = None):
     """Mark a fact as no longer true (set end date)."""
     _kg.invalidate(subject, predicate, object, ended=ended)
     return {
@@ -332,7 +338,7 @@ def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = N
     }
 
 
-def tool_kg_timeline(entity: str = None):
+def tool_kg_timeline(entity: Optional[str] = None):
     """Get chronological timeline of facts, optionally for one entity."""
     results = _kg.timeline(entity)
     return {"entity": entity or "all", "timeline": results, "count": len(results)}

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
+from typing import Optional
+
 import chromadb
 
 READABLE_EXTENSIONS = {
@@ -315,7 +317,7 @@ def scan_project(project_dir: str) -> list:
 def mine(
     project_dir: str,
     palace_path: str,
-    wing_override: str = None,
+    wing_override: Optional[str] = None,
     agent: str = "mempalace",
     limit: int = 0,
     dry_run: bool = False,

--- a/mempalace/onboarding.py
+++ b/mempalace/onboarding.py
@@ -17,6 +17,8 @@ Usage:
 """
 
 from pathlib import Path
+from typing import Optional
+
 from mempalace.entity_registry import EntityRegistry
 from mempalace.entity_detector import detect_entities, scan_for_detection
 
@@ -264,7 +266,7 @@ def _warn_ambiguous(people: list) -> list:
 
 
 def _generate_aaak_bootstrap(
-    people: list, projects: list, wings: list, mode: str, config_dir: Path = None
+    people: list, projects: list, wings: list, mode: str, config_dir: Optional[Path] = None
 ):
     """
     Generate AAAK entity registry + critical facts bootstrap from onboarding data.
@@ -364,7 +366,7 @@ def _generate_aaak_bootstrap(
 
 def run_onboarding(
     directory: str = ".",
-    config_dir: Path = None,
+    config_dir: Optional[Path] = None,
     auto_detect: bool = True,
 ) -> EntityRegistry:
     """
@@ -458,9 +460,9 @@ def run_onboarding(
 def quick_setup(
     mode: str,
     people: list,
-    projects: list = None,
-    aliases: dict = None,
-    config_dir: Path = None,
+    projects: Optional[list] = None,
+    aliases: Optional[dict] = None,
+    config_dir: Optional[Path] = None,
 ) -> EntityRegistry:
     """
     Programmatic setup without interactive prompts.

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -16,12 +16,14 @@ No external graph DB needed — built from ChromaDB metadata.
 """
 
 from collections import defaultdict, Counter
+from typing import Optional
+
 from .config import MempalaceConfig
 
 import chromadb
 
 
-def _get_collection(config=None):
+def _get_collection(config: Optional[MempalaceConfig] = None):
     config = config or MempalaceConfig()
     try:
         client = chromadb.PersistentClient(path=config.palace_path)
@@ -96,7 +98,9 @@ def build_graph(col=None, config=None):
     return nodes, edges
 
 
-def traverse(start_room: str, col=None, config=None, max_hops: int = 2):
+def traverse(
+    start_room: str, col=None, config: Optional[MempalaceConfig] = None, max_hops: int = 2
+):
     """
     Walk the graph from a starting room. Find connected rooms
     through shared wings.
@@ -158,7 +162,12 @@ def traverse(start_room: str, col=None, config=None, max_hops: int = 2):
     return results[:50]  # cap results
 
 
-def find_tunnels(wing_a: str = None, wing_b: str = None, col=None, config=None):
+def find_tunnels(
+    wing_a: Optional[str] = None,
+    wing_b: Optional[str] = None,
+    col=None,
+    config: Optional[MempalaceConfig] = None,
+):
     """
     Find rooms that connect two wings (or all tunnel rooms if no wings specified).
     These are the "hallways" — same named idea appearing in multiple domains.

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -9,10 +9,18 @@ Returns verbatim text — the actual words, never summaries.
 import sys
 from pathlib import Path
 
+from typing import Optional
+
 import chromadb
 
 
-def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
+def search(
+    query: str,
+    palace_path: str,
+    wing: Optional[str] = None,
+    room: Optional[str] = None,
+    n_results: int = 5,
+):
     """
     Search the palace. Returns verbatim drawer content.
     Optionally filter by wing (project) or room (aspect).
@@ -85,7 +93,11 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: str,
+    wing: Optional[str] = None,
+    room: Optional[str] = None,
+    n_results: int = 5,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.


### PR DESCRIPTION
## Summary
PEP 484 prohibits implicit `Optional` — `param: str = None` should be `param: Optional[str] = None`. Fixed ~50 sites across 10 files.

### Files changed
- **`knowledge_graph.py`** — 10 params
- **`layers.py`** — 17 params across Layer0/1/2/3 and MemoryStack
- **`mcp_server.py`** — 11 params across 7 tool functions
- **`dialect.py`** — 7 params including `Dialect.__init__`
- **`onboarding.py`** — 4 params (`_generate_aaak_bootstrap`, `run_onboarding`, `quick_setup`)
- **`searcher.py`** — 4 params
- **`palace_graph.py`** — 4 params (`_get_collection`, `traverse`, `find_tunnels`)
- **`entity_registry.py`** — 1 param
- **`miner.py`** — 1 param
- **`convo_miner.py`** — 1 param

Added `from typing import Optional` to the 8 files that didn't already have it. Uses `Optional[T]` (not `T | None`) for Python 3.9 compatibility per `pyproject.toml` target.

## Test plan
- [x] `ruff check mempalace/` passes clean
- [x] `ruff format --check mempalace/` all formatted
- [x] `python3 -m py_compile` compiles OK for all 10 files
- [x] Zero remaining `param: Type = None` patterns without `Optional` (verified via grep)
- [x] `Optional[X]` pattern confirmed correct for Python 3.9 via Context7 CPython docs