### PR TITLE
Fix IndexError when ChromaDB query returns empty results

### DIFF
--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 import chromadb
 
 from .config import MempalaceConfig
+from .searcher import safe_query
 
 
 # ---------------------------------------------------------------------------
@@ -282,11 +283,11 @@ class Layer3:
             kwargs["where"] = where
 
         try:
-            results = col.query(**kwargs)
+            results = safe_query(col, **kwargs)
         except Exception as e:
             return f"Search error: {e}"
 
-        if not results["documents"] or not results["documents"][0]:
+        if results is None:
             return "No results found."
 
         docs = results["documents"][0]
@@ -338,8 +339,11 @@ class Layer3:
             kwargs["where"] = where
 
         try:
-            results = col.query(**kwargs)
+            results = safe_query(col, **kwargs)
         except Exception:
+            return []
+
+        if results is None:
             return []
 
         hits = []

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -286,12 +286,12 @@ class Layer3:
         except Exception as e:
             return f"Search error: {e}"
 
+        if not results["documents"] or not results["documents"][0]:
+            return "No results found."
+
         docs = results["documents"][0]
         metas = results["metadatas"][0]
         dists = results["distances"][0]
-
-        if not docs:
-            return "No results found."
 
         lines = [f'## L3 — SEARCH RESULTS for "{query}"']
         for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -55,13 +55,13 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print(f"\n  Search error: {e}")
         raise SearchError(f"Search error: {e}") from e
 
+    if not results["documents"] or not results["documents"][0]:
+        print(f'\n  No results found for: "{query}"')
+        return
+
     docs = results["documents"][0]
     metas = results["metadatas"][0]
     dists = results["distances"][0]
-
-    if not docs:
-        print(f'\n  No results found for: "{query}"')
-        return
 
     print(f"\n{'=' * 60}")
     print(f'  Results for: "{query}"')
@@ -128,6 +128,13 @@ def search_memories(
         results = col.query(**kwargs)
     except Exception as e:
         return {"error": f"Search error: {e}"}
+
+    if not results["documents"] or not results["documents"][0]:
+        return {
+            "query": query,
+            "filters": {"wing": wing, "room": room},
+            "results": [],
+        }
 
     docs = results["documents"][0]
     metas = results["metadatas"][0]

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -14,6 +14,14 @@ import chromadb
 logger = logging.getLogger("mempalace_mcp")
 
 
+def safe_query(col, **kwargs):
+    """Run col.query() and return None when there are no hits."""
+    results = col.query(**kwargs)
+    if not results["documents"] or not results["documents"][0]:
+        return None
+    return results
+
+
 class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
 
@@ -49,13 +57,13 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         if where:
             kwargs["where"] = where
 
-        results = col.query(**kwargs)
+        results = safe_query(col, **kwargs)
 
     except Exception as e:
         print(f"\n  Search error: {e}")
         raise SearchError(f"Search error: {e}") from e
 
-    if not results["documents"] or not results["documents"][0]:
+    if results is None:
         print(f'\n  No results found for: "{query}"')
         return
 
@@ -125,11 +133,11 @@ def search_memories(
         if where:
             kwargs["where"] = where
 
-        results = col.query(**kwargs)
+        results = safe_query(col, **kwargs)
     except Exception as e:
         return {"error": f"Search error: {e}"}
 
-    if not results["documents"] or not results["documents"][0]:
+    if results is None:
         return {
             "query": query,
             "filters": {"wing": wing, "room": room},


### PR DESCRIPTION
Closes #195

## Summary

- Guard `results["documents"]` before indexing `[0]` in three search functions
- Return graceful "no results" responses instead of crashing with `IndexError`

### Changes

| File | Function | Fix |
|------|----------|-----|
| `searcher.py` | `search()` | Check empty before `[0]`, early return with print |
| `searcher.py` | `search_memories()` | Check empty before `[0]`, early return with proper dict |
| `layers.py` | `Layer3.search()` | Check empty before `[0]`, early return with string |

## Test plan

- [ ] `mempalace init` a fresh palace, then `mempalace search "anything"` — should print "No results found" instead of traceback
- [ ] Search with a non-existent wing filter — same graceful behavior
- [ ] Normal search with data still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)