### PR TITLE
fix: update dialect tests to match honest stats rename

### DIFF
--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -109,11 +109,12 @@ class TestCompressionStats:
         original = "We decided to use GraphQL instead of REST. " * 10
         compressed = d.compress(original)
         stats = d.compression_stats(original, compressed)
-        assert stats["ratio"] > 1
-        assert stats["original_chars"] > stats["compressed_chars"]
+        assert stats["size_ratio"] > 1
+        assert stats["original_chars"] > stats["summary_chars"]
 
     def test_count_tokens(self):
-        assert Dialect.count_tokens("hello world") == len("hello world") // 3
+        # Word-based heuristic: ~1.3 tokens per word
+        assert Dialect.count_tokens("hello world") == 2  # 2 words * 1.3 = 2.6 → 2
 
 
 class TestZettelEncoding:


### PR DESCRIPTION
## Summary

Commit 39c14be renamed `compression_stats()` fields to be honest about AAAK being lossy summarization:
- `"ratio"` → `"size_ratio"`
- `"compressed_chars"` → `"summary_chars"`
- `count_tokens()` changed from `len(text)//3` to word-based heuristic (`words * 1.3`)

The tests were not updated, breaking CI (2 failures out of 99).

## Files changed

| File | Change |
|------|--------|
| `tests/test_dialect.py` | Update `test_stats` and `test_count_tokens` to match new field names and formula |

## Test plan

- [x] All 99 tests pass (0 failures, was 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)