### PR TITLE
fix(mcp): harden error messages and add read-only server mode

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -37,6 +37,18 @@ logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
 logger = logging.getLogger("mempalace_mcp")
 
 _config = MempalaceConfig()
+_read_only = False
+
+# Tools that modify palace state. Blocked in read-only mode.
+WRITE_TOOLS = frozenset(
+    {
+        "mempalace_add_drawer",
+        "mempalace_delete_drawer",
+        "mempalace_kg_add",
+        "mempalace_kg_invalidate",
+        "mempalace_diary_write",
+    }
+)
 
 
 def _get_collection(create=False):
@@ -211,8 +223,9 @@ def tool_check_duplicate(content: str, threshold: float = 0.9):
             "is_duplicate": len(duplicates) > 0,
             "matches": duplicates,
         }
-    except Exception as e:
-        return {"error": str(e)}
+    except Exception:
+        logger.exception("Error in check_duplicate")
+        return {"error": "Duplicate check failed"}
 
 
 def tool_get_aaak_spec():
@@ -283,8 +296,9 @@ def tool_add_drawer(
         )
         logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
         return {"success": True, "drawer_id": drawer_id, "wing": wing, "room": room}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    except Exception:
+        logger.exception("Error adding drawer")
+        return {"success": False, "error": "Failed to add drawer"}
 
 
 def tool_delete_drawer(drawer_id: str):
@@ -299,8 +313,9 @@ def tool_delete_drawer(drawer_id: str):
         col.delete(ids=[drawer_id])
         logger.info(f"Deleted drawer: {drawer_id}")
         return {"success": True, "drawer_id": drawer_id}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    except Exception:
+        logger.exception("Error deleting drawer")
+        return {"success": False, "error": "Failed to delete drawer"}
 
 
 # ==================== KNOWLEDGE GRAPH ====================
@@ -388,8 +403,9 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
             "topic": topic,
             "timestamp": now.isoformat(),
         }
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    except Exception:
+        logger.exception("Error writing diary entry")
+        return {"success": False, "error": "Failed to write diary entry"}
 
 
 def tool_diary_read(agent_name: str, last_n: int = 10):
@@ -433,8 +449,9 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
             "total": len(results["ids"]),
             "showing": len(entries),
         }
-    except Exception as e:
-        return {"error": str(e)}
+    except Exception:
+        logger.exception("Error reading diary entries")
+        return {"error": "Failed to read diary entries"}
 
 
 # ==================== MCP PROTOCOL ====================
@@ -707,19 +724,29 @@ def handle_request(request):
     elif method == "notifications/initialized":
         return None
     elif method == "tools/list":
+        available = {n: t for n, t in TOOLS.items() if not (_read_only and n in WRITE_TOOLS)}
         return {
             "jsonrpc": "2.0",
             "id": req_id,
             "result": {
                 "tools": [
                     {"name": n, "description": t["description"], "inputSchema": t["input_schema"]}
-                    for n, t in TOOLS.items()
+                    for n, t in available.items()
                 ]
             },
         }
     elif method == "tools/call":
         tool_name = params.get("name")
         tool_args = params.get("arguments", {})
+        if _read_only and tool_name in WRITE_TOOLS:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {
+                    "code": -32600,
+                    "message": f"Server is in read-only mode. Tool '{tool_name}' is not available.",
+                },
+            }
         if tool_name not in TOOLS:
             return {
                 "jsonrpc": "2.0",
@@ -760,7 +787,12 @@ def handle_request(request):
 
 
 def main():
-    logger.info("MemPalace MCP Server starting...")
+    global _read_only
+    if "--read-only" in sys.argv:
+        _read_only = True
+        logger.info("MemPalace MCP Server starting (READ-ONLY mode)...")
+    else:
+        logger.info("MemPalace MCP Server starting...")
     while True:
         try:
             line = sys.stdin.readline()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -336,3 +336,90 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+
+# ── Read-Only Mode ─────────────────────────────────────────────────────
+
+
+class TestReadOnlyMode:
+    def test_read_only_blocks_write_tools(self, monkeypatch):
+        from mempalace import mcp_server
+        from mempalace.mcp_server import handle_request
+
+        monkeypatch.setattr(mcp_server, "_read_only", True)
+
+        for tool_name in mcp_server.WRITE_TOOLS:
+            resp = handle_request(
+                {
+                    "method": "tools/call",
+                    "id": 99,
+                    "params": {"name": tool_name, "arguments": {}},
+                }
+            )
+            assert "error" in resp, f"{tool_name} should be blocked in read-only mode"
+            assert resp["error"]["code"] == -32600
+
+        monkeypatch.setattr(mcp_server, "_read_only", False)
+
+    def test_read_only_allows_read_tools(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, palace_path, seeded_kg)
+        from mempalace import mcp_server
+        from mempalace.mcp_server import handle_request
+
+        _get_collection(palace_path, create=True)
+        monkeypatch.setattr(mcp_server, "_read_only", True)
+
+        resp = handle_request(
+            {
+                "method": "tools/call",
+                "id": 100,
+                "params": {"name": "mempalace_status", "arguments": {}},
+            }
+        )
+        assert "result" in resp
+        assert "error" not in resp
+
+        monkeypatch.setattr(mcp_server, "_read_only", False)
+
+    def test_read_only_hides_write_tools_from_list(self, monkeypatch):
+        from mempalace import mcp_server
+        from mempalace.mcp_server import handle_request
+
+        monkeypatch.setattr(mcp_server, "_read_only", True)
+
+        resp = handle_request({"method": "tools/list", "id": 101, "params": {}})
+        tool_names = {t["name"] for t in resp["result"]["tools"]}
+
+        for write_tool in mcp_server.WRITE_TOOLS:
+            assert write_tool not in tool_names, f"{write_tool} should be hidden in read-only mode"
+        assert "mempalace_status" in tool_names
+        assert "mempalace_search" in tool_names
+
+        monkeypatch.setattr(mcp_server, "_read_only", False)
+
+
+# ── Error Hardening ────────────────────────────────────────────────────
+
+
+class TestErrorHardening:
+    def test_error_responses_do_not_leak_exceptions(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, palace_path, kg)
+        _get_collection(palace_path, create=True)
+        from mempalace.mcp_server import handle_request
+
+        # Call delete with a nonexistent drawer to get a controlled error path
+        resp = handle_request(
+            {
+                "method": "tools/call",
+                "id": 200,
+                "params": {"name": "mempalace_delete_drawer", "arguments": {"drawer_id": "nope"}},
+            }
+        )
+        content = json.loads(resp["result"]["content"][0]["text"])
+        # Should get a clean error, not a Python traceback
+        assert "success" in content
+        assert content["success"] is False
+        # The error message should not contain Python exception class names
+        error_msg = content.get("error", "")
+        assert "Traceback" not in error_msg
+        assert "Exception" not in error_msg


### PR DESCRIPTION
## Summary

### Error hardening
- Replaces 5 instances of `str(e)` in MCP tool error responses with generic messages
- Raw exception strings can leak internal file paths, DB schema details, and ChromaDB internals to MCP clients
- Full exception details are still logged to stderr via `logger.exception()` for operator debugging

### Read-only mode
- Adds `--read-only` CLI flag: `python -m mempalace.mcp_server --read-only`
- Write tools (`add_drawer`, `delete_drawer`, `kg_add`, `kg_invalidate`, `diary_write`) return a JSON-RPC `-32600` error in read-only mode
- Write tools are hidden from `tools/list` in read-only mode
- Read tools continue to work normally

This is useful for shared deployments where the MCP server should expose palace data to AI agents without allowing mutations.

## Context

Cherry-picked from the security items in PR #34, which was asked to be split into focused PRs. The error hardening and read-only mode are the remaining unmerged security improvements from that PR.

## Test plan

- [x] `pytest tests/ -v` passes (4 new tests, 114 total)
- [x] `ruff check` and `ruff format --check` pass
- [ ] New tests cover:
  - Read-only mode blocks all write tools
  - Read-only mode allows read tools
  - Read-only mode hides write tools from tools/list
  - Error responses don't leak exception strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)