### PR TITLE
fix: shell injection in hooks, Claude Code mining, chromadb pin

### DIFF
--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -81,10 +81,10 @@ fi
 
 # Count human messages in the JSONL transcript
 if [ -f "$TRANSCRIPT_PATH" ]; then
-    EXCHANGE_COUNT=$(python3 -c "
+    EXCHANGE_COUNT=$(python3 - "$TRANSCRIPT_PATH" <<'PYEOF'
 import json, sys
 count = 0
-with open('$TRANSCRIPT_PATH') as f:
+with open(sys.argv[1]) as f:
     for line in f:
         try:
             entry = json.loads(line)
@@ -98,7 +98,8 @@ with open('$TRANSCRIPT_PATH') as f:
         except:
             pass
 print(count)
-" 2>/dev/null)
+PYEOF
+2>/dev/null)
 else
     EXCHANGE_COUNT=0
 fi

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -39,6 +39,8 @@ SKIP_DIRS = {
     "build",
     ".next",
     ".mempalace",
+    "tool-results",
+    "memory",
 }
 
 MIN_CHUNK_SIZE = 30
@@ -238,6 +240,8 @@ def scan_convos(convo_dir: str) -> list:
     for root, dirs, filenames in os.walk(convo_path):
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
         for filename in filenames:
+            if filename.endswith(".meta.json"):
+                continue
             filepath = Path(root) / filename
             if filepath.suffix.lower() in CONVO_EXTENSIONS:
                 files.append(filepath)

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -81,7 +81,7 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
             continue
         msg_type = entry.get("type", "")
         message = entry.get("message", {})
-        if msg_type == "human":
+        if msg_type in ("human", "user"):
             text = _extract_content(message.get("content", ""))
             if text:
                 messages.append(("user", text))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "chromadb>=0.4.0",
+    "chromadb>=0.4.0,<1",
     "pyyaml>=6.0",
 ]
 


### PR DESCRIPTION
## Summary

- **#110** — Shell injection fix in `hooks/mempal_save_hook.sh`: `$TRANSCRIPT_PATH` passed as `sys.argv[1]` via heredoc instead of interpolated into a `python3 -c` string
- **#111** — Claude Code JSONL mining: accept `type: "user"` (not just `"human"`), skip `tool-results/` and `memory/` dirs, skip `.meta.json` files
- **#100** — Pin `chromadb>=0.4.0,<1` to avoid segfaulting 1.x Rust bindings on macOS ARM64

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest tests/ -v` — 9/9 pass