### PR TITLE
fix(knowledge_graph): use named column access instead of hardcoded integer indices

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -305,8 +305,7 @@ class KnowledgeGraph:
             """)
 
         cols = [d[0] for d in cur.description]
-        conn.close()
-        return [
+        results = [
             {
                 "subject": row["sub_name"],
                 "predicate": row["predicate"],
@@ -317,6 +316,8 @@ class KnowledgeGraph:
             }
             for row in (dict(zip(cols, raw)) for raw in cur.fetchall())
         ]
+        conn.close()
+        return results
 
     # ── Stats ─────────────────────────────────────────────────────────────
 

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -201,18 +201,21 @@ class KnowledgeGraph:
             if as_of:
                 query += " AND (t.valid_from IS NULL OR t.valid_from <= ?) AND (t.valid_to IS NULL OR t.valid_to >= ?)"
                 params.extend([as_of, as_of])
-            for row in conn.execute(query, params).fetchall():
+            cur = conn.execute(query, params)
+            cols = [d[0] for d in cur.description]
+            for raw in cur.fetchall():
+                row = dict(zip(cols, raw))
                 results.append(
                     {
                         "direction": "outgoing",
                         "subject": name,
-                        "predicate": row[2],
-                        "object": row[10],  # obj_name
-                        "valid_from": row[4],
-                        "valid_to": row[5],
-                        "confidence": row[6],
-                        "source_closet": row[7],
-                        "current": row[5] is None,
+                        "predicate": row["predicate"],
+                        "object": row["obj_name"],
+                        "valid_from": row["valid_from"],
+                        "valid_to": row["valid_to"],
+                        "confidence": row["confidence"],
+                        "source_closet": row["source_closet"],
+                        "current": row["valid_to"] is None,
                     }
                 )
 
@@ -222,18 +225,21 @@ class KnowledgeGraph:
             if as_of:
                 query += " AND (t.valid_from IS NULL OR t.valid_from <= ?) AND (t.valid_to IS NULL OR t.valid_to >= ?)"
                 params.extend([as_of, as_of])
-            for row in conn.execute(query, params).fetchall():
+            cur = conn.execute(query, params)
+            cols = [d[0] for d in cur.description]
+            for raw in cur.fetchall():
+                row = dict(zip(cols, raw))
                 results.append(
                     {
                         "direction": "incoming",
-                        "subject": row[10],  # sub_name
-                        "predicate": row[2],
+                        "subject": row["sub_name"],
+                        "predicate": row["predicate"],
                         "object": name,
-                        "valid_from": row[4],
-                        "valid_to": row[5],
-                        "confidence": row[6],
-                        "source_closet": row[7],
-                        "current": row[5] is None,
+                        "valid_from": row["valid_from"],
+                        "valid_to": row["valid_to"],
+                        "confidence": row["confidence"],
+                        "source_closet": row["source_closet"],
+                        "current": row["valid_to"] is None,
                     }
                 )
 
@@ -256,18 +262,19 @@ class KnowledgeGraph:
             query += " AND (t.valid_from IS NULL OR t.valid_from <= ?) AND (t.valid_to IS NULL OR t.valid_to >= ?)"
             params.extend([as_of, as_of])
 
-        results = []
-        for row in conn.execute(query, params).fetchall():
-            results.append(
-                {
-                    "subject": row[10],
-                    "predicate": pred,
-                    "object": row[11],
-                    "valid_from": row[4],
-                    "valid_to": row[5],
-                    "current": row[5] is None,
-                }
-            )
+        cur = conn.execute(query, params)
+        cols = [d[0] for d in cur.description]
+        results = [
+            {
+                "subject": row["sub_name"],
+                "predicate": pred,
+                "object": row["obj_name"],
+                "valid_from": row["valid_from"],
+                "valid_to": row["valid_to"],
+                "current": row["valid_to"] is None,
+            }
+            for row in (dict(zip(cols, raw)) for raw in cur.fetchall())
+        ]
         conn.close()
         return results
 
@@ -276,7 +283,7 @@ class KnowledgeGraph:
         conn = self._conn()
         if entity_name:
             eid = self._entity_id(entity_name)
-            rows = conn.execute(
+            cur = conn.execute(
                 """
                 SELECT t.*, s.name as sub_name, o.name as obj_name
                 FROM triples t
@@ -286,28 +293,29 @@ class KnowledgeGraph:
                 ORDER BY t.valid_from ASC NULLS LAST
             """,
                 (eid, eid),
-            ).fetchall()
+            )
         else:
-            rows = conn.execute("""
+            cur = conn.execute("""
                 SELECT t.*, s.name as sub_name, o.name as obj_name
                 FROM triples t
                 JOIN entities s ON t.subject = s.id
                 JOIN entities o ON t.object = o.id
                 ORDER BY t.valid_from ASC NULLS LAST
                 LIMIT 100
-            """).fetchall()
+            """)
 
+        cols = [d[0] for d in cur.description]
         conn.close()
         return [
             {
-                "subject": r[10],
-                "predicate": r[2],
-                "object": r[11],
-                "valid_from": r[4],
-                "valid_to": r[5],
-                "current": r[5] is None,
+                "subject": row["sub_name"],
+                "predicate": row["predicate"],
+                "object": row["obj_name"],
+                "valid_from": row["valid_from"],
+                "valid_to": row["valid_to"],
+                "current": row["valid_to"] is None,
             }
-            for r in rows
+            for row in (dict(zip(cols, raw)) for raw in cur.fetchall())
         ]
 
     # ── Stats ─────────────────────────────────────────────────────────────

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,130 @@
+"""Tests for knowledge_graph.py — verifies named column access after fix."""
+
+import tempfile
+import os
+from mempalace.knowledge_graph import KnowledgeGraph
+
+
+def _make_kg(tmp_path):
+    db = str(tmp_path / "kg.sqlite3")
+    kg = KnowledgeGraph(db_path=db)
+    return kg
+
+
+def test_add_entity_and_triple(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_entity("Alice", "person")
+    kg.add_entity("Chess", "activity")
+    tid = kg.add_triple("Alice", "loves", "Chess", valid_from="2025-01-01")
+    assert tid is not None
+
+
+def test_query_entity_outgoing(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Alice", "loves", "Chess", valid_from="2025-01-01")
+    results = kg.query_entity("Alice", direction="outgoing")
+    assert len(results) == 1
+    r = results[0]
+    assert r["direction"] == "outgoing"
+    assert r["subject"] == "Alice"
+    assert r["predicate"] == "loves"
+    assert r["object"] == "Chess"
+    assert r["valid_from"] == "2025-01-01"
+    assert r["valid_to"] is None
+    assert r["current"] is True
+
+
+def test_query_entity_incoming(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Alice", "parent_of", "Max", valid_from="2015-01-01")
+    results = kg.query_entity("Max", direction="incoming")
+    assert len(results) == 1
+    r = results[0]
+    assert r["direction"] == "incoming"
+    assert r["subject"] == "Alice"
+    assert r["predicate"] == "parent_of"
+    assert r["object"] == "Max"
+
+
+def test_query_entity_both(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Alice", "parent_of", "Max")
+    kg.add_triple("Max", "loves", "Chess")
+    results = kg.query_entity("Max", direction="both")
+    assert len(results) == 2
+    directions = {r["direction"] for r in results}
+    assert directions == {"incoming", "outgoing"}
+
+
+def test_query_entity_temporal_filter(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Max", "does", "Swimming", valid_from="2025-01-01", valid_to="2025-06-01")
+    kg.add_triple("Max", "does", "Chess", valid_from="2025-03-01")
+    # Query as of April — both should match
+    results = kg.query_entity("Max", as_of="2025-04-01")
+    assert len(results) == 2
+    # Query as of August — only Chess (Swimming expired June)
+    results = kg.query_entity("Max", as_of="2025-08-01")
+    assert len(results) == 1
+    assert results[0]["object"] == "Chess"
+
+
+def test_query_relationship(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Alice", "loves", "Chess")
+    kg.add_triple("Max", "loves", "Swimming")
+    results = kg.query_relationship("loves")
+    assert len(results) == 2
+    subjects = {r["subject"] for r in results}
+    objects = {r["object"] for r in results}
+    assert "Alice" in subjects
+    assert "Chess" in objects
+    # Verify named fields are populated (not None from wrong index)
+    for r in results:
+        assert r["subject"] is not None
+        assert r["object"] is not None
+        assert r["predicate"] == "loves"
+
+
+def test_timeline(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Alice", "loves", "Chess", valid_from="2025-01-01")
+    kg.add_triple("Max", "does", "Swimming", valid_from="2025-06-01")
+    results = kg.timeline()
+    assert len(results) == 2
+    # Should be chronological
+    assert results[0]["valid_from"] <= results[1]["valid_from"]
+    for r in results:
+        assert r["subject"] is not None
+        assert r["object"] is not None
+        assert r["predicate"] is not None
+
+
+def test_timeline_entity_filter(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Alice", "loves", "Chess", valid_from="2025-01-01")
+    kg.add_triple("Max", "does", "Swimming", valid_from="2025-06-01")
+    results = kg.timeline(entity_name="Alice")
+    assert len(results) == 1
+    assert results[0]["subject"] == "Alice"
+
+
+def test_invalidate(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Max", "does", "Swimming", valid_from="2025-01-01")
+    kg.invalidate("Max", "does", "Swimming", ended="2025-06-01")
+    results = kg.query_entity("Max")
+    assert len(results) == 1
+    assert results[0]["valid_to"] == "2025-06-01"
+    assert results[0]["current"] is False
+
+
+def test_stats(tmp_path):
+    kg = _make_kg(tmp_path)
+    kg.add_triple("Alice", "loves", "Chess")
+    kg.add_triple("Max", "does", "Swimming")
+    s = kg.stats()
+    assert s["entities"] >= 4  # Alice, Chess, Max, Swimming
+    assert s["triples"] == 2
+    assert s["current_facts"] == 2
+    assert "loves" in s["relationship_types"]


### PR DESCRIPTION
## Problem

`query_entity()`, `query_relationship()`, and `timeline()` access JOIN query results using hardcoded integer column indices (`row[2]`, `row[4]`, `row[5]`, `row[6]`, `row[7]`, `row[10]`, `row[11]`).

These indices are derived from the position of columns in `SELECT t.*, ...` — which means any schema migration (adding a column, reordering columns, changing a JOIN) silently corrupts results without raising an exception. The bug would surface as wrong data returned from graph queries.

Example from `query_entity()` outgoing direction:
```python
results.append({
    "subject": name,
    "predicate": row[2],   # triples.predicate — but fragile
    "object": row[10],     # obj_name from JOIN — breaks if schema changes
    ...
})
```

## Fix

Use `cursor.description` to build a column name → value dict after every `execute()` call. All field access now uses named keys:

```python
cur = conn.execute(query, params)
cols = [d[0] for d in cur.description]
for raw in cur.fetchall():
    row = dict(zip(cols, raw))
    results.append({
        "predicate": row["predicate"],
        "object": row["obj_name"],
        ...
    })
```

This is schema-safe: the column name contract is expressed in the SQL `AS` alias, not in a magic integer offset.

## Test plan

- [ ] `kg.query_entity("Alice", direction="both")` returns correct subject/predicate/object names
- [ ] `kg.query_relationship("child_of")` returns correct sub_name/obj_name
- [ ] `kg.timeline()` returns facts in chronological order with correct field values
- [ ] Add a column to `triples` table schema and verify queries still return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)