### PR TITLE
Refresh mined drawers safely and consistently

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -32,6 +32,7 @@ import argparse
 from pathlib import Path
 
 from .config import MempalaceConfig
+from .drawer_store import DrawerStore
 
 
 def cmd_init(args):
@@ -64,14 +65,13 @@ def cmd_init(args):
 
 
 def cmd_mine(args):
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
-
     if args.mode == "convos":
         from .convo_miner import mine_convos
 
         mine_convos(
             convo_dir=args.dir,
-            palace_path=palace_path,
+            palace_path=args.palace,
+            collection_name=args.collection,
             wing=args.wing,
             agent=args.agent,
             limit=args.limit,
@@ -83,7 +83,8 @@ def cmd_mine(args):
 
         mine(
             project_dir=args.dir,
-            palace_path=palace_path,
+            palace_path=args.palace,
+            collection_name=args.collection,
             wing_override=args.wing,
             agent=args.agent,
             limit=args.limit,
@@ -94,13 +95,13 @@ def cmd_mine(args):
 def cmd_search(args):
     from .searcher import search
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     search(
         query=args.query,
-        palace_path=palace_path,
+        palace_path=args.palace,
         wing=args.wing,
         room=args.room,
         n_results=args.results,
+        collection_name=args.collection,
     )
 
 
@@ -108,8 +109,7 @@ def cmd_wakeup(args):
     """Show L0 (identity) + L1 (essential story) — the wake-up context."""
     from .layers import MemoryStack
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
-    stack = MemoryStack(palace_path=palace_path)
+    stack = MemoryStack(palace_path=args.palace, collection_name=args.collection)
 
     text = stack.wake_up(wing=args.wing)
     tokens = len(text) // 4
@@ -143,8 +143,7 @@ def cmd_split(args):
 def cmd_status(args):
     from .miner import status
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
-    status(palace_path=palace_path)
+    status(palace_path=args.palace, collection_name=args.collection)
 
 
 def cmd_compress(args):
@@ -152,12 +151,12 @@ def cmd_compress(args):
     import chromadb
     from .dialect import Dialect
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    store = DrawerStore(palace_path=args.palace, collection_name=args.collection)
 
     # Load dialect (with optional entity config)
     config_path = args.config
     if not config_path:
-        for candidate in ["entities.json", os.path.join(palace_path, "entities.json")]:
+        for candidate in ["entities.json", os.path.join(store.palace_path, "entities.json")]:
             if os.path.exists(candidate):
                 config_path = candidate
                 break
@@ -170,10 +169,10 @@ def cmd_compress(args):
 
     # Connect to palace
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        client = chromadb.PersistentClient(path=store.palace_path)
+        col = store.get_collection()
     except Exception:
-        print(f"\n  No palace found at {palace_path}")
+        print(f"\n  No palace found at {store.palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         sys.exit(1)
 
@@ -267,6 +266,11 @@ def main():
         "--palace",
         default=None,
         help="Where the palace lives (default: from ~/.mempalace/config.json or ~/.mempalace/palace)",
+    )
+    parser.add_argument(
+        "--collection",
+        default=None,
+        help="Drawer collection name (default: config value, or mempalace_drawers when --palace is set explicitly)",
     )
 
     sub = parser.add_subparsers(dest="command")

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -94,8 +94,8 @@ class MempalaceConfig:
         """Path to the memory palace data directory."""
         env_val = os.environ.get("MEMPALACE_PALACE_PATH") or os.environ.get("MEMPAL_PALACE_PATH")
         if env_val:
-            return env_val
-        return self._file_config.get("palace_path", DEFAULT_PALACE_PATH)
+            return str(Path(env_val).expanduser())
+        return str(Path(self._file_config.get("palace_path", DEFAULT_PALACE_PATH)).expanduser())
 
     @property
     def collection_name(self):

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -11,13 +11,13 @@ Same palace as project mining. Different ingest strategy.
 import os
 import sys
 import hashlib
+from dataclasses import dataclass, field
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-import chromadb
-
-from .normalize import normalize
+from .drawer_store import DrawerNamespace, DrawerStore, REFRESH_OWNER_KEY
+from .normalize import join_normalized_segments, normalize_segments
 
 
 # File types that might contain conversations
@@ -42,6 +42,10 @@ SKIP_DIRS = {
 }
 
 MIN_CHUNK_SIZE = 30
+CONVO_PIPELINE_FINGERPRINTS = {
+    "exchange": f"convos:exchange:v2:min={MIN_CHUNK_SIZE}:chunking=exchange",
+    "general": f"convos:general:v2:min={MIN_CHUNK_SIZE}:extractor=general",
+}
 
 
 # =============================================================================
@@ -209,21 +213,210 @@ def detect_convo_room(content: str) -> str:
 # =============================================================================
 
 
-def get_collection(palace_path: str):
-    os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
-    try:
-        return client.get_collection("mempalace_drawers")
-    except Exception:
-        return client.create_collection("mempalace_drawers")
+@dataclass
+class ConvoProcessResult:
+    status: str
+    drawers: int = 0
+    cleared: int = 0
+    room_counts: dict = field(default_factory=dict)
+    error: str = ""
 
 
-def file_already_mined(collection, source_file: str) -> bool:
-    try:
-        results = collection.get(where={"source_file": source_file}, limit=1)
-        return len(results.get("ids", [])) > 0
-    except Exception:
+def build_source_signature(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def convo_pipeline_fingerprint(extract_mode: str) -> str:
+    return CONVO_PIPELINE_FINGERPRINTS.get(extract_mode, f"convos:{extract_mode}:v2")
+
+
+def build_drawer_id(
+    wing: str, room: str, source_file: str, chunk_index: int, extract_mode: str
+) -> str:
+    digest = hashlib.md5(
+        f"{source_file}:{extract_mode}:{chunk_index}".encode()
+    ).hexdigest()[:16]
+    return f"drawer_{wing}_{room}_{extract_mode}_{digest}"
+
+
+def namespace_is_current(existing_rows: list, new_rows: list, source_signature: str) -> bool:
+    if not existing_rows or not new_rows:
         return False
+
+    existing_ids = [row["id"] for row in existing_rows]
+    new_ids = [row["id"] for row in new_rows]
+    if len(existing_ids) != len(new_ids):
+        return False
+    if set(existing_ids) != set(new_ids):
+        return False
+
+    pipeline_fingerprint = new_rows[0]["metadata"]["pipeline_fingerprint"]
+    for row in existing_rows:
+        metadata = row["metadata"]
+        if metadata.get("source_signature") != source_signature:
+            return False
+        if metadata.get("pipeline_fingerprint") != pipeline_fingerprint:
+            return False
+
+    return True
+
+
+def prepare_drawer_rows(
+    namespace: DrawerNamespace,
+    source_root: str,
+    source_signature: str,
+    chunks: list,
+    agent: str,
+) -> list:
+    pipeline_fingerprint = convo_pipeline_fingerprint(namespace.extract_mode or "exchange")
+    filed_at = datetime.now().isoformat()
+    rows = []
+    for chunk in chunks:
+        room = chunk["room"]
+        rows.append(
+            {
+                "id": build_drawer_id(
+                    wing=namespace.wing,
+                    room=room,
+                    source_file=namespace.source_file,
+                    chunk_index=chunk["chunk_index"],
+                    extract_mode=namespace.extract_mode or "exchange",
+                ),
+                "document": chunk["content"],
+                "metadata": {
+                    "wing": namespace.wing,
+                    "room": room,
+                    "source_file": namespace.source_file,
+                    "source_root": source_root,
+                    "source_signature": source_signature,
+                    "pipeline_fingerprint": pipeline_fingerprint,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": agent,
+                    "filed_at": filed_at,
+                    "ingest_mode": namespace.ingest_mode,
+                    "extract_mode": namespace.extract_mode,
+                    REFRESH_OWNER_KEY: namespace.refresh_owner,
+                },
+            }
+        )
+    return rows
+
+
+def build_exchange_chunks(segments: list[str]) -> list:
+    chunks = []
+    for segment in segments:
+        if not segment or len(segment.strip()) < MIN_CHUNK_SIZE:
+            continue
+
+        room = detect_convo_room(segment)
+        for raw_chunk in chunk_exchanges(segment):
+            chunks.append(
+                {
+                    "content": raw_chunk["content"],
+                    "chunk_index": len(chunks),
+                    "room": room,
+                }
+            )
+
+    return chunks
+
+
+def process_convo_file(
+    filepath: Path,
+    source_root: Path,
+    store: DrawerStore,
+    wing: str,
+    agent: str,
+    dry_run: bool,
+    extract_mode: str,
+) -> ConvoProcessResult:
+    source_file = str(filepath)
+    namespace = DrawerNamespace(
+        wing=wing,
+        source_file=source_file,
+        ingest_mode="convos",
+        extract_mode=extract_mode,
+    )
+
+    try:
+        existing_rows = store.get_namespace_rows(namespace)
+    except Exception:
+        existing_rows = []
+
+    try:
+        segments = normalize_segments(str(filepath))
+    except Exception as exc:
+        return ConvoProcessResult(status="error", error=str(exc))
+
+    content = join_normalized_segments(segments)
+    if not content or len(content.strip()) < MIN_CHUNK_SIZE:
+        if not existing_rows:
+            return ConvoProcessResult(status="ignored")
+        if dry_run:
+            return ConvoProcessResult(status="cleared", cleared=len(existing_rows))
+        try:
+            store.delete_ids([row["id"] for row in existing_rows])
+        except Exception as exc:
+            return ConvoProcessResult(status="error", error=str(exc))
+        return ConvoProcessResult(status="cleared", cleared=len(existing_rows))
+
+    if extract_mode == "general":
+        from .general_extractor import extract_memories
+
+        raw_chunks = extract_memories(content)
+        chunks = [
+            {
+                "content": chunk["content"],
+                "chunk_index": chunk["chunk_index"],
+                "room": chunk.get("memory_type", "general"),
+            }
+            for chunk in raw_chunks
+        ]
+    else:
+        chunks = build_exchange_chunks(segments)
+
+    if not chunks:
+        if not existing_rows:
+            return ConvoProcessResult(status="ignored")
+        if dry_run:
+            return ConvoProcessResult(status="cleared", cleared=len(existing_rows))
+        try:
+            store.delete_ids([row["id"] for row in existing_rows])
+        except Exception as exc:
+            return ConvoProcessResult(status="error", error=str(exc))
+        return ConvoProcessResult(status="cleared", cleared=len(existing_rows))
+
+    source_signature = build_source_signature(content)
+    new_rows = prepare_drawer_rows(
+        namespace=namespace,
+        source_root=str(source_root),
+        source_signature=source_signature,
+        chunks=chunks,
+        agent=agent,
+    )
+
+    if namespace_is_current(existing_rows, new_rows, source_signature):
+        return ConvoProcessResult(status="unchanged")
+
+    room_counts = defaultdict(int)
+    for chunk in chunks:
+        room_counts[chunk["room"]] += 1
+
+    if dry_run:
+        status = "new" if not existing_rows else "updated"
+        return ConvoProcessResult(status=status, drawers=len(new_rows), room_counts=dict(room_counts))
+
+    try:
+        store.upsert_rows(new_rows)
+        new_ids = {row["id"] for row in new_rows}
+        stale_ids = [row["id"] for row in existing_rows if row["id"] not in new_ids]
+        if stale_ids:
+            store.delete_ids(stale_ids)
+    except Exception as exc:
+        return ConvoProcessResult(status="error", error=str(exc))
+
+    status = "new" if not existing_rows else "updated"
+    return ConvoProcessResult(status=status, drawers=len(new_rows), room_counts=dict(room_counts))
 
 
 # =============================================================================
@@ -251,7 +444,8 @@ def scan_convos(convo_dir: str) -> list:
 
 def mine_convos(
     convo_dir: str,
-    palace_path: str,
+    palace_path: str = None,
+    collection_name: str = None,
     wing: str = None,
     agent: str = "mempalace",
     limit: int = 0,
@@ -279,114 +473,66 @@ def mine_convos(
     print(f"  Wing:    {wing}")
     print(f"  Source:  {convo_path}")
     print(f"  Files:   {len(files)}")
-    print(f"  Palace:  {palace_path}")
+    store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
+    print(f"  Palace:  {store.palace_path}")
     if dry_run:
         print("  DRY RUN — nothing will be filed")
     print(f"{'─' * 55}\n")
 
-    collection = get_collection(palace_path) if not dry_run else None
-
     total_drawers = 0
-    files_skipped = 0
+    total_cleared = 0
+    status_counts = defaultdict(int)
     room_counts = defaultdict(int)
 
     for i, filepath in enumerate(files, 1):
-        source_file = str(filepath)
-
-        # Skip if already filed
-        if not dry_run and file_already_mined(collection, source_file):
-            files_skipped += 1
-            continue
-
-        # Normalize format
-        try:
-            content = normalize(str(filepath))
-        except Exception:
-            continue
-
-        if not content or len(content.strip()) < MIN_CHUNK_SIZE:
-            continue
-
-        # Chunk — either exchange pairs or general extraction
-        if extract_mode == "general":
-            from .general_extractor import extract_memories
-
-            chunks = extract_memories(content)
-            # Each chunk already has memory_type; use it as the room name
-        else:
-            chunks = chunk_exchanges(content)
-
-        if not chunks:
-            continue
-
-        # Detect room from content (general mode uses memory_type instead)
-        if extract_mode != "general":
-            room = detect_convo_room(content)
-        else:
-            room = None  # set per-chunk below
+        result = process_convo_file(
+            filepath=filepath,
+            source_root=convo_path,
+            store=store,
+            wing=wing,
+            agent=agent,
+            dry_run=dry_run,
+            extract_mode=extract_mode,
+        )
+        status_counts[result.status] += 1
+        total_drawers += result.drawers
+        total_cleared += result.cleared
+        for room, count in result.room_counts.items():
+            room_counts[room] += count
 
         if dry_run:
-            if extract_mode == "general":
-                from collections import Counter
-
-                type_counts = Counter(c.get("memory_type", "general") for c in chunks)
-                types_str = ", ".join(f"{t}:{n}" for t, n in type_counts.most_common())
-                print(f"    [DRY RUN] {filepath.name} → {len(chunks)} memories ({types_str})")
-            else:
-                print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-            total_drawers += len(chunks)
-            # Track room counts
-            if extract_mode == "general":
-                for c in chunks:
-                    room_counts[c.get("memory_type", "general")] += 1
-            else:
-                room_counts[room] += 1
+            detail = []
+            if result.drawers:
+                detail.append(f"{result.drawers} drawers")
+            if result.cleared:
+                detail.append(f"clear {result.cleared}")
+            suffix = f" ({', '.join(detail)})" if detail else ""
+            print(f"    [DRY RUN] {filepath.name} → {result.status}{suffix}")
             continue
 
-        if extract_mode != "general":
-            room_counts[room] += 1
-
-        # File each chunk
-        drawers_added = 0
-        for chunk in chunks:
-            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-            if extract_mode == "general":
-                room_counts[chunk_room] += 1
-            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.md5((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:16]}"
-            try:
-                collection.add(
-                    documents=[chunk["content"]],
-                    ids=[drawer_id],
-                    metadatas=[
-                        {
-                            "wing": wing,
-                            "room": chunk_room,
-                            "source_file": source_file,
-                            "chunk_index": chunk["chunk_index"],
-                            "added_by": agent,
-                            "filed_at": datetime.now().isoformat(),
-                            "ingest_mode": "convos",
-                            "extract_mode": extract_mode,
-                        }
-                    ],
-                )
-                drawers_added += 1
-            except Exception as e:
-                if "already exists" not in str(e).lower():
-                    raise
-
-        total_drawers += drawers_added
-        print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+        if result.status in ("new", "updated"):
+            print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} {result.status:7} +{result.drawers}")
+        elif result.status == "cleared":
+            print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} cleared  -{result.cleared}")
+        elif result.status == "error":
+            print(f"  ! [{i:4}/{len(files)}] {filepath.name[:50]:50} error    {result.error}")
 
     print(f"\n{'=' * 55}")
     print("  Done.")
-    print(f"  Files processed: {len(files) - files_skipped}")
-    print(f"  Files skipped (already filed): {files_skipped}")
+    print(f"  Files scanned: {len(files)}")
+    print(f"  Files new: {status_counts['new']}")
+    print(f"  Files updated: {status_counts['updated']}")
+    print(f"  Files unchanged: {status_counts['unchanged']}")
+    print(f"  Files cleared: {status_counts['cleared']}")
+    print(f"  Files errored: {status_counts['error']}")
+    if status_counts["ignored"]:
+        print(f"  Files ignored (no usable content): {status_counts['ignored']}")
     print(f"  Drawers filed: {total_drawers}")
+    print(f"  Drawers cleared: {total_cleared}")
     if room_counts:
-        print("\n  By room:")
+        print("\n  Drawers filed by room:")
         for room, count in sorted(room_counts.items(), key=lambda x: x[1], reverse=True):
-            print(f"    {room:20} {count} files")
+            print(f"    {room:20} {count} drawers")
     print('\n  Next: mempalace search "what you\'re looking for"')
     print(f"{'=' * 55}\n")
 
@@ -395,6 +541,5 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python convo_miner.py <convo_dir> [--palace PATH] [--limit N] [--dry-run]")
         sys.exit(1)
-    from .config import MempalaceConfig
 
-    mine_convos(sys.argv[1], palace_path=MempalaceConfig().palace_path)
+    mine_convos(sys.argv[1])

--- a/mempalace/drawer_store.py
+++ b/mempalace/drawer_store.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+drawer_store.py — Shared access to the primary palace drawer collection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import chromadb
+
+from .config import DEFAULT_COLLECTION_NAME, MempalaceConfig
+
+DRAWER_PAGE_SIZE = 1000
+REFRESH_OWNER_KEY = "refresh_owner"
+MANUAL_INGEST_MODE = "manual"
+
+
+def _project_drawer_id(wing: str, room: str, source_file: str, chunk_index: int) -> str:
+    digest = hashlib.md5((source_file + str(chunk_index)).encode()).hexdigest()[:16]
+    return f"drawer_{wing}_{room}_{digest}"
+
+
+def _legacy_convo_drawer_id(wing: str, room: str, source_file: str, chunk_index: int) -> str:
+    digest = hashlib.md5((source_file + str(chunk_index)).encode()).hexdigest()[:16]
+    return f"drawer_{wing}_{room}_{digest}"
+
+
+def _convo_drawer_id(
+    wing: str, room: str, source_file: str, chunk_index: int, extract_mode: str
+) -> str:
+    digest = hashlib.md5(
+        f"{source_file}:{extract_mode}:{chunk_index}".encode()
+    ).hexdigest()[:16]
+    return f"drawer_{wing}_{room}_{extract_mode}_{digest}"
+
+
+def resolve_palace_path(
+    palace_path: Optional[str] = None, config: Optional[MempalaceConfig] = None
+) -> str:
+    """Resolve the drawer store path consistently across entrypoints."""
+    cfg = config or MempalaceConfig()
+    raw_path = palace_path if palace_path is not None else cfg.palace_path
+    return str(Path(raw_path).expanduser())
+
+
+def resolve_collection_name(
+    collection_name: Optional[str] = None,
+    palace_path: Optional[str] = None,
+    config: Optional[MempalaceConfig] = None,
+) -> str:
+    cfg = config or MempalaceConfig()
+    if collection_name is not None:
+        return collection_name
+    if palace_path is not None:
+        return DEFAULT_COLLECTION_NAME
+    return cfg.collection_name
+
+
+@dataclass(frozen=True)
+class DrawerNamespace:
+    """A namespace for source-backed drawers that can be refreshed safely."""
+
+    wing: str
+    source_file: str
+    ingest_mode: str
+    extract_mode: Optional[str] = None
+
+    @property
+    def where(self) -> Dict[str, List[Dict[str, str]]]:
+        return {"$and": [{"wing": self.wing}, {"source_file": self.source_file}]}
+
+    @property
+    def refresh_owner(self) -> str:
+        if self.ingest_mode == "convos":
+            return f"convos:{self.extract_mode or 'exchange'}"
+        return self.ingest_mode
+
+    def matches(self, row: Dict[str, object]) -> bool:
+        metadata = row["metadata"]
+        if metadata.get("wing") != self.wing:
+            return False
+        if metadata.get("source_file") != self.source_file:
+            return False
+
+        refresh_owner = metadata.get(REFRESH_OWNER_KEY)
+        if refresh_owner is not None:
+            return (
+                refresh_owner == self.refresh_owner
+                and metadata.get("ingest_mode") == self.ingest_mode
+                and metadata.get("extract_mode") == self.extract_mode
+            )
+
+        return self._matches_legacy_row(row["id"], metadata)
+
+    def _matches_legacy_row(self, row_id: str, metadata: Dict[str, object]) -> bool:
+        room = metadata.get("room")
+        chunk_index = metadata.get("chunk_index")
+        if room is None or chunk_index is None:
+            return False
+
+        try:
+            chunk_index = int(chunk_index)
+        except (TypeError, ValueError):
+            return False
+
+        expected_ids = []
+
+        ingest_mode = metadata.get("ingest_mode")
+        if self.ingest_mode == "projects":
+            if ingest_mode not in (None, "projects"):
+                return False
+            expected_ids.append(
+                _project_drawer_id(
+                    wing=self.wing,
+                    room=str(room),
+                    source_file=self.source_file,
+                    chunk_index=chunk_index,
+                )
+            )
+        elif self.ingest_mode == "convos":
+            if ingest_mode != "convos" or metadata.get("extract_mode") != self.extract_mode:
+                return False
+            expected_ids.extend(
+                [
+                    _convo_drawer_id(
+                        wing=self.wing,
+                        room=str(room),
+                        source_file=self.source_file,
+                        chunk_index=chunk_index,
+                        extract_mode=self.extract_mode or "exchange",
+                    ),
+                    _legacy_convo_drawer_id(
+                        wing=self.wing,
+                        room=str(room),
+                        source_file=self.source_file,
+                        chunk_index=chunk_index,
+                    ),
+                ]
+            )
+        else:
+            return False
+
+        return row_id in expected_ids
+
+
+class DrawerStore:
+    """Thin wrapper around the configured Chroma drawer collection."""
+
+    def __init__(
+        self,
+        palace_path: Optional[str] = None,
+        collection_name: Optional[str] = None,
+        config: Optional[MempalaceConfig] = None,
+    ):
+        self._config = config or MempalaceConfig()
+        self.palace_path = resolve_palace_path(palace_path, self._config)
+        self.collection_name = resolve_collection_name(collection_name, palace_path, self._config)
+
+    def get_collection(self, create: bool = False):
+        client = chromadb.PersistentClient(path=self.palace_path)
+        if create:
+            return client.get_or_create_collection(self.collection_name)
+        return client.get_collection(self.collection_name)
+
+    def count(self) -> int:
+        return self.get_collection().count()
+
+    def get_rows(self, where: Optional[Dict] = None, include_documents: bool = False) -> List[Dict]:
+        collection = self.get_collection()
+        include = ["metadatas"]
+        if include_documents:
+            include.append("documents")
+
+        rows = []
+        offset = 0
+
+        while True:
+            kwargs = {
+                "limit": DRAWER_PAGE_SIZE,
+                "offset": offset,
+                "include": include,
+            }
+            if where:
+                kwargs["where"] = where
+
+            results = collection.get(**kwargs)
+            ids = results.get("ids", [])
+            if not ids:
+                break
+
+            metadatas = results.get("metadatas", [])
+            documents = results.get("documents", []) if include_documents else []
+
+            for index, drawer_id in enumerate(ids):
+                row = {
+                    "id": drawer_id,
+                    "metadata": metadatas[index] or {},
+                }
+                if include_documents:
+                    row["document"] = documents[index]
+                rows.append(row)
+
+            if len(ids) < DRAWER_PAGE_SIZE:
+                break
+            offset += len(ids)
+
+        return rows
+
+    def get_namespace_rows(self, namespace: DrawerNamespace) -> List[Dict]:
+        rows = self.get_rows(where=namespace.where, include_documents=False)
+        return [row for row in rows if namespace.matches(row)]
+
+    def upsert_rows(self, rows: List[Dict]) -> None:
+        if not rows:
+            return
+
+        collection = self.get_collection(create=True)
+        for start in range(0, len(rows), DRAWER_PAGE_SIZE):
+            batch = rows[start : start + DRAWER_PAGE_SIZE]
+            collection.upsert(
+                ids=[row["id"] for row in batch],
+                documents=[row["document"] for row in batch],
+                metadatas=[row["metadata"] for row in batch],
+            )
+
+    def delete_ids(self, ids: List[str]) -> None:
+        if not ids:
+            return
+
+        collection = self.get_collection(create=True)
+        for start in range(0, len(ids), DRAWER_PAGE_SIZE):
+            batch = ids[start : start + DRAWER_PAGE_SIZE]
+            collection.delete(ids=batch)

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -21,9 +21,7 @@ import sys
 from pathlib import Path
 from collections import defaultdict
 
-import chromadb
-
-from .config import MempalaceConfig
+from .drawer_store import DrawerStore
 
 
 # ---------------------------------------------------------------------------
@@ -83,38 +81,30 @@ class Layer1:
     MAX_DRAWERS = 15  # at most 15 moments in wake-up
     MAX_CHARS = 3200  # hard cap on total L1 text (~800 tokens)
 
-    def __init__(self, palace_path: str = None, wing: str = None):
-        cfg = MempalaceConfig()
-        self.palace_path = palace_path or cfg.palace_path
+    def __init__(self, palace_path: str = None, collection_name: str = None, wing: str = None):
+        self.store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
+        self.palace_path = self.store.palace_path
+        self.collection_name = self.store.collection_name
         self.wing = wing
 
     def generate(self) -> str:
         """Pull top drawers from ChromaDB and format as compact L1 text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            rows = self.store.get_rows(
+                where={"wing": self.wing} if self.wing else None,
+                include_documents=True,
+            )
         except Exception:
             return "## L1 — No palace found. Run: mempalace mine <dir>"
 
-        # Fetch all drawers (with optional wing filter)
-        kwargs = {"include": ["documents", "metadatas"]}
-        if self.wing:
-            kwargs["where"] = {"wing": self.wing}
-
-        try:
-            results = col.get(**kwargs)
-        except Exception:
-            return "## L1 — No drawers found."
-
-        docs = results.get("documents", [])
-        metas = results.get("metadatas", [])
-
-        if not docs:
+        if not rows:
             return "## L1 — No memories yet."
 
         # Score each drawer: prefer high importance, recent filing
         scored = []
-        for doc, meta in zip(docs, metas):
+        for row in rows:
+            doc = row["document"]
+            meta = row["metadata"]
             importance = 3
             # Try multiple metadata keys that might carry weight info
             for key in ("importance", "emotional_weight", "weight"):
@@ -180,15 +170,15 @@ class Layer2:
     Queries ChromaDB with a wing/room filter.
     """
 
-    def __init__(self, palace_path: str = None):
-        cfg = MempalaceConfig()
-        self.palace_path = palace_path or cfg.palace_path
+    def __init__(self, palace_path: str = None, collection_name: str = None):
+        self.store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
+        self.palace_path = self.store.palace_path
+        self.collection_name = self.store.collection_name
 
     def retrieve(self, wing: str = None, room: str = None, n_results: int = 10) -> str:
         """Retrieve drawers filtered by wing and/or room."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = self.store.get_collection()
         except Exception:
             return "No palace found."
 
@@ -244,15 +234,15 @@ class Layer3:
     Reuses searcher.py logic against mempalace_drawers.
     """
 
-    def __init__(self, palace_path: str = None):
-        cfg = MempalaceConfig()
-        self.palace_path = palace_path or cfg.palace_path
+    def __init__(self, palace_path: str = None, collection_name: str = None):
+        self.store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
+        self.palace_path = self.store.palace_path
+        self.collection_name = self.store.collection_name
 
     def search(self, query: str, wing: str = None, room: str = None, n_results: int = 5) -> str:
         """Semantic search, returns compact result text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = self.store.get_collection()
         except Exception:
             return "No palace found."
 
@@ -307,8 +297,7 @@ class Layer3:
     ) -> list:
         """Return raw dicts instead of formatted text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = self.store.get_collection()
         except Exception:
             return []
 
@@ -367,15 +356,21 @@ class MemoryStack:
         print(stack.search("pricing change"))  # L3 deep search
     """
 
-    def __init__(self, palace_path: str = None, identity_path: str = None):
-        cfg = MempalaceConfig()
-        self.palace_path = palace_path or cfg.palace_path
+    def __init__(
+        self,
+        palace_path: str = None,
+        collection_name: str = None,
+        identity_path: str = None,
+    ):
+        self.store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
+        self.palace_path = self.store.palace_path
+        self.collection_name = self.store.collection_name
         self.identity_path = identity_path or os.path.expanduser("~/.mempalace/identity.txt")
 
         self.l0 = Layer0(self.identity_path)
-        self.l1 = Layer1(self.palace_path)
-        self.l2 = Layer2(self.palace_path)
-        self.l3 = Layer3(self.palace_path)
+        self.l1 = Layer1(self.palace_path, collection_name=self.collection_name)
+        self.l2 = Layer2(self.palace_path, collection_name=self.collection_name)
+        self.l3 = Layer3(self.palace_path, collection_name=self.collection_name)
 
     def wake_up(self, wing: str = None) -> str:
         """
@@ -410,6 +405,7 @@ class MemoryStack:
         """Status of all layers."""
         result = {
             "palace_path": self.palace_path,
+            "collection_name": self.collection_name,
             "L0_identity": {
                 "path": self.identity_path,
                 "exists": os.path.exists(self.identity_path),
@@ -428,10 +424,7 @@ class MemoryStack:
 
         # Count drawers
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
-            count = col.count()
-            result["total_drawers"] = count
+            result["total_drawers"] = self.store.count()
         except Exception:
             result["total_drawers"] = 0
 
@@ -472,7 +465,8 @@ if __name__ == "__main__":
             positional.append(arg)
 
     palace_path = flags.get("palace")
-    stack = MemoryStack(palace_path=palace_path)
+    collection_name = flags.get("collection")
+    stack = MemoryStack(palace_path=palace_path, collection_name=collection_name)
 
     if cmd in ("wake-up", "wakeup"):
         wing = flags.get("wing")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -23,10 +23,9 @@ import logging
 import hashlib
 from datetime import datetime
 
-from .config import MempalaceConfig
+from .drawer_store import DrawerStore, MANUAL_INGEST_MODE, REFRESH_OWNER_KEY
 from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
-import chromadb
 
 from .knowledge_graph import KnowledgeGraph
 
@@ -35,24 +34,20 @@ _kg = KnowledgeGraph()
 logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
 logger = logging.getLogger("mempalace_mcp")
 
-_config = MempalaceConfig()
-
 
 def _get_collection(create=False):
     """Return the ChromaDB collection, or None on failure."""
     try:
-        client = chromadb.PersistentClient(path=_config.palace_path)
-        if create:
-            return client.get_or_create_collection(_config.collection_name)
-        return client.get_collection(_config.collection_name)
+        return DrawerStore().get_collection(create=create)
     except Exception:
         return None
 
 
 def _no_palace():
+    store = DrawerStore()
     return {
         "error": "No palace found",
-        "palace_path": _config.palace_path,
+        "palace_path": store.palace_path,
         "hint": "Run: mempalace init <dir> && mempalace mine <dir>",
     }
 
@@ -64,12 +59,13 @@ def tool_status():
     col = _get_collection()
     if not col:
         return _no_palace()
-    count = col.count()
+    store = DrawerStore()
+    count = store.count()
     wings = {}
     rooms = {}
     try:
-        all_meta = col.get(include=["metadatas"])["metadatas"]
-        for m in all_meta:
+        for row in store.get_rows(include_documents=False):
+            m = row["metadata"]
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
             wings[w] = wings.get(w, 0) + 1
@@ -80,7 +76,7 @@ def tool_status():
         "total_drawers": count,
         "wings": wings,
         "rooms": rooms,
-        "palace_path": _config.palace_path,
+        "palace_path": store.palace_path,
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
     }
@@ -125,8 +121,8 @@ def tool_list_wings():
         return _no_palace()
     wings = {}
     try:
-        all_meta = col.get(include=["metadatas"])["metadatas"]
-        for m in all_meta:
+        for row in DrawerStore().get_rows(include_documents=False):
+            m = row["metadata"]
             w = m.get("wing", "unknown")
             wings[w] = wings.get(w, 0) + 1
     except Exception:
@@ -140,11 +136,12 @@ def tool_list_rooms(wing: str = None):
         return _no_palace()
     rooms = {}
     try:
-        kwargs = {"include": ["metadatas"]}
-        if wing:
-            kwargs["where"] = {"wing": wing}
-        all_meta = col.get(**kwargs)["metadatas"]
-        for m in all_meta:
+        rows = DrawerStore().get_rows(
+            where={"wing": wing} if wing else None,
+            include_documents=False,
+        )
+        for row in rows:
+            m = row["metadata"]
             r = m.get("room", "unknown")
             rooms[r] = rooms.get(r, 0) + 1
     except Exception:
@@ -158,8 +155,8 @@ def tool_get_taxonomy():
         return _no_palace()
     taxonomy = {}
     try:
-        all_meta = col.get(include=["metadatas"])["metadatas"]
-        for m in all_meta:
+        for row in DrawerStore().get_rows(include_documents=False):
+            m = row["metadata"]
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
             if w not in taxonomy:
@@ -171,9 +168,10 @@ def tool_get_taxonomy():
 
 
 def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+    store = DrawerStore()
     return search_memories(
         query,
-        palace_path=_config.palace_path,
+        palace_path=store.palace_path,
         wing=wing,
         room=room,
         n_results=limit,
@@ -278,6 +276,8 @@ def tool_add_drawer(
                     "chunk_index": 0,
                     "added_by": added_by,
                     "filed_at": datetime.now().isoformat(),
+                    "ingest_mode": MANUAL_INGEST_MODE,
+                    REFRESH_OWNER_KEY: MANUAL_INGEST_MODE,
                 }
             ],
         )

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -10,11 +10,12 @@ Stores verbatim chunks as drawers. No summaries. Ever.
 import os
 import sys
 import hashlib
+from dataclasses import dataclass, field
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-import chromadb
+from .drawer_store import DrawerNamespace, DrawerStore, REFRESH_OWNER_KEY
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -56,6 +57,9 @@ SKIP_DIRS = {
 CHUNK_SIZE = 800  # chars per drawer
 CHUNK_OVERLAP = 100  # overlap between chunks
 MIN_CHUNK_SIZE = 50  # skip tiny chunks
+PROJECT_PIPELINE_FINGERPRINT = (
+    f"projects:v2:chunk={CHUNK_SIZE}:overlap={CHUNK_OVERLAP}:min={MIN_CHUNK_SIZE}:single-room"
+)
 
 
 # =============================================================================
@@ -180,49 +184,81 @@ def chunk_text(content: str, source_file: str) -> list:
 # =============================================================================
 
 
-def get_collection(palace_path: str):
-    os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
-    try:
-        return client.get_collection("mempalace_drawers")
-    except Exception:
-        return client.create_collection("mempalace_drawers")
+@dataclass
+class ProcessResult:
+    status: str
+    drawers: int = 0
+    cleared: int = 0
+    room_counts: dict = field(default_factory=dict)
+    error: str = ""
 
 
-def file_already_mined(collection, source_file: str) -> bool:
-    """Fast check: has this file been filed before?"""
-    try:
-        results = collection.get(where={"source_file": source_file}, limit=1)
-        return len(results.get("ids", [])) > 0
-    except Exception:
+def build_source_signature(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def build_drawer_id(wing: str, room: str, source_file: str, chunk_index: int) -> str:
+    digest = hashlib.md5((source_file + str(chunk_index)).encode()).hexdigest()[:16]
+    return f"drawer_{wing}_{room}_{digest}"
+
+
+def prepare_drawer_rows(
+    namespace: DrawerNamespace,
+    source_root: str,
+    source_signature: str,
+    room: str,
+    chunks: list,
+    agent: str,
+) -> list:
+    rows = []
+    filed_at = datetime.now().isoformat()
+    for chunk in chunks:
+        rows.append(
+            {
+                "id": build_drawer_id(
+                    wing=namespace.wing,
+                    room=room,
+                    source_file=namespace.source_file,
+                    chunk_index=chunk["chunk_index"],
+                ),
+                "document": chunk["content"],
+                "metadata": {
+                    "wing": namespace.wing,
+                    "room": room,
+                    "source_file": namespace.source_file,
+                    "source_root": source_root,
+                    "source_signature": source_signature,
+                    "pipeline_fingerprint": PROJECT_PIPELINE_FINGERPRINT,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": agent,
+                    "filed_at": filed_at,
+                    "ingest_mode": namespace.ingest_mode,
+                    REFRESH_OWNER_KEY: namespace.refresh_owner,
+                },
+            }
+        )
+    return rows
+
+
+def namespace_is_current(existing_rows: list, new_rows: list, source_signature: str) -> bool:
+    if not existing_rows or not new_rows:
         return False
 
+    existing_ids = [row["id"] for row in existing_rows]
+    new_ids = [row["id"] for row in new_rows]
+    if len(existing_ids) != len(new_ids):
+        return False
+    if set(existing_ids) != set(new_ids):
+        return False
 
-def add_drawer(
-    collection, wing: str, room: str, content: str, source_file: str, chunk_index: int, agent: str
-):
-    """Add one drawer to the palace."""
-    drawer_id = f"drawer_{wing}_{room}_{hashlib.md5((source_file + str(chunk_index)).encode()).hexdigest()[:16]}"
-    try:
-        collection.add(
-            documents=[content],
-            ids=[drawer_id],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "source_file": source_file,
-                    "chunk_index": chunk_index,
-                    "added_by": agent,
-                    "filed_at": datetime.now().isoformat(),
-                }
-            ],
-        )
-        return True
-    except Exception as e:
-        if "already exists" in str(e).lower() or "duplicate" in str(e).lower():
+    for row in existing_rows:
+        metadata = row["metadata"]
+        if metadata.get("source_signature") != source_signature:
             return False
-        raise
+        if metadata.get("pipeline_fingerprint") != PROJECT_PIPELINE_FINGERPRINT:
+            return False
+
+    return True
 
 
 # =============================================================================
@@ -233,50 +269,79 @@ def add_drawer(
 def process_file(
     filepath: Path,
     project_path: Path,
-    collection,
+    store: DrawerStore,
     wing: str,
     rooms: list,
     agent: str,
     dry_run: bool,
-) -> int:
-    """Read, chunk, route, and file one file. Returns drawer count."""
-
-    # Skip if already filed
+) -> ProcessResult:
+    """Read, chunk, route, and refresh one source-backed namespace."""
     source_file = str(filepath)
-    if not dry_run and file_already_mined(collection, source_file):
-        return 0
+    namespace = DrawerNamespace(wing=wing, source_file=source_file, ingest_mode="projects")
+    existing_rows = []
+
+    try:
+        existing_rows = store.get_namespace_rows(namespace)
+    except Exception:
+        existing_rows = []
 
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")
-    except Exception:
-        return 0
+    except Exception as exc:
+        return ProcessResult(status="error", error=str(exc))
 
     content = content.strip()
     if len(content) < MIN_CHUNK_SIZE:
-        return 0
+        if not existing_rows:
+            return ProcessResult(status="ignored")
+        if dry_run:
+            return ProcessResult(status="cleared", cleared=len(existing_rows))
+        try:
+            store.delete_ids([row["id"] for row in existing_rows])
+        except Exception as exc:
+            return ProcessResult(status="error", error=str(exc))
+        return ProcessResult(status="cleared", cleared=len(existing_rows))
 
     room = detect_room(filepath, content, rooms, project_path)
     chunks = chunk_text(content, source_file)
+    if not chunks:
+        if not existing_rows:
+            return ProcessResult(status="ignored")
+        if dry_run:
+            return ProcessResult(status="cleared", cleared=len(existing_rows))
+        try:
+            store.delete_ids([row["id"] for row in existing_rows])
+        except Exception as exc:
+            return ProcessResult(status="error", error=str(exc))
+        return ProcessResult(status="cleared", cleared=len(existing_rows))
+
+    source_signature = build_source_signature(content)
+    new_rows = prepare_drawer_rows(
+        namespace=namespace,
+        source_root=str(project_path),
+        source_signature=source_signature,
+        room=room,
+        chunks=chunks,
+        agent=agent,
+    )
+
+    if namespace_is_current(existing_rows, new_rows, source_signature):
+        return ProcessResult(status="unchanged")
 
     if dry_run:
-        print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-        return len(chunks)
+        status = "new" if not existing_rows else "updated"
+        return ProcessResult(status=status, drawers=len(new_rows), room_counts={room: len(new_rows)})
 
-    drawers_added = 0
-    for chunk in chunks:
-        added = add_drawer(
-            collection=collection,
-            wing=wing,
-            room=room,
-            content=chunk["content"],
-            source_file=source_file,
-            chunk_index=chunk["chunk_index"],
-            agent=agent,
-        )
-        if added:
-            drawers_added += 1
+    try:
+        store.upsert_rows(new_rows)
+        stale_ids = [row["id"] for row in existing_rows if row["id"] not in {r["id"] for r in new_rows}]
+        if stale_ids:
+            store.delete_ids(stale_ids)
+    except Exception as exc:
+        return ProcessResult(status="error", error=str(exc))
 
-    return drawers_added
+    status = "new" if not existing_rows else "updated"
+    return ProcessResult(status=status, drawers=len(new_rows), room_counts={room: len(new_rows)})
 
 
 # =============================================================================
@@ -314,7 +379,8 @@ def scan_project(project_dir: str) -> list:
 
 def mine(
     project_dir: str,
-    palace_path: str,
+    palace_path: str = None,
+    collection_name: str = None,
     wing_override: str = None,
     agent: str = "mempalace",
     limit: int = 0,
@@ -338,47 +404,66 @@ def mine(
     print(f"  Wing:    {wing}")
     print(f"  Rooms:   {', '.join(r['name'] for r in rooms)}")
     print(f"  Files:   {len(files)}")
-    print(f"  Palace:  {palace_path}")
+    store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
+    print(f"  Palace:  {store.palace_path}")
     if dry_run:
         print("  DRY RUN — nothing will be filed")
     print(f"{'─' * 55}\n")
 
-    if not dry_run:
-        collection = get_collection(palace_path)
-    else:
-        collection = None
-
     total_drawers = 0
-    files_skipped = 0
+    total_cleared = 0
+    status_counts = defaultdict(int)
     room_counts = defaultdict(int)
 
     for i, filepath in enumerate(files, 1):
-        drawers = process_file(
+        result = process_file(
             filepath=filepath,
             project_path=project_path,
-            collection=collection,
+            store=store,
             wing=wing,
             rooms=rooms,
             agent=agent,
             dry_run=dry_run,
         )
-        if drawers == 0 and not dry_run:
-            files_skipped += 1
-        else:
-            total_drawers += drawers
-            room = detect_room(filepath, "", rooms, project_path)
-            room_counts[room] += 1
-            if not dry_run:
-                print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
+        status_counts[result.status] += 1
+        total_drawers += result.drawers
+        total_cleared += result.cleared
+        for room, count in result.room_counts.items():
+            room_counts[room] += count
+
+        if dry_run:
+            detail = []
+            if result.drawers:
+                detail.append(f"{result.drawers} drawers")
+            if result.cleared:
+                detail.append(f"clear {result.cleared}")
+            suffix = f" ({', '.join(detail)})" if detail else ""
+            print(f"    [DRY RUN] {filepath.name} → {result.status}{suffix}")
+            continue
+
+        if result.status in ("new", "updated"):
+            print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} {result.status:7} +{result.drawers}")
+        elif result.status == "cleared":
+            print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} cleared  -{result.cleared}")
+        elif result.status == "error":
+            print(f"  ! [{i:4}/{len(files)}] {filepath.name[:50]:50} error    {result.error}")
 
     print(f"\n{'=' * 55}")
     print("  Done.")
-    print(f"  Files processed: {len(files) - files_skipped}")
-    print(f"  Files skipped (already filed): {files_skipped}")
+    print(f"  Files scanned: {len(files)}")
+    print(f"  Files new: {status_counts['new']}")
+    print(f"  Files updated: {status_counts['updated']}")
+    print(f"  Files unchanged: {status_counts['unchanged']}")
+    print(f"  Files cleared: {status_counts['cleared']}")
+    print(f"  Files errored: {status_counts['error']}")
+    if status_counts["ignored"]:
+        print(f"  Files ignored (no usable content): {status_counts['ignored']}")
     print(f"  Drawers filed: {total_drawers}")
-    print("\n  By room:")
-    for room, count in sorted(room_counts.items(), key=lambda x: x[1], reverse=True):
-        print(f"    {room:20} {count} files")
+    print(f"  Drawers cleared: {total_cleared}")
+    if room_counts:
+        print("\n  Drawers filed by room:")
+        for room, count in sorted(room_counts.items(), key=lambda x: x[1], reverse=True):
+            print(f"    {room:20} {count} drawers")
     print('\n  Next: mempalace search "what you\'re looking for"')
     print(f"{'=' * 55}\n")
 
@@ -388,26 +473,24 @@ def mine(
 # =============================================================================
 
 
-def status(palace_path: str):
+def status(palace_path: str = None, collection_name: str = None):
     """Show what's been filed in the palace."""
+    store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        total_drawers = store.count()
+        rows = store.get_rows(include_documents=False)
     except Exception:
-        print(f"\n  No palace found at {palace_path}")
+        print(f"\n  No palace found at {store.palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
-
     wing_rooms = defaultdict(lambda: defaultdict(int))
-    for m in metas:
+    for row in rows:
+        m = row["metadata"]
         wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
 
     print(f"\n{'=' * 55}")
-    print(f"  MemPalace Status — {len(metas)} drawers")
+    print(f"  MemPalace Status — {total_drawers} drawers")
     print(f"{'=' * 55}\n")
     for wing, rooms in sorted(wing_rooms.items()):
         print(f"  WING: {wing}")

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -18,11 +18,30 @@ import os
 from pathlib import Path
 from typing import Optional
 
+SEGMENT_SEPARATOR = "\n\n---\n\n"
+
 
 def normalize(filepath: str) -> str:
     """
     Load a file and normalize to transcript format if it's a chat export.
     Plain text files pass through unchanged.
+    """
+    return join_normalized_segments(normalize_segments(filepath))
+
+
+def join_normalized_segments(segments: list[str]) -> str:
+    if not segments:
+        return ""
+    if len(segments) == 1:
+        return segments[0]
+    return SEGMENT_SEPARATOR.join(segment.strip() for segment in segments if segment.strip())
+
+
+def normalize_segments(filepath: str) -> list[str]:
+    """
+    Load a file and normalize it to one or more transcript segments.
+    Most current formats produce a single segment, but callers can use this
+    helper to preserve boundaries when that changes.
     """
     try:
         with open(filepath, "r", encoding="utf-8", errors="replace") as f:
@@ -31,21 +50,21 @@ def normalize(filepath: str) -> str:
         raise IOError(f"Could not read {filepath}: {e}")
 
     if not content.strip():
-        return content
+        return [content]
 
     # Already has > markers — pass through
     lines = content.split("\n")
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
-        return content
+        return [content]
 
     # Try JSON normalization
     ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
         if normalized:
-            return normalized
+            return [normalized]
 
-    return content
+    return [content]
 
 
 def _try_normalize_json(content: str) -> Optional[str]:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -9,19 +9,26 @@ Returns verbatim text — the actual words, never summaries.
 import sys
 from pathlib import Path
 
-import chromadb
+from .drawer_store import DrawerStore
 
 
-def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
+def search(
+    query: str,
+    palace_path: str = None,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    collection_name: str = None,
+):
     """
     Search the palace. Returns verbatim drawer content.
     Optionally filter by wing (project) or room (aspect).
     """
+    store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = store.get_collection()
     except Exception:
-        print(f"\n  No palace found at {palace_path}")
+        print(f"\n  No palace found at {store.palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         sys.exit(1)
 
@@ -85,17 +92,22 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: str = None,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    collection_name: str = None,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
     Used by the MCP server and other callers that need data.
     """
+    store = DrawerStore(palace_path=palace_path, collection_name=collection_name)
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = store.get_collection()
     except Exception as e:
-        return {"error": f"No palace found at {palace_path}: {e}"}
+        return {"error": f"No palace found at {store.palace_path}: {e}"}
 
     # Build where filter
     where = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+import hashlib
+import math
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+TEST_HOME = Path(tempfile.mkdtemp(prefix="mempalace-home-"))
+os.environ["HOME"] = str(TEST_HOME)
+os.environ["XDG_CACHE_HOME"] = str(TEST_HOME / ".cache")
+os.environ["CHROMA_TELEMETRY"] = "FALSE"
+
+
+def _embed_text(text: str) -> list:
+    vector = [0.0] * 8
+    tokens = text.lower().split() or [text.lower()]
+    for token in tokens:
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        for index in range(len(vector)):
+            vector[index] += digest[index] / 255.0
+
+    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
+    return [value / norm for value in vector]
+
+
+import chromadb.api.types as chroma_types  # noqa: E402
+
+
+class TestDefaultEmbeddingFunction(chroma_types.DefaultEmbeddingFunction):
+    def __call__(self, input):
+        return [_embed_text(document) for document in input]
+
+
+chroma_types.DefaultEmbeddingFunction = TestDefaultEmbeddingFunction
+
+
+@pytest.fixture(autouse=True)
+def reset_global_config(monkeypatch):
+    config_dir = Path.home() / ".mempalace"
+    if config_dir.exists():
+        shutil.rmtree(config_dir)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.delenv("MEMPALACE_PALACE_PATH", raising=False)
+    monkeypatch.delenv("MEMPAL_PALACE_PATH", raising=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
-import os
 import json
 import tempfile
+from pathlib import Path
+
 from mempalace.config import MempalaceConfig
 
 
@@ -10,23 +11,28 @@ def test_default_config():
     assert cfg.collection_name == "mempalace_drawers"
 
 
-def test_config_from_file():
+def test_config_from_file_expands_user_path():
     tmpdir = tempfile.mkdtemp()
-    with open(os.path.join(tmpdir, "config.json"), "w") as f:
-        json.dump({"palace_path": "/custom/palace"}, f)
+    with open(Path(tmpdir) / "config.json", "w") as f:
+        json.dump({"palace_path": "~/custom/palace"}, f)
+
     cfg = MempalaceConfig(config_dir=tmpdir)
-    assert cfg.palace_path == "/custom/palace"
+
+    assert cfg.palace_path == str(Path.home() / "custom" / "palace")
 
 
-def test_env_override():
-    os.environ["MEMPALACE_PALACE_PATH"] = "/env/palace"
+def test_env_override_expands_user_path(monkeypatch):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", "~/env/palace")
+
     cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
-    assert cfg.palace_path == "/env/palace"
-    del os.environ["MEMPALACE_PALACE_PATH"]
+
+    assert cfg.palace_path == str(Path.home() / "env" / "palace")
 
 
 def test_init():
     tmpdir = tempfile.mkdtemp()
     cfg = MempalaceConfig(config_dir=tmpdir)
+
     cfg.init()
-    assert os.path.exists(os.path.join(tmpdir, "config.json"))
+
+    assert (Path(tmpdir) / "config.json").exists()

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,26 +1,57 @@
-import os
 import tempfile
-import shutil
+from pathlib import Path
+
 import chromadb
+
 from mempalace.convo_miner import mine_convos
 
 
-def test_convo_mining():
-    tmpdir = tempfile.mkdtemp()
-    with open(os.path.join(tmpdir, "chat.txt"), "w") as f:
-        f.write(
-            "> What is memory?\nMemory is persistence.\n\n> Why does it matter?\nIt enables continuity.\n\n> How do we build it?\nWith structured storage.\n"
-        )
+def get_collection(palace_path: Path):
+    client = chromadb.PersistentClient(path=str(palace_path))
+    return client.get_collection("mempalace_drawers")
 
-    palace_path = os.path.join(tmpdir, "palace")
-    mine_convos(tmpdir, palace_path, wing="test_convos")
 
-    client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_collection("mempalace_drawers")
-    assert col.count() >= 2
+def test_convo_mining_refreshes_without_duplicates(capsys):
+    tmpdir = Path(tempfile.mkdtemp())
+    chat = tmpdir / "chat.txt"
+    chat.write_text(
+        "> What is memory?\nMemory is persistence.\n\n"
+        "> Why does it matter?\nIt enables continuity.\n\n"
+        "> How do we build it?\nWith structured storage.\n"
+    )
+    palace_path = tmpdir / "palace"
 
-    # Verify search works
-    results = col.query(query_texts=["memory persistence"], n_results=1)
-    assert len(results["documents"][0]) > 0
+    mine_convos(str(tmpdir), str(palace_path), wing="test_convos")
+    col = get_collection(palace_path)
+    first_count = col.count()
 
-    shutil.rmtree(tmpdir)
+    mine_convos(str(tmpdir), str(palace_path), wing="test_convos")
+    output = capsys.readouterr().out
+
+    assert first_count >= 2
+    assert col.count() == first_count
+    assert "Files unchanged: 1" in output
+
+
+def test_same_convo_file_can_be_mined_in_exchange_and_general_modes():
+    tmpdir = Path(tempfile.mkdtemp())
+    chat = tmpdir / "chat.txt"
+    chat.write_text(
+        "> We should use Clerk because Auth0 is expensive.\n"
+        "Agreed. Let's switch to Clerk.\n\n"
+        "> The deploy bug is fixed now.\n"
+        "Yes, the root cause was the token refresh path.\n\n"
+        "> I prefer functional tests for auth flows.\n"
+        "That preference makes sense.\n"
+    )
+    palace_path = tmpdir / "palace"
+
+    mine_convos(str(tmpdir), str(palace_path), wing="test_convos", extract_mode="exchange")
+    col = get_collection(palace_path)
+    exchange_count = col.count()
+
+    mine_convos(str(tmpdir), str(palace_path), wing="test_convos", extract_mode="general")
+    results = col.get(where={"source_file": str(chat.resolve())}, include=["metadatas"])
+
+    assert col.count() > exchange_count
+    assert {meta["extract_mode"] for meta in results["metadatas"]} == {"exchange", "general"}

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -1,36 +1,304 @@
-import os
+import json
 import tempfile
-import shutil
-import yaml
+from pathlib import Path
+
 import chromadb
-from mempalace.miner import mine
+import pytest
+import yaml
+
+from mempalace.config import DEFAULT_COLLECTION_NAME
+from mempalace.layers import MemoryStack
+from mempalace.mcp_server import tool_add_drawer, tool_status
+from mempalace.miner import build_drawer_id, chunk_text, mine, status
+from mempalace.searcher import search_memories
 
 
-def test_project_mining():
-    tmpdir = tempfile.mkdtemp()
-    # Create a mini project
-    os.makedirs(os.path.join(tmpdir, "backend"))
-    with open(os.path.join(tmpdir, "backend", "app.py"), "w") as f:
-        f.write("def main():\n    print('hello world')\n" * 20)
-    # Create config
-    with open(os.path.join(tmpdir, "mempalace.yaml"), "w") as f:
+def write_project_config(project_dir: Path, wing: str = "test_project"):
+    (project_dir / "mempalace.yaml").write_text(
         yaml.dump(
             {
-                "wing": "test_project",
+                "wing": wing,
                 "rooms": [
-                    {"name": "backend", "description": "Backend code"},
+                    {"name": "billing", "description": "Billing work", "keywords": ["invoice", "billing", "payment"]},
+                    {"name": "auth", "description": "Authentication", "keywords": ["auth", "oauth", "token"]},
                     {"name": "general", "description": "General"},
                 ],
-            },
-            f,
+            }
         )
+    )
 
-    palace_path = os.path.join(tmpdir, "palace")
-    mine(tmpdir, palace_path)
 
-    # Verify
-    client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_collection("mempalace_drawers")
+def get_collection(palace_path: Path, collection_name: str = "mempalace_drawers"):
+    client = chromadb.PersistentClient(path=str(palace_path))
+    return client.get_collection(collection_name)
+
+
+def write_global_config(palace_path: Path, collection_name: str = DEFAULT_COLLECTION_NAME):
+    config_dir = Path.home() / ".mempalace"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "palace_path": str(palace_path),
+                "collection_name": collection_name,
+            }
+        )
+    )
+
+
+def get_source_rows(col, source_file: Path, wing: str):
+    results = col.get(
+        where={"$and": [{"source_file": str(source_file.resolve())}, {"wing": wing}]},
+        include=["documents", "metadatas"],
+    )
+    return list(zip(results["ids"], results["documents"], results["metadatas"]))
+
+
+def test_project_mining_refreshes_updates_and_removes_stale_room_drawers(capsys):
+    tmpdir = Path(tempfile.mkdtemp())
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    write_project_config(project_dir)
+    notes = project_dir / "notes.txt"
+    notes.write_text(("billing invoice payment details\n" * 40).strip())
+    palace_path = tmpdir / "palace"
+
+    mine(str(project_dir), str(palace_path))
+    col = get_collection(palace_path)
+    first_rows = get_source_rows(col, notes, "test_project")
+
+    assert first_rows
+    assert {meta["room"] for _, _, meta in first_rows} == {"billing"}
+    assert all(meta["ingest_mode"] == "projects" for _, _, meta in first_rows)
+    assert all(meta["source_signature"] for _, _, meta in first_rows)
+    assert all(meta["pipeline_fingerprint"] for _, _, meta in first_rows)
+
+    mine(str(project_dir), str(palace_path))
+    unchanged_output = capsys.readouterr().out
+    second_rows = get_source_rows(col, notes, "test_project")
+
+    assert "Files unchanged: 1" in unchanged_output
+    assert {row[0] for row in second_rows} == {row[0] for row in first_rows}
+
+    notes.write_text(("auth oauth token login flow\n" * 35).strip())
+    mine(str(project_dir), str(palace_path))
+    updated_rows = get_source_rows(col, notes, "test_project")
+
+    assert {meta["room"] for _, _, meta in updated_rows} == {"auth"}
+    assert {row[0] for row in updated_rows}.isdisjoint({row[0] for row in first_rows})
+    assert "oauth token" in search_memories("oauth token", palace_path=str(palace_path))["results"][0]["text"]
+
+
+def test_project_mining_keeps_namespaces_per_wing():
+    tmpdir = Path(tempfile.mkdtemp())
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    write_project_config(project_dir, wing="alpha")
+    source = project_dir / "notes.txt"
+    source.write_text(("billing invoice payment details\n" * 30).strip())
+    palace_path = tmpdir / "palace"
+
+    mine(str(project_dir), str(palace_path), wing_override="alpha")
+    mine(str(project_dir), str(palace_path), wing_override="beta")
+
+    col = get_collection(palace_path)
+    results = col.get(where={"source_file": str(source.resolve())}, include=["metadatas"])
+
     assert col.count() > 0
+    assert {meta["wing"] for meta in results["metadatas"]} == {"alpha", "beta"}
 
-    shutil.rmtree(tmpdir)
+
+def test_project_refresh_clears_empty_content_but_preserves_old_drawers_on_read_error(monkeypatch, capsys):
+    tmpdir = Path(tempfile.mkdtemp())
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    write_project_config(project_dir)
+    source = project_dir / "notes.txt"
+    source.write_text(("billing invoice payment details\n" * 30).strip())
+    palace_path = tmpdir / "palace"
+
+    mine(str(project_dir), str(palace_path))
+    col = get_collection(palace_path)
+    original_rows = get_source_rows(col, source, "test_project")
+    assert original_rows
+
+    source.write_text("")
+    mine(str(project_dir), str(palace_path))
+    cleared_output = capsys.readouterr().out
+    assert "Files cleared: 1" in cleared_output
+    assert get_source_rows(col, source, "test_project") == []
+
+    source.write_text(("billing invoice payment details\n" * 30).strip())
+    mine(str(project_dir), str(palace_path))
+    restored_rows = get_source_rows(col, source, "test_project")
+    assert restored_rows
+
+    original_read_text = Path.read_text
+
+    def broken_read_text(self, *args, **kwargs):
+        if self.resolve() == source.resolve():
+            raise OSError("boom")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", broken_read_text)
+    mine(str(project_dir), str(palace_path))
+    errored_output = capsys.readouterr().out
+
+    assert "Files errored: 1" in errored_output
+    assert {row[0] for row in get_source_rows(col, source, "test_project")} == {
+        row[0] for row in restored_rows
+    }
+
+
+def test_manual_source_backed_drawers_survive_project_refresh():
+    tmpdir = Path(tempfile.mkdtemp())
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    write_project_config(project_dir)
+    source = project_dir / "notes.txt"
+    source.write_text(("billing invoice payment details\n" * 30).strip())
+    palace_path = tmpdir / "palace"
+    write_global_config(palace_path)
+
+    response = tool_add_drawer(
+        wing="test_project",
+        room="manual_notes",
+        content="Remember the migration checklist.",
+        source_file=str(source.resolve()),
+        added_by="test",
+    )
+    assert response["success"] is True
+
+    mine(str(project_dir), str(palace_path))
+    col = get_collection(palace_path)
+    rows = get_source_rows(col, source, "test_project")
+
+    assert any(doc == "Remember the migration checklist." for _, doc, _ in rows)
+    assert any(meta.get("ingest_mode") == "manual" for _, _, meta in rows)
+    assert any(meta.get("ingest_mode") == "projects" for _, _, meta in rows)
+
+
+def test_legacy_project_rows_are_refreshed_and_rewritten_with_explicit_lifecycle_metadata():
+    tmpdir = Path(tempfile.mkdtemp())
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    write_project_config(project_dir)
+    source = project_dir / "notes.txt"
+    source.write_text(("billing invoice payment details\n" * 35).strip())
+    palace_path = tmpdir / "palace"
+
+    chunks = chunk_text(source.read_text(), str(source.resolve()))
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_or_create_collection(DEFAULT_COLLECTION_NAME)
+    col.upsert(
+        ids=[
+            build_drawer_id("test_project", "billing", str(source.resolve()), chunk["chunk_index"])
+            for chunk in chunks
+        ],
+        documents=[chunk["content"] for chunk in chunks],
+        metadatas=[
+            {
+                "wing": "test_project",
+                "room": "billing",
+                "source_file": str(source.resolve()),
+                "chunk_index": chunk["chunk_index"],
+                "added_by": "legacy",
+                "filed_at": "2026-01-01T00:00:00",
+            }
+            for chunk in chunks
+        ],
+    )
+
+    mine(str(project_dir), str(palace_path))
+    rows = get_source_rows(col, source, "test_project")
+
+    assert rows
+    assert all(meta.get("ingest_mode") == "projects" for _, _, meta in rows)
+    assert all(meta.get("refresh_owner") == "projects" for _, _, meta in rows)
+    assert all(meta.get("source_signature") for _, _, meta in rows)
+
+
+def test_collection_name_override_is_shared_across_mine_search_status_layers_and_mcp(capsys):
+    tmpdir = Path(tempfile.mkdtemp())
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    write_project_config(project_dir)
+    source = project_dir / "notes.txt"
+    source.write_text(("auth oauth token login flow\n" * 30).strip())
+    palace_path = tmpdir / "custom-palace"
+    write_global_config(palace_path, collection_name="custom_drawers")
+
+    mine(str(project_dir), str(palace_path), collection_name="custom_drawers")
+
+    custom_collection = get_collection(palace_path, "custom_drawers")
+    assert custom_collection.count() > 0
+
+    assert search_memories(
+        "oauth token", palace_path=str(palace_path), collection_name="custom_drawers"
+    )["results"]
+    assert (
+        MemoryStack(palace_path=str(palace_path), collection_name="custom_drawers").status()[
+            "total_drawers"
+        ]
+        == custom_collection.count()
+    )
+
+    status(str(palace_path), collection_name="custom_drawers")
+    status_output = capsys.readouterr().out
+    assert "MemPalace Status" in status_output
+    assert str(custom_collection.count()) in status_output
+
+    mcp_status = tool_status()
+    assert mcp_status["total_drawers"] == custom_collection.count()
+    assert mcp_status["palace_path"] == str(palace_path)
+
+
+def test_explicit_palace_path_defaults_to_primary_collection_even_with_custom_global_collection(capsys):
+    tmpdir = Path(tempfile.mkdtemp())
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    write_project_config(project_dir)
+    source = project_dir / "notes.txt"
+    source.write_text(("auth oauth token login flow\n" * 30).strip())
+    configured_palace = tmpdir / "configured-palace"
+    explicit_palace = tmpdir / "explicit-palace"
+    write_global_config(configured_palace, collection_name="custom_drawers")
+
+    mine(str(project_dir), str(explicit_palace))
+
+    default_collection = get_collection(explicit_palace, DEFAULT_COLLECTION_NAME)
+    assert default_collection.count() > 0
+
+    assert search_memories("oauth token", palace_path=str(explicit_palace))["results"]
+    assert MemoryStack(palace_path=str(explicit_palace)).status()["total_drawers"] == default_collection.count()
+
+    status(str(explicit_palace))
+    status_output = capsys.readouterr().out
+    assert str(default_collection.count()) in status_output
+
+    client = chromadb.PersistentClient(path=str(explicit_palace))
+    with pytest.raises(Exception):
+        client.get_collection("custom_drawers")
+
+
+def test_status_counts_all_drawers_past_ten_thousand(capsys):
+    tmpdir = Path(tempfile.mkdtemp())
+    palace_path = tmpdir / "palace"
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_or_create_collection("mempalace_drawers")
+
+    total = 10001
+    for start in range(0, total, 2000):
+        end = min(start + 2000, total)
+        ids = [f"drawer-{index}" for index in range(start, end)]
+        docs = [f"document {index}" for index in range(start, end)]
+        metas = [
+            {"wing": "bulk", "room": "general", "source_file": f"file-{index}.txt"}
+            for index in range(start, end)
+        ]
+        col.upsert(ids=ids, documents=docs, metadatas=metas)
+
+    status(str(palace_path))
+    output = capsys.readouterr().out
+
+    assert "10001 drawers" in output


### PR DESCRIPTION
## What this PR does

This PR fixes the biggest trust problem in MemPalace: re-running `mine` now updates the same source safely instead of silently skipping it forever.

## In simple terms

Before:
- if you mined a file once and later edited it, MemPalace could keep the old memory and ignore the new one
- different parts of the tool could point at different drawer collections or resolve palace paths differently
- `status` could undercount large palaces
- manual drawers attached to a source file were at risk of getting mixed into automatic refresh logic

After:
- unchanged files stay untouched
- changed files refresh in place
- empty files clear their old automatic drawers
- read/normalize failures keep existing memory instead of deleting it
- the same source can be mined into different wings or convo extract modes without collisions
- CLI, search, layers, status, and MCP use the same drawer store rules
- large `status` output is counted exactly
- manual drawers stay separate from automatic refresh ownership

## Main changes

- Added a shared drawer-store layer for palace path / collection handling.
- Reworked project and conversation mining around namespace-aware refresh.
- Made refresh logic non-destructive on read failures.
- Fixed reporting to distinguish new / updated / unchanged / cleared / error.
- Added regression coverage for refresh behavior, namespace isolation, manual drawer preservation, custom collection handling, and exact 10k+ status counts.

## Validation

- `pytest -q tests/test_config.py tests/test_convo_miner.py tests/test_miner.py`
- `ruff check mempalace/cli.py mempalace/config.py mempalace/convo_miner.py mempalace/drawer_store.py mempalace/layers.py mempalace/mcp_server.py mempalace/miner.py mempalace/normalize.py mempalace/searcher.py tests/conftest.py tests/test_config.py tests/test_convo_miner.py tests/test_miner.py`
