### PR TITLE
fix: replace Unicode separator character for Windows compatibility

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -286,7 +286,7 @@ def mine_convos(
     print(f"  Palace:  {palace_path}")
     if dry_run:
         print("  DRY RUN — nothing will be filed")
-    print(f"{'─' * 55}\n")
+    print(f"{'-' * 55}\n")
 
     collection = get_collection(palace_path) if not dry_run else None
 


### PR DESCRIPTION
## What

Replace `─` (U+2500) with `-` in `convo_miner.py`.

## The Problem

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2500' in position 0: character maps to <undefined>
```

Windows terminals using `cp1252` (the default Windows encoding) crash on every `--mode convos` run when printing the `─` separator unless `PYTHONUTF8=1` is set explicitly — which most users won't know to do.

## Fix

Replace with `-` which is ASCII and works on all platforms without any environment variable workaround.