### PR TITLE
fix: add missing dirs to SKIP_DIRS (Obsidian, build caches, vendor)

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -61,6 +61,17 @@ SKIP_DIRS = {
     ".idea",
     ".vscode",
     ".ipynb_checkpoints",
+    # Obsidian
+    ".obsidian",
+    ".smart-connections",
+    ".smart-env",
+    ".trash",
+    # Build/cache
+    ".vite",
+    ".parcel-cache",
+    ".turbo",
+    # PHP dependencies
+    "vendor",
     ".eggs",
     "htmlcov",
     "target",


### PR DESCRIPTION
## What

Add missing directories to `SKIP_DIRS` that were being indexed unnecessarily.

## Changes

- **Obsidian dirs**: `.obsidian`, `.smart-connections`, `.smart-env`, `.trash` — Obsidian plugin JS bundles were being indexed as memories when mining a vault
- **Build caches**: `.vite`, `.parcel-cache`, `.turbo`
- **PHP dependencies**: `vendor` — equivalent of `node_modules` for PHP projects

## Why

Found while mining an Obsidian vault: the `.obsidian/` directory contains large minified plugin bundles that flooded the palace with useless content.