### PR TITLE
fix(bench): remove global SSL verification bypass in convomem_bench

### DIFF
--- a/benchmarks/convomem_bench.py
+++ b/benchmarks/convomem_bench.py
@@ -25,7 +25,6 @@ import os
 import sys
 import json
 import shutil
-import ssl
 import tempfile
 import argparse
 import urllib.request
@@ -34,9 +33,6 @@ from collections import defaultdict
 from datetime import datetime
 
 import chromadb
-
-# Bypass SSL for restricted environments
-ssl._create_default_https_context = ssl._create_unverified_context
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 


### PR DESCRIPTION
## Summary

- Removes `ssl._create_default_https_context = ssl._create_unverified_context` from `convomem_bench.py`
- This module-level patch disables certificate verification for **all** urllib requests in the process, silently exposing the benchmark runner to MITM attacks
- Users in restricted environments (corporate proxies, etc.) can set `PYTHONHTTPSVERIFY=0` on a per-invocation basis instead of having it hardcoded

## Context

Identified while reviewing the security fixes in PR #34, which bundled this with several other changes. Per reviewer feedback on #34, submitting this as a focused, standalone fix.

## Test plan

- [ ] `pytest tests/ -v` passes (no test changes needed; benchmarks are not part of the test suite)
- [ ] `python benchmarks/convomem_bench.py --limit 5` still downloads from HuggingFace successfully over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)