### PR TITLE
test(dialect): strengthen compression_stats and count_tokens assertions

### DIFF
--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -111,9 +111,14 @@ class TestCompressionStats:
         stats = d.compression_stats(original, compressed)
         assert stats["size_ratio"] > 1
         assert stats["original_chars"] > stats["summary_chars"]
+        assert stats["original_tokens_est"] > stats["summary_tokens_est"]
 
     def test_count_tokens(self):
+        # count_tokens uses a word-based heuristic (~1.3 tokens per word).
+        # "hello world" is 2 words -> max(1, int(2 * 1.3)) == 2.
         assert Dialect.count_tokens("hello world") == 2
+        assert Dialect.count_tokens("") == 1
+        assert Dialect.count_tokens("one") == 1
 
     def test_compression_stats_keys(self):
         """Verify compression_stats() returns the expected key set."""


### PR DESCRIPTION
## What does this PR do?

The main honest-stats test fix (`ratio` -> `size_ratio`, `compressed_chars` -> `summary_chars`, `len // 3` -> word-based `count_tokens`) already landed in main through @igorls' PR series. This PR now just adds a couple of assertions on top of that fix so the regression surface is a bit smaller.

- `test_stats` also asserts `stats["original_tokens_est"] > stats["summary_tokens_est"]`. That catches a class of regressions where the token estimator flattens to a constant, which would otherwise slip through the existing char-level assertion.
- `test_count_tokens` gains edge cases for the empty string and the single-word input. Both exercise the `max(1, ...)` guard in `Dialect.count_tokens`, so a future refactor that drops the guard fails loudly instead of silently returning 0.

Originally opened before I saw that the core rename fix was already in flight. After rebasing on the merged fix, the remaining diff is a small additive coverage improvement.

## How to test

```bash
python -m pytest tests/test_dialect.py -v
ruff check tests/test_dialect.py
ruff format --check tests/test_dialect.py
```

18 tests pass locally.

## Checklist

- [x] Tests pass
- [x] Linter passes
- [x] Python 3.9 compatible
