### PR TITLE
fix: remove redundant "r" mode in config.py open() calls

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -84,7 +84,7 @@ class MempalaceConfig:
 
         if self._config_file.exists():
             try:
-                with open(self._config_file, "r") as f:
+                with open(self._config_file) as f:
                     self._file_config = json.load(f)
             except (json.JSONDecodeError, OSError):
                 self._file_config = {}
@@ -107,7 +107,7 @@ class MempalaceConfig:
         """Mapping of name variants to canonical names."""
         if self._people_map_file.exists():
             try:
-                with open(self._people_map_file, "r") as f:
+                with open(self._people_map_file) as f:
                     return json.load(f)
             except (json.JSONDecodeError, OSError):
                 pass


### PR DESCRIPTION
## Summary
Remove unnecessary `"r"` mode argument from two `open()` calls in `config.py`. Python's `open()` defaults to read mode — the explicit `"r"` is redundant. Flagged by ruff UP015.

## Changes
1 file changed, 2 lines modified.

## Test plan
- [x] `ruff check mempalace/config.py` passes clean
- [x] `ruff format --check` already formatted
- [x] `python3 -m py_compile mempalace/config.py` compiles OK