### PR TITLE
fix: use actual detected room in mine summary stats

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -451,29 +451,29 @@ def process_file(
     rooms: list,
     agent: str,
     dry_run: bool,
-) -> int:
-    """Read, chunk, route, and file one file. Returns drawer count."""
+) -> tuple:
+    """Read, chunk, route, and file one file. Returns (drawer_count, room_name)."""
 
     # Skip if already filed
     source_file = str(filepath)
     if not dry_run and file_already_mined(collection, source_file):
-        return 0
+        return 0, None
 
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")
     except OSError:
-        return 0
+        return 0, None
 
     content = content.strip()
     if len(content) < MIN_CHUNK_SIZE:
-        return 0
+        return 0, None
 
     room = detect_room(filepath, content, rooms, project_path)
     chunks = chunk_text(content, source_file)
 
     if dry_run:
         print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-        return len(chunks)
+        return len(chunks), room
 
     drawers_added = 0
     for chunk in chunks:
@@ -489,7 +489,7 @@ def process_file(
         if added:
             drawers_added += 1
 
-    return drawers_added
+    return drawers_added, room
 
 
 # =============================================================================
@@ -608,7 +608,7 @@ def mine(
     room_counts = defaultdict(int)
 
     for i, filepath in enumerate(files, 1):
-        drawers = process_file(
+        drawers, room = process_file(
             filepath=filepath,
             project_path=project_path,
             collection=collection,
@@ -621,7 +621,6 @@ def mine(
             files_skipped += 1
         else:
             total_drawers += drawers
-            room = detect_room(filepath, "", rooms, project_path)
             room_counts[room] += 1
             if not dry_run:
                 print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")


### PR DESCRIPTION
## Summary
The `mempalace mine` summary prints wrong room counts. `process_file()` routes files using `detect_room(filepath, content, rooms, ...)` with real content, but the mine loop re-calls `detect_room(filepath, "", rooms, ...)` with **empty content** for the stats summary. When routing relied on content keyword scoring (Priority 3), the printed room differs from the filed room.

## Fix
`process_file()` now returns `(drawer_count, room)` instead of just `drawer_count`. The mine loop uses the returned room directly, eliminating the redundant `detect_room("")` call.

## Changes
1 file changed (`mempalace/miner.py`), 8 insertions, 9 deletions.

## Test plan
- [x] `ruff check` + `ruff format --check` pass
- [x] `python3 -m py_compile` compiles OK
- [x] Pyright reports 0 new diagnostics

Refs: #159 (point 3)