### PR TITLE
fix: add PHP and other missing extensions to READABLE_EXTENSIONS

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -38,6 +38,23 @@ READABLE_EXTENSIONS = {
     ".csv",
     ".sql",
     ".toml",
+    # PHP ecosystem
+    ".php",
+    ".twig",
+    ".blade",
+    # Frontend frameworks
+    ".vue",
+    ".svelte",
+    # Other languages
+    ".dart",
+    ".c",
+    ".cpp",
+    ".h",
+    ".cs",
+    # Config formats
+    ".ini",
+    ".xml",
+    ".env.example",
 }
 
 SKIP_DIRS = {


### PR DESCRIPTION
## What

Add missing file extensions to `READABLE_EXTENSIONS`.

## Changes

- **PHP ecosystem**: `.php`, `.twig`, `.blade`
- **Frontend frameworks**: `.vue`, `.svelte`
- **Other languages**: `.dart`, `.c`, `.cpp`, `.h`, `.cs`
- **Config formats**: `.ini`, `.xml`, `.env.example`

## Why

Found while mining a Dolibarr PHP project: **285 .php files were silently skipped** because `.php` was not in `READABLE_EXTENSIONS`. The project was mined with 0 PHP files indexed — a critical miss for anyone using MemPalace on a PHP codebase.