### PR TITLE
fix windows unicode separator crash in search output

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from collections import defaultdict
 
 from mempalace.i18n import get_entity_patterns
+from .output import safe_separator
 
 
 # ==================== LANGUAGE-AWARE PATTERN LOADING ====================
@@ -617,7 +618,7 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
             "topics": confirmed_topics,
         }
 
-    print(f"\n{'─' * 58}")
+    print(f"\n{safe_separator(58)}")
     print("  Options:")
     print("    [enter]  Accept all")
     print("    [edit]   Remove wrong entries or reclassify uncertain")

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -33,6 +33,8 @@ from .palace import (
 
 logger = logging.getLogger("mempalace_mcp")
 
+from mempalace.output import safe_separator
+
 READABLE_EXTENSIONS = {
     ".txt",
     ".md",
@@ -1093,7 +1095,7 @@ def _mine_impl(
         print("  .gitignore: DISABLED")
     if include_ignored:
         print(f"  Include: {', '.join(sorted(normalize_include_paths(include_ignored)))}")
-    print(f"{'-' * 55}\n")
+    print(f"{safe_separator(55)}\n")
 
     if not dry_run:
         collection = get_collection(palace_path)

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -33,7 +33,7 @@ from .palace import (
 
 logger = logging.getLogger("mempalace_mcp")
 
-from mempalace.output import safe_separator
+from .output import safe_separator
 
 READABLE_EXTENSIONS = {
     ".txt",

--- a/mempalace/onboarding.py
+++ b/mempalace/onboarding.py
@@ -18,7 +18,7 @@ Usage:
 
 from pathlib import Path
 from mempalace.entity_registry import EntityRegistry
-from mempalace.output import safe_separator
+from .output import safe_separator
 from mempalace.entity_detector import detect_entities, scan_for_detection
 
 

--- a/mempalace/onboarding.py
+++ b/mempalace/onboarding.py
@@ -18,6 +18,7 @@ Usage:
 
 from pathlib import Path
 from mempalace.entity_registry import EntityRegistry
+from mempalace.output import safe_separator
 from mempalace.entity_detector import detect_entities, scan_for_detection
 
 
@@ -57,7 +58,7 @@ DEFAULT_WINGS = {
 
 
 def _hr():
-    print(f"\n{'─' * 58}")
+    print(f"\n{safe_separator(58)}")
 
 
 def _header(text):

--- a/mempalace/output.py
+++ b/mempalace/output.py
@@ -1,0 +1,20 @@
+"""
+output.py — Shared terminal output helpers.
+"""
+
+import sys
+
+
+def safe_separator(width: int = 56) -> str:
+    """
+    Return a separator line safe for the active stdout encoding.
+
+    Windows cp1252 terminals cannot encode the Unicode box-drawing char
+    U+2500 (─), so we fall back to plain hyphens when needed.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        "─".encode(encoding)
+        return "─" * width
+    except (UnicodeEncodeError, LookupError):
+        return "-" * width

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -16,6 +16,8 @@ import yaml
 from pathlib import Path
 from collections import defaultdict
 
+from mempalace.output import safe_separator
+
 logger = logging.getLogger(__name__)
 
 # Common room patterns — detected from folder names and filenames
@@ -239,7 +241,7 @@ def print_proposed_structure(project_name: str, rooms: list, total_files: int, s
     for room in rooms:
         print(f"    ROOM: {room['name']}")
         print(f"          {room['description']}")
-    print(f"\n{'─' * 55}")
+    print(f"\n{safe_separator(55)}")
 
 
 def get_user_approval(rooms: list) -> list:

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -16,7 +16,7 @@ import yaml
 from pathlib import Path
 from collections import defaultdict
 
-from mempalace.output import safe_separator
+from .output import safe_separator
 
 logger = logging.getLogger(__name__)
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -14,6 +14,7 @@ import math
 import os
 import re
 import sqlite3
+import sys
 from pathlib import Path
 
 from .palace import get_closets_collection, get_collection
@@ -279,15 +280,26 @@ def _warn_if_legacy_metric(col) -> None:
     if space == "cosine":
         return
     # Either missing or set to something else — both are suspect.
-    import sys as _sys
-
     detail = f"hnsw:space={space!r}" if space else "no hnsw:space metadata"
     print(
         f"\n  NOTICE: this palace was created without cosine distance ({detail}).\n"
         "          Semantic similarity scores will not be meaningful.\n"
         "          Run `mempalace repair` to rebuild the index with the correct metric.",
-        file=_sys.stderr,
+        file=sys.stderr,
     )
+
+
+def _separator_line(width: int = 56) -> str:
+    """Return a separator line safe for the active stdout encoding.
+
+    Windows cp1252 terminals cannot encode the Unicode box-drawing char.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        "─".encode(encoding)
+        return "─" * width
+    except Exception:
+        return "-" * width
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
@@ -352,6 +364,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     if room:
         print(f"  Room: {room}")
     print(f"{'=' * 60}\n")
+    separator = _separator_line()
 
     for i, hit in enumerate(hits, 1):
         vec_sim = round(max(0.0, 1 - hit["distance"]), 3)
@@ -369,7 +382,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         for line in hit["text"].strip().split("\n"):
             print(f"      {line}")
         print()
-        print(f"  {'─' * 56}")
+        print(f"  {separator}")
 
     print()
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 
 from .palace import get_closets_collection, get_collection
+from mempalace.output import safe_separator
 
 # Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
 # Multiple lines may join with newlines inside one closet document.
@@ -290,16 +291,7 @@ def _warn_if_legacy_metric(col) -> None:
 
 
 def _separator_line(width: int = 56) -> str:
-    """Return a separator line safe for the active stdout encoding.
-
-    Windows cp1252 terminals cannot encode the Unicode box-drawing char.
-    """
-    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
-    try:
-        "─".encode(encoding)
-        return "─" * width
-    except Exception:
-        return "-" * width
+    return safe_separator(width)
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from .palace import get_closets_collection, get_collection
-from mempalace.output import safe_separator
+from .output import safe_separator
 
 # Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
 # Multiple lines may join with newlines inside one closet document.
@@ -289,11 +289,6 @@ def _warn_if_legacy_metric(col) -> None:
         file=sys.stderr,
     )
 
-
-def _separator_line(width: int = 56) -> str:
-    return safe_separator(width)
-
-
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
     """
     Search the palace. Returns verbatim drawer content.
@@ -356,7 +351,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     if room:
         print(f"  Room: {room}")
     print(f"{'=' * 60}\n")
-    separator = _separator_line()
+    separator = safe_separator()
 
     for i, hit in enumerate(hits, 1):
         vec_sim = round(max(0.0, 1 - hit["distance"]), 3)

--- a/mempalace/split_mega_files.py
+++ b/mempalace/split_mega_files.py
@@ -28,7 +28,7 @@ import os
 import re
 from pathlib import Path
 
-from mempalace.output import safe_separator
+from .output import safe_separator
 
 HOME = Path.home()
 LUMI_DIR = Path(os.environ.get("MEMPALACE_SOURCE_DIR", str(HOME / "Desktop/transcripts")))

--- a/mempalace/split_mega_files.py
+++ b/mempalace/split_mega_files.py
@@ -28,6 +28,8 @@ import os
 import re
 from pathlib import Path
 
+from mempalace.output import safe_separator
+
 HOME = Path.home()
 LUMI_DIR = Path(os.environ.get("MEMPALACE_SOURCE_DIR", str(HOME / "Desktop/transcripts")))
 
@@ -290,7 +292,7 @@ def main():
     print(f"  Source:      {src_dir}")
     print(f"  Output:      {output_dir or 'same dir as source'}")
     print(f"  Mega-files:  {len(mega_files)}")
-    print(f"{'-' * 60}\n")
+    print(f"{safe_separator(60)}\n")
 
     total_written = 0
     for f, n_sessions in mega_files:
@@ -305,7 +307,7 @@ def main():
         else:
             print()
 
-    print(f"{'-' * 60}")
+    print(f"{safe_separator(60)}")
     if args.dry_run:
         print(f"  DRY RUN — would create {total_written} files from {len(mega_files)} mega-files")
     else:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,42 @@
+"""
+test_output.py — Unit tests for mempalace.output helpers.
+"""
+
+import io
+import sys
+
+from mempalace.output import safe_separator
+
+
+class TestSafeSeparator:
+    def test_utf8_returns_unicode_char(self, monkeypatch):
+        buf = io.BytesIO()
+        monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(buf, encoding="utf-8"))
+        assert safe_separator(4) == "────"
+
+    def test_cp1252_returns_hyphens(self, monkeypatch):
+        buf = io.BytesIO()
+        monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(buf, encoding="cp1252"))
+        assert safe_separator(4) == "----"
+
+    def test_default_width_is_56(self, monkeypatch):
+        buf = io.BytesIO()
+        monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(buf, encoding="utf-8"))
+        assert len(safe_separator()) == 56
+
+    def test_custom_width(self, monkeypatch):
+        buf = io.BytesIO()
+        monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(buf, encoding="utf-8"))
+        assert len(safe_separator(10)) == 10
+
+    def test_none_encoding_defaults_to_utf8(self, monkeypatch):
+        class _NoEncoding:
+            encoding = None
+        monkeypatch.setattr(sys, "stdout", _NoEncoding())
+        assert safe_separator(4) == "────"
+
+    def test_unknown_encoding_returns_hyphens(self, monkeypatch):
+        class _BadEncoding:
+            encoding = "not-a-real-encoding"
+        monkeypatch.setattr(sys, "stdout", _BadEncoding())
+        assert safe_separator(4) == "----"

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -407,27 +407,31 @@ class _FakeClient:
 
 class TestSearchCli:
     def test_uses_ascii_separator_on_cp1252_stdout(self, monkeypatch):
-        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", _FakeClient)
+        monkeypatch.setattr("mempalace.searcher.get_collection", lambda path, create=False: _FakeCollection())
 
         buf = io.BytesIO()
         fake_stdout = io.TextIOWrapper(buf, encoding="cp1252", errors="strict")
         monkeypatch.setattr("sys.stdout", fake_stdout)
 
-        search("anything", "/tmp/fake-palace")
-        fake_stdout.flush()
-        output = buf.getvalue().decode("cp1252")
+        try:
+            search("anything", "/tmp/fake-palace")
+        finally:
+            fake_stdout.flush()
 
+        output = buf.getvalue().decode("cp1252")
         assert "  " + ("-" * 56) in output
 
     def test_uses_unicode_separator_on_utf8_stdout(self, monkeypatch):
-        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", _FakeClient)
+        monkeypatch.setattr("mempalace.searcher.get_collection", lambda path, create=False: _FakeCollection())
 
         buf = io.BytesIO()
         fake_stdout = io.TextIOWrapper(buf, encoding="utf-8")
         monkeypatch.setattr("sys.stdout", fake_stdout)
 
-        search("anything", "/tmp/fake-palace")
-        fake_stdout.flush()
-        output = buf.getvalue().decode("utf-8")
+        try:
+            search("anything", "/tmp/fake-palace")
+        finally:
+            fake_stdout.flush()
 
+        output = buf.getvalue().decode("utf-8")
         assert "  " + ("─" * 56) in output

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -269,10 +269,8 @@ class TestSearchCLI:
 
     def test_search_no_results(self, palace_path, collection, capsys):
         """Empty collection returns no results message."""
-        # collection is empty (no seeded data)
         result = search("xyzzy_nonexistent_query", palace_path, n_results=1)
         captured = capsys.readouterr()
-        # Either prints "No results" or returns None
         assert result is None or "No results" in captured.out
 
     def test_search_query_error_raises(self):
@@ -287,7 +285,6 @@ class TestSearchCLI:
     def test_search_n_results(self, palace_path, seeded_collection, capsys):
         search("code", palace_path, n_results=1)
         captured = capsys.readouterr()
-        # Should have output with at least one result block
         assert "[1]" in captured.out
 
     def test_search_applies_bm25_hybrid_rerank(self, capsys):
@@ -388,22 +385,28 @@ class TestSearchCLI:
         # Second result renders with fallback '?' values instead of crashing
         assert "second doc" in captured.out
 
-    def test_cli_search_uses_ascii_separator_on_cp1252_stdout(self, monkeypatch):
-        class _FakeCollection:
-            def query(self, **_kwargs):
-                return {
-                    "documents": [["JWT auth details"]],
-                    "metadatas": [[{"wing": "project", "room": "backend", "source_file": "auth.py"}]],
-                    "distances": [[0.1]],
-                }
+# ── Shared fakes for CLI separator tests ──────────────────────────────
 
-        class _FakeClient:
-            def __init__(self, path):
-                self.path = path
 
-            def get_collection(self, _name):
-                return _FakeCollection()
+class _FakeCollection:
+    def query(self, **_kwargs):
+        return {
+            "documents": [["JWT auth details"]],
+            "metadatas": [[{"wing": "project", "room": "backend", "source_file": "auth.py"}]],
+            "distances": [[0.1]],
+        }
 
+
+class _FakeClient:
+    def __init__(self, path):
+        self.path = path
+
+    def get_collection(self, _name):
+        return _FakeCollection()
+
+
+class TestSearchCli:
+    def test_uses_ascii_separator_on_cp1252_stdout(self, monkeypatch):
         monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", _FakeClient)
 
         buf = io.BytesIO()
@@ -415,3 +418,16 @@ class TestSearchCLI:
         output = buf.getvalue().decode("cp1252")
 
         assert "  " + ("-" * 56) in output
+
+    def test_uses_unicode_separator_on_utf8_stdout(self, monkeypatch):
+        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", _FakeClient)
+
+        buf = io.BytesIO()
+        fake_stdout = io.TextIOWrapper(buf, encoding="utf-8")
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+
+        search("anything", "/tmp/fake-palace")
+        fake_stdout.flush()
+        output = buf.getvalue().decode("utf-8")
+
+        assert "  " + ("─" * 56) in output

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -5,6 +5,7 @@ Uses the real ChromaDB fixtures from conftest.py for integration tests,
 plus mock-based tests for error paths.
 """
 
+import io
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from mempalace.searcher import SearchError, search, search_memories
 
 
 # ── search_memories (API) ──────────────────────────────────────────────
+
 
 
 class TestSearchMemories:
@@ -385,3 +387,31 @@ class TestSearchCLI:
         assert "[2]" in captured.out
         # Second result renders with fallback '?' values instead of crashing
         assert "second doc" in captured.out
+
+    def test_cli_search_uses_ascii_separator_on_cp1252_stdout(self, monkeypatch):
+        class _FakeCollection:
+            def query(self, **_kwargs):
+                return {
+                    "documents": [["JWT auth details"]],
+                    "metadatas": [[{"wing": "project", "room": "backend", "source_file": "auth.py"}]],
+                    "distances": [[0.1]],
+                }
+
+        class _FakeClient:
+            def __init__(self, path):
+                self.path = path
+
+            def get_collection(self, _name):
+                return _FakeCollection()
+
+        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", _FakeClient)
+
+        buf = io.BytesIO()
+        fake_stdout = io.TextIOWrapper(buf, encoding="cp1252", errors="strict")
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+
+        search("anything", "/tmp/fake-palace")
+        fake_stdout.flush()
+        output = buf.getvalue().decode("cp1252")
+
+        assert "  " + ("-" * 56) in output


### PR DESCRIPTION
Added stdout-encoding-aware separator fallback in searcher.py so cp1252 consoles use ASCII - instead of Unicode ─.
Added regression test in test_searcher.py that simulates cp1252 stdout and verifies no crash.

Validation:
```
python3 -m ruff check mempalace/searcher.py tests/test_searcher.py
python3 -m pytest tests/test_searcher.py -v
python3 -m pytest tests/ -q (102 passed)
```