### PR TITLE
feat(mine): add --project-config flag to specify mempalace.yaml externally

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -88,6 +88,7 @@ def cmd_mine(args):
             agent=args.agent,
             limit=args.limit,
             dry_run=args.dry_run,
+            config_path=getattr(args, "project_config", None),
         )
 
 
@@ -296,6 +297,13 @@ def main():
     p_mine.add_argument("--limit", type=int, default=0, help="Max files to process (0 = all)")
     p_mine.add_argument(
         "--dry-run", action="store_true", help="Show what would be filed without filing"
+    )
+    p_mine.add_argument(
+        "--project-config",
+        default=None,
+        metavar="PATH",
+        help="Path to mempalace.yaml (default: <dir>/mempalace.yaml). "
+             "Use this to keep project configs in a central location outside the repository.",
     )
     p_mine.add_argument(
         "--extract",

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -63,21 +63,37 @@ MIN_CHUNK_SIZE = 50  # skip tiny chunks
 # =============================================================================
 
 
-def load_config(project_dir: str) -> dict:
-    """Load mempalace.yaml from project directory (falls back to mempal.yaml)."""
+def load_config(project_dir: str, config_path: str = None) -> dict:
+    """Load mempalace.yaml from an explicit path or from the project directory.
+
+    Args:
+        project_dir: Project directory to mine (used as fallback search location).
+        config_path: Explicit path to a mempalace.yaml file. When provided, the
+                     project directory is not searched. This allows storing project
+                     configs in a central location without placing any files inside
+                     the repository.
+    """
     import yaml
 
-    config_path = Path(project_dir).expanduser().resolve() / "mempalace.yaml"
-    if not config_path.exists():
-        # Fallback to legacy name
-        legacy_path = Path(project_dir).expanduser().resolve() / "mempal.yaml"
-        if legacy_path.exists():
-            config_path = legacy_path
-        else:
-            print(f"ERROR: No mempalace.yaml found in {project_dir}")
-            print(f"Run: mempalace init {project_dir}")
+    if config_path:
+        path = Path(config_path).expanduser().resolve()
+        if not path.exists():
+            print(f"ERROR: project config not found: {config_path}")
             sys.exit(1)
-    with open(config_path) as f:
+    else:
+        path = Path(project_dir).expanduser().resolve() / "mempalace.yaml"
+        if not path.exists():
+            # Fallback to legacy name
+            legacy_path = Path(project_dir).expanduser().resolve() / "mempal.yaml"
+            if legacy_path.exists():
+                path = legacy_path
+            else:
+                print(f"ERROR: No mempalace.yaml found in {project_dir}")
+                print("Tip: use --project-config to point to a central config file,")
+                print(f"     or run: mempalace init {project_dir}")
+                sys.exit(1)
+
+    with open(path) as f:
         return yaml.safe_load(f)
 
 
@@ -319,11 +335,12 @@ def mine(
     agent: str = "mempalace",
     limit: int = 0,
     dry_run: bool = False,
+    config_path: str = None,
 ):
     """Mine a project directory into the palace."""
 
     project_path = Path(project_dir).expanduser().resolve()
-    config = load_config(project_dir)
+    config = load_config(project_dir, config_path=config_path)
 
     wing = wing_override or config["wing"]
     rooms = config.get("rooms", [{"name": "general", "description": "All project files"}])


### PR DESCRIPTION
## Problem
  The `mine` command requires `mempalace.yaml` to be present inside the project directory being mined, with no way to override this path. This forces users to place mempalace-specific files inside every repository they want to index.

  This is particularly inconvenient for users who manage configurations in a separate dotfiles repository (e.g. with GNU Stow), as it either pollutes project repositories or requires adding `mempalace.yaml` to each repo's `.gitignore`.

## Solution
  Add a `--project-config PATH` argument to the `mine` command that allows specifying the path to a `mempalace.yaml` file explicitly, decoupling the project config from the project directory.

```bash
  mempalace mine ~/projects/my-app \
      --project-config ~/.config/mempalace/projects/my-app.yaml
```
The flag is fully backwards-compatible: when omitted, the existing behaviour of looking for mempalace.yaml in the project directory is preserved, including the mempal.yaml legacy fallback.

## Changes

- miner.py: load_config() accepts an optional config_path argument; when provided the project directory is not searched
- miner.py: mine() accepts and forwards config_path
- cli.py: exposes --project-config PATH on the mine subcommand

## Checklist

- Tests pass (python -m pytest tests/ -v) — 9/9 passed
- No hardcoded paths
- Linter passes (ruff check .) — no issues

