### PR TITLE
fix(mcp_server): validate tool arguments before dispatch, return JSON-RPC errors on bad params

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -688,6 +688,43 @@ TOOLS = {
 }
 
 
+def _validate_tool_args(tool_name: str, tool_args: dict, req_id) -> dict:
+    """
+    Validate tool arguments against the tool's input_schema.
+    Returns a JSON-RPC error response dict if invalid, or None if valid.
+    """
+    schema = TOOLS[tool_name]["input_schema"]
+    required = schema.get("required", [])
+    properties = schema.get("properties", {})
+
+    for param in required:
+        if param not in tool_args:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32602, "message": f"Missing required parameter: '{param}'"},
+            }
+
+    _type_map = {"string": str, "integer": int, "number": (int, float), "boolean": bool}
+    for param, value in tool_args.items():
+        if param not in properties:
+            continue
+        expected = properties[param].get("type")
+        if expected in _type_map and not isinstance(value, _type_map[expected]):
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {
+                    "code": -32602,
+                    "message": (
+                        f"Parameter '{param}' must be {expected}, "
+                        f"got {type(value).__name__}"
+                    ),
+                },
+            }
+    return None
+
+
 def handle_request(request):
     method = request.get("method", "")
     params = request.get("params", {})
@@ -725,6 +762,9 @@ def handle_request(request):
                 "id": req_id,
                 "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
             }
+        validation_error = _validate_tool_args(tool_name, tool_args, req_id)
+        if validation_error:
+            return validation_error
         try:
             result = TOOLS[tool_name]["handler"](**tool_args)
             return {

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,83 @@
+"""Tests for mcp_server.py — verifies _validate_tool_args param validation."""
+
+from mempalace.mcp_server import _validate_tool_args, TOOLS
+
+
+def test_validate_passes_valid_args():
+    """Valid args for search tool should return None (no error)."""
+    result = _validate_tool_args(
+        "mempalace_search", {"query": "test search"}, req_id=1
+    )
+    assert result is None
+
+
+def test_validate_rejects_missing_required():
+    """Missing 'query' param should return JSON-RPC error."""
+    result = _validate_tool_args("mempalace_search", {}, req_id=1)
+    assert result is not None
+    assert result["error"]["code"] == -32602
+    assert "query" in result["error"]["message"]
+
+
+def test_validate_rejects_wrong_type():
+    """Passing integer for 'query' (expects string) should return error."""
+    result = _validate_tool_args(
+        "mempalace_search", {"query": 42}, req_id=1
+    )
+    assert result is not None
+    assert result["error"]["code"] == -32602
+    assert "string" in result["error"]["message"]
+
+
+def test_validate_passes_optional_params():
+    """Optional params with correct types should pass."""
+    result = _validate_tool_args(
+        "mempalace_search",
+        {"query": "test", "limit": 10, "wing": "myproject"},
+        req_id=1,
+    )
+    assert result is None
+
+
+def test_validate_rejects_wrong_optional_type():
+    """Optional param with wrong type should still be rejected."""
+    result = _validate_tool_args(
+        "mempalace_search",
+        {"query": "test", "limit": "not_a_number"},
+        req_id=1,
+    )
+    assert result is not None
+    assert "integer" in result["error"]["message"]
+
+
+def test_validate_number_type_accepts_int_and_float():
+    """Number type should accept both int and float."""
+    # check_duplicate has threshold as "number" type
+    result_int = _validate_tool_args(
+        "mempalace_check_duplicate",
+        {"content": "test", "threshold": 1},
+        req_id=1,
+    )
+    result_float = _validate_tool_args(
+        "mempalace_check_duplicate",
+        {"content": "test", "threshold": 0.9},
+        req_id=1,
+    )
+    assert result_int is None
+    assert result_float is None
+
+
+def test_validate_ignores_unknown_params():
+    """Extra params not in schema should be ignored (not rejected)."""
+    result = _validate_tool_args(
+        "mempalace_search",
+        {"query": "test", "unknown_param": "value"},
+        req_id=1,
+    )
+    assert result is None
+
+
+def test_validate_tool_with_no_required():
+    """Tools with no required params should pass with empty args."""
+    result = _validate_tool_args("mempalace_status", {}, req_id=1)
+    assert result is None


### PR DESCRIPTION
## Problem

`handle_request()` dispatches tool calls directly with `**tool_args` before any validation:

```python
result = TOOLS[tool_name]["handler"](**tool_args)
```

If a caller passes wrong types or omits required parameters, raw Python exceptions leak into the JSON-RPC error response. Callers receive unstructured tracebacks instead of standards-compliant error objects. This also means any MCP client can probe internal implementation details through exception messages.

## Fix

Add `_validate_tool_args()` — a lightweight validator that checks required parameters are present and that declared types match the tool's existing `input_schema` definitions:

```python
def _validate_tool_args(tool_name: str, tool_args: dict, req_id) -> dict:
    schema = TOOLS[tool_name]["input_schema"]
    # check required params present
    # check declared types match
    # return JSON-RPC -32602 error dict on violation, or None if valid
```

Wire it into the tools/call handler before the dispatch call:

```python
validation_error = _validate_tool_args(tool_name, tool_args, req_id)
if validation_error:
    return validation_error
result = TOOLS[tool_name]["handler"](**tool_args)
```

On violation, callers receive a proper `{"code": -32602, "message": "Missing required parameter: 'query'"}` error. The handler is never invoked. No logic changes to existing tools.

## Test plan

- [ ] Call `search` tool without `query` parameter → JSON-RPC error `-32602 Missing required parameter: 'query'`
- [ ] Call `kg_add` tool with `confidence` as string instead of number → JSON-RPC error `-32602 Parameter 'confidence' must be number, got str`
- [ ] All 19 tools with valid parameters → behavior unchanged, handlers invoked normally
- [ ] Malformed JSON body → existing error handling unchanged (validation only runs after successful parse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)