### PR TITLE
feat: add Claude Code plugin (hooks + MCP server)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "mempalace",
+  "description": "MemPalace plugin marketplace — memory hooks and MCP tools for Claude Code",
+  "owner": {
+    "name": "milla-jovovich",
+    "email": "noreply@github.com"
+  },
+  "plugins": [
+    {
+      "name": "mempalace",
+      "description": "Auto-save hooks and MCP server for MemPalace — the AI memory system",
+      "source": "./plugins/mempalace",
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -112,10 +112,19 @@ Three mining modes: **projects** (code and docs), **convos** (conversation expor
 
 After the one-time setup (install → init → mine), you don't run MemPalace commands manually. Your AI uses it for you. There are two ways, depending on which AI you use.
 
-### With Claude, ChatGPT, Cursor, Gemini (MCP-compatible tools)
+### With Claude Code (plugin — recommended)
 
 ```bash
-# Connect MemPalace once
+# Install the MemPalace plugin (hooks + MCP server in one step)
+claude plugin add mempalace@mempalace --marketplace github:milla-jovovich/mempalace
+```
+
+This installs the MCP server (19 tools) and auto-save hooks (save every 15 messages + emergency save before compaction). No manual configuration needed.
+
+### With Claude, ChatGPT, Cursor, Gemini (MCP — manual)
+
+```bash
+# Or connect the MCP server directly
 claude mcp add mempalace -- python -m mempalace.mcp_server
 ```
 
@@ -438,6 +447,12 @@ Letta charges $20–200/mo for agent-managed memory. MemPalace does it with a wi
 
 ## MCP Server
 
+**Plugin install (recommended):**
+```bash
+claude plugin add mempalace@mempalace --marketplace github:milla-jovovich/mempalace
+```
+
+**Manual install:**
 ```bash
 claude mcp add mempalace -- python -m mempalace.mcp_server
 ```
@@ -500,14 +515,13 @@ Two hooks for Claude Code that automatically save memories during work:
 
 **PreCompact Hook** — fires before context compression. Emergency save before the window shrinks.
 
-```json
-{
-  "hooks": {
-    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "/path/to/mempalace/hooks/mempal_save_hook.sh"}]}],
-    "PreCompact": [{"matcher": "", "hooks": [{"type": "command", "command": "/path/to/mempalace/hooks/mempal_precompact_hook.sh"}]}]
-  }
-}
+**Plugin install (recommended):** Both hooks are included in the plugin — no manual configuration needed:
+
+```bash
+claude plugin add mempalace@mempalace --marketplace github:milla-jovovich/mempalace
 ```
+
+**Manual install:** See [hooks/README.md](hooks/README.md) for copy-paste configuration.
 
 ---
 

--- a/examples/mcp_setup.md
+++ b/examples/mcp_setup.md
@@ -2,16 +2,22 @@
 
 ## Setup
 
-Run the MCP server:
+**Plugin install (recommended):** Installs the MCP server and auto-save hooks in one step:
 
 ```bash
-python -m mempalace.mcp_server
+claude plugin add mempalace@mempalace --marketplace github:milla-jovovich/mempalace
 ```
 
-Or add it to Claude Code:
+**Manual install:** Add the MCP server directly:
 
 ```bash
 claude mcp add mempalace -- python -m mempalace.mcp_server
+```
+
+**Standalone:** Run the MCP server outside Claude Code:
+
+```bash
+python -m mempalace.mcp_server
 ```
 
 ## Available Tools

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -11,15 +11,25 @@ These hook scripts make MemPalace save automatically. No manual "save" commands 
 
 The AI does the actual filing — it knows the conversation context, so it classifies memories into the right wings/halls/closets. The hooks just tell it WHEN to save.
 
-## Install — Claude Code
+## Install — Claude Code (Plugin)
 
-Add to `.claude/settings.local.json`:
+The easiest way to install both hooks and the MCP server:
+
+```bash
+claude plugin add mempalace@mempalace --marketplace github:milla-jovovich/mempalace
+```
+
+This installs Python versions of both hooks with no manual configuration needed.
+
+## Install — Claude Code (Manual)
+
+If you prefer manual setup, add to `.claude/settings.local.json`:
 
 ```json
 {
   "hooks": {
     "Stop": [{
-      "matcher": "*",
+      "matcher": "",
       "hooks": [{
         "type": "command",
         "command": "/absolute/path/to/hooks/mempal_save_hook.sh",

--- a/plugins/mempalace/.claude-plugin/plugin.json
+++ b/plugins/mempalace/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "mempalace",
+  "version": "3.0.0",
+  "description": "Auto-save hooks and MCP server for MemPalace — saves memories every 15 messages and before context compaction",
+  "author": {
+    "name": "milla-jovovich",
+    "email": "noreply@github.com"
+  },
+  "capabilities": ["shell", "mcp"],
+  "mcpServers": {
+    "mempalace": {
+      "command": "python3",
+      "args": ["-m", "mempalace.mcp_server"],
+      "type": "stdio"
+    }
+  }
+}

--- a/plugins/mempalace/hooks/hooks.json
+++ b/plugins/mempalace/hooks/hooks.json
@@ -1,0 +1,52 @@
+{
+  "hooks": {
+    "Setup": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PLUGIN_ROOT/hooks/setup_check.py\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PLUGIN_ROOT/hooks/setup_check.py\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PLUGIN_ROOT/hooks/mempal_save.py\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PLUGIN_ROOT/hooks/mempal_precompact.py\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/mempalace/hooks/mempal_precompact.py
+++ b/plugins/mempalace/hooks/mempal_precompact.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""mempal_precompact.py — Emergency save before context compaction.
+
+PreCompact hook. Always blocks, telling the AI to save everything
+before the context window gets compressed and detailed context is lost.
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".mempalace" / "hook_state"
+
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        hook_input = {}
+
+    session_id = hook_input.get("session_id", "unknown")
+
+    # Log
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    log_file = STATE_DIR / "hook.log"
+    safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", session_id) or "unknown"
+    safe_id = safe_id[:200]
+    try:
+        with open(log_file, "a") as f:
+            ts = datetime.now().strftime("%H:%M:%S")
+            f.write(f"[{ts}] PRE-COMPACT triggered for session {safe_id}\n")
+    except OSError:
+        pass
+
+    # Always block — compaction always warrants a save
+    print(
+        json.dumps(
+            {
+                "decision": "block",
+                "reason": "COMPACTION IMMINENT. Save ALL topics, decisions, quotes, code, and important context from this session to your memory system. Be thorough — after compaction, detailed context will be lost. Organize into appropriate categories. Use verbatim quotes where possible. Save everything, then allow compaction to proceed.",
+            }
+        )
+    )
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/mempalace/hooks/mempal_save.py
+++ b/plugins/mempalace/hooks/mempal_save.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""mempal_save.py — Auto-save checkpoint every N human messages.
+
+Stop hook. Counts human messages in the session transcript and blocks
+every SAVE_INTERVAL messages, telling the AI to save key memories to
+the palace. Uses stop_hook_active flag to prevent infinite loops.
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+SAVE_INTERVAL = 15
+STATE_DIR = Path.home() / ".mempalace" / "hook_state"
+
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    session_id = hook_input.get("session_id", "unknown")
+    stop_hook_active = hook_input.get("stop_hook_active", False)
+    transcript_path = hook_input.get("transcript_path", "")
+
+    # If already in a save cycle, let the AI stop normally
+    if stop_hook_active:
+        return
+
+    # Expand ~ and validate path
+    if transcript_path:
+        transcript_path = os.path.expanduser(transcript_path)
+
+    # Count human messages in the JSONL transcript
+    exchange_count = 0
+    if transcript_path and os.path.isfile(transcript_path):
+        try:
+            with open(transcript_path) as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line)
+                        msg = entry.get("message", {})
+                        if isinstance(msg, dict) and msg.get("role") == "user":
+                            content = msg.get("content", "")
+                            if isinstance(content, str) and "<command-message>" in content:
+                                continue
+                            exchange_count += 1
+                    except (json.JSONDecodeError, AttributeError):
+                        pass
+        except OSError:
+            pass
+
+    # Track last save point — sanitize session_id for filename safety
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", session_id) or "unknown"
+    safe_id = safe_id[:200]  # Avoid ENAMETOOLONG on ext4/APFS
+    last_save_file = STATE_DIR / f"{safe_id}_last_save"
+
+    last_save = 0
+    if last_save_file.is_file():
+        try:
+            last_save = int(last_save_file.read_text().strip())
+        except (ValueError, OSError):
+            pass
+
+    since_last = exchange_count - last_save
+
+    # Log for debugging
+    log_file = STATE_DIR / "hook.log"
+    try:
+        with open(log_file, "a") as f:
+            ts = datetime.now().strftime("%H:%M:%S")
+            f.write(
+                f"[{ts}] Session {safe_id}: {exchange_count} exchanges, {since_last} since last save\n"
+            )
+    except OSError:
+        pass
+
+    # Time to save?
+    if since_last >= SAVE_INTERVAL and exchange_count > 0:
+        last_save_file.write_text(str(exchange_count))
+
+        try:
+            with open(log_file, "a") as f:
+                ts = datetime.now().strftime("%H:%M:%S")
+                f.write(f"[{ts}] TRIGGERING SAVE at exchange {exchange_count}\n")
+        except OSError:
+            pass
+
+        print(
+            json.dumps(
+                {
+                    "decision": "block",
+                    "reason": "AUTO-SAVE checkpoint. Save key topics, decisions, quotes, and code from this session to your memory system. Organize into appropriate categories. Use verbatim quotes where possible. Continue conversation after saving.",
+                }
+            )
+        )
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/mempalace/hooks/setup_check.py
+++ b/plugins/mempalace/hooks/setup_check.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""setup_check.py — Verify mempalace is installed when plugin is first enabled.
+
+Setup/SessionStart hook. Checks if the mempalace package is importable.
+If not, detects common install locations (pipx, uv) and tells the user
+how to fix the MCP server configuration.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_mempalace_python():
+    """Try to find a Python interpreter that has mempalace installed."""
+    candidates = []
+
+    # Check pipx venv
+    pipx_venv = Path.home() / ".local" / "share" / "pipx" / "venvs" / "mempalace" / "bin" / "python"
+    if pipx_venv.exists():
+        candidates.append(str(pipx_venv))
+
+    # Check uv tool
+    uv_venv = Path.home() / ".local" / "share" / "uv" / "tools" / "mempalace" / "bin" / "python"
+    if uv_venv.exists():
+        candidates.append(str(uv_venv))
+
+    # Check common brew python paths
+    for brew_python in ["/opt/homebrew/bin/python3", "/usr/local/bin/python3"]:
+        if os.path.exists(brew_python):
+            candidates.append(brew_python)
+
+    for python_path in candidates:
+        try:
+            result = subprocess.run(
+                [python_path, "-c", "import mempalace"],
+                capture_output=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return python_path
+        except Exception:
+            pass
+
+    return None
+
+
+def main():
+    try:
+        json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        pass
+
+    # Check if system python3 can import mempalace
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import mempalace"],
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return  # All good
+    except Exception:
+        pass
+
+    # System python can't import it — try to find it elsewhere
+    found = find_mempalace_python()
+
+    if found:
+        msg = (
+            f"MemPalace plugin: the mempalace package is not available to the system python3, "
+            f"but it was found at: {found}\n\n"
+            f"The MCP server may not work with the default configuration. "
+            f"To fix this, run:\n"
+            f"  claude mcp add mempalace -- {found} -m mempalace.mcp_server\n\n"
+            f"Or reinstall mempalace so it is available to the system Python."
+        )
+    else:
+        msg = (
+            "MemPalace plugin: the mempalace Python package is not installed. "
+            "The MCP server will not work without it.\n\n"
+            "Install with one of:\n"
+            "  pipx install mempalace\n"
+            "  uv tool install mempalace\n"
+            "  pip install --user mempalace\n\n"
+            "If you installed via pipx, also run:\n"
+            "  claude mcp add mempalace -- "
+            "~/.local/share/pipx/venvs/mempalace/bin/python -m mempalace.mcp_server"
+        )
+
+    print(json.dumps({"additionalContext": msg}))
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_plugin_hooks.py
+++ b/tests/test_plugin_hooks.py
@@ -1,0 +1,240 @@
+"""
+test_plugin_hooks.py — Tests for the Claude Code plugin hooks.
+
+Tests the Python save and precompact hooks for correct behavior:
+trigger/allow logic, session ID sanitization, and output format.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent / "plugins" / "mempalace" / "hooks"
+SAVE_HOOK = HOOKS_DIR / "mempal_save.py"
+PRECOMPACT_HOOK = HOOKS_DIR / "mempal_precompact.py"
+
+
+def run_hook(hook_path, input_data):
+    """Run a hook script with JSON input, return (stdout, stderr, exit_code)."""
+    proc = subprocess.run(
+        [sys.executable, str(hook_path)],
+        input=json.dumps(input_data),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.stdout.strip(), proc.stderr.strip(), proc.returncode
+
+
+def parse_output(stdout):
+    """Parse hook JSON output, return None if empty."""
+    if not stdout:
+        return None
+    return json.loads(stdout)
+
+
+class TestSaveHook:
+    def test_allows_when_stop_hook_active(self):
+        stdout, _, code = run_hook(
+            SAVE_HOOK,
+            {
+                "session_id": "test-active",
+                "stop_hook_active": True,
+                "transcript_path": "",
+            },
+        )
+        assert code == 0
+        assert stdout == ""
+
+    def test_allows_when_no_transcript(self):
+        stdout, _, code = run_hook(
+            SAVE_HOOK,
+            {
+                "session_id": "test-no-transcript",
+                "stop_hook_active": False,
+                "transcript_path": "",
+            },
+        )
+        assert code == 0
+        assert stdout == ""
+
+    def test_allows_when_under_threshold(self, tmp_path):
+        # Create transcript with 5 user messages (under 15 threshold)
+        transcript = tmp_path / "short.jsonl"
+        lines = []
+        for i in range(5):
+            lines.append(json.dumps({"message": {"role": "user", "content": f"msg {i}"}}))
+            lines.append(json.dumps({"message": {"role": "assistant", "content": f"resp {i}"}}))
+        transcript.write_text("\n".join(lines))
+
+        stdout, _, code = run_hook(
+            SAVE_HOOK,
+            {
+                "session_id": "test-under-threshold",
+                "stop_hook_active": False,
+                "transcript_path": str(transcript),
+            },
+        )
+        assert code == 0
+        assert stdout == ""
+
+    def test_triggers_save_at_threshold(self, tmp_path):
+        # Create transcript with 16 user messages (over 15 threshold)
+        transcript = tmp_path / "long.jsonl"
+        lines = []
+        for i in range(16):
+            lines.append(json.dumps({"message": {"role": "user", "content": f"msg {i}"}}))
+            lines.append(json.dumps({"message": {"role": "assistant", "content": f"resp {i}"}}))
+        transcript.write_text("\n".join(lines))
+
+        stdout, _, code = run_hook(
+            SAVE_HOOK,
+            {
+                "session_id": "test-at-threshold",
+                "stop_hook_active": False,
+                "transcript_path": str(transcript),
+            },
+        )
+        assert code == 0
+        result = parse_output(stdout)
+        assert result is not None
+        assert result["decision"] == "block"
+        assert "AUTO-SAVE" in result["reason"]
+
+    def test_skips_command_messages(self, tmp_path):
+        # 16 messages but all are command messages — should not trigger
+        transcript = tmp_path / "commands.jsonl"
+        lines = []
+        for i in range(16):
+            lines.append(
+                json.dumps(
+                    {
+                        "message": {
+                            "role": "user",
+                            "content": f"<command-message>cmd {i}</command-message>",
+                        }
+                    }
+                )
+            )
+            lines.append(json.dumps({"message": {"role": "assistant", "content": f"resp {i}"}}))
+        transcript.write_text("\n".join(lines))
+
+        stdout, _, code = run_hook(
+            SAVE_HOOK,
+            {
+                "session_id": "test-commands-only",
+                "stop_hook_active": False,
+                "transcript_path": str(transcript),
+            },
+        )
+        assert code == 0
+        assert stdout == ""
+
+    def test_handles_malformed_json_input(self):
+        proc = subprocess.run(
+            [sys.executable, str(SAVE_HOOK)],
+            input="not valid json",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+    def test_handles_empty_input(self):
+        proc = subprocess.run(
+            [sys.executable, str(SAVE_HOOK)],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+    def test_sanitizes_session_id(self, tmp_path):
+        # Path traversal attempt in session_id
+        transcript = tmp_path / "traverse.jsonl"
+        lines = []
+        for i in range(16):
+            lines.append(json.dumps({"message": {"role": "user", "content": f"msg {i}"}}))
+            lines.append(json.dumps({"message": {"role": "assistant", "content": f"resp {i}"}}))
+        transcript.write_text("\n".join(lines))
+
+        stdout, _, code = run_hook(
+            SAVE_HOOK,
+            {
+                "session_id": "../../tmp/evil",
+                "stop_hook_active": False,
+                "transcript_path": str(transcript),
+            },
+        )
+        assert code == 0
+        # Should trigger save (16 messages) but session ID should be sanitized
+        result = parse_output(stdout)
+        assert result is not None
+        assert result["decision"] == "block"
+
+        # Verify no file written outside state dir
+        state_dir = Path.home() / ".mempalace" / "hook_state"
+        if state_dir.exists():
+            for f in state_dir.iterdir():
+                assert ".." not in f.name
+
+    def test_always_exits_zero(self, tmp_path):
+        """Hooks must always exit 0 — non-zero is treated as a warning by Claude Code."""
+        test_cases = [
+            {"session_id": "x", "stop_hook_active": True},
+            {"session_id": "x", "stop_hook_active": False, "transcript_path": "/nonexistent"},
+            {"session_id": "x"},
+            {},
+        ]
+        for case in test_cases:
+            _, _, code = run_hook(SAVE_HOOK, case)
+            assert code == 0, f"Non-zero exit for input: {case}"
+
+
+class TestPrecompactHook:
+    def test_always_blocks(self):
+        stdout, _, code = run_hook(
+            PRECOMPACT_HOOK,
+            {
+                "session_id": "test-compact",
+            },
+        )
+        assert code == 0
+        result = parse_output(stdout)
+        assert result is not None
+        assert result["decision"] == "block"
+        assert "COMPACTION" in result["reason"]
+
+    def test_blocks_with_empty_input(self):
+        stdout, _, code = run_hook(PRECOMPACT_HOOK, {})
+        assert code == 0
+        result = parse_output(stdout)
+        assert result is not None
+        assert result["decision"] == "block"
+
+    def test_handles_malformed_json(self):
+        proc = subprocess.run(
+            [sys.executable, str(PRECOMPACT_HOOK)],
+            input="garbage",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+        result = parse_output(proc.stdout.strip())
+        assert result is not None
+        assert result["decision"] == "block"
+
+    def test_always_exits_zero(self):
+        test_cases = [
+            {"session_id": "x"},
+            {},
+            {"session_id": "../../evil"},
+        ]
+        for case in test_cases:
+            _, _, code = run_hook(PRECOMPACT_HOOK, case)
+            assert code == 0, f"Non-zero exit for input: {case}"


### PR DESCRIPTION
## Summary

- Adds a Claude Code plugin that installs the MCP server and auto-save hooks in one step
- Rewrites hooks in Python, fixing the shell injection issue from #110 (SESSION_ID path traversal)
- Updates docs to show plugin install as the recommended method

Closes #187

## What changed

**New files:**
- `.claude-plugin/marketplace.json` - marketplace manifest
- `plugins/mempalace/.claude-plugin/plugin.json` - plugin manifest with MCP server
- `plugins/mempalace/hooks/hooks.json` - hook registration (Stop + PreCompact)
- `plugins/mempalace/hooks/mempal_save.py` - save hook (Python rewrite)
- `plugins/mempalace/hooks/mempal_precompact.py` - precompact hook (Python rewrite)

**Updated docs:**
- `README.md` - plugin install as primary method in setup, MCP, and hooks sections
- `examples/mcp_setup.md` - plugin install recommended, manual as alternative
- `hooks/README.md` - plugin install section added above manual instructions

## Install

```bash
claude plugin add mempalace@mempalace --marketplace github:milla-jovovich/mempalace
```

## Test plan

- [x] Plugin installs from GitHub repo and hooks fire correctly
- [x] Save hook triggers every 15 human messages
- [x] PreCompact hook always blocks with save instruction
- [x] Malicious session IDs (path traversal) are sanitized
- [x] Existing test suite passes (97/99, 2 pre-existing failures in test_dialect.py)
- [x] Manual MCP and hook setup still works as documented