### PR TITLE
fix: pin posthog<6 (#163), Windows search UTF-8 (#47), README community/collab/language (#105 #7 #50 #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Other memory systems try to fix this by letting AI decide what's worth rememberi
 >
 > — *Milla Jovovich & Ben Sigman*
 
+
+---
+
+## Community fork, collaboration, and language
+
+**Another project also uses the MemPalace name** — an unrelated community org at [github.com/mempalace/mempalace](https://github.com/mempalace/mempalace). This repo (**milla-jovovich/mempalace**) is the one described in this README. If you landed from a link or fork, double-check which codebase you are using ([#105](https://github.com/milla-jovovich/mempalace/issues/105)).
+
+**Collaboration across people and devices** — MemPalace stores your palace as local files (ChromaDB + config under your home directory by default). There is no built-in real-time sync or merge for two people editing the same palace. Practical patterns: each person keeps their own palace path; share **source** materials (exported chats, repos) via Git and re-mine; or use one shared machine / copy of the palace directory with normal file-sync discipline and avoid concurrent `mine` on the same DB ([#7](https://github.com/milla-jovovich/mempalace/issues/7)).
+
+**Multilingual search** — Default embeddings are English-centric (`all-MiniLM-L6-v2`). Cross-lingual quality varies; improving it usually means a different embedding model or provider. See the discussion in [#50](https://github.com/milla-jovovich/mempalace/issues/50) and [#92](https://github.com/milla-jovovich/mempalace/issues/92). Chinese-speaking users may also want [#37](https://github.com/milla-jovovich/mempalace/issues/37).
+
 ---
 
 ## Quick Start

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -7,6 +7,7 @@ Returns verbatim text — the actual words, never summaries.
 """
 
 import logging
+import sys
 from pathlib import Path
 
 import chromadb
@@ -62,6 +63,13 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     if not docs:
         print(f'\n  No results found for: "{query}"')
         return
+
+    # Windows consoles often default to cp1252; box-drawing chars crash print (#47)
+    if sys.platform == "win32" and hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            pass
 
     print(f"\n{'=' * 60}")
     print(f'  Results for: "{query}"')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
 dependencies = [
     "chromadb>=0.5.0,<0.7",
     "pyyaml>=6.0",
+    # Chroma telemetry uses posthog; posthog>=6 breaks capture() signature (#163)
+    "posthog>=2.4.0,<6.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- **#163** — Pin `posthog>=2.4.0,<6.0.0` so Chroma telemetry does not break on posthog 6+ (`capture() takes 1 positional argument but 3 were given`).
- **#47** — Reconfigure stdout to UTF-8 on Windows before printing box-drawing characters in `searcher.search()`.
- **#105** — README: clarify this repo vs community org [mempalace/mempalace](https://github.com/mempalace/mempalace).
- **#7** — README: practical guidance for collaboration / multiple devices (no built-in palace merge; per-user paths, Git for sources, avoid concurrent mine).
- **#50 / #37** — README: multilingual / Chinese pointers to issues.

## Testing
`ruff check .` and `pytest` (101 tests) on NewDev after `pip install -e ".[dev]"`.
