### PR TITLE
Add Elasticsearch support

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -149,12 +149,11 @@ def cmd_status(args):
 
 def cmd_compress(args):
     """Compress drawers in a wing using AAAK Dialect."""
-    import chromadb
     from .dialect import Dialect
+    from .storage import get_collection
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
 
-    # Load dialect (with optional entity config)
     config_path = args.config
     if not config_path:
         for candidate in ["entities.json", os.path.join(palace_path, "entities.json")]:
@@ -168,16 +167,13 @@ def cmd_compress(args):
     else:
         dialect = Dialect()
 
-    # Connect to palace
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = get_collection("mempalace_drawers")
     except Exception:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         sys.exit(1)
 
-    # Query drawers in the wing
     where = {"wing": args.wing} if args.wing else None
     try:
         kwargs = {"include": ["documents", "metadatas"]}
@@ -228,10 +224,9 @@ def cmd_compress(args):
             print(f"    {compressed}")
             print()
 
-    # Store compressed versions (unless dry-run)
     if not args.dry_run:
         try:
-            comp_col = client.get_or_create_collection("mempalace_compressed")
+            comp_col = get_collection("mempalace_compressed", create=True)
             for doc_id, compressed, meta, stats in compressed_entries:
                 comp_meta = dict(meta)
                 comp_meta["compression_ratio"] = round(stats["ratio"], 1)
@@ -248,7 +243,6 @@ def cmd_compress(args):
             print(f"  Error storing compressed drawers: {e}")
             sys.exit(1)
 
-    # Summary
     ratio = total_original / max(total_compressed, 1)
     orig_tokens = Dialect.count_tokens("x" * total_original)
     comp_tokens = Dialect.count_tokens("x" * total_compressed)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -99,8 +99,32 @@ class MempalaceConfig:
 
     @property
     def collection_name(self):
-        """ChromaDB collection name."""
+        """Collection name (used across all backends)."""
         return self._file_config.get("collection_name", DEFAULT_COLLECTION_NAME)
+
+    @property
+    def storage_backend(self):
+        """Storage backend: 'chromadb' (default) or 'elasticsearch'."""
+        env_val = os.environ.get("MEMPALACE_STORAGE_BACKEND")
+        if env_val:
+            return env_val
+        return self._file_config.get("storage_backend", "chromadb")
+
+    @property
+    def graph_backend(self):
+        """Knowledge graph backend: 'sqlite' (default) or 'elasticsearch'."""
+        env_val = os.environ.get("MEMPALACE_GRAPH_BACKEND")
+        if env_val:
+            return env_val
+        return self._file_config.get("graph_backend", "sqlite")
+
+    @property
+    def elasticsearch(self):
+        """Elasticsearch connection settings dict.
+
+        Expected keys: hosts, api_key, index_prefix, inference_id, rerank_id.
+        """
+        return self._file_config.get("elasticsearch", {})
 
     @property
     def people_map(self):

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -15,8 +15,6 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-import chromadb
-
 from .normalize import normalize
 
 
@@ -210,12 +208,9 @@ def detect_convo_room(content: str) -> str:
 
 
 def get_collection(palace_path: str):
-    os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
-    try:
-        return client.get_collection("mempalace_drawers")
-    except Exception:
-        return client.create_collection("mempalace_drawers")
+    from .storage import get_collection as _get_storage_collection
+
+    return _get_storage_collection("mempalace_drawers", create=True, palace_path=palace_path)
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -5,34 +5,16 @@ knowledge_graph.py — Temporal Entity-Relationship Graph for MemPalace
 Real knowledge graph with:
   - Entity nodes (people, projects, tools, concepts)
   - Typed relationship edges (daughter_of, does, loves, works_on, etc.)
-  - Temporal validity (valid_from → valid_to — knows WHEN facts are true)
+  - Temporal validity (valid_from -> valid_to -- knows WHEN facts are true)
   - Closet references (links back to the verbatim memory)
 
-Storage: SQLite (local, no dependencies, no subscriptions)
-Query: entity-first traversal with time filtering
-
-This is what competes with Zep's temporal knowledge graph.
-Zep uses Neo4j in the cloud ($25/mo+). We use SQLite locally (free).
+Backends:
+  - SQLite (default, local, no dependencies)
+  - Elasticsearch (when graph_backend="elasticsearch" in config)
 
 Usage:
-    from mempalace.knowledge_graph import KnowledgeGraph
-
-    kg = KnowledgeGraph()
-    kg.add_triple("Max", "child_of", "Alice", valid_from="2015-04-01")
-    kg.add_triple("Max", "does", "swimming", valid_from="2025-01-01")
-    kg.add_triple("Max", "loves", "chess", valid_from="2025-10-01")
-
-    # Query: everything about Max
-    kg.query_entity("Max")
-
-    # Query: what was true about Max in January 2026?
-    kg.query_entity("Max", as_of="2026-01-15")
-
-    # Query: who is connected to Alice?
-    kg.query_entity("Alice", direction="both")
-
-    # Invalidate: Max's sports injury resolved
-    kg.invalidate("Max", "has_issue", "sports_injury", ended="2026-02-15")
+    from mempalace.knowledge_graph import get_knowledge_graph
+    kg = get_knowledge_graph()
 """
 
 import hashlib
@@ -382,3 +364,386 @@ class KnowledgeGraph:
             # Interests
             for interest in facts.get("interests", []):
                 self.add_triple(name, "loves", interest.capitalize(), valid_from="2025-01-01")
+
+
+# =============================================================================
+# Elasticsearch Knowledge Graph
+# =============================================================================
+
+
+class ElasticsearchKnowledgeGraph:
+    """Knowledge graph stored in Elasticsearch indices.
+
+    Uses two indices:
+      - {prefix}-kg-entities: entity nodes
+      - {prefix}-kg-triples: relationship triples
+    """
+
+    def __init__(self, config=None):
+        from .config import MempalaceConfig
+
+        config = config or MempalaceConfig()
+        es_conf = config._file_config.get("elasticsearch", {})
+
+        self._prefix = es_conf.get("index_prefix", "mempalace")
+        self._entities_index = f"{self._prefix}-kg-entities"
+        self._triples_index = f"{self._prefix}-kg-triples"
+
+        try:
+            from elasticsearch import Elasticsearch
+        except ImportError:
+            raise ImportError(
+                "elasticsearch package required for ES graph backend. "
+                "Install with: pip install 'mempalace[elasticsearch]'"
+            )
+
+        hosts = es_conf.get("hosts", ["http://localhost:9200"])
+        api_key = es_conf.get("api_key")
+        connect_kwargs = {"hosts": hosts, "request_timeout": 30}
+        if api_key:
+            connect_kwargs["api_key"] = api_key
+
+        self._es = Elasticsearch(**connect_kwargs)
+        self._ensure_indices()
+
+    def _ensure_indices(self):
+        if not self._es.indices.exists(index=self._entities_index):
+            self._es.indices.create(
+                index=self._entities_index,
+                body={
+                    "mappings": {
+                        "properties": {
+                            "name": {"type": "keyword"},
+                            "name_text": {"type": "text"},
+                            "type": {"type": "keyword"},
+                            "properties": {"type": "text"},
+                            "created_at": {"type": "keyword"},
+                        }
+                    }
+                },
+            )
+        if not self._es.indices.exists(index=self._triples_index):
+            self._es.indices.create(
+                index=self._triples_index,
+                body={
+                    "mappings": {
+                        "properties": {
+                            "subject": {"type": "keyword"},
+                            "predicate": {"type": "keyword"},
+                            "object": {"type": "keyword"},
+                            "subject_name": {"type": "text"},
+                            "object_name": {"type": "text"},
+                            "valid_from": {"type": "keyword"},
+                            "valid_to": {"type": "keyword"},
+                            "confidence": {"type": "float"},
+                            "source_closet": {"type": "keyword"},
+                            "source_file": {"type": "keyword"},
+                            "extracted_at": {"type": "keyword"},
+                        }
+                    }
+                },
+            )
+
+    def _entity_id(self, name: str) -> str:
+        return name.lower().replace(" ", "_").replace("'", "")
+
+    def add_entity(self, name: str, entity_type: str = "unknown", properties: dict = None):
+        eid = self._entity_id(name)
+        self._es.index(
+            index=self._entities_index,
+            id=eid,
+            document={
+                "name": name,
+                "name_text": name,
+                "type": entity_type,
+                "properties": json.dumps(properties or {}),
+                "created_at": datetime.now().isoformat(),
+            },
+            refresh="wait_for",
+        )
+        return eid
+
+    def add_triple(
+        self,
+        subject,
+        predicate,
+        obj,
+        valid_from=None,
+        valid_to=None,
+        confidence=1.0,
+        source_closet=None,
+        source_file=None,
+    ):
+        sub_id = self._entity_id(subject)
+        obj_id = self._entity_id(obj)
+        pred = predicate.lower().replace(" ", "_")
+
+        # Auto-create entities
+        for eid, name in [(sub_id, subject), (obj_id, obj)]:
+            if not self._es.exists(index=self._entities_index, id=eid):
+                self._es.index(
+                    index=self._entities_index,
+                    id=eid,
+                    document={"name": name, "name_text": name, "type": "unknown", "properties": "{}"},
+                )
+
+        # Check for existing active triple
+        existing = self._es.search(
+            index=self._triples_index,
+            query={
+                "bool": {
+                    "must": [
+                        {"term": {"subject": sub_id}},
+                        {"term": {"predicate": pred}},
+                        {"term": {"object": obj_id}},
+                    ],
+                    "must_not": [{"exists": {"field": "valid_to"}}],
+                }
+            },
+            size=1,
+        )
+        if existing["hits"]["hits"]:
+            return existing["hits"]["hits"][0]["_id"]
+
+        triple_id = (
+            f"t_{sub_id}_{pred}_{obj_id}_"
+            f"{hashlib.md5(f'{valid_from}{datetime.now().isoformat()}'.encode()).hexdigest()[:8]}"
+        )
+        self._es.index(
+            index=self._triples_index,
+            id=triple_id,
+            document={
+                "subject": sub_id,
+                "predicate": pred,
+                "object": obj_id,
+                "subject_name": subject,
+                "object_name": obj,
+                "valid_from": valid_from,
+                "valid_to": valid_to,
+                "confidence": confidence,
+                "source_closet": source_closet,
+                "source_file": source_file,
+                "extracted_at": datetime.now().isoformat(),
+            },
+            refresh="wait_for",
+        )
+        return triple_id
+
+    def invalidate(self, subject, predicate, obj, ended=None):
+        sub_id = self._entity_id(subject)
+        obj_id = self._entity_id(obj)
+        pred = predicate.lower().replace(" ", "_")
+        ended = ended or date.today().isoformat()
+
+        self._es.update_by_query(
+            index=self._triples_index,
+            body={
+                "script": {"source": f"ctx._source.valid_to = '{ended}'"},
+                "query": {
+                    "bool": {
+                        "must": [
+                            {"term": {"subject": sub_id}},
+                            {"term": {"predicate": pred}},
+                            {"term": {"object": obj_id}},
+                        ],
+                        "must_not": [{"exists": {"field": "valid_to"}}],
+                    }
+                },
+            },
+            refresh=True,
+        )
+
+    def query_entity(self, name, as_of=None, direction="outgoing"):
+        eid = self._entity_id(name)
+        results = []
+
+        if direction in ("outgoing", "both"):
+            results.extend(self._query_direction(name, eid, "subject", "object", as_of, "outgoing"))
+        if direction in ("incoming", "both"):
+            results.extend(self._query_direction(name, eid, "object", "subject", as_of, "incoming"))
+        return results
+
+    def _query_direction(self, name, eid, match_field, other_field, as_of, direction):
+        must = [{"term": {match_field: eid}}]
+        if as_of:
+            must.append(
+                {
+                    "bool": {
+                        "should": [
+                            {"bool": {"must_not": [{"exists": {"field": "valid_from"}}]}},
+                            {"range": {"valid_from": {"lte": as_of}}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+            must.append(
+                {
+                    "bool": {
+                        "should": [
+                            {"bool": {"must_not": [{"exists": {"field": "valid_to"}}]}},
+                            {"range": {"valid_to": {"gte": as_of}}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+
+        resp = self._es.search(index=self._triples_index, query={"bool": {"must": must}}, size=1000)
+
+        results = []
+        for hit in resp["hits"]["hits"]:
+            src = hit["_source"]
+            other_name = src.get("object_name", src["object"]) if direction == "outgoing" else src.get("subject_name", src["subject"])
+            results.append(
+                {
+                    "direction": direction,
+                    "subject": name if direction == "outgoing" else other_name,
+                    "predicate": src["predicate"],
+                    "object": other_name if direction == "outgoing" else name,
+                    "valid_from": src.get("valid_from"),
+                    "valid_to": src.get("valid_to"),
+                    "confidence": src.get("confidence", 1.0),
+                    "source_closet": src.get("source_closet"),
+                    "current": src.get("valid_to") is None,
+                }
+            )
+        return results
+
+    def query_relationship(self, predicate, as_of=None):
+        pred = predicate.lower().replace(" ", "_")
+        must = [{"term": {"predicate": pred}}]
+        if as_of:
+            must.append(
+                {
+                    "bool": {
+                        "should": [
+                            {"bool": {"must_not": [{"exists": {"field": "valid_from"}}]}},
+                            {"range": {"valid_from": {"lte": as_of}}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+            must.append(
+                {
+                    "bool": {
+                        "should": [
+                            {"bool": {"must_not": [{"exists": {"field": "valid_to"}}]}},
+                            {"range": {"valid_to": {"gte": as_of}}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+
+        resp = self._es.search(index=self._triples_index, query={"bool": {"must": must}}, size=1000)
+        return [
+            {
+                "subject": h["_source"].get("subject_name", h["_source"]["subject"]),
+                "predicate": pred,
+                "object": h["_source"].get("object_name", h["_source"]["object"]),
+                "valid_from": h["_source"].get("valid_from"),
+                "valid_to": h["_source"].get("valid_to"),
+                "current": h["_source"].get("valid_to") is None,
+            }
+            for h in resp["hits"]["hits"]
+        ]
+
+    def timeline(self, entity_name=None):
+        if entity_name:
+            eid = self._entity_id(entity_name)
+            query = {
+                "bool": {
+                    "should": [{"term": {"subject": eid}}, {"term": {"object": eid}}],
+                    "minimum_should_match": 1,
+                }
+            }
+        else:
+            query = {"match_all": {}}
+
+        resp = self._es.search(
+            index=self._triples_index,
+            query=query,
+            sort=[{"valid_from": {"order": "asc", "missing": "_last"}}],
+            size=100,
+        )
+        return [
+            {
+                "subject": h["_source"].get("subject_name", h["_source"]["subject"]),
+                "predicate": h["_source"]["predicate"],
+                "object": h["_source"].get("object_name", h["_source"]["object"]),
+                "valid_from": h["_source"].get("valid_from"),
+                "valid_to": h["_source"].get("valid_to"),
+                "current": h["_source"].get("valid_to") is None,
+            }
+            for h in resp["hits"]["hits"]
+        ]
+
+    def stats(self):
+        entities = self._es.count(index=self._entities_index)["count"]
+        triples = self._es.count(index=self._triples_index)["count"]
+        current = self._es.count(
+            index=self._triples_index,
+            query={"bool": {"must_not": [{"exists": {"field": "valid_to"}}]}},
+        )["count"]
+
+        preds_resp = self._es.search(
+            index=self._triples_index,
+            size=0,
+            aggs={"predicates": {"terms": {"field": "predicate", "size": 100}}},
+        )
+        predicates = [
+            b["key"] for b in preds_resp["aggregations"]["predicates"]["buckets"]
+        ]
+
+        return {
+            "entities": entities,
+            "triples": triples,
+            "current_facts": current,
+            "expired_facts": triples - current,
+            "relationship_types": sorted(predicates),
+        }
+
+    def seed_from_entity_facts(self, entity_facts):
+        for key, facts in entity_facts.items():
+            name = facts.get("full_name", key.capitalize())
+            etype = facts.get("type", "person")
+            self.add_entity(
+                name,
+                etype,
+                {"gender": facts.get("gender", ""), "birthday": facts.get("birthday", "")},
+            )
+            parent = facts.get("parent")
+            if parent:
+                self.add_triple(name, "child_of", parent.capitalize(), valid_from=facts.get("birthday"))
+            partner = facts.get("partner")
+            if partner:
+                self.add_triple(name, "married_to", partner.capitalize())
+            relationship = facts.get("relationship", "")
+            if relationship == "daughter":
+                self.add_triple(name, "is_child_of", facts.get("parent", "").capitalize() or name, valid_from=facts.get("birthday"))
+            elif relationship == "husband":
+                self.add_triple(name, "is_partner_of", facts.get("partner", name).capitalize())
+            elif relationship == "brother":
+                self.add_triple(name, "is_sibling_of", facts.get("sibling", name).capitalize())
+            elif relationship == "dog":
+                self.add_triple(name, "is_pet_of", facts.get("owner", name).capitalize())
+                self.add_entity(name, "animal")
+            for interest in facts.get("interests", []):
+                self.add_triple(name, "loves", interest.capitalize(), valid_from="2025-01-01")
+
+
+# =============================================================================
+# Factory
+# =============================================================================
+
+
+def get_knowledge_graph(config=None):
+    """Return the appropriate KnowledgeGraph backend based on configuration."""
+    from .config import MempalaceConfig
+
+    config = config or MempalaceConfig()
+    if config.graph_backend == "elasticsearch":
+        return ElasticsearchKnowledgeGraph(config)
+    return KnowledgeGraph()

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -21,9 +21,8 @@ import sys
 from pathlib import Path
 from collections import defaultdict
 
-import chromadb
-
 from .config import MempalaceConfig
+from .storage import get_collection as _get_storage_collection
 
 
 # ---------------------------------------------------------------------------
@@ -89,10 +88,9 @@ class Layer1:
         self.wing = wing
 
     def generate(self) -> str:
-        """Pull top drawers from ChromaDB and format as compact L1 text."""
+        """Pull top drawers from the palace and format as compact L1 text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = _get_storage_collection("mempalace_drawers")
         except Exception:
             return "## L1 — No palace found. Run: mempalace mine <dir>"
 
@@ -187,8 +185,7 @@ class Layer2:
     def retrieve(self, wing: str = None, room: str = None, n_results: int = 10) -> str:
         """Retrieve drawers filtered by wing and/or room."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = _get_storage_collection("mempalace_drawers")
         except Exception:
             return "No palace found."
 
@@ -251,8 +248,7 @@ class Layer3:
     def search(self, query: str, wing: str = None, room: str = None, n_results: int = 5) -> str:
         """Semantic search, returns compact result text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = _get_storage_collection("mempalace_drawers")
         except Exception:
             return "No palace found."
 
@@ -307,8 +303,7 @@ class Layer3:
     ) -> list:
         """Return raw dicts instead of formatted text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = _get_storage_collection("mempalace_drawers")
         except Exception:
             return []
 
@@ -426,10 +421,8 @@ class MemoryStack:
             },
         }
 
-        # Count drawers
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = _get_storage_collection("mempalace_drawers")
             count = col.count()
             result["total_drawers"] = count
         except Exception:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -26,25 +26,20 @@ from datetime import datetime
 from .config import MempalaceConfig
 from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
-import chromadb
-
-from .knowledge_graph import KnowledgeGraph
-
-_kg = KnowledgeGraph()
+from .storage import get_collection as _get_storage_collection
+from .knowledge_graph import get_knowledge_graph
 
 logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
 logger = logging.getLogger("mempalace_mcp")
 
 _config = MempalaceConfig()
+_kg = get_knowledge_graph(_config)
 
 
 def _get_collection(create=False):
-    """Return the ChromaDB collection, or None on failure."""
+    """Return the storage collection, or None on failure."""
     try:
-        client = chromadb.PersistentClient(path=_config.palace_path)
-        if create:
-            return client.get_or_create_collection(_config.collection_name)
-        return client.get_collection(_config.collection_name)
+        return _get_storage_collection(_config.collection_name, create=create, config=_config)
     except Exception:
         return None
 

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -14,8 +14,6 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-import chromadb
-
 READABLE_EXTENSIONS = {
     ".txt",
     ".md",
@@ -181,12 +179,9 @@ def chunk_text(content: str, source_file: str) -> list:
 
 
 def get_collection(palace_path: str):
-    os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
-    try:
-        return client.get_collection("mempalace_drawers")
-    except Exception:
-        return client.create_collection("mempalace_drawers")
+    from .storage import get_collection as _get_storage_collection
+
+    return _get_storage_collection("mempalace_drawers", create=True, palace_path=palace_path)
 
 
 def file_already_mined(collection, source_file: str) -> bool:
@@ -390,9 +385,10 @@ def mine(
 
 def status(palace_path: str):
     """Show what's been filed in the palace."""
+    from .storage import get_collection as _get_storage_collection
+
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = _get_storage_collection("mempalace_drawers")
     except Exception:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -17,15 +17,13 @@ No external graph DB needed — built from ChromaDB metadata.
 
 from collections import defaultdict, Counter
 from .config import MempalaceConfig
-
-import chromadb
+from .storage import get_collection as _get_storage_collection
 
 
 def _get_collection(config=None):
     config = config or MempalaceConfig()
     try:
-        client = chromadb.PersistentClient(path=config.palace_path)
-        return client.get_collection(config.collection_name)
+        return _get_storage_collection(config.collection_name, config=config)
     except Exception:
         return None
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -9,7 +9,8 @@ Returns verbatim text — the actual words, never summaries.
 import sys
 from pathlib import Path
 
-import chromadb
+from .config import MempalaceConfig
+from .storage import get_collection
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
@@ -18,8 +19,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     Optionally filter by wing (project) or room (aspect).
     """
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = get_collection("mempalace_drawers")
     except Exception:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
@@ -92,8 +92,7 @@ def search_memories(
     Used by the MCP server and other callers that need data.
     """
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = get_collection("mempalace_drawers")
     except Exception as e:
         return {"error": f"No palace found at {palace_path}: {e}"}
 

--- a/mempalace/storage/__init__.py
+++ b/mempalace/storage/__init__.py
@@ -1,0 +1,9 @@
+"""Storage abstraction layer for MemPalace.
+
+Provides a unified interface for different storage backends (ChromaDB, Elasticsearch).
+"""
+
+from .base import BaseCollection
+from .factory import get_collection
+
+__all__ = ["BaseCollection", "get_collection"]

--- a/mempalace/storage/base.py
+++ b/mempalace/storage/base.py
@@ -1,0 +1,42 @@
+"""Abstract base class for storage backends.
+
+Return format mirrors ChromaDB's dict structure so callers need minimal changes:
+    {"ids": [...], "documents": [...], "metadatas": [...], "distances": [...]}
+"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseCollection(ABC):
+    """Abstract collection interface matching the ChromaDB collection API surface."""
+
+    @abstractmethod
+    def add(self, ids, documents, metadatas=None):
+        """Add documents with IDs and optional metadata."""
+
+    @abstractmethod
+    def get(self, ids=None, where=None, include=None, limit=None, offset=None):
+        """Retrieve documents by IDs or metadata filters.
+
+        Returns dict with keys: ids, documents, metadatas (based on include).
+        """
+
+    @abstractmethod
+    def query(self, query_texts, n_results=5, where=None, include=None):
+        """Semantic search against the collection.
+
+        Returns dict with keys: ids, documents, metadatas, distances
+        (each a list-of-lists matching ChromaDB convention).
+        """
+
+    @abstractmethod
+    def delete(self, ids):
+        """Delete documents by IDs."""
+
+    @abstractmethod
+    def count(self):
+        """Return total document count."""
+
+    @abstractmethod
+    def upsert(self, ids, documents, metadatas=None):
+        """Insert or update documents."""

--- a/mempalace/storage/chromadb_backend.py
+++ b/mempalace/storage/chromadb_backend.py
@@ -1,0 +1,83 @@
+"""ChromaDB storage backend — wraps chromadb.PersistentClient into BaseCollection."""
+
+import os
+
+import chromadb
+
+from .base import BaseCollection
+
+
+class ChromaCollection(BaseCollection):
+    """Thin wrapper around a ChromaDB collection implementing BaseCollection."""
+
+    def __init__(self, name="mempalace_drawers", config=None, create=False, palace_path=None):
+        from ..config import MempalaceConfig
+
+        config = config or MempalaceConfig()
+        palace_path = palace_path or config.palace_path
+        os.makedirs(palace_path, exist_ok=True)
+
+        self._client = chromadb.PersistentClient(path=palace_path)
+        try:
+            if create:
+                self._col = self._client.get_or_create_collection(name)
+            else:
+                self._col = self._client.get_collection(name)
+        except Exception:
+            self._col = None
+
+    @property
+    def _ready(self):
+        return self._col is not None
+
+    def add(self, ids, documents, metadatas=None):
+        if not self._ready:
+            raise RuntimeError("Collection not available")
+        kwargs = {"ids": ids, "documents": documents}
+        if metadatas is not None:
+            kwargs["metadatas"] = metadatas
+        self._col.add(**kwargs)
+
+    def get(self, ids=None, where=None, include=None, limit=None, offset=None):
+        if not self._ready:
+            return {"ids": [], "documents": [], "metadatas": []}
+        kwargs = {}
+        if ids is not None:
+            kwargs["ids"] = ids
+        if where:
+            kwargs["where"] = where
+        if include is not None:
+            kwargs["include"] = include
+        if limit is not None:
+            kwargs["limit"] = limit
+        if offset is not None:
+            kwargs["offset"] = offset
+        return self._col.get(**kwargs)
+
+    def query(self, query_texts, n_results=5, where=None, include=None):
+        if not self._ready:
+            return {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]}
+        kwargs = {"query_texts": query_texts, "n_results": n_results}
+        if where:
+            kwargs["where"] = where
+        if include is not None:
+            kwargs["include"] = include
+        return self._col.query(**kwargs)
+
+    def delete(self, ids):
+        if not self._ready:
+            return
+        self._col.delete(ids=ids)
+
+    def count(self):
+        if not self._ready:
+            return 0
+        return self._col.count()
+
+    def upsert(self, ids, documents, metadatas=None):
+        if not self._ready:
+            raise RuntimeError("Collection not available")
+        kwargs = {"ids": ids, "documents": documents}
+        if metadatas is not None:
+            kwargs["metadatas"] = metadatas
+        self._col.upsert(**kwargs)

--- a/mempalace/storage/elasticsearch_backend.py
+++ b/mempalace/storage/elasticsearch_backend.py
@@ -1,0 +1,386 @@
+"""Elasticsearch storage backend using semantic_text + inference endpoints.
+
+Uses Elastic inference endpoints for:
+  - Embeddings: configured via inference_id (e.g. .jina-embeddings-v5-text-small)
+  - Reranking: configured via rerank_id (e.g. .jina-reranker-v2)
+
+The semantic_text field type handles embedding generation automatically at index
+and query time. Reranking is applied via the text_similarity_reranker retriever.
+"""
+
+import logging
+
+from .base import BaseCollection
+
+logger = logging.getLogger("mempalace.elasticsearch")
+
+_METADATA_KEYWORD_FIELDS = {
+    "wing",
+    "room",
+    "source_file",
+    "added_by",
+    "hall",
+    "topic",
+    "type",
+    "agent",
+    "date",
+    "ingest_mode",
+    "extract_mode",
+}
+
+_METADATA_NUMERIC_FIELDS = {
+    "chunk_index",
+    "importance",
+    "emotional_weight",
+    "weight",
+    "compression_ratio",
+    "original_tokens",
+}
+
+
+def _es_config(config):
+    """Extract elasticsearch settings from MempalaceConfig."""
+    return config._file_config.get("elasticsearch", {})
+
+
+def _build_index_name(prefix, collection_name):
+    return f"{prefix}-{collection_name}"
+
+
+def _where_to_es_filter(where):
+    """Translate ChromaDB where-filter syntax to ES query DSL.
+
+    Supports:
+        {"field": "value"}            -> {"term": {"field": "value"}}
+        {"$and": [{...}, {...}]}      -> {"bool": {"must": [...]}}
+        {"$or": [{...}, {...}]}       -> {"bool": {"should": [...]}}
+    """
+    if not where:
+        return None
+
+    if "$and" in where:
+        clauses = [_where_to_es_filter(clause) for clause in where["$and"]]
+        return {"bool": {"must": [c for c in clauses if c]}}
+
+    if "$or" in where:
+        clauses = [_where_to_es_filter(clause) for clause in where["$or"]]
+        return {"bool": {"should": [c for c in clauses if c], "minimum_should_match": 1}}
+
+    terms = []
+    for key, value in where.items():
+        terms.append({"term": {key: value}})
+
+    if len(terms) == 1:
+        return terms[0]
+    return {"bool": {"must": terms}}
+
+
+def _hit_to_metadata(hit):
+    """Extract flat metadata dict from an ES hit's _source."""
+    source = hit["_source"]
+    meta = {}
+    for key, value in source.items():
+        if key in ("content", "content_text"):
+            continue
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            meta[key] = value
+    return meta
+
+
+class ElasticsearchCollection(BaseCollection):
+    """Elasticsearch collection using semantic_text for embeddings and reranker for search."""
+
+    def __init__(self, name="mempalace_drawers", config=None, create=False):
+        from ..config import MempalaceConfig
+
+        config = config or MempalaceConfig()
+        es_conf = _es_config(config)
+
+        self._index_prefix = es_conf.get("index_prefix", "mempalace")
+        self._index = _build_index_name(self._index_prefix, name)
+        self._inference_id = es_conf.get("inference_id", ".jina-embeddings-v5-text-small")
+        self._rerank_id = es_conf.get("rerank_id", ".jina-reranker-v2")
+
+        try:
+            from elasticsearch import Elasticsearch
+        except ImportError:
+            raise ImportError(
+                "elasticsearch package required for ES backend. "
+                "Install with: pip install 'mempalace[elasticsearch]'"
+            )
+
+        hosts = es_conf.get("hosts", ["http://localhost:9200"])
+        api_key = es_conf.get("api_key")
+
+        connect_kwargs = {"hosts": hosts, "request_timeout": 30}
+        if api_key:
+            connect_kwargs["api_key"] = api_key
+
+        self._es = Elasticsearch(**connect_kwargs)
+        self._ready = False
+
+        if create:
+            self._ensure_index()
+        else:
+            self._ready = self._es.indices.exists(index=self._index)
+
+    def _ensure_index(self):
+        """Create the index with semantic_text mapping if it doesn't exist."""
+        if self._es.indices.exists(index=self._index):
+            self._ready = True
+            return
+
+        mapping = {
+            "mappings": {
+                "properties": {
+                    "content": {
+                        "type": "semantic_text",
+                        "inference_id": self._inference_id,
+                    },
+                    "content_text": {"type": "text"},
+                    "wing": {"type": "keyword"},
+                    "room": {"type": "keyword"},
+                    "source_file": {"type": "keyword"},
+                    "added_by": {"type": "keyword"},
+                    "filed_at": {"type": "keyword"},
+                    "hall": {"type": "keyword"},
+                    "topic": {"type": "keyword"},
+                    "type": {"type": "keyword"},
+                    "agent": {"type": "keyword"},
+                    "date": {"type": "keyword"},
+                    "ingest_mode": {"type": "keyword"},
+                    "extract_mode": {"type": "keyword"},
+                    "chunk_index": {"type": "integer"},
+                    "importance": {"type": "float"},
+                    "emotional_weight": {"type": "float"},
+                    "weight": {"type": "float"},
+                    "compression_ratio": {"type": "float"},
+                    "original_tokens": {"type": "integer"},
+                }
+            }
+        }
+
+        self._es.indices.create(index=self._index, body=mapping)
+        self._ready = True
+        logger.info(f"Created index {self._index} with inference_id={self._inference_id}")
+
+    def add(self, ids, documents, metadatas=None):
+        if not self._ready:
+            self._ensure_index()
+
+        ops = []
+        for i, (doc_id, doc) in enumerate(zip(ids, documents)):
+            body = {"content": doc, "content_text": doc}
+            if metadatas and i < len(metadatas):
+                for key, value in metadatas[i].items():
+                    body[key] = value
+            ops.append({"index": {"_index": self._index, "_id": doc_id}})
+            ops.append(body)
+
+        if ops:
+            resp = self._es.bulk(operations=ops, refresh="wait_for")
+            if resp.get("errors"):
+                for item in resp["items"]:
+                    action = item.get("index", item.get("create", {}))
+                    if action.get("error"):
+                        err = action["error"]
+                        raise RuntimeError(
+                            f"Bulk index error for {action.get('_id')}: "
+                            f"{err.get('type')}: {err.get('reason')}"
+                        )
+
+    def get(self, ids=None, where=None, include=None, limit=None, offset=None):
+        if not self._ready:
+            return {"ids": [], "documents": [], "metadatas": []}
+
+        if ids is not None:
+            return self._get_by_ids(ids, include)
+
+        return self._get_by_filter(where, include, limit, offset)
+
+    def _get_by_ids(self, ids, include=None):
+        try:
+            resp = self._es.mget(index=self._index, ids=ids)
+        except Exception:
+            return {"ids": [], "documents": [], "metadatas": []}
+
+        result_ids = []
+        result_docs = []
+        result_metas = []
+
+        for doc in resp.get("docs", []):
+            if not doc.get("found"):
+                continue
+            result_ids.append(doc["_id"])
+            source = doc["_source"]
+            if include is None or "documents" in include:
+                result_docs.append(source.get("content_text", ""))
+            if include is None or "metadatas" in include:
+                result_metas.append(_hit_to_metadata(doc))
+
+        result = {"ids": result_ids}
+        if include is None or "documents" in include:
+            result["documents"] = result_docs
+        if include is None or "metadatas" in include:
+            result["metadatas"] = result_metas
+        return result
+
+    def _get_by_filter(self, where, include=None, limit=None, offset=None):
+        query_body = {"match_all": {}}
+        es_filter = _where_to_es_filter(where)
+        if es_filter:
+            query_body = {"bool": {"must": [{"match_all": {}}, es_filter]}}
+
+        search_kwargs = {
+            "index": self._index,
+            "query": query_body,
+            "size": limit or 10000,
+        }
+        if offset:
+            search_kwargs["from_"] = offset
+
+        try:
+            resp = self._es.search(**search_kwargs)
+        except Exception:
+            return {"ids": [], "documents": [], "metadatas": []}
+
+        result_ids = []
+        result_docs = []
+        result_metas = []
+
+        for hit in resp["hits"]["hits"]:
+            result_ids.append(hit["_id"])
+            source = hit["_source"]
+            if include is None or "documents" in include:
+                result_docs.append(source.get("content_text", ""))
+            if include is None or "metadatas" in include:
+                result_metas.append(_hit_to_metadata(hit))
+
+        result = {"ids": result_ids}
+        if include is None or "documents" in include:
+            result["documents"] = result_docs
+        if include is None or "metadatas" in include:
+            result["metadatas"] = result_metas
+        return result
+
+    def query(self, query_texts, n_results=5, where=None, include=None):
+        """Semantic search with optional reranking.
+
+        First stage: semantic query against the content field (uses inference endpoint).
+        Second stage: rerank top results via text_similarity_reranker.
+        """
+        if not self._ready:
+            return {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+        text = query_texts[0] if query_texts else ""
+        rank_window = max(n_results * 5, 25)
+
+        inner_retriever = {
+            "standard": {
+                "query": self._build_semantic_query(text, where),
+            }
+        }
+
+        retriever = {
+            "text_similarity_reranker": {
+                "retriever": inner_retriever,
+                "field": "content_text",
+                "inference_id": self._rerank_id,
+                "inference_text": text,
+                "rank_window_size": rank_window,
+            }
+        }
+
+        try:
+            resp = self._es.search(
+                index=self._index,
+                retriever=retriever,
+                size=n_results,
+            )
+        except Exception as e:
+            logger.warning(f"Reranker search failed, falling back to semantic-only: {e}")
+            resp = self._search_semantic_only(text, where, n_results)
+
+        return self._format_query_response(resp, include)
+
+    def _build_semantic_query(self, text, where=None):
+        semantic = {"semantic": {"field": "content", "query": text}}
+        es_filter = _where_to_es_filter(where)
+        if es_filter:
+            return {"bool": {"must": [semantic], "filter": [es_filter]}}
+        return semantic
+
+    def _search_semantic_only(self, text, where, n_results):
+        """Fallback when reranker is unavailable."""
+        query = self._build_semantic_query(text, where)
+        return self._es.search(index=self._index, query=query, size=n_results)
+
+    def _format_query_response(self, resp, include=None):
+        """Convert ES search response to ChromaDB-compatible query result format.
+
+        Normalizes ES scores to a 0-1 distance range to match ChromaDB convention
+        where callers compute similarity = 1 - distance.
+        """
+        all_ids = []
+        all_docs = []
+        all_metas = []
+        all_dists = []
+
+        hits = resp["hits"]["hits"]
+        max_score = hits[0]["_score"] if hits else 1.0
+        max_score = max(max_score, 1e-9)
+
+        for hit in hits:
+            all_ids.append(hit["_id"])
+            source = hit["_source"]
+
+            if include is None or "documents" in include:
+                all_docs.append(source.get("content_text", ""))
+            if include is None or "metadatas" in include:
+                all_metas.append(_hit_to_metadata(hit))
+            if include is None or "distances" in include:
+                score = hit.get("_score", 0)
+                similarity = min(score / max_score, 1.0)
+                distance = 1.0 - similarity
+                all_dists.append(round(distance, 6))
+
+        result = {"ids": [all_ids]}
+        if include is None or "documents" in include:
+            result["documents"] = [all_docs]
+        if include is None or "metadatas" in include:
+            result["metadatas"] = [all_metas]
+        if include is None or "distances" in include:
+            result["distances"] = [all_dists]
+        return result
+
+    def delete(self, ids):
+        if not self._ready:
+            return
+        ops = [{"delete": {"_index": self._index, "_id": doc_id}} for doc_id in ids]
+        if ops:
+            self._es.bulk(operations=ops, refresh="wait_for")
+
+    def count(self):
+        if not self._ready:
+            return 0
+        try:
+            resp = self._es.count(index=self._index)
+            return resp["count"]
+        except Exception:
+            return 0
+
+    def upsert(self, ids, documents, metadatas=None):
+        if not self._ready:
+            self._ensure_index()
+
+        ops = []
+        for i, (doc_id, doc) in enumerate(zip(ids, documents)):
+            body = {"content": doc, "content_text": doc}
+            if metadatas and i < len(metadatas):
+                for key, value in metadatas[i].items():
+                    body[key] = value
+            ops.append({"index": {"_index": self._index, "_id": doc_id}})
+            ops.append(body)
+
+        if ops:
+            self._es.bulk(operations=ops, refresh="wait_for")

--- a/mempalace/storage/factory.py
+++ b/mempalace/storage/factory.py
@@ -1,0 +1,28 @@
+"""Factory for creating storage backend collections based on configuration."""
+
+from ..config import MempalaceConfig
+
+
+def get_collection(name="mempalace_drawers", create=False, config=None, palace_path=None):
+    """Return a collection for the configured storage backend.
+
+    Args:
+        name: Collection / index name.
+        create: If True, create the collection if it doesn't exist.
+        config: MempalaceConfig instance (uses default if None).
+        palace_path: Override palace path for ChromaDB backend (ignored by ES).
+
+    Returns:
+        A BaseCollection implementation (ChromaCollection or ElasticsearchCollection).
+    """
+    config = config or MempalaceConfig()
+    backend = config.storage_backend
+
+    if backend == "elasticsearch":
+        from .elasticsearch_backend import ElasticsearchCollection
+
+        return ElasticsearchCollection(name, config=config, create=create)
+    else:
+        from .chromadb_backend import ChromaCollection
+
+        return ChromaCollection(name, config=config, create=create, palace_path=palace_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ name = "mempalace"
 version = "3.0.0"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 authors = [
     {name = "milla-jovovich"},
 ]
 keywords = [
-    "ai", "memory", "llm", "rag", "chromadb", "mcp",
+    "ai", "memory", "llm", "rag", "chromadb", "elasticsearch", "mcp",
     "vector-database", "claude", "chatgpt", "embeddings",
 ]
 classifiers = [
@@ -21,10 +21,10 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Utilities",
 ]
@@ -45,11 +45,12 @@ include = ["mempalace*"]
 mempalace = "mempalace:main"
 
 [project.optional-dependencies]
+elasticsearch = ["elasticsearch>=9.0.0,<10.0.0"]
 dev = ["pytest>=7.0", "build>=1.0", "twine>=4.0"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W"]

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,26 +1,34 @@
 import os
 import tempfile
 import shutil
-import chromadb
 from mempalace.convo_miner import mine_convos
+from mempalace.storage import get_collection
 
 
 def test_convo_mining():
     tmpdir = tempfile.mkdtemp()
     with open(os.path.join(tmpdir, "chat.txt"), "w") as f:
         f.write(
-            "> What is memory?\nMemory is persistence.\n\n> Why does it matter?\nIt enables continuity.\n\n> How do we build it?\nWith structured storage.\n"
+            "> What is memory?\nMemory is persistence.\n\n"
+            "> Why does it matter?\nIt enables continuity.\n\n"
+            "> How do we build it?\nWith structured storage.\n"
         )
 
     palace_path = os.path.join(tmpdir, "palace")
-    mine_convos(tmpdir, palace_path, wing="test_convos")
 
-    client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_collection("mempalace_drawers")
-    assert col.count() >= 2
+    # Force chromadb backend for test isolation
+    old_env = os.environ.get("MEMPALACE_STORAGE_BACKEND")
+    os.environ["MEMPALACE_STORAGE_BACKEND"] = "chromadb"
+    try:
+        mine_convos(tmpdir, palace_path, wing="test_convos")
+        col = get_collection("mempalace_drawers", palace_path=palace_path)
+        assert col.count() >= 2
 
-    # Verify search works
-    results = col.query(query_texts=["memory persistence"], n_results=1)
-    assert len(results["documents"][0]) > 0
-
-    shutil.rmtree(tmpdir)
+        results = col.query(query_texts=["memory persistence"], n_results=1)
+        assert len(results["documents"][0]) > 0
+    finally:
+        if old_env is not None:
+            os.environ["MEMPALACE_STORAGE_BACKEND"] = old_env
+        else:
+            os.environ.pop("MEMPALACE_STORAGE_BACKEND", None)
+        shutil.rmtree(tmpdir)

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -1,18 +1,17 @@
+import json
 import os
 import tempfile
 import shutil
 import yaml
-import chromadb
 from mempalace.miner import mine
+from mempalace.storage import get_collection
 
 
 def test_project_mining():
     tmpdir = tempfile.mkdtemp()
-    # Create a mini project
     os.makedirs(os.path.join(tmpdir, "backend"))
     with open(os.path.join(tmpdir, "backend", "app.py"), "w") as f:
         f.write("def main():\n    print('hello world')\n" * 20)
-    # Create config
     with open(os.path.join(tmpdir, "mempalace.yaml"), "w") as f:
         yaml.dump(
             {
@@ -26,11 +25,17 @@ def test_project_mining():
         )
 
     palace_path = os.path.join(tmpdir, "palace")
-    mine(tmpdir, palace_path)
 
-    # Verify
-    client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_collection("mempalace_drawers")
-    assert col.count() > 0
-
-    shutil.rmtree(tmpdir)
+    # Force chromadb backend for test isolation
+    old_env = os.environ.get("MEMPALACE_STORAGE_BACKEND")
+    os.environ["MEMPALACE_STORAGE_BACKEND"] = "chromadb"
+    try:
+        mine(tmpdir, palace_path)
+        col = get_collection("mempalace_drawers", palace_path=palace_path)
+        assert col.count() > 0
+    finally:
+        if old_env is not None:
+            os.environ["MEMPALACE_STORAGE_BACKEND"] = old_env
+        else:
+            os.environ.pop("MEMPALACE_STORAGE_BACKEND", None)
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION


## What does this PR do?

Adding the option for additional storage providers, in this case Elasticsearch running models through GPU endpoints.

As default use Jina SOTA multi language models for reranking and embedding.

Sample config changes.
```json
~/.mempalace/config.json
{
  "palace_path": "~/.mempalace/palace",
  "storage_backend": "elasticsearch",
  "graph_backend": "elasticsearch",
  "elasticsearch": {
    "hosts": ["https://es-endpoint:443"],
    "api_key": "<INSERT_API_KEY",
    "index_prefix": "mempalace",
    "inference_id": ".jina-embeddings-v5-text-small",
    "rerank_id": ".jina-reranker-v2"
  }
}
```

## How to test

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
