### PR TITLE
Add grok JSON support for convo mining

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ mempalace init ~/projects/myapp
 
 # Mine your data
 mempalace mine ~/projects/myapp                    # projects — code, docs, notes
-mempalace mine ~/chats/ --mode convos              # convos — Claude, ChatGPT, Slack exports
+mempalace mine ~/chats/ --mode convos              # convos — Claude, ChatGPT, Grok, Slack exports
 mempalace mine ~/chats/ --mode convos --extract general  # general — classifies into decisions, milestones, problems
 
 # Search anything you've ever discussed
@@ -105,7 +105,6 @@ mempalace status
 ```
 
 Three mining modes: **projects** (code and docs), **convos** (conversation exports), and **general** (auto-classifies into decisions, preferences, milestones, problems, and emotional context). Everything stays on your machine.
-
 ---
 
 ## How You Actually Use It

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -5,6 +5,7 @@ normalize.py — Convert any chat export format to MemPalace transcript format.
 Supported:
     - Plain text with > markers (pass through)
     - Claude.ai JSON export
+    - Grok JSON export
     - ChatGPT conversations.json
     - Claude Code JSONL
     - OpenAI Codex CLI JSONL
@@ -65,7 +66,7 @@ def _try_normalize_json(content: str) -> Optional[str]:
     except json.JSONDecodeError:
         return None
 
-    for parser in (_try_claude_ai_json, _try_chatgpt_json, _try_slack_json):
+    for parser in (_try_grok_json, _try_claude_ai_json, _try_chatgpt_json, _try_slack_json):
         normalized = parser(data)
         if normalized:
             return normalized
@@ -185,6 +186,44 @@ def _try_claude_ai_json(data) -> Optional[str]:
             messages.append(("user", text))
         elif role in ("assistant", "ai") and text:
             messages.append(("assistant", text))
+    if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    return None
+
+
+def _try_grok_json(data) -> Optional[str]:
+    """Grok / xAI JSON export with nested conversations and responses."""
+    conversations = data.get("conversations") if isinstance(data, dict) else None
+    if not isinstance(conversations, list):
+        return None
+
+    messages = []
+    for convo in conversations:
+        if not isinstance(convo, dict):
+            continue
+
+        responses = convo.get("responses", [])
+        if not isinstance(responses, list):
+            continue
+
+        for item in responses:
+            if not isinstance(item, dict):
+                continue
+            response = item.get("response", {})
+            if not isinstance(response, dict):
+                continue
+
+            sender = str(response.get("sender", "")).lower()
+            message = _extract_content(response.get("message", ""))
+            if sender == "human" and message:
+                role = "user"
+            elif sender == "assistant" and message:
+                role = "assistant"
+            else:
+                continue
+
+            messages.append((role, message))
+
     if len(messages) >= 2:
         return _messages_to_transcript(messages)
     return None

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -7,6 +7,7 @@ from mempalace.normalize import (
     _try_chatgpt_json,
     _try_claude_ai_json,
     _try_claude_code_jsonl,
+    _try_grok_json,
     _try_codex_jsonl,
     _try_normalize_json,
     _try_slack_json,
@@ -32,10 +33,40 @@ def test_claude_json(tmp_path):
     assert "Hi" in result
 
 
-def test_empty(tmp_path):
-    f = tmp_path / "empty.txt"
-    f.write_text("")
+def test_grok_json(tmp_path):
+    data = {
+        "conversations": [
+            {
+                "conversation": {"title": "Test Conversation 1"},
+                "responses": [
+                    {"response": {"sender": "human", "message": "Hello, how are you?"}},
+                    {"response": {"sender": "ASSISTANT", "message": "I'm doing great, thanks!"}},
+                ],
+            },
+            {
+                "conversation": {"title": "Test Conversation 2"},
+                "responses": [
+                    {"response": {"sender": "human", "message": "What's the weather?"}},
+                    {"response": {"sender": "ASSISTANT", "message": "It's sunny today."}},
+                ],
+            },
+        ]
+    }
+
+    f = tmp_path / "grok.json"
+    f.write_text(json.dumps(data))
     result = normalize(str(f))
+
+    assert "> Hello, how are you?" in result
+    assert "I'm doing great, thanks!" in result
+    assert "> What's the weather?" in result
+    assert "It's sunny today." in result
+
+
+def test_empty():
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False)
+    f.close()
+    result = normalize(f.name)
     assert result.strip() == ""
 
 
@@ -459,6 +490,81 @@ def test_slack_json_username_fallback():
     ]
     result = _try_slack_json(data)
     assert result is not None
+
+
+# ── _try_grok_json ─────────────────────────────────────────────────────
+
+def test_grok_json_valid():
+    data = {
+        "conversations": [
+            {
+                "responses": [
+                    {"response": {"sender": "human", "message": "Hello"}},
+                    {"response": {"sender": "ASSISTANT", "message": "Hi"}},
+                ]
+            }
+        ]
+    }
+    result = _try_grok_json(data)
+    assert result is not None
+    assert "> Hello" in result
+    assert "Hi" in result
+
+
+def test_grok_json_case_insensitive_sender():
+    data = {
+        "conversations": [
+            {
+                "responses": [
+                    {"response": {"sender": "HUMAN", "message": "Hey"}},
+                    {"response": {"sender": "assistant", "message": "Yo"}},
+                ]
+            }
+        ]
+    }
+    result = _try_grok_json(data)
+    assert result is not None
+
+
+def test_grok_json_not_dict():
+    assert _try_grok_json([1, 2, 3]) is None
+
+
+def test_grok_json_missing_conversations():
+    assert _try_grok_json({"foo": "bar"}) is None
+
+
+def test_grok_json_too_few_messages():
+    data = {
+        "conversations": [
+            {
+                "responses": [
+                    {"response": {"sender": "human", "message": "Solo"}}
+                ]
+            }
+        ]
+    }
+    assert _try_grok_json(data) is None
+
+
+def test_grok_json_skips_malformed_nested_items():
+    data = {
+        "conversations": [
+            "not a dict",
+            {
+                "responses": [
+                    "not a dict",
+                    {"response": "not a dict"},
+                    {"response": {"sender": "human", "message": "Q"}},
+                    {"response": {"sender": "assistant", "message": "A"}},
+                ]
+            },
+        ]
+    }
+    result = _try_grok_json(data)
+    assert result is not None
+    assert "> Q" in result
+    assert "A" in result
 
 
 # ── _try_normalize_json ────────────────────────────────────────────────


### PR DESCRIPTION
This PR adds support for Grok JSON exports in conversation normalization.

Changes:
- add Grok export parsing in normalize.py
- add a test for Grok JSON normalization
- update the README convo mining example to mention Grok exports

Note:
- this supports the Grok JSON file from the export bundle; the export zip needs to be extracted first

Tested locally by extracting a Grok export and mining the JSON with 'mempalace mine ... --mode convos'