### PR TITLE
fix: Claude Code mining, hooks, split CLI, Chroma pin, status, Windows search

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -57,9 +57,17 @@ MEMPAL_DIR=""
 # Read JSON input from stdin
 INPUT=$(cat)
 
-SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | python3 -c "
+import json, re, sys
+try:
+    d = json.load(sys.stdin)
+except json.JSONDecodeError:
+    d = {}
+sid = str(d.get('session_id', 'unknown'))
+print(re.sub(r'[^a-zA-Z0-9._-]+', '_', sid)[:200])
+" 2>/dev/null)
 
-echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
+echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session ${SESSION_ID:-unknown}" >> "$STATE_DIR/hook.log"
 
 # Optional: run mempalace ingest synchronously so memories land before compaction
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -64,10 +64,24 @@ MEMPAL_DIR=""
 # Read JSON input from stdin
 INPUT=$(cat)
 
-# Parse fields from Claude Code's JSON
-SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
-STOP_HOOK_ACTIVE=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('stop_hook_active', False))" 2>/dev/null)
-TRANSCRIPT_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
+# Parse fields from Claude Code's JSON (one pass; path passed to Python via argv — #110)
+eval "$(echo "$INPUT" | python3 -c "
+import json, re, sys
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except json.JSONDecodeError:
+    d = {}
+sid = str(d.get('session_id', 'unknown'))
+sid_safe = re.sub(r'[^a-zA-Z0-9._-]+', '_', sid)[:200]
+tp = d.get('transcript_path', '') or ''
+sh = d.get('stop_hook_active', False)
+# Emit shell-safe assignments (no user-controlled strings in shell code)
+print('SESSION_ID=' + json.dumps(sid))
+print('SESSION_ID_SAFE=' + json.dumps(sid_safe))
+print('STOP_HOOK_ACTIVE=' + ('true' if sh else 'false'))
+print('TRANSCRIPT_PATH=' + json.dumps(tp))
+" 2>/dev/null)"
 
 # Expand ~ in path
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
@@ -79,32 +93,40 @@ if [ "$STOP_HOOK_ACTIVE" = "True" ] || [ "$STOP_HOOK_ACTIVE" = "true" ]; then
     exit 0
 fi
 
-# Count human messages in the JSONL transcript
+# Count user turns in the JSONL transcript (path via argv; type user|human — #110 / #111)
 if [ -f "$TRANSCRIPT_PATH" ]; then
     EXCHANGE_COUNT=$(python3 -c "
 import json, sys
+path = sys.argv[1]
 count = 0
-with open('$TRANSCRIPT_PATH') as f:
-    for line in f:
-        try:
-            entry = json.loads(line)
-            msg = entry.get('message', {})
-            if isinstance(msg, dict) and msg.get('role') == 'user':
-                content = msg.get('content', '')
-                # Skip system/command messages — only count real human input
+try:
+    with open(path, encoding='utf-8', errors='replace') as f:
+        for line in f:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            msg = entry.get('message', {}) if isinstance(entry, dict) else {}
+            if entry.get('type') in ('user', 'human'):
+                content = msg.get('content', '') if isinstance(msg, dict) else ''
                 if isinstance(content, str) and '<command-message>' in content:
                     continue
                 count += 1
-        except:
-            pass
+            elif isinstance(msg, dict) and msg.get('role') == 'user':
+                content = msg.get('content', '')
+                if isinstance(content, str) and '<command-message>' in content:
+                    continue
+                count += 1
+except OSError:
+    pass
 print(count)
-" 2>/dev/null)
+" "$TRANSCRIPT_PATH" 2>/dev/null)
 else
     EXCHANGE_COUNT=0
 fi
 
-# Track last save point for this session
-LAST_SAVE_FILE="$STATE_DIR/${SESSION_ID}_last_save"
+# Track last save point for this session (sanitized id — #110)
+LAST_SAVE_FILE="$STATE_DIR/${SESSION_ID_SAFE}_last_save"
 LAST_SAVE=0
 if [ -f "$LAST_SAVE_FILE" ]; then
     LAST_SAVE=$(cat "$LAST_SAVE_FILE")

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -123,8 +123,8 @@ def cmd_split(args):
     from .split_mega_files import main as split_main
     import sys
 
-    # Rebuild argv for split_mega_files argparse
-    argv = [args.dir]
+    # Rebuild argv for split_mega_files argparse (it expects --source, not a bare path; #63)
+    argv = ["--source", os.path.expanduser(args.dir)]
     if args.output_dir:
         argv += ["--output-dir", args.output_dir]
     if args.dry_run:

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -94,8 +94,9 @@ class MempalaceConfig:
         """Path to the memory palace data directory."""
         env_val = os.environ.get("MEMPALACE_PALACE_PATH") or os.environ.get("MEMPAL_PALACE_PATH")
         if env_val:
-            return env_val
-        return self._file_config.get("palace_path", DEFAULT_PALACE_PATH)
+            return os.path.expanduser(env_val)
+        raw = self._file_config.get("palace_path", DEFAULT_PALACE_PATH)
+        return os.path.expanduser(raw)
 
     @property
     def collection_name(self):

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -39,6 +39,9 @@ SKIP_DIRS = {
     "build",
     ".next",
     ".mempalace",
+    # Claude Code: tool dumps and file-based memory (see #111)
+    "tool-results",
+    "memory",
 }
 
 MIN_CHUNK_SIZE = 30
@@ -238,6 +241,8 @@ def scan_convos(convo_dir: str) -> list:
     for root, dirs, filenames in os.walk(convo_path):
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
         for filename in filenames:
+            if filename.endswith(".meta.json"):
+                continue
             filepath = Path(root) / filename
             if filepath.suffix.lower() in CONVO_EXTENSIONS:
                 files.append(filepath)

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -390,6 +390,7 @@ def mine(
 
 def status(palace_path: str):
     """Show what's been filed in the palace."""
+    palace_path = os.path.expanduser(palace_path)
     try:
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")
@@ -398,9 +399,19 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
+    # Count by wing and room (paginate — Chroma get() is capped per call; #40)
+    metas = []
+    batch = 10000
+    offset = 0
+    while True:
+        r = col.get(limit=batch, offset=offset, include=["metadatas"])
+        chunk = r["metadatas"]
+        if not chunk:
+            break
+        metas.extend(chunk)
+        if len(chunk) < batch:
+            break
+        offset += batch
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -81,7 +81,8 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
             continue
         msg_type = entry.get("type", "")
         message = entry.get("message", {})
-        if msg_type == "human":
+        # Claude Code JSONL uses type "user"; some exports use "human"
+        if msg_type in ("human", "user"):
             text = _extract_content(message.get("content", ""))
             if text:
                 messages.append(("user", text))

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -57,6 +57,13 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print(f'\n  No results found for: "{query}"')
         return
 
+    # Windows consoles often default to cp1252; box-drawing chars crash print (#47)
+    if sys.platform == "win32" and hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            pass
+
     print(f"\n{'=' * 60}")
     print(f'  Results for: "{query}"')
     if wing:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "chromadb>=0.4.0",
+    "chromadb>=0.6,<1",
     "pyyaml>=6.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-chromadb>=0.4.0
+chromadb>=0.6,<1
 pyyaml>=6.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,3 +30,23 @@ def test_init():
     cfg = MempalaceConfig(config_dir=tmpdir)
     cfg.init()
     assert os.path.exists(os.path.join(tmpdir, "config.json"))
+
+
+def test_palace_path_expanduser_in_config():
+    """Tilde in config.json should expand (#40)."""
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "config.json"), "w") as f:
+        json.dump({"palace_path": "~/mempalace_unit_test_palace_path_expand"}, f)
+    cfg = MempalaceConfig(config_dir=tmpdir)
+    assert cfg.palace_path == os.path.join(
+        os.path.expanduser("~"), "mempalace_unit_test_palace_path_expand"
+    )
+
+
+def test_palace_path_expanduser_env():
+    try:
+        os.environ["MEMPALACE_PALACE_PATH"] = "~/from_env_palace_test"
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        assert cfg.palace_path == os.path.join(os.path.expanduser("~"), "from_env_palace_test")
+    finally:
+        del os.environ["MEMPALACE_PALACE_PATH"]

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import shutil
 import chromadb
-from mempalace.convo_miner import mine_convos
+from mempalace.convo_miner import mine_convos, scan_convos
 
 
 def test_convo_mining():
@@ -24,3 +24,23 @@ def test_convo_mining():
     assert len(results["documents"][0]) > 0
 
     shutil.rmtree(tmpdir)
+
+
+def test_scan_convos_skips_tool_results_and_meta():
+    """tool-results/ and *.meta.json should not be mined as conversations (#111)."""
+    tmp = tempfile.mkdtemp()
+    try:
+        os.makedirs(os.path.join(tmp, "session", "sub"))
+        good = os.path.join(tmp, "session", "sub", "chat.txt")
+        with open(good, "w") as f:
+            f.write("hello")
+        os.makedirs(os.path.join(tmp, "tool-results"))
+        with open(os.path.join(tmp, "tool-results", "huge.txt"), "w") as f:
+            f.write("noise")
+        with open(os.path.join(tmp, "noise.meta.json"), "w") as f:
+            f.write("{}")
+        files = scan_convos(tmp)
+        assert len(files) == 1
+        assert files[0].name == "chat.txt"
+    finally:
+        shutil.rmtree(tmp)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -29,3 +29,19 @@ def test_empty():
     result = normalize(f.name)
     assert result.strip() == ""
     os.unlink(f.name)
+
+
+def test_claude_code_jsonl_user_type():
+    """Claude Code JSONL uses type \"user\", not \"human\" (#111)."""
+    lines = [
+        '{"type":"user","message":{"content":"fix the bug in auth.py"}}',
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"I will look."}]}}',
+    ]
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, encoding="utf-8")
+    f.write("\n".join(lines))
+    f.close()
+    try:
+        result = normalize(f.name)
+        assert "fix the bug" in result
+    finally:
+        os.unlink(f.name)


### PR DESCRIPTION
This PR bundles six small, high-signal fixes (five tracked issues plus **#40**, which matches the same class of “silent wrong behavior”).

| Issue | What was wrong | Fix |
|-------|----------------|-----|
| [#111](https://github.com/milla-jovovich/mempalace/issues/111) | Claude Code JSONL uses `type: "user"` but only `human` was recognized; `tool-results/` and `memory/` polluted mining | Accept `user`; skip those dirs and `*.meta.json` |
| [#110](https://github.com/milla-jovovich/mempalace/issues/110) | Hook scripts interpolated paths into `python -c` strings | Parse JSON once into safe assignments; open transcript via `sys.argv[1]`; sanitize session id for state filenames |
| [#63](https://github.com/milla-jovovich/mempalace/issues/63) | `mempalace split <dir>` passed a bare path; inner CLI expects `--source` | Forward `--source` + expanded path |
| [#100](https://github.com/milla-jovovich/mempalace/issues/100) | Unpinned `chromadb` could pull 1.x with crashes | `chromadb>=0.6,<1` in `pyproject.toml` and `requirements.txt` |
| [#40](https://github.com/milla-jovovich/mempalace/issues/40) | `status` used `get(limit=10000)` only; `palace_path` with `~` not expanded from config | Paginate `get()`; `os.path.expanduser` on config/env palace path |
| [#47](https://github.com/milla-jovovich/mempalace/issues/47) | Box-drawing chars break `print` on Windows cp1252 | `stdout.reconfigure(utf-8)` on win32 before search output |

**Tests:** `ruff check`, `ruff format --check`, `pytest` (13 tests) — run on Linux x86_64 with the pinned Chroma range.
