### PR TITLE
fix(entity_registry): gate Wikipedia HTTP calls behind MEMPALACE_WIKIPEDIA env var

### DIFF
--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -16,6 +16,7 @@ Usage:
 """
 
 import json
+import os
 import re
 import urllib.request
 import urllib.parse
@@ -178,10 +179,21 @@ PLACE_INDICATOR_PHRASES = [
 
 def _wikipedia_lookup(word: str) -> dict:
     """
-    Look up a word via Wikipedia REST API.
+    Look up a word via Wikipedia REST API (opt-in only).
+
+    Disabled by default to honour the no-internet-after-install contract.
+    Enable by setting the environment variable MEMPALACE_WIKIPEDIA=1.
+
     Returns inferred type (person/place/concept/unknown) + confidence + summary.
     Free, no API key, handles disambiguation pages.
     """
+    if not os.environ.get("MEMPALACE_WIKIPEDIA"):
+        return {
+            "inferred_type": "unknown",
+            "confidence": 0.0,
+            "wiki_summary": None,
+            "note": "Wikipedia lookup disabled. Set MEMPALACE_WIKIPEDIA=1 to enable.",
+        }
     try:
         url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{urllib.parse.quote(word)}"
         req = urllib.request.Request(url, headers={"User-Agent": "MemPalace/1.0"})

--- a/tests/test_entity_registry.py
+++ b/tests/test_entity_registry.py
@@ -1,0 +1,46 @@
+"""Tests for entity_registry.py — verifies Wikipedia opt-in guard."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+from mempalace.entity_registry import _wikipedia_lookup, EntityRegistry
+
+
+def test_wikipedia_lookup_disabled_by_default():
+    """_wikipedia_lookup returns unknown when MEMPALACE_WIKIPEDIA is not set."""
+    os.environ.pop("MEMPALACE_WIKIPEDIA", None)
+    result = _wikipedia_lookup("Paris")
+    assert result["inferred_type"] == "unknown"
+    assert result["confidence"] == 0.0
+    assert "disabled" in result.get("note", "").lower() or result["wiki_summary"] is None
+
+
+def test_wikipedia_lookup_respects_env_var():
+    """_wikipedia_lookup attempts HTTP when MEMPALACE_WIKIPEDIA=1."""
+    os.environ["MEMPALACE_WIKIPEDIA"] = "1"
+    try:
+        with patch("mempalace.entity_registry.urllib.request.urlopen") as mock_urlopen:
+            import json
+            mock_response = type("MockResponse", (), {
+                "read": lambda self: json.dumps({
+                    "type": "standard",
+                    "title": "Paris",
+                    "extract": "Paris is the capital of France.",
+                }).encode(),
+                "__enter__": lambda self: self,
+                "__exit__": lambda self, *a: None,
+            })()
+            mock_urlopen.return_value = mock_response
+            result = _wikipedia_lookup("Paris")
+            mock_urlopen.assert_called_once()
+    finally:
+        del os.environ["MEMPALACE_WIKIPEDIA"]
+
+
+def test_entity_registry_load():
+    """EntityRegistry.load() initializes from a temp directory without errors."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reg = EntityRegistry.load(config_dir=Path(tmpdir))
+        assert reg is not None
+        assert hasattr(reg, "research")


### PR DESCRIPTION
## Problem

`EntityRegistry._wikipedia_lookup()` makes live HTTP requests to `en.wikipedia.org/api/rest_v1/` during entity disambiguation (called from `research()`). This fires automatically on first use — no opt-in, no warning.

This contradicts the README's stated contract:

> **No API key. No internet.**

A user who installs mempalace in an air-gapped environment or on a machine with outbound HTTP restrictions will see silent failures or unexpected network calls during onboarding.

## Fix

Add an opt-in env var guard as the very first check in `_wikipedia_lookup()`:

```python
if not os.environ.get("MEMPALACE_WIKIPEDIA"):
    return {
        "inferred_type": "unknown",
        "confidence": 0.0,
        "wiki_summary": None,
        "note": "Wikipedia lookup disabled. Set MEMPALACE_WIKIPEDIA=1 to enable.",
    }
```

By default (env var absent), the function returns the same shape of dict as a successful lookup with unknown type and zero confidence — callers require no changes. HTTP is only attempted when the user explicitly sets `MEMPALACE_WIKIPEDIA=1`.

No API surface changes. Backward compatible.

## Test plan

- [ ] Without `MEMPALACE_WIKIPEDIA` set: `_wikipedia_lookup("Paris")` returns `{"inferred_type": "unknown", "confidence": 0.0, ...}` — no network call
- [ ] With `MEMPALACE_WIKIPEDIA=1`: existing Wikipedia lookup behavior unchanged
- [ ] `mempalace init` in offline environment completes without network errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)