### PR TITLE
fix: room detection checks keywords against folder paths

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -311,11 +311,12 @@ def detect_room(filepath: Path, content: str, rooms: list, project_path: Path) -
     filename = filepath.stem.lower()
     content_lower = content[:2000].lower()
 
-    # Priority 1: folder path contains room name
+    # Priority 1: folder path matches room name or keywords
     path_parts = relative.replace("\\", "/").split("/")
     for part in path_parts[:-1]:  # skip filename itself
         for room in rooms:
-            if room["name"].lower() in part or part in room["name"].lower():
+            candidates = [room["name"].lower()] + [k.lower() for k in room.get("keywords", [])]
+            if any(part == c or c in part or part in c for c in candidates):
                 return room["name"]
 
     # Priority 2: filename matches room name


### PR DESCRIPTION
## Summary

`detect_room()` now matches folder path parts against room keywords, not just the room name. Previously, files in `docs/` would route to `general` instead of `documentation` because `"docs"` is not a substring of `"documentation"`.

Now the keywords list (persisted in mempalace.yaml since #119) is checked during path matching: `docs/` matches keyword `"docs"` → routes to room `"documentation"`.

Found during end-to-end testing after merging the keyword persistence fix.

## Test plan

- [x] `ruff check .` / `ruff format --check .` pass
- [x] `pytest tests/ -v` — 27/27 pass
- [x] Manual: `mempalace init --yes` + `mempalace mine` correctly routes `docs/` files to `documentation` room