### PR TITLE
fix search handling for empty chroma query payloads

### DIFF
--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -24,18 +24,7 @@ from collections import defaultdict
 import chromadb
 
 from .config import MempalaceConfig
-
-
-def _extract_query_lists(results: dict):
-    """Return (docs, metas, dists) from a Chroma query payload safely."""
-    documents = results.get("documents") or []
-    metadatas = results.get("metadatas") or []
-    distances = results.get("distances") or []
-
-    docs = documents[0] if documents else []
-    metas = metadatas[0] if metadatas else []
-    dists = distances[0] if distances else []
-    return docs, metas, dists
+from .utils import extract_query_lists
 
 
 # ---------------------------------------------------------------------------
@@ -298,7 +287,7 @@ class Layer3:
         except Exception as e:
             return f"Search error: {e}"
 
-        docs, metas, dists = _extract_query_lists(results)
+        docs, metas, dists = extract_query_lists(results)
 
         if not docs:
             return "No results found."
@@ -353,7 +342,7 @@ class Layer3:
             return []
 
         hits = []
-        docs, metas, dists = _extract_query_lists(results)
+        docs, metas, dists = extract_query_lists(results)
         for doc, meta, dist in zip(docs, metas, dists):
             hits.append(
                 {

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -26,6 +26,18 @@ import chromadb
 from .config import MempalaceConfig
 
 
+def _extract_query_lists(results: dict):
+    """Return (docs, metas, dists) from a Chroma query payload safely."""
+    documents = results.get("documents") or []
+    metadatas = results.get("metadatas") or []
+    distances = results.get("distances") or []
+
+    docs = documents[0] if documents else []
+    metas = metadatas[0] if metadatas else []
+    dists = distances[0] if distances else []
+    return docs, metas, dists
+
+
 # ---------------------------------------------------------------------------
 # Layer 0 — Identity
 # ---------------------------------------------------------------------------
@@ -286,9 +298,7 @@ class Layer3:
         except Exception as e:
             return f"Search error: {e}"
 
-        docs = results["documents"][0]
-        metas = results["metadatas"][0]
-        dists = results["distances"][0]
+        docs, metas, dists = _extract_query_lists(results)
 
         if not docs:
             return "No results found."
@@ -343,11 +353,8 @@ class Layer3:
             return []
 
         hits = []
-        for doc, meta, dist in zip(
-            results["documents"][0],
-            results["metadatas"][0],
-            results["distances"][0],
-        ):
+        docs, metas, dists = _extract_query_lists(results)
+        for doc, meta, dist in zip(docs, metas, dists):
             hits.append(
                 {
                     "text": doc,

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -11,28 +11,13 @@ from pathlib import Path
 
 import chromadb
 
+from mempalace.utils import extract_query_lists
+
 logger = logging.getLogger("mempalace_mcp")
 
 
 class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
-
-
-def _extract_query_lists(results: dict):
-    """
-    Return (docs, metas, dists) from a Chroma query payload safely.
-
-    Chroma can return {"documents": []} when no matches are found.
-    In that case, indexing [0] raises IndexError unless guarded.
-    """
-    documents = results.get("documents") or []
-    metadatas = results.get("metadatas") or []
-    distances = results.get("distances") or []
-
-    docs = documents[0] if documents else []
-    metas = metadatas[0] if metadatas else []
-    dists = distances[0] if distances else []
-    return docs, metas, dists
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
@@ -72,7 +57,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print(f"\n  Search error: {e}")
         raise SearchError(f"Search error: {e}") from e
 
-    docs, metas, dists = _extract_query_lists(results)
+    docs, metas, dists = extract_query_lists(results)
 
     if not docs:
         print(f'\n  No results found for: "{query}"')
@@ -144,7 +129,7 @@ def search_memories(
     except Exception as e:
         return {"error": f"Search error: {e}"}
 
-    docs, metas, dists = _extract_query_lists(results)
+    docs, metas, dists = extract_query_lists(results)
 
     hits = []
     for doc, meta, dist in zip(docs, metas, dists):

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -18,6 +18,23 @@ class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
 
 
+def _extract_query_lists(results: dict):
+    """
+    Return (docs, metas, dists) from a Chroma query payload safely.
+
+    Chroma can return {"documents": []} when no matches are found.
+    In that case, indexing [0] raises IndexError unless guarded.
+    """
+    documents = results.get("documents") or []
+    metadatas = results.get("metadatas") or []
+    distances = results.get("distances") or []
+
+    docs = documents[0] if documents else []
+    metas = metadatas[0] if metadatas else []
+    dists = distances[0] if distances else []
+    return docs, metas, dists
+
+
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
     """
     Search the palace. Returns verbatim drawer content.
@@ -55,9 +72,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print(f"\n  Search error: {e}")
         raise SearchError(f"Search error: {e}") from e
 
-    docs = results["documents"][0]
-    metas = results["metadatas"][0]
-    dists = results["distances"][0]
+    docs, metas, dists = _extract_query_lists(results)
 
     if not docs:
         print(f'\n  No results found for: "{query}"')
@@ -129,9 +144,7 @@ def search_memories(
     except Exception as e:
         return {"error": f"Search error: {e}"}
 
-    docs = results["documents"][0]
-    metas = results["metadatas"][0]
-    dists = results["distances"][0]
+    docs, metas, dists = _extract_query_lists(results)
 
     hits = []
     for doc, meta, dist in zip(docs, metas, dists):

--- a/mempalace/utils.py
+++ b/mempalace/utils.py
@@ -1,0 +1,20 @@
+"""
+utils.py — Shared utility helpers.
+"""
+
+
+def extract_query_lists(results: dict):
+    """
+    Return (docs, metas, dists) from a ChromaDB query payload safely.
+
+    ChromaDB can return {"documents": []} when no matches are found.
+    Indexing [0] on an empty outer list raises IndexError unless guarded.
+    """
+    documents = results.get("documents") or []
+    metadatas = results.get("metadatas") or []
+    distances = results.get("distances") or []
+
+    docs = documents[0] if documents else []
+    metas = metadatas[0] if metadatas else []
+    dists = distances[0] if distances else []
+    return docs, metas, dists

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,47 @@
+"""
+test_layers.py — Regression tests for layered retrieval helpers.
+"""
+
+from mempalace.layers import Layer3
+
+
+class TestLayer3Search:
+    def test_search_handles_empty_query_payload(self, monkeypatch):
+        class _FakeCollection:
+            def query(self, **_kwargs):
+                return {"documents": [], "metadatas": [], "distances": []}
+
+        class _FakeClient:
+            def __init__(self, path):
+                self.path = path
+
+            def get_collection(self, _name):
+                return _FakeCollection()
+
+        monkeypatch.setattr(
+            "mempalace.layers.chromadb.PersistentClient",
+            _FakeClient,
+        )
+
+        result = Layer3(palace_path="/tmp/fake-palace").search("anything")
+        assert result == "No results found."
+
+    def test_search_raw_handles_empty_query_payload(self, monkeypatch):
+        class _FakeCollection:
+            def query(self, **_kwargs):
+                return {"documents": [], "metadatas": [], "distances": []}
+
+        class _FakeClient:
+            def __init__(self, path):
+                self.path = path
+
+            def get_collection(self, _name):
+                return _FakeCollection()
+
+        monkeypatch.setattr(
+            "mempalace.layers.chromadb.PersistentClient",
+            _FakeClient,
+        )
+
+        result = Layer3(palace_path="/tmp/fake-palace").search_raw("anything")
+        assert result == []

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -4,7 +4,7 @@ test_searcher.py — Tests for the programmatic search_memories API.
 Tests the library-facing search interface (not the CLI print variant).
 """
 
-from mempalace.searcher import search_memories
+from mempalace.searcher import search, search_memories
 
 
 class TestSearchMemories:
@@ -43,3 +43,44 @@ class TestSearchMemories:
         assert "source_file" in hit
         assert "similarity" in hit
         assert isinstance(hit["similarity"], float)
+
+    def test_handles_empty_query_payload(self, monkeypatch):
+        class _FakeCollection:
+            def query(self, **_kwargs):
+                return {"documents": [], "metadatas": [], "distances": []}
+
+        class _FakeClient:
+            def __init__(self, path):
+                self.path = path
+
+            def get_collection(self, _name):
+                return _FakeCollection()
+
+        monkeypatch.setattr(
+            "mempalace.searcher.chromadb.PersistentClient",
+            _FakeClient,
+        )
+
+        result = search_memories("anything", "/tmp/fake-palace")
+        assert result["results"] == []
+
+    def test_cli_search_handles_empty_query_payload(self, monkeypatch, capsys):
+        class _FakeCollection:
+            def query(self, **_kwargs):
+                return {"documents": [], "metadatas": [], "distances": []}
+
+        class _FakeClient:
+            def __init__(self, path):
+                self.path = path
+
+            def get_collection(self, _name):
+                return _FakeCollection()
+
+        monkeypatch.setattr(
+            "mempalace.searcher.chromadb.PersistentClient",
+            _FakeClient,
+        )
+
+        search("anything", "/tmp/fake-palace")
+        out = capsys.readouterr().out
+        assert 'No results found for: "anything"' in out


### PR DESCRIPTION
## What does this PR do?

Fixes crash reported in #195 when ChromaDB returns an empty outer query payload (for example `{"documents": []}`) on searches with no matches.

Previously, multiple paths assumed `results["documents"][0]` exists and could raise `IndexError: list index out of range`:
- `mempalace/searcher.py::search`
- `mempalace/searcher.py::search_memories`
- `mempalace/layers.py::Layer3.search`
- `mempalace/layers.py::Layer3.search_raw`

This PR adds safe query-result extraction helpers in `searcher.py` and `layers.py` that treat missing/empty outer lists as empty results, preserving expected behavior:
- CLI search prints “No results found” instead of crashing
- programmatic APIs return empty result sets instead of throwing

Also adds regression tests:
- `tests/test_searcher.py`
  - `test_handles_empty_query_payload`
  - `test_cli_search_handles_empty_query_payload`
- `tests/test_layers.py` (new)
  - `test_search_handles_empty_query_payload`
  - `test_search_raw_handles_empty_query_payload`

## How to test

```bash
# Install deps
python -m pip install ".[dev]"

# Focused regression tests for this fix
python -m pytest tests/test_searcher.py tests/test_layers.py -v

# Full suite
python -m pytest tests/ -v

# Lint
python -m ruff check .
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
