### PR TITLE
fix: coerce MCP integer arguments to native Python int

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -725,6 +725,17 @@ def handle_request(request):
                 "id": req_id,
                 "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
             }
+        # Coerce argument types based on input_schema.
+        # MCP JSON transport may deliver integers as floats or strings;
+        # ChromaDB and Python slicing require native int.
+        schema_props = TOOLS[tool_name]["input_schema"].get("properties", {})
+        for key, value in list(tool_args.items()):
+            prop_schema = schema_props.get(key, {})
+            declared_type = prop_schema.get("type")
+            if declared_type == "integer" and not isinstance(value, int):
+                tool_args[key] = int(value)
+            elif declared_type == "number" and not isinstance(value, (int, float)):
+                tool_args[key] = float(value)
         try:
             result = TOOLS[tool_name]["handler"](**tool_args)
             return {


### PR DESCRIPTION
## Summary

- MCP JSON-RPC transport can deliver `integer`-typed arguments as floats (`3.0`) or strings (`"3"`) depending on the client
- ChromaDB's `collection.query(n_results=...)` requires a native Python `int`, causing `mempalace_search` to fail with: `"Expected requested number of results to be a int, got 3 in query."`
- This affects all tools with integer params: `limit` (search), `max_hops` (traverse), `last_n` (diary_read)

## Fix

Auto-coerce tool arguments in `handle_request()` based on the declared `input_schema` types before calling handlers. This is generic — covers all current and future tools without per-handler changes.

```python
schema_props = TOOLS[tool_name]["input_schema"].get("properties", {})
for key, value in list(tool_args.items()):
    declared_type = schema_props.get(key, {}).get("type")
    if declared_type == "integer" and not isinstance(value, int):
        tool_args[key] = int(value)
    elif declared_type == "number" and not isinstance(value, (int, float)):
        tool_args[key] = float(value)
```

## Reproduction

```python
from mempalace.searcher import search_memories
search_memories("test", palace_path, n_results=3.0)
# → "Search error: Expected requested number of results to be a int, got 3.0 in query."
```

## Test plan

- [x] `limit=3` (int) — works before and after
- [x] `limit=3.0` (float from JSON) — fails before, works after
- [x] `limit="3"` (string) — fails before, works after
- [x] No regressions on tools without integer params

Discovered while using MemPalace via Claude Code MCP integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)