### PR TITLE
feat: add Gemini CLI session JSON normalizer

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -8,6 +8,7 @@ Supported:
     - ChatGPT conversations.json
     - Claude Code JSONL
     - OpenAI Codex CLI JSONL
+    - Gemini CLI JSON
     - Slack JSON export
     - Plain text (pass through for paragraph chunking)
 
@@ -71,7 +72,7 @@ def _try_normalize_json(content: str) -> Optional[str]:
     except json.JSONDecodeError:
         return None
 
-    for parser in (_try_claude_ai_json, _try_chatgpt_json, _try_slack_json):
+    for parser in (_try_claude_ai_json, _try_chatgpt_json, _try_gemini_json, _try_slack_json):
         normalized = parser(data)
         if normalized:
             return normalized
@@ -232,6 +233,51 @@ def _try_chatgpt_json(data) -> Optional[str]:
                     messages.append(("assistant", text))
             children = node.get("children", [])
             current_id = children[0] if children else None
+    if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    return None
+
+
+def _try_gemini_json(data) -> Optional[str]:
+    """Gemini CLI session JSON (~/.gemini/tmp/{hash}/chats/session-*.json).
+
+    Sessions are single JSON files with a messages array. User messages have
+    type "user" with content as a list of {text: "..."} blocks. Assistant
+    messages have type "gemini" with content as a plain string.
+    """
+    if not isinstance(data, dict):
+        return None
+    if "sessionId" not in data or "messages" not in data:
+        return None
+    messages_list = data.get("messages", [])
+    if not isinstance(messages_list, list):
+        return None
+
+    messages = []
+    for item in messages_list:
+        if not isinstance(item, dict):
+            continue
+        msg_type = item.get("type", "")
+        content = item.get("content", "")
+        # Gemini user content is [{"text": "..."}] (no "type" key);
+        # assistant content is a plain string.
+        if isinstance(content, str):
+            text = content.strip()
+        elif isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, str):
+                    parts.append(block)
+                elif isinstance(block, dict) and "text" in block:
+                    parts.append(block["text"])
+            text = " ".join(parts).strip()
+        else:
+            text = ""
+        if msg_type == "user" and text:
+            messages.append(("user", text))
+        elif msg_type == "gemini" and text:
+            messages.append(("assistant", text))
+
     if len(messages) >= 2:
         return _messages_to_transcript(messages)
     return None


### PR DESCRIPTION
## Summary
Add `_try_gemini_json` parser for Gemini CLI session files stored at `~/.gemini/tmp/{project_hash}/chats/session-{timestamp}-{id}.json`. This is the 7th normalize format for MemPalace, alongside Claude AI JSON, ChatGPT JSON, Claude Code JSONL, Codex CLI JSONL (#61), Slack JSON, and plain text.

## Gemini CLI session format

Gemini CLI auto-saves every conversation as a single JSON file per session. Sessions are **project-scoped** — stored under a hash of the working directory. Retention defaults to 30 days / 100 sessions (configurable via `settings.json`).

**Path**: `~/.gemini/tmp/{project_hash}/chats/session-{timestamp}-{short_id}.json`

**Structure**:
```json
{
  "sessionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
  "projectHash": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...",
  "startTime": "2026-03-30T10:28:04.070Z",
  "lastUpdated": "2026-03-30T10:28:16.793Z",
  "messages": [
    {
      "id": "xxxxxxxx-...",
      "timestamp": "2026-03-30T10:28:04.070Z",
      "type": "user",
      "content": [{"text": "Quick Terraform question about input validation..."}]
    },
    {
      "id": "xxxxxxxx-...",
      "timestamp": "2026-03-30T10:28:16.793Z",
      "type": "gemini",
      "content": "Yes, the validation is **worth adding**..."
    }
  ],
  "kind": "main"
}
```

### Message types
| `type` value | `content` format | Represents |
|-------------|-----------------|------------|
| `"user"` | List of `{"text": "..."}` blocks | User prompts |
| `"gemini"` | Plain string | Assistant replies |

Other message types (model changes, tool calls, etc.) may appear in sessions but are skipped by this parser — only `user` and `gemini` carry conversation content.

## Design decisions

### Custom content extraction instead of shared `_extract_content`
Gemini user content blocks are `{"text": "..."}` **without** a `"type"` field. The shared `_extract_content` helper in normalize.py expects `{"type": "text", "text": "..."}` (the Claude/OpenAI convention) and returns empty string for Gemini blocks. Rather than modifying the shared helper (which could affect 5 other parsers), `_try_gemini_json` does its own extraction:
- Plain string → use directly
- List of dicts → extract `"text"` key from each block
- List of strings → join directly

### Fingerprints on `sessionId` + `messages` keys
The parser requires both `sessionId` and `messages` in the top-level dict. This prevents false positives on:
- **ChatGPT** — has `mapping` key, no `sessionId`
- **Claude AI** — flat list or `chat_messages` wrapper, no `sessionId`
- **Slack** — is a list (not dict)
- **Arbitrary JSON** — unlikely to have both keys

### Single JSON file (not JSONL)
Unlike Codex (JSONL per line) and Claude Code (JSONL per line), Gemini stores the entire session as one JSON object with a `messages` array. This means the parser registers in the `_try_normalize_json` dispatcher alongside the other JSON parsers (after `json.loads`), not in the JSONL section.

## What's NOT handled (and why)

- **Checkpoints / forked sessions**: Gemini supports `/resume save <tag>` for manual checkpoints and conversation forking. These may create additional session files. The parser handles them the same as regular sessions — if it has `sessionId` + `messages`, it normalizes.
- **Aborted/empty sessions**: Sessions with fewer than 2 messages return `None` (same threshold as all other parsers).
- **Tool call details**: Only `"user"` and `"gemini"` message types are extracted. Tool calls, model changes, and thinking level changes are skipped — they're operational metadata, not conversation content.
- **`/chat share` exports**: Gemini can export conversations to Markdown or JSON via `/chat share`. The exported JSON format may differ from the auto-saved session format. This parser targets auto-saved sessions only.

## Prior art
- **PR #106** (merged) added a Gemini CLI setup guide (docs only, no normalizer)
- **Issue #107** (open) tracks Gemini CLI integration and hooks
- Format verified against real session files on disk and confirmed via [Gemini CLI session management docs](https://geminicli.com/docs/cli/tutorials/session-management/) and Context7 (`google-gemini/gemini-cli` library)

## Changes
1 file changed (`mempalace/normalize.py`), 47 insertions:
- New `_try_gemini_json()` parser function with custom content extraction
- Registered in `_try_normalize_json()` dispatcher alongside other JSON parsers
- Module docstring updated to list Gemini CLI JSON as supported format

## Test plan
- [x] `ruff check mempalace/normalize.py` passes clean
- [x] `ruff format --check` already formatted
- [x] `python3 -m py_compile mempalace/normalize.py` compiles OK
- [x] Tested against 2 real local Gemini CLI sessions (2-turn and multi-turn) — produces correct `>` marker transcripts
- [x] False positive check — returns `None` for Claude AI JSON, ChatGPT JSON, Slack JSON, plain dict, empty dict, and list inputs
- [x] Pyright reports 0 new diagnostics
- [x] Session storage path and format confirmed via Gemini CLI docs and Context7

Refs: #59
