### PR TITLE
fix: entity detection prefers git repo directory names over README content

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -393,6 +393,67 @@ STOPWORDS = {
     "networks",
     "training",
     "inference",
+    # Common tech/programming terms that appear capitalized in READMEs
+    # but are not project or person entities (see issue #97)
+    "code",
+    "typescript",
+    "javascript",
+    "node",
+    "python",
+    "rust",
+    "ruby",
+    "java",
+    "swift",
+    "kotlin",
+    "dart",
+    "react",
+    "angular",
+    "vue",
+    "svelte",
+    "docker",
+    "linux",
+    "windows",
+    "macos",
+    "android",
+    "plugin",
+    "plugins",
+    "icon",
+    "icons",
+    "widget",
+    "widgets",
+    "module",
+    "modules",
+    "package",
+    "packages",
+    "component",
+    "components",
+    "config",
+    "configuration",
+    "readme",
+    "changelog",
+    "license",
+    "documentation",
+    "description",
+    "features",
+    "feature",
+    "overview",
+    "summary",
+    "contents",
+    "installation",
+    "setup",
+    "dependencies",
+    "requirements",
+    "contributing",
+    "contributors",
+    "modify",
+    "low",
+    "high",
+    "medium",
+    "visual",
+    "studio",
+    "figma",
+    "task",
+    "tasks",
 }
 
 # For entity detection — prose only, no code files
@@ -626,16 +687,57 @@ def classify_entity(name: str, frequency: int, scores: dict) -> dict:
     }
 
 
+# ==================== DIRECTORY-BASED PROJECT DETECTION ====================
+
+
+def detect_directory_projects(project_dir: str) -> list:
+    """
+    Detect git repositories as immediate children of the target directory.
+
+    When the init target contains git repos as children, their directory names
+    are the strongest signal for project candidates — stronger than content-based
+    detection from README files (see issue #97).
+
+    Returns a list of entity dicts with type="project" and high confidence.
+    """
+    project_path = Path(project_dir).expanduser().resolve()
+    projects = []
+
+    if not project_path.is_dir():
+        return projects
+
+    for child in sorted(project_path.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name.startswith("."):
+            continue
+        if child.name in SKIP_DIRS:
+            continue
+        if (child / ".git").is_dir() or (child / ".git").is_file():
+            projects.append(
+                {
+                    "name": child.name,
+                    "type": "project",
+                    "confidence": 0.95,
+                    "frequency": 0,
+                    "signals": ["git repository directory"],
+                }
+            )
+
+    return projects
+
+
 # ==================== MAIN DETECT ====================
 
 
-def detect_entities(file_paths: list, max_files: int = 10) -> dict:
+def detect_entities(file_paths: list, max_files: int = 10, base_dir: str = None) -> dict:
     """
     Scan files and detect entity candidates.
 
     Args:
         file_paths: List of Path objects to scan
         max_files: Max files to read (for speed)
+        base_dir: Optional directory to scan for git repo children as projects
 
     Returns:
         {
@@ -668,13 +770,13 @@ def detect_entities(file_paths: list, max_files: int = 10) -> dict:
     # Extract candidates
     candidates = extract_candidates(combined_text)
 
-    if not candidates:
-        return {"people": [], "projects": [], "uncertain": []}
-
     # Score and classify each candidate
     people = []
     projects = []
     uncertain = []
+
+    if not candidates and not base_dir:
+        return {"people": [], "projects": [], "uncertain": []}
 
     for name, frequency in sorted(candidates.items(), key=lambda x: x[1], reverse=True):
         scores = score_entity(name, combined_text, all_lines)
@@ -686,6 +788,17 @@ def detect_entities(file_paths: list, max_files: int = 10) -> dict:
             projects.append(entity)
         else:
             uncertain.append(entity)
+
+    # Merge directory-based project detection when base_dir is provided.
+    # Directory names of git repos are the strongest project signal — they take
+    # priority over content-based detection from README files (issue #97).
+    if base_dir:
+        dir_projects = detect_directory_projects(base_dir)
+        existing_project_names = {p["name"].lower() for p in projects}
+        for dp in dir_projects:
+            if dp["name"].lower() not in existing_project_names:
+                projects.append(dp)
+                existing_project_names.add(dp["name"].lower())
 
     # Sort by confidence descending
     people.sort(key=lambda x: x["confidence"], reverse=True)
@@ -848,6 +961,6 @@ if __name__ == "__main__":
     print(f"Scanning: {project_dir}")
     files = scan_for_detection(project_dir)
     print(f"Reading {len(files)} files...")
-    detected = detect_entities(files)
+    detected = detect_entities(files, base_dir=project_dir)
     confirmed = confirm_entities(detected)
     print("Confirmed entities:", confirmed)

--- a/mempalace/onboarding.py
+++ b/mempalace/onboarding.py
@@ -220,23 +220,32 @@ def _ask_wings(mode: str) -> list:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _auto_detect(directory: str, known_people: list) -> list:
-    """Scan directory for additional entity candidates."""
+def _auto_detect(directory: str, known_people: list) -> tuple:
+    """Scan directory for additional entity candidates.
+
+    Returns (new_people, dir_projects) — people not already known,
+    and projects detected from git repository directory names.
+    """
     known_names = {p["name"].lower() for p in known_people}
 
     try:
         files = scan_for_detection(directory)
-        if not files:
-            return []
-        detected = detect_entities(files)
+        detected = (
+            detect_entities(files, base_dir=directory)
+            if files
+            else detect_entities([], base_dir=directory)
+        )
         new_people = [
             e
             for e in detected["people"]
             if e["name"].lower() not in known_names and e["confidence"] >= 0.7
         ]
-        return new_people
+        dir_projects = [
+            e for e in detected["projects"] if "git repository directory" in e.get("signals", [])
+        ]
+        return new_people, dir_projects
     except Exception:
-        return []
+        return [], []
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -383,21 +392,38 @@ def run_onboarding(
     # Step 4: Wings (stored in config, not registry — just show user)
     wings = _ask_wings(mode)
 
-    # Step 5: Auto-detect additional people from files
+    # Step 5: Auto-detect additional people and projects from files
     if auto_detect and _yn("\nScan your files for additional names we might have missed?"):
         directory = _ask("Directory to scan", default=directory)
-        detected = _auto_detect(directory, people)
-        if detected:
+        detected_people, dir_projects = _auto_detect(directory, people)
+
+        # Show detected projects from git repository directories
+        if dir_projects:
+            known_project_names = {p.lower() for p in projects}
+            new_dir_projects = [
+                dp for dp in dir_projects if dp["name"].lower() not in known_project_names
+            ]
+            if new_dir_projects:
+                _hr()
+                print(f"\n  Found {len(new_dir_projects)} projects from git repositories:\n")
+                for dp in new_dir_projects:
+                    print(f"    {dp['name']}")
+                print()
+                if _yn("  Add these projects to your registry?"):
+                    for dp in new_dir_projects:
+                        projects.append(dp["name"])
+
+        if detected_people:
             _hr()
-            print(f"\n  Found {len(detected)} additional name candidates:\n")
-            for e in detected:
+            print(f"\n  Found {len(detected_people)} additional name candidates:\n")
+            for e in detected_people:
                 print(
                     f"    {e['name']:20} confidence={e['confidence']:.0%}  "
                     f"({', '.join(e['signals'][:1])})"
                 )
             print()
             if _yn("  Add any of these to your registry?"):
-                for e in detected:
+                for e in detected_people:
                     ans = input(f"    {e['name']} — (p)erson, (s)kip? ").strip().lower()
                     if ans == "p":
                         rel = input(f"    Relationship/role for {e['name']}? ").strip()

--- a/tests/test_entity_detector.py
+++ b/tests/test_entity_detector.py
@@ -1,0 +1,266 @@
+"""Tests for entity_detector.py — entity detection from content and directory structure."""
+
+import textwrap
+
+import pytest
+
+from mempalace.entity_detector import (
+    STOPWORDS,
+    classify_entity,
+    detect_directory_projects,
+    detect_entities,
+    extract_candidates,
+    scan_for_detection,
+    score_entity,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def repos_dir(tmp_path):
+    """Create a temporary directory with several git repos as children."""
+    for name in ["acme-dashboard", "acme-chess", "acme-notes"]:
+        repo = tmp_path / name
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "README.md").write_text(f"# {name}\nA project.")
+
+    # Non-git directory (should be ignored)
+    plain_dir = tmp_path / "random-notes"
+    plain_dir.mkdir()
+    (plain_dir / "notes.txt").write_text("some notes")
+
+    # Hidden directory (should be ignored)
+    hidden = tmp_path / ".hidden-repo"
+    hidden.mkdir()
+    (hidden / ".git").mkdir()
+
+    # SKIP_DIRS entry (should be ignored)
+    node_modules = tmp_path / "node_modules"
+    node_modules.mkdir()
+    (node_modules / ".git").mkdir()
+
+    return tmp_path
+
+
+@pytest.fixture
+def prose_dir(tmp_path):
+    """Create a directory with prose files containing entity-like content."""
+    content = textwrap.dedent("""\
+        Kai said the auth migration was critical. Kai pushed the fix.
+        Kai told Maya about the deadline. Maya replied with the timeline.
+        Maya asked about the deployment schedule.
+        Hey Kai, thanks for the review.
+        Building Orion is the top priority. We shipped Orion last week.
+        The Orion architecture needs refactoring. Deploy Orion to staging.
+        Kai said Orion v2 is ready.
+    """)
+    md = tmp_path / "notes.md"
+    md.write_text(content)
+    return tmp_path
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# detect_directory_projects
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDetectDirectoryProjects:
+    def test_finds_git_repos(self, repos_dir):
+        projects = detect_directory_projects(str(repos_dir))
+        names = [p["name"] for p in projects]
+        assert "acme-dashboard" in names
+        assert "acme-chess" in names
+        assert "acme-notes" in names
+
+    def test_skips_non_git_directories(self, repos_dir):
+        projects = detect_directory_projects(str(repos_dir))
+        names = [p["name"] for p in projects]
+        assert "random-notes" not in names
+
+    def test_skips_hidden_directories(self, repos_dir):
+        projects = detect_directory_projects(str(repos_dir))
+        names = [p["name"] for p in projects]
+        assert ".hidden-repo" not in names
+
+    def test_skips_skip_dirs(self, repos_dir):
+        projects = detect_directory_projects(str(repos_dir))
+        names = [p["name"] for p in projects]
+        assert "node_modules" not in names
+
+    def test_high_confidence(self, repos_dir):
+        projects = detect_directory_projects(str(repos_dir))
+        for p in projects:
+            assert p["confidence"] >= 0.9
+            assert p["type"] == "project"
+            assert "git repository directory" in p["signals"]
+
+    def test_returns_empty_for_nonexistent_dir(self, tmp_path):
+        result = detect_directory_projects(str(tmp_path / "nonexistent"))
+        assert result == []
+
+    def test_returns_empty_for_dir_without_repos(self, tmp_path):
+        (tmp_path / "just-a-folder").mkdir()
+        (tmp_path / "another-folder").mkdir()
+        result = detect_directory_projects(str(tmp_path))
+        assert result == []
+
+    def test_detects_git_file_worktrees(self, tmp_path):
+        """Git worktrees use a .git file instead of a .git directory."""
+        repo = tmp_path / "worktree-repo"
+        repo.mkdir()
+        (repo / ".git").write_text("gitdir: /some/path/.git/worktrees/worktree-repo")
+        projects = detect_directory_projects(str(tmp_path))
+        names = [p["name"] for p in projects]
+        assert "worktree-repo" in names
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# detect_entities with base_dir
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDetectEntitiesWithBaseDir:
+    def test_includes_directory_projects(self, repos_dir):
+        result = detect_entities([], base_dir=str(repos_dir))
+        project_names = [p["name"] for p in result["projects"]]
+        assert "acme-dashboard" in project_names
+        assert "acme-chess" in project_names
+        assert "acme-notes" in project_names
+
+    def test_merges_content_and_directory_projects(self, repos_dir, prose_dir):
+        # Add a repo with same name as a content-detected project
+        orion_repo = repos_dir / "Orion"
+        orion_repo.mkdir()
+        (orion_repo / ".git").mkdir()
+
+        # Create prose file in repos_dir
+        content = textwrap.dedent("""\
+            Building Orion is key. The Orion pipeline is fast.
+            Ship Orion today. Deploy Orion to prod.
+            The Orion system handles auth. Install Orion now.
+        """)
+        (repos_dir / "notes.md").write_text(content)
+
+        files = scan_for_detection(str(repos_dir))
+        result = detect_entities(files, base_dir=str(repos_dir))
+        project_names = [p["name"] for p in result["projects"]]
+
+        # Orion should appear only once (no duplicates)
+        assert project_names.count("Orion") <= 1
+        # Directory repos should be present
+        assert "acme-dashboard" in project_names
+
+    def test_without_base_dir_no_directory_projects(self, repos_dir):
+        """Without base_dir, no directory-based projects are detected."""
+        result = detect_entities([])
+        assert result["projects"] == []
+
+    def test_directory_projects_sorted_by_confidence(self, repos_dir):
+        result = detect_entities([], base_dir=str(repos_dir))
+        confidences = [p["confidence"] for p in result["projects"]]
+        assert confidences == sorted(confidences, reverse=True)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# extract_candidates and stopwords
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStopwords:
+    @pytest.mark.parametrize(
+        "word",
+        ["Code", "Typescript", "Javascript", "Node", "Plugin", "Icon", "Low", "Visual", "Figma"],
+    )
+    def test_generic_tech_words_in_stopwords(self, word):
+        """Words from issue #97 that should be filtered as stopwords."""
+        assert word.lower() in STOPWORDS
+
+    def test_extract_candidates_filters_stopwords(self):
+        # Repeat each word 5+ times to pass the frequency filter
+        text = " ".join(["Code"] * 10 + ["Typescript"] * 10 + ["Node"] * 10)
+        candidates = extract_candidates(text)
+        assert "Code" not in candidates
+        assert "Typescript" not in candidates
+        assert "Node" not in candidates
+
+    def test_extract_candidates_keeps_real_entities(self):
+        text = " ".join(["Kai"] * 5 + ["Orion"] * 5 + ["Maya"] * 5)
+        candidates = extract_candidates(text)
+        assert "Kai" in candidates
+        assert "Orion" in candidates
+        assert "Maya" in candidates
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# score_entity and classify_entity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestScoreAndClassify:
+    def test_person_with_strong_signals(self):
+        text = (
+            "Kai said hello. Kai pushed the fix. Hey Kai, thanks for the review.\n"
+            "Kai told Maya about it. She was happy."
+        )
+        lines = text.splitlines()
+        scores = score_entity("Kai", text, lines)
+        assert scores["person_score"] > 0
+        assert scores["person_score"] > scores["project_score"]
+
+    def test_project_with_strong_signals(self):
+        text = (
+            "Building Orion is critical. Deploy Orion today.\n"
+            "The Orion pipeline runs fast. Ship Orion to prod.\n"
+            "Install Orion via pip install Orion."
+        )
+        lines = text.splitlines()
+        scores = score_entity("Orion", text, lines)
+        assert scores["project_score"] > 0
+        assert scores["project_score"] > scores["person_score"]
+
+    def test_classify_uncertain_no_signals(self):
+        result = classify_entity(
+            "Unknown",
+            5,
+            {"person_score": 0, "project_score": 0, "person_signals": [], "project_signals": []},
+        )
+        assert result["type"] == "uncertain"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scan_for_detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestScanForDetection:
+    def test_finds_prose_files(self, tmp_path):
+        (tmp_path / "readme.md").write_text("# Hello")
+        (tmp_path / "notes.txt").write_text("Some notes")
+        (tmp_path / "data.csv").write_text("a,b,c")
+        files = scan_for_detection(str(tmp_path))
+        extensions = {f.suffix for f in files}
+        assert ".md" in extensions
+        assert ".txt" in extensions
+
+    def test_skips_git_dir(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text("git config")
+        (tmp_path / "readme.md").write_text("# Hello")
+        files = scan_for_detection(str(tmp_path))
+        for f in files:
+            assert ".git" not in str(f)
+
+    def test_falls_back_to_readable_files(self, tmp_path):
+        """When fewer than 3 prose files, includes readable code files too."""
+        (tmp_path / "main.py").write_text("print('hello')")
+        (tmp_path / "readme.md").write_text("# Hello")
+        files = scan_for_detection(str(tmp_path))
+        extensions = {f.suffix for f in files}
+        assert ".py" in extensions
+        assert ".md" in extensions


### PR DESCRIPTION
## Summary

Fixes #97 — `mempalace init` on a folder of git repositories now detects repo directory names as project candidates instead of surfacing generic words scraped from README files.

**Problem:** Running `mempalace init <folder-of-repos>` where the folder contains ~40 sibling git repositories produces useless entity suggestions like "Code (21x), Typescript (10x), Node (5x)" instead of the actual repo names (`acme-dashboard`, `acme-chess`, etc.).

**Root cause:** `detect_entities()` only scans file *content* for capitalized proper nouns. Directory names — the strongest signal for project identity — are completely ignored.

## Changes

- **`detect_directory_projects(project_dir)`** — new function that scans for immediate child directories containing `.git` (supports both directories and worktree files) and returns them as high-confidence (0.95) project entities
- **`detect_entities(file_paths, base_dir=None)`** — new `base_dir` parameter triggers directory-based detection and merges results with content-based detection (deduplicating by name)
- **50+ tech stopwords added** — common programming terms (`Code`, `Typescript`, `Node`, `Plugin`, `Icon`, `React`, `Docker`, etc.) that appear capitalized in READMEs but are not real entities
- **`onboarding.py` updated** — `_auto_detect()` now returns both detected people and directory-detected projects, and `run_onboarding()` presents them separately during the interactive flow
- **CLI entry point updated** — `entity_detector.py __main__` now passes `base_dir` to `detect_entities()`

## Test plan

- [x] 29 new tests in `tests/test_entity_detector.py` (all passing)
- [x] `detect_directory_projects`: finds git repos, skips non-git/hidden/SKIP_DIRS, handles worktrees, returns empty for nonexistent dirs
- [x] `detect_entities` with `base_dir`: includes directory projects, merges without duplicates, sorted by confidence
- [x] Stopwords: all issue-reported words filtered, real entity names preserved
- [x] `score_entity`/`classify_entity`: person and project signal detection verified
- [x] `scan_for_detection`: prose files found, `.git` skipped, fallback to readable files
- [x] Full test suite passes (126/128 — 2 pre-existing failures in `test_dialect.py` unrelated to this PR)
- [x] `ruff check` and `ruff format` clean