### PR TITLE
fix(bench): remove hardcoded credential paths from benchmark runners

### DIFF
--- a/benchmarks/HYBRID_MODE.md
+++ b/benchmarks/HYBRID_MODE.md
@@ -435,7 +435,6 @@ If the API call fails (timeout, rate limit, no key), the function catches the ex
 **Key loading priority:**
 1. `--llm-key` CLI flag
 2. `ANTHROPIC_API_KEY` environment variable
-3. `~/.config/lu/keys.json` (checks `anthropic.lu_key` and similar paths)
 
 ## What Changed in the Code
 

--- a/benchmarks/locomo_bench.py
+++ b/benchmarks/locomo_bench.py
@@ -580,29 +580,12 @@ def llm_rerank_locomo(
 
 
 def _load_api_key(key_arg):
+    """Load API key from --llm-key arg or ANTHROPIC_API_KEY env var."""
     if key_arg:
         return key_arg
     env_key = os.environ.get("ANTHROPIC_API_KEY", "")
     if env_key:
         return env_key
-    keys_path = os.path.expanduser("~/.config/lu/keys.json")
-    if os.path.exists(keys_path):
-        try:
-            with open(keys_path) as f:
-                keys = json.load(f)
-            for name in ("lu_key", "anthropic_milla", "anthropic_claude_code_main"):
-                val = keys.get(name, "")
-                if isinstance(val, str) and val.startswith("sk-ant-"):
-                    return val
-            for section in ("anthropic", "anthropic_milla", "anthropic_claude_code_main"):
-                sec = keys.get(section, {})
-                if isinstance(sec, dict):
-                    for subkey in ("lu_key", "key", "api_key"):
-                        val = sec.get(subkey, "")
-                        if isinstance(val, str) and val.startswith("sk-ant-"):
-                            return val
-        except Exception:
-            pass
     return ""
 
 

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -2861,32 +2861,12 @@ def llm_rerank(
 
 
 def _load_api_key(key_arg):
-    """Load API key from --llm-key arg, env var, or ~/.config/lu/keys.json."""
+    """Load API key from --llm-key arg or ANTHROPIC_API_KEY env var."""
     if key_arg:
         return key_arg
     env_key = os.environ.get("ANTHROPIC_API_KEY", "")
     if env_key:
         return env_key
-    keys_path = os.path.expanduser("~/.config/lu/keys.json")
-    if os.path.exists(keys_path):
-        try:
-            with open(keys_path) as f:
-                keys = json.load(f)
-            # Flat string keys
-            for name in ("lu_key", "anthropic_milla", "anthropic_claude_code_main"):
-                val = keys.get(name, "")
-                if isinstance(val, str) and val.startswith("sk-ant-"):
-                    return val
-            # Nested dict: keys["anthropic"]["lu_key"]
-            for section in ("anthropic", "anthropic_milla", "anthropic_claude_code_main"):
-                sec = keys.get(section, {})
-                if isinstance(sec, dict):
-                    for subkey in ("lu_key", "key", "api_key"):
-                        val = sec.get(subkey, "")
-                        if isinstance(val, str) and val.startswith("sk-ant-"):
-                            return val
-        except Exception:
-            pass
     return ""
 
 
@@ -2970,8 +2950,7 @@ def run_benchmark(
         if not api_key:
             print(
                 "ERROR: --llm-rerank / --mode diary requires an API key. "
-                "Set ANTHROPIC_API_KEY, use --llm-key, "
-                "or store in ~/.config/lu/keys.json as 'lu_key'."
+                "Set ANTHROPIC_API_KEY or use --llm-key."
             )
             sys.exit(1)
 
@@ -3290,8 +3269,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--llm-key",
         default="",
-        help="Anthropic API key for LLM re-ranking. Falls back to ANTHROPIC_API_KEY "
-        "env var or ~/.config/lu/keys.json 'lu_key' field if not provided.",
+        help="Anthropic API key for LLM re-ranking. Falls back to ANTHROPIC_API_KEY env var.",
     )
     parser.add_argument(
         "--llm-model",


### PR DESCRIPTION
## Summary

- Removes `_load_api_key()` fallback to `~/.config/lu/keys.json` with personal key names (`anthropic_milla`, `anthropic_claude_code_main`) from `longmemeval_bench.py` and `locomo_bench.py`
- Simplifies API key loading to: `--llm-key` flag > `ANTHROPIC_API_KEY` env var
- Updates help text and `HYBRID_MODE.md` docs to match

The hardcoded path and personal key names leak internal infrastructure details. The standard `ANTHROPIC_API_KEY` env var is the expected pattern for Anthropic API consumers.

## Context

Identified while reviewing the security fixes in PR #34, which bundled this with several other changes. Per reviewer feedback on #34, submitting as a focused standalone fix.

## Test plan

- [ ] `pytest tests/ -v` passes (benchmarks are not part of the test suite)
- [ ] `python benchmarks/longmemeval_bench.py --help` shows updated help text
- [ ] `ANTHROPIC_API_KEY=sk-ant-... python benchmarks/longmemeval_bench.py ... --mode diary` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)