### PR TITLE
fix: --yes flag skips all interactive prompts in init

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -59,7 +59,7 @@ def cmd_init(args):
             print("  No entities detected — proceeding with directory-based rooms.")
 
     # Pass 2: detect rooms from folder structure
-    detect_rooms_local(project_dir=args.dir)
+    detect_rooms_local(project_dir=args.dir, yes=getattr(args, "yes", False))
     MempalaceConfig().init()
 
 

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -274,7 +274,7 @@ def save_config(project_dir: str, project_name: str, rooms: list):
     print(f"\n{'=' * 55}\n")
 
 
-def detect_rooms_local(project_dir: str):
+def detect_rooms_local(project_dir: str, yes: bool = False):
     """Main entry point for local setup."""
     project_path = Path(project_dir).expanduser().resolve()
     project_name = project_path.name.lower().replace(" ", "_").replace("-", "_")
@@ -303,5 +303,8 @@ def detect_rooms_local(project_dir: str):
         source = "fallback (flat project)"
 
     print_proposed_structure(project_name, rooms, len(files), source)
-    approved_rooms = get_user_approval(rooms)
+    if yes:
+        approved_rooms = rooms
+    else:
+        approved_rooms = get_user_approval(rooms)
     save_config(project_dir, project_name, approved_rooms)


### PR DESCRIPTION
## Summary

`mempalace init --yes` now skips room confirmation in addition to entity detection. Previously `--yes` only applied to the entity step, so agents and CI would still hit `EOFError` on the room approval prompt.

Two-line fix: pass `yes` through `cmd_init` → `detect_rooms_local`, skip `get_user_approval` when set.

Fixes #8

## Test plan

- [x] `ruff check .` / `ruff format --check .` pass
- [x] `pytest tests/ -v` — 20/20 pass
- [x] Manually verified: `mempalace init sample-project --yes` completes without any stdin prompts