### PR TITLE
fix: update input prompt for entity confirmation in entity_detector.py

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -789,7 +789,7 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
             name = input("  Name (or enter to stop): ").strip()
             if not name:
                 break
-            kind = input(f"  Is '{name}' a (p)erson or (r)roject? ").strip().lower()
+            kind = input(f"  Is '{name}' a (p)erson or p(r)oject? ").strip().lower()
             if kind == "p":
                 confirmed_people.append(name)
             elif kind == "r":


### PR DESCRIPTION
Refine the prompt for distinguishing between person and project entities by adjusting the wording for clarity.

## What does this PR do?

## How to test

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
