### PR TITLE
fix(searcher): replace sys.exit() with RuntimeError to stop library from killing host process

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -95,13 +95,17 @@ def cmd_search(args):
     from .searcher import search
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
-    search(
-        query=args.query,
-        palace_path=palace_path,
-        wing=args.wing,
-        room=args.room,
-        n_results=args.results,
-    )
+    try:
+        search(
+            query=args.query,
+            palace_path=palace_path,
+            wing=args.wing,
+            room=args.room,
+            n_results=args.results,
+        )
+    except RuntimeError as e:
+        print(f"\n  Error: {e}")
+        sys.exit(1)
 
 
 def cmd_wakeup(args):

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -6,7 +6,6 @@ Semantic search against the palace.
 Returns verbatim text — the actual words, never summaries.
 """
 
-import sys
 from pathlib import Path
 
 import chromadb
@@ -21,9 +20,10 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")
     except Exception:
-        print(f"\n  No palace found at {palace_path}")
-        print("  Run: mempalace init <dir> then mempalace mine <dir>")
-        sys.exit(1)
+        raise RuntimeError(
+            f"No palace found at {palace_path}. "
+            "Run: mempalace init <dir> then mempalace mine <dir>"
+        )
 
     # Build where filter
     where = {}
@@ -46,8 +46,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         results = col.query(**kwargs)
 
     except Exception as e:
-        print(f"\n  Search error: {e}")
-        sys.exit(1)
+        raise RuntimeError(f"Search error: {e}") from e
 
     docs = results["documents"][0]
     metas = results["metadatas"][0]

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -1,0 +1,52 @@
+"""Tests for searcher.py — verifies sys.exit replaced with RuntimeError."""
+
+import tempfile
+import pytest
+from mempalace.searcher import search, search_memories
+
+
+def test_search_raises_on_missing_palace():
+    """search() must raise RuntimeError, not sys.exit, when palace is missing."""
+    with pytest.raises(RuntimeError, match="No palace found"):
+        search("test query", palace_path="/nonexistent/palace/path")
+
+
+def test_search_memories_returns_error_dict():
+    """search_memories() must return error dict, never sys.exit."""
+    result = search_memories("test query", palace_path="/nonexistent/palace/path")
+    assert "error" in result
+    assert "No palace found" in result["error"]
+
+
+def test_search_returns_results(tmp_path):
+    """search() works normally when palace exists with data."""
+    import chromadb
+
+    palace_path = str(tmp_path / "palace")
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_or_create_collection("mempalace_drawers")
+    col.add(
+        ids=["test1"],
+        documents=["The quick brown fox jumps over the lazy dog"],
+        metadatas=[{"wing": "test", "room": "general", "source_file": "test.txt"}],
+    )
+    # Should not raise
+    search("fox", palace_path=palace_path, n_results=1)
+
+
+def test_search_memories_returns_hits(tmp_path):
+    """search_memories() returns structured results when palace has data."""
+    import chromadb
+
+    palace_path = str(tmp_path / "palace")
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_or_create_collection("mempalace_drawers")
+    col.add(
+        ids=["test1"],
+        documents=["Memory about artificial intelligence"],
+        metadatas=[{"wing": "tech", "room": "ai", "source_file": "notes.md"}],
+    )
+    result = search_memories("artificial intelligence", palace_path=palace_path, n_results=1)
+    assert "results" in result
+    assert len(result["results"]) == 1
+    assert result["results"][0]["wing"] == "tech"


### PR DESCRIPTION
## Problem

`search()` in `searcher.py` calls `sys.exit(1)` on two error paths:

```python
# line 24-26
except Exception:
    print(f"\n  No palace found at {palace_path}")
    sys.exit(1)   # ← kills the host process

# line 48-50
except Exception as e:
    print(f"\n  Search error: {e}")
    sys.exit(1)   # ← kills the host process
```

This is fine for a standalone CLI but mempalace ships an MCP server. When `search()` is called via the MCP server (which is a long-running subprocess managed by Claude Code or any MCP host), these `sys.exit(1)` calls **terminate the entire MCP server process**, killing the host's connection to all mempalace tools.

## Fix

Replace both `sys.exit(1)` calls with `raise RuntimeError(...)`. The CLI caller (`cmd_search` in `cli.py`) now catches the exception and calls `sys.exit(1)` itself — same UX for CLI users, no process death for MCP/library callers.

`search_memories()` (the programmatic API already used by the MCP server) was already correct — it returns `{"error": ...}` dicts. This PR only touches the print-and-exit `search()` path.

## Test plan

- [ ] `mempalace search "something"` against a missing palace → prints error and exits 1 (CLI behavior unchanged)
- [ ] Calling `search()` directly from Python → raises `RuntimeError` (catchable)
- [ ] MCP server `search` tool with bad palace path → returns JSON-RPC error, server process stays alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)