### PR TITLE
feat: add Ollama wake-up wrapper for local LLM integration

### DIFF
--- a/examples/ollama_wake_wrapper.md
+++ b/examples/ollama_wake_wrapper.md
@@ -1,0 +1,65 @@
+# Ollama + MemPalace Wake-Up Wrapper
+
+This example shows how to connect MemPalace memory with a local LLM using Ollama.
+
+## What it does
+
+- Runs `mempalace wake-up`
+- Injects the retrieved context into a prompt
+- Sends the combined prompt to a local model (Gemma, Llama, etc.)
+
+## Usage
+
+```bash
+chmod +x examples/ollama_wake_wrapper.sh
+
+# Interactive
+./examples/ollama_wake_wrapper.sh
+
+# Non-interactive
+./examples/ollama_wake_wrapper.sh "summarize my canon"
+```
+
+## Model Selection
+
+Default model:
+
+```bash
+MODEL=gemma4:26b
+```
+
+Override per run:
+
+```bash
+MODEL=llama3.1:8b ./examples/ollama_wake_wrapper.sh "analyze this"
+```
+
+## Why this matters
+
+MemPalace provides memory retrieval, but does not include a built-in execution loop for local models.
+
+This wrapper demonstrates a minimal integration pattern:
+
+```
+memory (MemPalace) → context injection → local model (Ollama)
+```
+
+This allows:
+- Reduced prompt size
+- Lower token usage
+- More consistent behavior
+- Fully local execution (no API calls)
+
+## Notes
+
+- Works entirely offline
+- Requires Ollama installed and running
+- Requires MemPalace initialized and mined
+
+## Next steps
+
+- Add streaming output support
+- Add multi-query retrieval
+- Integrate with LiteLLM routing
+- Build a full orchestration layer
+

--- a/examples/ollama_wake_wrapper.sh
+++ b/examples/ollama_wake_wrapper.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL="${MODEL:-gemma4:26b}"
+WAKE_FILE="$(mktemp /tmp/mempalace-wake.XXXXXX.txt)"
+PROMPT_FILE="$(mktemp /tmp/mempalace-prompt.XXXXXX.txt)"
+
+cleanup() {
+  rm -f "$WAKE_FILE" "$PROMPT_FILE"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd mempalace
+require_cmd ollama
+
+mempalace wake-up > "$WAKE_FILE"
+
+printf '\n===== MEMPALACE WAKE-UP =====\n\n'
+cat "$WAKE_FILE"
+printf '\n===== END WAKE-UP =====\n\n'
+
+if [ "$#" -gt 0 ]; then
+  TASK="$*"
+else
+  printf 'Enter task for %s: ' "$MODEL"
+  IFS= read -r TASK
+fi
+
+cat > "$PROMPT_FILE" <<EOP
+You are the local MemPalace-assisted ArtistPro assistant.
+
+Treat the retrieved context below as binding operating context.
+Do not invent facts not supported by the retrieved context.
+Prefer controlled, verified actions.
+If the request is ambiguous, state what is missing instead of guessing.
+
+=== RETRIEVED CONTEXT START ===
+$(cat "$WAKE_FILE")
+=== RETRIEVED CONTEXT END ===
+
+=== USER TASK START ===
+$TASK
+=== USER TASK END ===
+EOP
+
+printf '\n===== OLLAMA RESPONSE (%s) =====\n\n' "$MODEL"
+ollama run "$MODEL" < "$PROMPT_FILE"
+printf '\n'


### PR DESCRIPTION
## Summary

Adds a minimal local-model integration example for MemPalace using Ollama.

This contribution includes:

- `examples/ollama_wake_wrapper.sh`
- `examples/ollama_wake_wrapper.md`

## What it does

The wrapper:

- runs `mempalace wake-up`
- captures the retrieved context
- injects that context into a prompt
- sends the combined prompt to a local Ollama model

It supports both:

- interactive usage
- one-shot CLI usage

It also allows model override via environment variable, for example:

```bash
MODEL=llama3.1:8b ./examples/ollama_wake_wrapper.sh "summarize my canon"