### PR TITLE
feat: add brief retrieval mode for wing/room overviews

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -112,6 +112,14 @@ def cmd_search(args):
         sys.exit(1)
 
 
+def cmd_brief(args):
+    from .searcher import brief
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    result = brief(palace_path=palace_path, wing=args.wing, room=args.room)
+    print(result)
+
+
 def cmd_wakeup(args):
     """Show L0 (identity) + L1 (essential story) — the wake-up context."""
     from .layers import MemoryStack
@@ -412,6 +420,11 @@ def main():
     p_search.add_argument("--room", default=None, help="Limit to one room")
     p_search.add_argument("--results", type=int, default=5, help="Number of results")
 
+    p_brief = sub.add_parser("brief", help="Condensed overview of a wing or room")
+    p_brief.add_argument("--wing", default=None, help="Wing to summarize")
+    p_brief.add_argument("--room", default=None, help="Room to summarize")
+    p_brief.add_argument("--palace", default=None, help="Palace path")
+
     # compress
     p_compress = sub.add_parser(
         "compress", help="Compress drawers using AAAK Dialect (~30x reduction)"
@@ -471,6 +484,7 @@ def main():
         "mine": cmd_mine,
         "split": cmd_split,
         "search": cmd_search,
+        "brief": cmd_brief,
         "compress": cmd_compress,
         "wake-up": cmd_wakeup,
         "repair": cmd_repair,

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -424,7 +424,9 @@ class MemoryStack:
 
         # Parse the L2 output to get individual drawer lines
         lines = raw.split("\n")
-        content_lines = [line.strip() for line in lines if line.strip() and not line.startswith("## ")]
+        content_lines = [
+            line.strip() for line in lines if line.strip() and not line.startswith("## ")
+        ]
 
         # Deduplicate: skip lines with >70% overlap with already-seen content
         seen = []

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -415,6 +415,52 @@ class MemoryStack:
         """Deep L3 semantic search."""
         return self.l3.search(query, wing=wing, room=room, n_results=n_results)
 
+    def brief(self, wing: str = None, room: str = None, n_results: int = 20) -> str:
+        """Compressed overview of a wing/room - deduplicated top drawers."""
+        # Use L2 to get drawers but with more results for broader coverage
+        raw = self.l2.retrieve(wing=wing, room=room, n_results=n_results)
+        if raw.startswith("No "):
+            return raw
+
+        # Parse the L2 output to get individual drawer lines
+        lines = raw.split("\n")
+        content_lines = [line.strip() for line in lines if line.strip() and not line.startswith("## ")]
+
+        # Deduplicate: skip lines with >70% overlap with already-seen content
+        seen = []
+        unique = []
+        for line in content_lines:
+            words = set(line.lower().split())
+            is_dupe = False
+            for prev_words in seen:
+                if len(words & prev_words) > 0.7 * max(len(words), len(prev_words), 1):
+                    is_dupe = True
+                    break
+            if not is_dupe:
+                unique.append(line)
+                seen.append(words)
+
+        # Format as brief overview
+        label_parts = []
+        if wing:
+            label_parts.append(f"wing={wing}")
+        if room:
+            label_parts.append(f"room={room}")
+        label = ", ".join(label_parts) if label_parts else "all"
+
+        header = f"## Brief - {label} ({len(unique)} topics)"
+        # Truncate to ~2000 chars total
+        result_lines = [header]
+        total = len(header)
+        for line in unique:
+            if total + len(line) > 2000:
+                result_lines.append("  ...")
+                break
+            result_lines.append(line)
+            total += len(line)
+
+        return "\n".join(result_lines)
+
     def status(self) -> dict:
         """Status of all layers."""
         result = {

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -419,7 +419,7 @@ class MemoryStack:
         """Compressed overview of a wing/room - deduplicated top drawers."""
         # Use L2 to get drawers but with more results for broader coverage
         raw = self.l2.retrieve(wing=wing, room=room, n_results=n_results)
-        if raw.startswith("No "):
+        if raw.startswith("No ") or raw.startswith("Retrieval error"):
             return raw
 
         # Parse the L2 output to get individual drawer lines

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -150,3 +150,11 @@ def search_memories(
         "filters": {"wing": wing, "room": room},
         "results": hits,
     }
+
+
+def brief(palace_path: str, wing: str = None, room: str = None):
+    """Brief overview of a wing/room - deduplicated top drawers."""
+    from mempalace.layers import MemoryStack
+
+    stack = MemoryStack(palace_path=palace_path)
+    return stack.brief(wing=wing, room=room)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -4,7 +4,7 @@ test_searcher.py — Tests for the programmatic search_memories API.
 Tests the library-facing search interface (not the CLI print variant).
 """
 
-from mempalace.searcher import search_memories
+from mempalace.searcher import brief, search_memories
 
 
 class TestSearchMemories:
@@ -43,3 +43,9 @@ class TestSearchMemories:
         assert "source_file" in hit
         assert "similarity" in hit
         assert isinstance(hit["similarity"], float)
+
+    def test_brief(self, palace_path, seeded_collection):
+        """Brief returns a deduplicated overview."""
+        result = brief(palace_path=palace_path)
+        assert "Brief" in result
+        assert "topics" in result


### PR DESCRIPTION
## What does this PR do?

Adds a `brief()` retrieval mode that returns a deduplicated, truncated overview of a wing or room's contents. Complements the existing `recall()` (raw L2 retrieval) and `search()` (semantic L3 search) with a "catch me up" mode.

How it works:
- Fetches top 20 drawers via L2
- Deduplicates using 70% word-overlap threshold
- Caps output at ~2000 chars
- Formats with topic count header

Available via:
- `MemoryStack.brief(wing=..., room=...)` in Python
- `searcher.brief()` wrapper
- `mempalace brief --wing X --room Y` CLI subcommand

Closes #73.

## How to test

```bash
# CLI
mempalace brief --wing my_project

# Python
from mempalace.layers import MemoryStack
stack = MemoryStack()
print(stack.brief(wing="my_project"))
```

Or run the test:
```bash
pytest tests/test_searcher.py::TestSearchMemories::test_brief -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

This contribution was developed with AI assistance (Codex).