### PR TITLE
fix: sanitize SESSION_ID to prevent path traversal

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -58,6 +58,10 @@ MEMPAL_DIR=""
 INPUT=$(cat)
 
 SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+# Sanitize SESSION_ID to prevent path traversal and log injection
+# Only allow alphanumeric, underscore, and hyphen characters
+SESSION_ID=$(echo "$SESSION_ID" | tr -cd '[:alnum:]_-')
+[ -z "$SESSION_ID" ] && SESSION_ID="unknown"
 
 echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
 

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -66,6 +66,11 @@ INPUT=$(cat)
 
 # Parse fields from Claude Code's JSON
 SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+# Sanitize SESSION_ID to prevent path traversal (e.g., "../../etc/cron.d/evil")
+# Only allow alphanumeric, underscore, and hyphen characters
+SESSION_ID=$(echo "$SESSION_ID" | tr -cd '[:alnum:]_-')
+[ -z "$SESSION_ID" ] && SESSION_ID="unknown"
+
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('stop_hook_active', False))" 2>/dev/null)
 TRANSCRIPT_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
 


### PR DESCRIPTION
Strip all characters except alphanumeric, underscore, and hyphen using `tr -cd '[:alnum:]_-'`.
  Fall back to 'unknown' if result is empty.

  Fixes #121

  ## What does this PR do?

  Sanitizes `SESSION_ID` in both hook scripts to prevent path traversal and log injection. A
  malicious `session_id` like `../../etc/cron.d/evil` could write files outside `$STATE_DIR` or
  inject content into logs.

  **Affected files:**
  - `hooks/mempal_save_hook.sh`
  - `hooks/mempal_precompact_hook.sh`

  ## How to test

  ```bash
  # Malicious input gets stripped
  echo "../../etc/cron.d/evil" | tr -cd '[:alnum:]_-'
  # Output: etccrondevil

  # Normal input unchanged
  echo "abc123-session_01" | tr -cd '[:alnum:]_-'
  # Output: abc123-session_01

  # Empty result falls back to "unknown"
  SANITIZED=$(echo "../../../" | tr -cd '[:alnum:]_-')
  [ -z "$SANITIZED" ] && echo "unknown"
  # Output: unknown

  Checklist

  - Tests pass (python -m pytest tests/ -v) — N/A, bash scripts only
  - No hardcoded paths
  - Linter passes (ruff check .) — N/A, bash scripts only