### PR TITLE
fix: portable SQLite ordering in timeline() (drop NULLS LAST)

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -283,7 +283,7 @@ class KnowledgeGraph:
                 JOIN entities s ON t.subject = s.id
                 JOIN entities o ON t.object = o.id
                 WHERE (t.subject = ? OR t.object = ?)
-                ORDER BY t.valid_from ASC NULLS LAST
+                ORDER BY (t.valid_from IS NULL), t.valid_from ASC
             """,
                 (eid, eid),
             ).fetchall()
@@ -293,7 +293,7 @@ class KnowledgeGraph:
                 FROM triples t
                 JOIN entities s ON t.subject = s.id
                 JOIN entities o ON t.object = o.id
-                ORDER BY t.valid_from ASC NULLS LAST
+                ORDER BY (t.valid_from IS NULL), t.valid_from ASC
                 LIMIT 100
             """).fetchall()
 


### PR DESCRIPTION
## Summary

`timeline()` uses `ORDER BY t.valid_from ASC NULLS LAST`, which requires SQLite >= 3.30.0. While Python 3.9+ bundles SQLite 3.33+, custom/system SQLite builds (some Linux distros, conda environments, pyenv with system SQLite) may have older versions — causing a SQL syntax error that crashes `timeline()`, `tool_kg_timeline()` in the MCP server, and any code path that calls them.

Replace with the portable equivalent:
```sql
ORDER BY (t.valid_from IS NULL), t.valid_from ASC
```
This sorts non-NULL values first (`IS NULL` = 0), NULLs last (`= 1`) — identical semantics, works on all SQLite versions.

## Files changed

| File | Change |
|------|--------|
| `mempalace/knowledge_graph.py` | Replace 2 instances of `NULLS LAST` with portable ordering |

## Test plan

- [x] All 47 KG + MCP tests pass
- [x] Timeline ordering preserved (NULLs sort last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)