### PR TITLE
fix: batch ChromaDB reads to prevent silent truncation on large palaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ Plain text. Becomes Layer 0 — loaded every session.
 
 | File | What |
 |------|------|
+| `chromadb_utils.py` | Safe batched reads from ChromaDB collections |
 | `cli.py` | CLI entry point |
 | `config.py` | Configuration loading and defaults |
 | `normalize.py` | Converts 5 chat formats to standard transcript |

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -6,6 +6,7 @@ The Python package that powers MemPalace. All modules, all logic.
 
 | Module | What it does |
 |--------|-------------|
+| `chromadb_utils.py` | Safe batched reads from ChromaDB — prevents silent truncation on large palaces |
 | `cli.py` | CLI entry point — routes to mine, search, init, compress, wake-up |
 | `config.py` | Configuration loading — `~/.mempalace/config.json`, env vars, defaults |
 | `normalize.py` | Converts 5 chat formats (Claude Code JSONL, Claude.ai JSON, ChatGPT JSON, Slack JSON, plain text) to standard transcript format |

--- a/mempalace/chromadb_utils.py
+++ b/mempalace/chromadb_utils.py
@@ -1,0 +1,55 @@
+"""
+Utilities for safe ChromaDB collection reads.
+
+ChromaDB's ``col.get()`` without an explicit ``limit`` applies a small
+internal default that silently truncates results on large palaces.
+Even with a limit, very large values can exceed SQLite's ~999 variable
+cap.  The helper below reads in batches so every caller gets complete
+results regardless of palace size.
+"""
+
+_BATCH_SIZE = 5000
+
+
+def get_all(col, *, include=None, where=None, batch_size=_BATCH_SIZE):
+    """Read **all** records from a ChromaDB collection in safe batches.
+
+    Args:
+        col: A ChromaDB collection object.
+        include: List of fields to include (e.g. ``["metadatas"]``).
+        where: Optional ChromaDB ``where`` filter dict.
+        batch_size: Records per batch (default 5 000).
+
+    Returns:
+        A merged result dict with the same shape as ``col.get()``
+        (keys: ``ids``, and whichever extras were requested via *include*).
+    """
+    total = col.count()
+    if total == 0:
+        result = {"ids": []}
+        for field in include or []:
+            result[field] = []
+        return result
+
+    all_ids = []
+    all_fields = {field: [] for field in (include or [])}
+
+    offset = 0
+    while offset < total:
+        kwargs = {"limit": batch_size, "offset": offset, "include": include or []}
+        if where:
+            kwargs["where"] = where
+        batch = col.get(**kwargs)
+
+        all_ids.extend(batch["ids"])
+        for field in include or []:
+            all_fields[field].extend(batch.get(field, []))
+
+        # Guard against empty batches (e.g. filtered where returns nothing)
+        if not batch["ids"]:
+            break
+        offset += len(batch["ids"])
+
+    result = {"ids": all_ids}
+    result.update(all_fields)
+    return result

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -32,6 +32,7 @@ import argparse
 from pathlib import Path
 
 from .config import MempalaceConfig
+from .chromadb_utils import get_all
 
 
 def cmd_init(args):
@@ -256,10 +257,7 @@ def cmd_compress(args):
     # Query drawers in the wing
     where = {"wing": args.wing} if args.wing else None
     try:
-        kwargs = {"include": ["documents", "metadatas"]}
-        if where:
-            kwargs["where"] = where
-        results = col.get(**kwargs)
+        results = get_all(col, include=["documents", "metadatas"], where=where)
     except Exception as e:
         print(f"\n  Error reading drawers: {e}")
         sys.exit(1)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -94,8 +94,8 @@ class MempalaceConfig:
         """Path to the memory palace data directory."""
         env_val = os.environ.get("MEMPALACE_PALACE_PATH") or os.environ.get("MEMPAL_PALACE_PATH")
         if env_val:
-            return env_val
-        return self._file_config.get("palace_path", DEFAULT_PALACE_PATH)
+            return os.path.expanduser(env_val)
+        return os.path.expanduser(self._file_config.get("palace_path", DEFAULT_PALACE_PATH))
 
     @property
     def collection_name(self):

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 import chromadb
 
 from .config import MempalaceConfig
+from .chromadb_utils import get_all
 
 
 # ---------------------------------------------------------------------------
@@ -97,12 +98,9 @@ class Layer1:
             return "## L1 — No palace found. Run: mempalace mine <dir>"
 
         # Fetch all drawers (with optional wing filter)
-        kwargs = {"include": ["documents", "metadatas"]}
-        if self.wing:
-            kwargs["where"] = {"wing": self.wing}
-
+        where = {"wing": self.wing} if self.wing else None
         try:
-            results = col.get(**kwargs)
+            results = get_all(col, include=["documents", "metadatas"], where=where)
         except Exception:
             return "## L1 — No drawers found."
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from .config import MempalaceConfig
 from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
+from .chromadb_utils import get_all
 import chromadb
 
 from .knowledge_graph import KnowledgeGraph
@@ -68,8 +69,8 @@ def tool_status():
     wings = {}
     rooms = {}
     try:
-        all_meta = col.get(include=["metadatas"])["metadatas"]
-        for m in all_meta:
+        results = get_all(col, include=["metadatas"])
+        for m in results["metadatas"]:
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
             wings[w] = wings.get(w, 0) + 1
@@ -125,8 +126,8 @@ def tool_list_wings():
         return _no_palace()
     wings = {}
     try:
-        all_meta = col.get(include=["metadatas"])["metadatas"]
-        for m in all_meta:
+        results = get_all(col, include=["metadatas"])
+        for m in results["metadatas"]:
             w = m.get("wing", "unknown")
             wings[w] = wings.get(w, 0) + 1
     except Exception:
@@ -140,11 +141,9 @@ def tool_list_rooms(wing: str = None):
         return _no_palace()
     rooms = {}
     try:
-        kwargs = {"include": ["metadatas"]}
-        if wing:
-            kwargs["where"] = {"wing": wing}
-        all_meta = col.get(**kwargs)["metadatas"]
-        for m in all_meta:
+        where = {"wing": wing} if wing else None
+        results = get_all(col, include=["metadatas"], where=where)
+        for m in results["metadatas"]:
             r = m.get("room", "unknown")
             rooms[r] = rooms.get(r, 0) + 1
     except Exception:
@@ -158,8 +157,8 @@ def tool_get_taxonomy():
         return _no_palace()
     taxonomy = {}
     try:
-        all_meta = col.get(include=["metadatas"])["metadatas"]
-        for m in all_meta:
+        results = get_all(col, include=["metadatas"])
+        for m in results["metadatas"]:
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
             if w not in taxonomy:
@@ -403,9 +402,10 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
         return _no_palace()
 
     try:
-        results = col.get(
-            where={"$and": [{"wing": wing}, {"room": "diary"}]},
+        results = get_all(
+            col,
             include=["documents", "metadatas"],
+            where={"$and": [{"wing": wing}, {"room": "diary"}]},
         )
 
         if not results["ids"]:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -17,6 +17,8 @@ from collections import defaultdict
 
 import chromadb
 
+from .chromadb_utils import get_all
+
 READABLE_EXTENSIONS = {
     ".txt",
     ".md",
@@ -653,7 +655,7 @@ def status(palace_path: str):
         return
 
     # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
+    r = get_all(col, include=["metadatas"])
     metas = r["metadatas"]
 
     wing_rooms = defaultdict(lambda: defaultdict(int))

--- a/tests/test_chromadb_utils.py
+++ b/tests/test_chromadb_utils.py
@@ -1,0 +1,132 @@
+"""Tests for chromadb_utils.get_all — batched reads from ChromaDB."""
+
+import shutil
+import tempfile
+
+import chromadb
+
+from mempalace.chromadb_utils import get_all
+
+
+def _create_palace(n_drawers, n_wings=1):
+    """Create a temp palace with *n_drawers* spread across *n_wings* wings.
+
+    Returns (palace_path, collection).
+    """
+    palace_path = tempfile.mkdtemp()
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_or_create_collection("mempalace_drawers")
+
+    wing_names = [f"wing_{i}" for i in range(n_wings)]
+    room_names = ["src", "docs", "tests"]
+
+    ids = []
+    docs = []
+    metas = []
+    for i in range(n_drawers):
+        ids.append(f"drawer_{i}")
+        docs.append(f"content for drawer {i}")
+        metas.append(
+            {
+                "wing": wing_names[i % n_wings],
+                "room": room_names[i % len(room_names)],
+                "source_file": f"file_{i}.py",
+            }
+        )
+
+    # ChromaDB add has its own batch limits, so insert in chunks
+    batch_size = 5000
+    for start in range(0, len(ids), batch_size):
+        end = start + batch_size
+        col.add(
+            ids=ids[start:end],
+            documents=docs[start:end],
+            metadatas=metas[start:end],
+        )
+
+    return palace_path, col
+
+
+def test_get_all_returns_all_metadata():
+    """get_all must return every drawer's metadata, not just a default subset."""
+    palace_path, col = _create_palace(50)
+    try:
+        results = get_all(col, include=["metadatas"])
+        assert len(results["ids"]) == 50
+        assert len(results["metadatas"]) == 50
+    finally:
+        shutil.rmtree(palace_path)
+
+
+def test_get_all_returns_documents_and_metadatas():
+    """get_all should return multiple include fields correctly."""
+    palace_path, col = _create_palace(20)
+    try:
+        results = get_all(col, include=["documents", "metadatas"])
+        assert len(results["ids"]) == 20
+        assert len(results["documents"]) == 20
+        assert len(results["metadatas"]) == 20
+        assert "content for drawer 0" in results["documents"][0]
+    finally:
+        shutil.rmtree(palace_path)
+
+
+def test_get_all_with_where_filter():
+    """get_all should respect where filters and only return matching drawers."""
+    palace_path, col = _create_palace(30, n_wings=3)
+    try:
+        results = get_all(col, include=["metadatas"], where={"wing": "wing_0"})
+        assert len(results["ids"]) == 10
+        for m in results["metadatas"]:
+            assert m["wing"] == "wing_0"
+    finally:
+        shutil.rmtree(palace_path)
+
+
+def test_get_all_on_empty_collection():
+    """get_all on an empty collection should return empty lists, not error."""
+    palace_path = tempfile.mkdtemp()
+    try:
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_or_create_collection("mempalace_drawers")
+        results = get_all(col, include=["metadatas"])
+        assert results["ids"] == []
+        assert results["metadatas"] == []
+    finally:
+        shutil.rmtree(palace_path)
+
+
+def test_get_all_batches_large_collections():
+    """get_all with a small batch_size must still return all drawers."""
+    palace_path, col = _create_palace(100)
+    try:
+        # Force tiny batches to exercise the pagination loop
+        results = get_all(col, include=["metadatas"], batch_size=7)
+        assert len(results["ids"]) == 100
+        assert len(results["metadatas"]) == 100
+    finally:
+        shutil.rmtree(palace_path)
+
+
+def test_get_all_no_duplicate_ids():
+    """Batched reads must not produce duplicate drawer IDs."""
+    palace_path, col = _create_palace(50)
+    try:
+        results = get_all(col, include=["metadatas"], batch_size=13)
+        assert len(results["ids"]) == len(set(results["ids"]))
+    finally:
+        shutil.rmtree(palace_path)
+
+
+def test_get_all_filtered_pagination():
+    """get_all with a where filter and small batch_size must return all matching drawers."""
+    palace_path, col = _create_palace(60, n_wings=3)
+    try:
+        # 60 drawers across 3 wings → 20 per wing; batch_size=7 forces multiple pages
+        results = get_all(col, include=["metadatas"], where={"wing": "wing_0"}, batch_size=7)
+        assert len(results["ids"]) == 20
+        for m in results["metadatas"]:
+            assert m["wing"] == "wing_0"
+        assert len(results["ids"]) == len(set(results["ids"]))
+    finally:
+        shutil.rmtree(palace_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,25 @@ def test_env_override():
     del os.environ["MEMPALACE_PALACE_PATH"]
 
 
+def test_config_file_tilde_is_expanded():
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "config.json"), "w") as f:
+        json.dump({"palace_path": "~/.mempalace/palace"}, f)
+    cfg = MempalaceConfig(config_dir=tmpdir)
+    assert not cfg.palace_path.startswith("~")
+    assert cfg.palace_path == os.path.expanduser("~/.mempalace/palace")
+
+
+def test_env_var_tilde_is_expanded():
+    os.environ["MEMPALACE_PALACE_PATH"] = "~/custom/palace"
+    try:
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        assert not cfg.palace_path.startswith("~")
+        assert cfg.palace_path == os.path.expanduser("~/custom/palace")
+    finally:
+        del os.environ["MEMPALACE_PALACE_PATH"]
+
+
 def test_init():
     tmpdir = tempfile.mkdtemp()
     cfg = MempalaceConfig(config_dir=tmpdir)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,96 @@
+"""Tests for layers.py — Layer1 essential story generation.
+
+Layer1.generate() previously called col.get() without a limit, which could
+return truncated results on large palaces.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import chromadb
+import yaml
+
+from mempalace.layers import Layer1
+from mempalace.miner import mine
+
+
+def _write_file(path, content):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(content, encoding="utf-8")
+
+
+def test_layer1_returns_content_from_all_rooms():
+    """Layer1 should pull drawers from every room in the palace."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project = Path(tmpdir) / "project"
+        project.mkdir()
+
+        # Create files in two directories to trigger two rooms
+        _write_file(
+            project / "backend" / "api.py",
+            "def handle_request():\n    return 'ok'\n" * 20,
+        )
+        _write_file(
+            project / "docs" / "guide.md",
+            "# User Guide\nThis is the documentation.\n" * 20,
+        )
+
+        with open(project / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_wing",
+                    "rooms": [
+                        {"name": "backend", "description": "Backend API code"},
+                        {"name": "docs", "description": "Documentation"},
+                    ],
+                },
+                f,
+            )
+
+        palace_path = str(Path(tmpdir) / "palace")
+        mine(str(project), palace_path)
+
+        layer1 = Layer1(palace_path=palace_path)
+        output = layer1.generate()
+
+        assert "L1" in output
+        assert output != "## L1 — No drawers found."
+        assert output != "## L1 — No memories yet."
+        # Verify content from both rooms is represented
+        output_lower = output.lower()
+        assert "backend" in output_lower or "api" in output_lower, "backend room content missing"
+        assert "docs" in output_lower or "guide" in output_lower, "docs room content missing"
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_layer1_with_wing_filter():
+    """Layer1 with a wing filter should only return drawers from that wing."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        palace_path = str(Path(tmpdir) / "palace")
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_or_create_collection("mempalace_drawers")
+
+        # Insert drawers across two wings
+        ids = []
+        docs = []
+        metas = []
+        for i in range(20):
+            wing = "alpha" if i < 10 else "beta"
+            ids.append(f"d_{i}")
+            docs.append(f"content from {wing} drawer {i}")
+            metas.append({"wing": wing, "room": "general", "source_file": f"f{i}.py"})
+        col.add(ids=ids, documents=docs, metadatas=metas)
+
+        layer1 = Layer1(palace_path=palace_path, wing="alpha")
+        output = layer1.generate()
+
+        assert "L1" in output
+        assert output != "## L1 — No memories yet."
+        # Verify the filter excluded "beta" wing content
+        assert "content from beta" not in output
+    finally:
+        shutil.rmtree(tmpdir)

--- a/tests/test_mcp_server_reads.py
+++ b/tests/test_mcp_server_reads.py
@@ -1,0 +1,222 @@
+"""Tests for MCP server read tools — status, list_wings, list_rooms, get_taxonomy.
+
+These tools previously called col.get() without a limit, causing them to return
+empty results on palaces with more drawers than ChromaDB's internal default.
+"""
+
+import shutil
+import tempfile
+from unittest.mock import patch
+
+import chromadb
+
+from mempalace import mcp_server
+
+
+def _populate_palace(palace_path, drawers):
+    """Insert drawers into a fresh palace.
+
+    Args:
+        palace_path: Directory for the ChromaDB persistent client.
+        drawers: List of (id, document, metadata) tuples.
+
+    Returns:
+        The ChromaDB collection.
+    """
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_or_create_collection("mempalace_drawers")
+    batch_size = 5000
+    for start in range(0, len(drawers), batch_size):
+        batch = drawers[start : start + batch_size]
+        col.add(
+            ids=[d[0] for d in batch],
+            documents=[d[1] for d in batch],
+            metadatas=[d[2] for d in batch],
+        )
+    return col
+
+
+def _make_drawers(n, n_wings=2, n_rooms=3):
+    """Generate n drawer tuples spread across wings and rooms."""
+    wings = [f"wing_{i}" for i in range(n_wings)]
+    rooms = [f"room_{i}" for i in range(n_rooms)]
+    return [
+        (
+            f"drawer_{i}",
+            f"content {i}",
+            {"wing": wings[i % n_wings], "room": rooms[i % n_rooms], "source_file": f"f{i}.py"},
+        )
+        for i in range(n)
+    ]
+
+
+def _patch_config(palace_path):
+    """Return a mock _get_collection that points at our temp palace."""
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_collection("mempalace_drawers")
+
+    def fake_get_collection(create=False):
+        return col
+
+    return patch.object(mcp_server, "_get_collection", side_effect=fake_get_collection)
+
+
+class TestToolStatus:
+    def test_status_returns_all_wings_and_rooms(self):
+        palace_path = tempfile.mkdtemp()
+        try:
+            drawers = _make_drawers(60, n_wings=3, n_rooms=2)
+            _populate_palace(palace_path, drawers)
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_status()
+
+            assert result["total_drawers"] == 60
+            assert len(result["wings"]) == 3
+            assert sum(result["wings"].values()) == 60
+            assert len(result["rooms"]) == 2
+            assert sum(result["rooms"].values()) == 60
+        finally:
+            shutil.rmtree(palace_path)
+
+    def test_status_empty_palace(self):
+        palace_path = tempfile.mkdtemp()
+        try:
+            client = chromadb.PersistentClient(path=palace_path)
+            client.get_or_create_collection("mempalace_drawers")
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_status()
+
+            assert result["total_drawers"] == 0
+            assert result["wings"] == {}
+            assert result["rooms"] == {}
+        finally:
+            shutil.rmtree(palace_path)
+
+
+class TestToolListWings:
+    def test_lists_all_wings_with_counts(self):
+        palace_path = tempfile.mkdtemp()
+        try:
+            drawers = _make_drawers(40, n_wings=4)
+            _populate_palace(palace_path, drawers)
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_list_wings()
+
+            assert len(result["wings"]) == 4
+            for wing_name, count in result["wings"].items():
+                assert count == 10
+        finally:
+            shutil.rmtree(palace_path)
+
+    def test_lists_wings_empty_palace(self):
+        palace_path = tempfile.mkdtemp()
+        try:
+            client = chromadb.PersistentClient(path=palace_path)
+            client.get_or_create_collection("mempalace_drawers")
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_list_wings()
+
+            assert result["wings"] == {}
+        finally:
+            shutil.rmtree(palace_path)
+
+
+class TestToolListRooms:
+    def test_lists_all_rooms(self):
+        palace_path = tempfile.mkdtemp()
+        try:
+            drawers = _make_drawers(30, n_wings=1, n_rooms=3)
+            _populate_palace(palace_path, drawers)
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_list_rooms()
+
+            assert result["wing"] == "all"
+            assert len(result["rooms"]) == 3
+            assert sum(result["rooms"].values()) == 30
+        finally:
+            shutil.rmtree(palace_path)
+
+    def test_lists_rooms_filtered_by_wing(self):
+        palace_path = tempfile.mkdtemp()
+        try:
+            drawers = _make_drawers(60, n_wings=3, n_rooms=2)
+            _populate_palace(palace_path, drawers)
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_list_rooms(wing="wing_0")
+
+            assert result["wing"] == "wing_0"
+            assert sum(result["rooms"].values()) == 20
+        finally:
+            shutil.rmtree(palace_path)
+
+
+class TestToolGetTaxonomy:
+    def test_taxonomy_returns_full_tree(self):
+        palace_path = tempfile.mkdtemp()
+        try:
+            drawers = _make_drawers(60, n_wings=3, n_rooms=2)
+            _populate_palace(palace_path, drawers)
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_get_taxonomy()
+
+            taxonomy = result["taxonomy"]
+            assert len(taxonomy) == 3  # 3 wings
+            total = 0
+            for wing, rooms in taxonomy.items():
+                for room, count in rooms.items():
+                    total += count
+            assert total == 60
+        finally:
+            shutil.rmtree(palace_path)
+
+
+class TestToolDiaryRead:
+    def test_diary_read_returns_all_entries(self):
+        """tool_diary_read must return all diary entries, not a truncated subset."""
+        palace_path = tempfile.mkdtemp()
+        try:
+            drawers = [
+                (
+                    f"diary_{i}",
+                    f"diary entry {i}",
+                    {
+                        "wing": "wing_reviewer",
+                        "room": "diary",
+                        "topic": f"topic_{i}",
+                        "filed_at": f"2026-04-{i + 1:02d}T12:00:00",
+                        "date": f"2026-04-{i + 1:02d}",
+                    },
+                )
+                for i in range(25)
+            ]
+            _populate_palace(palace_path, drawers)
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_diary_read("reviewer", last_n=50)
+
+            assert result["total"] == 25
+            assert result["showing"] == 25
+            assert len(result["entries"]) == 25
+        finally:
+            shutil.rmtree(palace_path)
+
+    def test_diary_read_empty(self):
+        """tool_diary_read on a palace with no diary entries returns an empty list."""
+        palace_path = tempfile.mkdtemp()
+        try:
+            client = chromadb.PersistentClient(path=palace_path)
+            client.get_or_create_collection("mempalace_drawers")
+
+            with _patch_config(palace_path):
+                result = mcp_server.tool_diary_read("reviewer")
+
+            assert result["entries"] == []
+        finally:
+            shutil.rmtree(palace_path)

--- a/tests/test_miner_status.py
+++ b/tests/test_miner_status.py
@@ -1,0 +1,93 @@
+"""Tests for miner.status() — palace status display.
+
+The status function previously used a hardcoded limit=10000, which caused it
+to miss wings and rooms filed after the first 10k drawers.  The fix uses
+get_all() which reads in batches with no cap.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import chromadb
+import yaml
+
+from mempalace.miner import mine, status
+
+
+def _write_file(path, content):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(content, encoding="utf-8")
+
+
+def test_status_counts_all_drawers(capsys):
+    """status() must report the total drawer count accurately."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project = Path(tmpdir) / "project"
+        project.mkdir()
+
+        # Create enough content to generate multiple drawers
+        _write_file(
+            project / "src" / "app.py",
+            "def main():\n    print('hello world')\n" * 30,
+        )
+        _write_file(
+            project / "src" / "utils.py",
+            "def helper():\n    return 42\n" * 30,
+        )
+
+        with open(project / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "my_project",
+                    "rooms": [{"name": "src", "description": "Source code"}],
+                },
+                f,
+            )
+
+        palace_path = str(Path(tmpdir) / "palace")
+        mine(str(project), palace_path)
+
+        # Verify the drawer count matches what ChromaDB reports
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+        expected_count = col.count()
+
+        status(palace_path)
+        output = capsys.readouterr().out
+
+        assert f"{expected_count} drawers" in output
+        assert "WING: my_project" in output
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_status_reports_multiple_wings(capsys):
+    """status() must list all wings when palace has drawers in multiple wings."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        palace_path = str(Path(tmpdir) / "palace")
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_or_create_collection("mempalace_drawers")
+
+        # Insert drawers across 3 wings
+        ids = []
+        docs = []
+        metas = []
+        for i in range(90):
+            wing = f"wing_{i % 3}"
+            ids.append(f"d_{i}")
+            docs.append(f"content {i}")
+            metas.append({"wing": wing, "room": "general"})
+        col.add(ids=ids, documents=docs, metadatas=metas)
+
+        status(palace_path)
+        output = capsys.readouterr().out
+
+        assert "90 drawers" in output
+        assert "WING: wing_0" in output
+        assert "WING: wing_1" in output
+        assert "WING: wing_2" in output
+    finally:
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
## Summary

Closes #40.

ChromaDB's `col.get()` without an explicit `limit` applies a small internal default (currently 10). On palaces with more drawers than that default, every read-only tool — `mempalace status`, Layer1 wake-up, and all MCP read tools (status, list_wings, list_rooms, get_taxonomy, diary_read) — silently returns incomplete results. Users see missing wings, undercounted rooms, and truncated Layer1 context with no error or warning. The `miner.py` status function had a `limit=10000` that would similarly break once a palace exceeded 10k drawers.

PR #120 attempted to address these issues alongside several other fixes but was closed. PR #114 and #119 fixed related problems (shell injection, ChromaDB pin) but did not address the unbounded read truncation.

- Add `chromadb_utils.get_all()` helper that paginates in safe batches, replace all unbounded `col.get()` call sites
- Fix tilde expansion in `config.py` palace_path resolution (paths like `~/.mempalace/palace` from config file or env var were passed unexpanded to ChromaDB, causing "palace not found" errors)

## Changes

**New file:** `mempalace/chromadb_utils.py` — batched `get_all()` utility

**Fixed call sites:**
- `cli.py` — status command
- `layers.py` — Layer1 generation
- `mcp_server.py` — `tool_status`, `tool_list_wings`, `tool_list_rooms`, `tool_get_taxonomy`, `tool_diary_read`
- `miner.py` — `status()` (previously hardcoded `limit=10000`)

**Config fix:** `config.py` — `os.path.expanduser()` on palace_path from file config and env var

**Documentation:** Added `chromadb_utils.py` to file reference tables in `README.md` and `mempalace/README.md`

## Test plan

- [x] `test_chromadb_utils.py` — 7 tests: all records, docs+meta, where filter, empty collection, batching, no duplicates, filtered pagination
- [x] `test_layers.py` — 2 tests: Layer1 pulls from all rooms, wing filter excludes other wings
- [x] `test_mcp_server_reads.py` — 9 tests: status, list_wings, list_rooms, taxonomy, diary read (all entries + empty)
- [x] `test_miner_status.py` — 2 tests: accurate drawer count, multiple wings reported
- [x] `test_config.py` — 2 new tests: tilde expansion from file config and env var
- [x] Full suite: 42 passed, ruff clean