### PR TITLE
Keep imported conversations verbatim

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ mempalace wake-up
 For Claude Code, Gemini CLI, MCP-compatible tools, and local models, see
 [mempalaceofficial.com/guide/getting-started](https://mempalaceofficial.com/guide/getting-started.html).
 
+Behavior note: conversation imports preserve original transcript text by
+default. MemPalace no longer spell-corrects imported chat messages during
+`--mode convos`; the spellcheck helper remains available as a separate utility.
+
 ---
 
 ## Benchmarks

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -8,7 +8,7 @@ The Python package that powers MemPalace. All modules, all logic.
 |--------|-------------|
 | `cli.py` | CLI entry point — routes to mine, search, init, compress, wake-up |
 | `config.py` | Configuration loading — `~/.mempalace/config.json`, env vars, defaults |
-| `normalize.py` | Converts 5 chat formats (Claude Code JSONL, Claude.ai JSON, ChatGPT JSON, Slack JSON, plain text) to standard transcript format |
+| `normalize.py` | Converts 5 chat formats (Claude Code JSONL, Claude.ai JSON, ChatGPT JSON, Slack JSON, plain text) to standard transcript format without mutating imported transcript text by default |
 | `miner.py` | Project file ingest — scans directories, chunks by paragraph, stores to ChromaDB |
 | `convo_miner.py` | Conversation ingest — chunks by exchange pair (Q+A), detects rooms from content |
 | `searcher.py` | Semantic search via ChromaDB vectors — filters by wing/room, returns verbatim + scores |
@@ -22,7 +22,7 @@ The Python package that powers MemPalace. All modules, all logic.
 | `entity_detector.py` | Auto-detect people and projects from file content |
 | `general_extractor.py` | Classifies text into 5 memory types (decision, preference, milestone, problem, emotional) |
 | `room_detector_local.py` | Maps folders to room names using 70+ patterns — no API |
-| `spellcheck.py` | Name-aware spellcheck — won't "correct" proper nouns in your entity registry |
+| `spellcheck.py` | Optional name-aware spellcheck utility — won't "correct" proper nouns in your entity registry |
 | `split_mega_files.py` | Splits concatenated transcript files into per-session files |
 
 ## Architecture

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -25,6 +25,7 @@ from typing import Optional
 _SLACK_PROVENANCE_FOOTER = (
     "\n[source: slack-export | multi-party chat — speaker roles are positional, not verified]"
 )
+SEGMENT_SEPARATOR = "\n\n---\n\n"
 
 
 # ─── Noise stripping ─────────────────────────────────────────────────────
@@ -114,6 +115,23 @@ def normalize(filepath: str) -> str:
     Load a file and normalize to transcript format if it's a chat export.
     Plain text files pass through unchanged.
     """
+    return join_normalized_segments(normalize_segments(filepath))
+
+
+def join_normalized_segments(segments: list[str]) -> str:
+    if not segments:
+        return ""
+    if len(segments) == 1:
+        return segments[0]
+    return SEGMENT_SEPARATOR.join(segment.strip() for segment in segments if segment.strip())
+
+
+def normalize_segments(filepath: str) -> list[str]:
+    """
+    Load a file and normalize it to one or more transcript segments.
+    Most formats produce a single segment; ChatGPT export arrays preserve
+    one segment per conversation so callers can keep routing boundaries.
+    """
     try:
         file_size = os.path.getsize(filepath)
     except OSError as e:
@@ -127,45 +145,57 @@ def normalize(filepath: str) -> str:
         raise IOError(f"Could not read {filepath}: {e}")
 
     if not content.strip():
-        return content
+        return [content]
 
     # Already has > markers — pass through unchanged.
     lines = content.split("\n")
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
-        return content
+        return [content]
 
     # Try JSON normalization. strip_noise is applied inside the Claude Code
     # JSONL parser (the only format that injects system tags/hook chrome);
     # other formats pass through verbatim.
     ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
-        normalized = _try_normalize_json(content)
-        if normalized:
-            return normalized
+        normalized_segments = _try_normalize_json_segments(content)
+        if normalized_segments:
+            return normalized_segments
 
-    return content
+    return [content]
 
 
 def _try_normalize_json(content: str) -> Optional[str]:
     """Try all known JSON chat schemas."""
+    normalized_segments = _try_normalize_json_segments(content)
+    if normalized_segments:
+        return join_normalized_segments(normalized_segments)
+    return None
+
+
+def _try_normalize_json_segments(content: str) -> Optional[list[str]]:
+    """Try all known JSON chat schemas, preserving segments when available."""
 
     normalized = _try_claude_code_jsonl(content)
     if normalized:
-        return normalized
+        return [normalized]
 
     normalized = _try_codex_jsonl(content)
     if normalized:
-        return normalized
+        return [normalized]
 
     try:
         data = json.loads(content)
     except json.JSONDecodeError:
         return None
 
+    chatgpt_export_segments = _try_chatgpt_export_json_segments(data)
+    if chatgpt_export_segments:
+        return chatgpt_export_segments
+
     for parser in (_try_claude_ai_json, _try_chatgpt_json, _try_slack_json):
         normalized = parser(data)
         if normalized:
-            return normalized
+            return [normalized]
 
     return None
 
@@ -370,6 +400,32 @@ def _try_chatgpt_json(data) -> Optional[str]:
     return None
 
 
+def _try_chatgpt_export_json(data) -> Optional[str]:
+    """ChatGPT export file: top-level list of conversation objects."""
+    segments = _try_chatgpt_export_json_segments(data)
+    if segments:
+        return join_normalized_segments(segments)
+    return None
+
+
+def _try_chatgpt_export_json_segments(data) -> Optional[list[str]]:
+    """ChatGPT export file: top-level list of conversation objects."""
+    if not isinstance(data, list):
+        return None
+    if not any(isinstance(item, dict) and "mapping" in item for item in data):
+        return None
+
+    transcripts = []
+    for item in data:
+        if not isinstance(item, dict) or "mapping" not in item:
+            continue
+        transcript = _try_chatgpt_json(item)
+        if transcript and transcript.strip():
+            transcripts.append(transcript.strip())
+
+    return transcripts or None
+
+
 def _try_slack_json(data) -> Optional[str]:
     """
     Slack channel export: [{"type": "message", "user": "...", "text": "..."}]
@@ -556,7 +612,7 @@ def _format_tool_result(content, tool_name: str) -> str:
     return "→ " + text
 
 
-def _messages_to_transcript(messages: list, spellcheck: bool = True) -> str:
+def _messages_to_transcript(messages: list, spellcheck: bool = False) -> str:
     """Convert [(role, text), ...] to transcript format with > markers."""
     if spellcheck:
         try:

--- a/mempalace/spellcheck.py
+++ b/mempalace/spellcheck.py
@@ -119,9 +119,13 @@ def _load_known_names() -> set:
 
         reg = EntityRegistry.load()
         names = set()
-        for entity in reg._data.get("entities", {}).values():
-            names.add(entity.get("canonical", "").lower())
-            for alias in entity.get("aliases", []):
+        for name, person in reg.people.items():
+            if name:
+                names.add(name.lower())
+            canonical = person.get("canonical", "")
+            if canonical:
+                names.add(canonical.lower())
+            for alias in person.get("aliases", []):
                 names.add(alias.lower())
         return names
     except Exception:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -77,6 +77,84 @@ def test_normalize_whitespace_only(tmp_path):
     assert result.strip() == ""
 
 
+def test_chatgpt_export_array_normalizes_multiple_conversations(tmp_path):
+    export = [
+        {
+            "mapping": {
+                "root": {"id": "root", "parent": None, "message": None, "children": ["u1"]},
+                "u1": {
+                    "id": "u1",
+                    "parent": "root",
+                    "message": {
+                        "author": {"role": "user"},
+                        "content": {"parts": ["First question"]},
+                    },
+                    "children": ["a1"],
+                },
+                "a1": {
+                    "id": "a1",
+                    "parent": "u1",
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "content": {"parts": ["First answer"]},
+                    },
+                    "children": [],
+                },
+            }
+        },
+        {"title": "broken entry"},
+        {
+            "mapping": {
+                "root": {"id": "root", "parent": None, "message": None, "children": ["u2"]},
+                "u2": {
+                    "id": "u2",
+                    "parent": "root",
+                    "message": {
+                        "author": {"role": "user"},
+                        "content": {"parts": ["Second question"]},
+                    },
+                    "children": ["a2"],
+                },
+                "a2": {
+                    "id": "a2",
+                    "parent": "u2",
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "content": {"parts": ["Second answer"]},
+                    },
+                    "children": [],
+                },
+            }
+        },
+    ]
+    path = tmp_path / "conversations.json"
+    path.write_text(json.dumps(export))
+
+    result = normalize(str(path))
+
+    assert "> First question" in result
+    assert "First answer" in result
+    assert "> Second question" in result
+    assert "Second answer" in result
+    assert "\n---\n" in result
+
+
+def test_normalize_preserves_user_typos_verbatim(tmp_path):
+    path = tmp_path / "chat.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"role": "user", "content": "lsresdy knoe the question befor"},
+                {"role": "assistant", "content": "I will keep it verbatim."},
+            ]
+        )
+    )
+
+    result = normalize(str(path))
+
+    assert "> lsresdy knoe the question befor" in result
+
+
 # ── _extract_content ───────────────────────────────────────────────────
 
 

--- a/tests/test_spellcheck.py
+++ b/tests/test_spellcheck.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from mempalace.spellcheck import (
     _edit_distance,
     _get_system_words,
+    _load_known_names,
     _should_skip,
     spellcheck_transcript,
     spellcheck_transcript_line,

--- a/tests/test_spellcheck.py
+++ b/tests/test_spellcheck.py
@@ -1,5 +1,7 @@
 """Tests for mempalace.spellcheck — spell-correction utilities."""
 
+import json
+from pathlib import Path
 from unittest.mock import patch
 
 from mempalace.spellcheck import (
@@ -158,3 +160,73 @@ def test_spellcheck_transcript_processes_content():
         assert lines[0] == "Assistant line"
         assert "fixed" in lines[1]
         assert lines[2] == "Another assistant line"
+
+
+def test_load_known_names_reads_people_and_aliases():
+    registry_path = Path.home() / ".mempalace" / "entity_registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "mode": "personal",
+                "people": {
+                    "Maxwell": {
+                        "source": "onboarding",
+                        "contexts": ["personal"],
+                        "aliases": ["Max"],
+                        "confidence": 1.0,
+                    },
+                    "Max": {
+                        "source": "onboarding",
+                        "contexts": ["personal"],
+                        "aliases": ["Maxwell"],
+                        "canonical": "Maxwell",
+                        "confidence": 1.0,
+                    },
+                },
+                "projects": [],
+                "ambiguous_flags": [],
+                "wiki_cache": {},
+            }
+        )
+    )
+
+    known_names = _load_known_names()
+
+    assert {"max", "maxwell"} <= known_names
+
+
+def test_spellcheck_helper_preserves_registered_names_and_aliases(monkeypatch):
+    registry_path = Path.home() / ".mempalace" / "entity_registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "mode": "personal",
+                "people": {
+                    "Sam": {
+                        "source": "onboarding",
+                        "contexts": ["personal"],
+                        "aliases": ["Sammie"],
+                        "confidence": 1.0,
+                    }
+                },
+                "projects": [],
+                "ambiguous_flags": [],
+                "wiki_cache": {},
+            }
+        )
+    )
+
+    class AggressiveSpeller:
+        def __call__(self, token):
+            replacements = {"sammie": "sammy", "functionalityy": "functionality"}
+            return replacements.get(token.lower(), token)
+
+    monkeypatch.setattr("mempalace.spellcheck._get_speller", lambda: AggressiveSpeller())
+
+    corrected = spellcheck_user_text("Sammie fixed functionalityy")
+
+    assert corrected == "Sammie fixed functionality"

--- a/tests/test_spellcheck_extra.py
+++ b/tests/test_spellcheck_extra.py
@@ -11,11 +11,9 @@ from mempalace.spellcheck import (
 class TestLoadKnownNames:
     def test_returns_names_from_registry(self):
         mock_reg = MagicMock()
-        mock_reg._data = {
-            "entities": {
-                "e1": {"canonical": "Alice", "aliases": ["ali"]},
-                "e2": {"canonical": "Bob", "aliases": []},
-            }
+        mock_reg.people = {
+            "Alice": {"canonical": "Alice", "aliases": ["ali"]},
+            "Bob": {"aliases": []},
         }
         with patch("mempalace.entity_registry.EntityRegistry") as MockER:
             MockER.load.return_value = mock_reg


### PR DESCRIPTION
## What this PR does

This PR makes conversation import safer and more faithful to the user's original source material.

## In simple terms

Before:
- imported user text could be silently spell-corrected during normalization
- ChatGPT export arrays were not handled the way real `conversations.json` files are usually structured
- the spellcheck helper looked in the wrong registry shape for known names

After:
- imports keep the user's original words by default
- ChatGPT export arrays normalize correctly
- the spellcheck helper preserves registered people names and aliases from the real registry schema

## Main changes

- Removed default spell-correction from transcript normalization.
- Added segment-aware normalization helpers.
- Fixed top-level ChatGPT export-array normalization.
- Corrected known-name loading in `spellcheck.py` to use `people` and aliases.
- Added regression coverage for verbatim fidelity and ChatGPT export handling.

## Validation

- `pytest -q tests/test_normalize.py tests/test_spellcheck.py`
- `ruff check mempalace/normalize.py mempalace/spellcheck.py tests/test_normalize.py tests/test_spellcheck.py`
