### PR TITLE
feat: add OpenAI Codex CLI JSONL normalizer

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -7,6 +7,7 @@ Supported:
     - Claude.ai JSON export
     - ChatGPT conversations.json
     - Claude Code JSONL
+    - OpenAI Codex CLI JSONL
     - Slack JSON export
     - Plain text (pass through for paragraph chunking)
 
@@ -55,6 +56,10 @@ def _try_normalize_json(content: str) -> Optional[str]:
     if normalized:
         return normalized
 
+    normalized = _try_codex_jsonl(content)
+    if normalized:
+        return normalized
+
     try:
         data = json.loads(content)
     except json.JSONDecodeError:
@@ -90,6 +95,54 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
             if text:
                 messages.append(("assistant", text))
     if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    return None
+
+
+def _try_codex_jsonl(content: str) -> Optional[str]:
+    """OpenAI Codex CLI sessions (~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl).
+
+    Uses only event_msg entries (user_message / agent_message) which represent
+    the canonical conversation turns. response_item entries are skipped because
+    they include synthetic context injections and duplicate the real messages.
+    """
+    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    messages = []
+    has_session_meta = False
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        entry_type = entry.get("type", "")
+        if entry_type == "session_meta":
+            has_session_meta = True
+            continue
+
+        if entry_type != "event_msg":
+            continue
+
+        payload = entry.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+
+        payload_type = payload.get("type", "")
+        msg = payload.get("message")
+        if not isinstance(msg, str):
+            continue
+        text = msg.strip()
+        if not text:
+            continue
+
+        if payload_type == "user_message":
+            messages.append(("user", text))
+        elif payload_type == "agent_message":
+            messages.append(("assistant", text))
+
+    if len(messages) >= 2 and has_session_meta:
         return _messages_to_transcript(messages)
     return None
 


### PR DESCRIPTION
## Summary
Add `_try_codex_jsonl` parser for OpenAI Codex CLI session files stored at `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. This is the 6th normalize format supported by MemPalace, alongside Claude AI JSON, ChatGPT JSON, Claude Code JSONL, Slack JSON, and plain text.

## Codex JSONL format

Codex CLI stores session transcripts as JSONL files with one event per line. Each line has:
```json
{"timestamp": "...", "type": "<event_type>", "payload": {...}}
```

Relevant event types for conversation extraction:
| Event type | Payload subtype | Contains |
|------------|----------------|----------|
| `session_meta` | — | Session ID, cwd, model, git info |
| `event_msg` | `user_message` | Real user prompts (`payload.message`) |
| `event_msg` | `agent_message` | Real assistant replies (`payload.message`) |
| `response_item` | `message` | API-level items — **includes synthetic context, duplicates real messages** |
| `event_msg` | other subtypes | Tool calls, turn boundaries, exec results — not conversation content |

## Design decisions

### Only `event_msg` entries are extracted
The parser uses `event_msg` with `user_message` / `agent_message` subtypes as the sole source of conversation turns. These represent the canonical user-authored prompts and assistant replies.

### `response_item` entries are intentionally skipped
Codex rollout files can contain `response_item` entries with `role: "user"` that are **not** real user input — they include auto-injected `<environment_context>` blocks and other synthetic setup context. The same assistant reply can also appear both as an `event_msg/agent_message` and as a `response_item` with `role: "assistant"`, leading to duplicated turns if both are extracted. Skipping `response_item` entirely avoids both problems.

### `session_meta` header required
The parser only recognizes a file as a Codex rollout if it contains at least one `session_meta` event. This prevents false-positive matches on Claude Code JSONL or other JSONL formats that happen to contain `event_msg`-like structures.

### Defensive payload handling
`payload.message` is checked with `isinstance(msg, str)` before `.strip()` to avoid `AttributeError` if the field is null or non-string in an unexpected rollout variant.

## Prior art
- **PR #5** (self-closed by author as "not ready") proposed a Codex normalizer that only handled `response_item` with a `role` field. That approach would pull in synthetic environment context as real user input and miss the primary `event_msg` conversation events entirely.
- Format based on Codex source tests at [`codex-rs/rollout/src/recorder_tests.rs`](https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder_tests.rs). This is a conservative interpretation — it extracts conversation messages without attempting full rollout reconstruction.

## Changes
1 file changed (`mempalace/normalize.py`), 53 insertions:
- New `_try_codex_jsonl()` parser function
- Registered in `_try_normalize_json()` dispatcher after Claude Code JSONL
- Module docstring updated to list Codex CLI JSONL as a supported format

## Test plan
- [x] `ruff check mempalace/normalize.py` passes clean
- [x] `ruff format --check` already formatted
- [x] `python3 -m py_compile mempalace/normalize.py` compiles OK
- [x] Pyright reports 0 new diagnostics
- [x] JSONL event structure based on Codex source tests (`recorder_tests.rs`)
- [x] `session_meta` gating verified to prevent false positives on Claude Code JSONL
- [x] `response_item` exclusion prevents synthetic context pollution and message duplication

Refs: #59