### PR TITLE
fix: allow mining directories without local mempalace.yaml

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -8,7 +8,6 @@ Stores verbatim chunks as drawers. No summaries. Ever.
 """
 
 import os
-import sys
 import hashlib
 import fnmatch
 from pathlib import Path

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -279,16 +279,28 @@ def load_config(project_dir: str) -> dict:
     """Load mempalace.yaml from project directory (falls back to mempal.yaml)."""
     import yaml
 
-    config_path = Path(project_dir).expanduser().resolve() / "mempalace.yaml"
+    resolved_project_dir = Path(project_dir).expanduser().resolve()
+    config_path = resolved_project_dir / "mempalace.yaml"
     if not config_path.exists():
         # Fallback to legacy name
-        legacy_path = Path(project_dir).expanduser().resolve() / "mempal.yaml"
+        legacy_path = resolved_project_dir / "mempal.yaml"
         if legacy_path.exists():
             config_path = legacy_path
         else:
-            print(f"ERROR: No mempalace.yaml found in {project_dir}")
-            print(f"Run: mempalace init {project_dir}")
-            sys.exit(1)
+            print(
+                f"  No mempalace.yaml found in {resolved_project_dir} "
+                "— using auto-detected defaults"
+            )
+            return {
+                "wing": resolved_project_dir.name,
+                "rooms": [
+                    {
+                        "name": "general",
+                        "description": "All project files",
+                        "keywords": ["general"],
+                    }
+                ],
+            }
     with open(config_path) as f:
         return yaml.safe_load(f)
 

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import chromadb
 import yaml
 
-from mempalace.miner import mine, scan_project
+from mempalace.miner import load_config, mine, scan_project
 
 
 def write_file(path: Path, content: str):
@@ -46,6 +46,20 @@ def test_project_mining():
         client = chromadb.PersistentClient(path=str(palace_path))
         col = client.get_collection("mempalace_drawers")
         assert col.count() > 0
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_load_config_uses_defaults_when_yaml_missing():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        config = load_config(str(project_root))
+
+        assert isinstance(config, dict)
+        assert "wing" in config
+        assert "rooms" in config
+        assert config["wing"] == project_root.name
     finally:
         shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
## What does this PR do?

Changes `load_config()` in `miner.py` to return sensible defaults instead of `sys.exit(1)` when no `mempalace.yaml` exists in the source directory.

The bug: `mempalace mine ~/chats/` fails with `ERROR: No mempalace.yaml found` when the user init'd in a different directory (`~/projects/myapp`). The miner requires `mempalace.yaml` in every source directory, but users expect to init once and mine from anywhere.

The fix: when no yaml is found, derive a wing name from the directory basename and use a single "general" room. Prints an informational message instead of crashing.

Closes #14.

## How to test

```bash
# Create a directory with no mempalace.yaml
mkdir /tmp/test-mine
echo "some content" > /tmp/test-mine/file.txt
mempalace mine /tmp/test-mine
# Should work instead of crashing
```

Or run the new test:
```bash
pytest tests/test_miner.py::test_load_config_uses_defaults_when_yaml_missing -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

This contribution was developed with AI assistance (Codex).