### PR TITLE
Refresh project mining safely on reruns

### DIFF
--- a/mempalace/drawer_store.py
+++ b/mempalace/drawer_store.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+drawer_store.py — Minimal shared access to the primary drawer collection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import chromadb
+
+from .config import DEFAULT_COLLECTION_NAME, MempalaceConfig
+
+DRAWER_PAGE_SIZE = 1000
+PROJECT_INGEST_MODE = "projects"
+MANUAL_INGEST_MODE = "manual"
+REFRESH_OWNER_KEY = "refresh_owner"
+
+
+def _project_drawer_id(wing: str, room: str, source_file: str, chunk_index: int) -> str:
+    digest = hashlib.sha256((source_file + str(chunk_index)).encode()).hexdigest()[:24]
+    return f"drawer_{wing}_{room}_{digest}"
+
+
+def _legacy_project_drawer_id(wing: str, room: str, source_file: str, chunk_index: int) -> str:
+    digest = hashlib.md5(
+        (source_file + str(chunk_index)).encode(), usedforsecurity=False
+    ).hexdigest()[:16]
+    return f"drawer_{wing}_{room}_{digest}"
+
+
+def resolve_palace_path(
+    palace_path: Optional[str] = None, config: Optional[MempalaceConfig] = None
+) -> str:
+    cfg = config or MempalaceConfig()
+    raw_path = palace_path if palace_path is not None else cfg.palace_path
+    return str(Path(raw_path).expanduser())
+
+
+def resolve_collection_name(
+    collection_name: Optional[str] = None,
+    palace_path: Optional[str] = None,
+    config: Optional[MempalaceConfig] = None,
+) -> str:
+    cfg = config or MempalaceConfig()
+    if collection_name is not None:
+        return collection_name
+    if palace_path is not None:
+        return DEFAULT_COLLECTION_NAME
+    return cfg.collection_name
+
+
+@dataclass(frozen=True)
+class DrawerNamespace:
+    """A source-backed drawer namespace that can be refreshed safely."""
+
+    wing: str
+    source_file: str
+    ingest_mode: str
+
+    @property
+    def where(self) -> Dict[str, List[Dict[str, str]]]:
+        return {"$and": [{"wing": self.wing}, {"source_file": self.source_file}]}
+
+    @property
+    def refresh_owner(self) -> str:
+        return self.ingest_mode
+
+    def matches(self, row: Dict[str, object]) -> bool:
+        metadata = row["metadata"]
+        if metadata.get("wing") != self.wing:
+            return False
+        if metadata.get("source_file") != self.source_file:
+            return False
+
+        refresh_owner = metadata.get(REFRESH_OWNER_KEY)
+        if refresh_owner is not None:
+            return (
+                refresh_owner == self.refresh_owner
+                and metadata.get("ingest_mode") == self.ingest_mode
+            )
+
+        return self._matches_legacy_row(row["id"], metadata)
+
+    def _matches_legacy_row(self, row_id: str, metadata: Dict[str, object]) -> bool:
+        if self.ingest_mode != PROJECT_INGEST_MODE:
+            return False
+
+        legacy_ingest_mode = metadata.get("ingest_mode")
+        if legacy_ingest_mode not in (None, PROJECT_INGEST_MODE):
+            return False
+
+        room = metadata.get("room")
+        chunk_index = metadata.get("chunk_index")
+        if room is None or chunk_index is None:
+            return False
+
+        try:
+            chunk_index = int(chunk_index)
+        except (TypeError, ValueError):
+            return False
+
+        expected_id = _project_drawer_id(
+            wing=self.wing,
+            room=str(room),
+            source_file=self.source_file,
+            chunk_index=chunk_index,
+        )
+        legacy_id = _legacy_project_drawer_id(
+            wing=self.wing,
+            room=str(room),
+            source_file=self.source_file,
+            chunk_index=chunk_index,
+        )
+        return row_id in {expected_id, legacy_id}
+
+
+class DrawerStore:
+    """Thin wrapper around the configured Chroma drawer collection."""
+
+    def __init__(
+        self,
+        palace_path: Optional[str] = None,
+        collection_name: Optional[str] = None,
+        config: Optional[MempalaceConfig] = None,
+    ):
+        self._config = config or MempalaceConfig()
+        self.palace_path = resolve_palace_path(palace_path, self._config)
+        self.collection_name = resolve_collection_name(collection_name, palace_path, self._config)
+
+    def get_collection(self, create: bool = False):
+        client = chromadb.PersistentClient(path=self.palace_path)
+        if create:
+            return client.get_or_create_collection(self.collection_name)
+        return client.get_collection(self.collection_name)
+
+    def get_rows(self, where: Optional[Dict] = None, include_documents: bool = False) -> List[Dict]:
+        collection = self.get_collection()
+        include = ["metadatas"]
+        if include_documents:
+            include.append("documents")
+
+        rows = []
+        offset = 0
+
+        while True:
+            kwargs = {
+                "limit": DRAWER_PAGE_SIZE,
+                "offset": offset,
+                "include": include,
+            }
+            if where:
+                kwargs["where"] = where
+
+            results = collection.get(**kwargs)
+            ids = results.get("ids", [])
+            if not ids:
+                break
+
+            metadatas = results.get("metadatas", [])
+            documents = results.get("documents", []) if include_documents else []
+
+            for index, drawer_id in enumerate(ids):
+                row = {
+                    "id": drawer_id,
+                    "metadata": metadatas[index] or {},
+                }
+                if include_documents:
+                    row["document"] = documents[index]
+                rows.append(row)
+
+            if len(ids) < DRAWER_PAGE_SIZE:
+                break
+            offset += len(ids)
+
+        return rows
+
+    def get_namespace_rows(self, namespace: DrawerNamespace) -> List[Dict]:
+        rows = self.get_rows(where=namespace.where, include_documents=False)
+        return [row for row in rows if namespace.matches(row)]
+
+    def upsert_rows(self, rows: List[Dict]) -> None:
+        if not rows:
+            return
+
+        collection = self.get_collection(create=True)
+        for start in range(0, len(rows), DRAWER_PAGE_SIZE):
+            batch = rows[start : start + DRAWER_PAGE_SIZE]
+            collection.upsert(
+                ids=[row["id"] for row in batch],
+                documents=[row["document"] for row in batch],
+                metadatas=[row["metadata"] for row in batch],
+            )
+
+    def delete_ids(self, ids: List[str]) -> None:
+        if not ids:
+            return
+
+        collection = self.get_collection(create=True)
+        for start in range(0, len(ids), DRAWER_PAGE_SIZE):
+            batch = ids[start : start + DRAWER_PAGE_SIZE]
+            collection.delete(ids=batch)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 from .config import MempalaceConfig, sanitize_name, sanitize_content
 from .version import __version__
+from .drawer_store import MANUAL_INGEST_MODE, REFRESH_OWNER_KEY
 from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
 import chromadb
@@ -372,6 +373,8 @@ def tool_add_drawer(
                     "chunk_index": 0,
                     "added_by": added_by,
                     "filed_at": datetime.now().isoformat(),
+                    "ingest_mode": MANUAL_INGEST_MODE,
+                    REFRESH_OWNER_KEY: MANUAL_INGEST_MODE,
                 }
             ],
         )

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -11,13 +11,15 @@ import os
 import sys
 import hashlib
 import fnmatch
+from dataclasses import dataclass, field
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
 import chromadb
 
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import SKIP_DIRS
+from .drawer_store import DrawerNamespace, DrawerStore, PROJECT_INGEST_MODE, REFRESH_OWNER_KEY
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -55,6 +57,9 @@ CHUNK_SIZE = 800  # chars per drawer
 CHUNK_OVERLAP = 100  # overlap between chunks
 MIN_CHUNK_SIZE = 50  # skip tiny chunks
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
+PROJECT_PIPELINE_FINGERPRINT = (
+    f"projects:v2:chunk={CHUNK_SIZE}:overlap={CHUNK_OVERLAP}:min={MIN_CHUNK_SIZE}:single-room"
+)
 
 
 # =============================================================================
@@ -366,37 +371,85 @@ def chunk_text(content: str, source_file: str) -> list:
 
 
 # =============================================================================
-# PALACE — ChromaDB operations
+# PALACE — source refresh operations
 # =============================================================================
 
 
-def add_drawer(
-    collection, wing: str, room: str, content: str, source_file: str, chunk_index: int, agent: str
-):
-    """Add one drawer to the palace."""
-    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(chunk_index)).encode()).hexdigest()[:24]}"
-    try:
-        metadata = {
-            "wing": wing,
-            "room": room,
-            "source_file": source_file,
-            "chunk_index": chunk_index,
-            "added_by": agent,
-            "filed_at": datetime.now().isoformat(),
-        }
-        # Store file mtime so we can detect modifications later.
-        try:
-            metadata["source_mtime"] = os.path.getmtime(source_file)
-        except OSError:
-            pass
-        collection.upsert(
-            documents=[content],
-            ids=[drawer_id],
-            metadatas=[metadata],
+@dataclass
+class ProcessResult:
+    status: str
+    drawers: int = 0
+    cleared: int = 0
+    room_counts: dict = field(default_factory=dict)
+    error: str = ""
+
+
+def build_source_signature(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def build_drawer_id(wing: str, room: str, source_file: str, chunk_index: int) -> str:
+    digest = hashlib.sha256((source_file + str(chunk_index)).encode()).hexdigest()[:24]
+    return f"drawer_{wing}_{room}_{digest}"
+
+
+def prepare_drawer_rows(
+    namespace: DrawerNamespace,
+    source_root: str,
+    source_signature: str,
+    room: str,
+    chunks: list,
+    agent: str,
+) -> list:
+    rows = []
+    filed_at = datetime.now().isoformat()
+    for chunk in chunks:
+        rows.append(
+            {
+                "id": build_drawer_id(
+                    wing=namespace.wing,
+                    room=room,
+                    source_file=namespace.source_file,
+                    chunk_index=chunk["chunk_index"],
+                ),
+                "document": chunk["content"],
+                "metadata": {
+                    "wing": namespace.wing,
+                    "room": room,
+                    "source_file": namespace.source_file,
+                    "source_root": source_root,
+                    "source_signature": source_signature,
+                    "pipeline_fingerprint": PROJECT_PIPELINE_FINGERPRINT,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": agent,
+                    "filed_at": filed_at,
+                    "ingest_mode": namespace.ingest_mode,
+                    REFRESH_OWNER_KEY: namespace.refresh_owner,
+                },
+            }
         )
-        return True
-    except Exception:
-        raise
+    return rows
+
+
+def namespace_is_current(existing_rows: list, new_rows: list, source_signature: str) -> bool:
+    if not existing_rows or not new_rows:
+        return False
+
+    existing_ids = [row["id"] for row in existing_rows]
+    new_ids = [row["id"] for row in new_rows]
+    if len(existing_ids) != len(new_ids):
+        return False
+    if set(existing_ids) != set(new_ids):
+        return False
+
+    for row in existing_rows:
+        metadata = row["metadata"]
+        if metadata.get("source_signature") != source_signature:
+            return False
+        if metadata.get("pipeline_fingerprint") != PROJECT_PIPELINE_FINGERPRINT:
+            return False
+
+    return True
 
 
 # =============================================================================
@@ -407,50 +460,84 @@ def add_drawer(
 def process_file(
     filepath: Path,
     project_path: Path,
-    collection,
+    store: DrawerStore,
     wing: str,
     rooms: list,
     agent: str,
     dry_run: bool,
-) -> tuple:
-    """Read, chunk, route, and file one file. Returns (drawer_count, room_name)."""
-
-    # Skip if already filed
+) -> ProcessResult:
+    """Read, chunk, route, and refresh one source-backed namespace."""
     source_file = str(filepath)
-    if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
-        return 0, None
+    namespace = DrawerNamespace(
+        wing=wing,
+        source_file=source_file,
+        ingest_mode=PROJECT_INGEST_MODE,
+    )
+    existing_rows = []
+
+    try:
+        existing_rows = store.get_namespace_rows(namespace)
+    except Exception:
+        existing_rows = []
 
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return 0, None
+    except OSError as exc:
+        return ProcessResult(status="error", error=str(exc))
 
     content = content.strip()
     if len(content) < MIN_CHUNK_SIZE:
-        return 0, None
+        if not existing_rows:
+            return ProcessResult(status="ignored")
+        if dry_run:
+            return ProcessResult(status="cleared", cleared=len(existing_rows))
+        try:
+            store.delete_ids([row["id"] for row in existing_rows])
+        except Exception as exc:
+            return ProcessResult(status="error", error=str(exc))
+        return ProcessResult(status="cleared", cleared=len(existing_rows))
 
     room = detect_room(filepath, content, rooms, project_path)
     chunks = chunk_text(content, source_file)
+    if not chunks:
+        if not existing_rows:
+            return ProcessResult(status="ignored")
+        if dry_run:
+            return ProcessResult(status="cleared", cleared=len(existing_rows))
+        try:
+            store.delete_ids([row["id"] for row in existing_rows])
+        except Exception as exc:
+            return ProcessResult(status="error", error=str(exc))
+        return ProcessResult(status="cleared", cleared=len(existing_rows))
+
+    source_signature = build_source_signature(content)
+    new_rows = prepare_drawer_rows(
+        namespace=namespace,
+        source_root=str(project_path),
+        source_signature=source_signature,
+        room=room,
+        chunks=chunks,
+        agent=agent,
+    )
+
+    if namespace_is_current(existing_rows, new_rows, source_signature):
+        return ProcessResult(status="unchanged")
 
     if dry_run:
-        print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-        return len(chunks), room
+        status = "new" if not existing_rows else "updated"
+        return ProcessResult(status=status, drawers=len(new_rows), room_counts={room: len(new_rows)})
 
-    drawers_added = 0
-    for chunk in chunks:
-        added = add_drawer(
-            collection=collection,
-            wing=wing,
-            room=room,
-            content=chunk["content"],
-            source_file=source_file,
-            chunk_index=chunk["chunk_index"],
-            agent=agent,
-        )
-        if added:
-            drawers_added += 1
+    try:
+        store.upsert_rows(new_rows)
+        new_ids = {row["id"] for row in new_rows}
+        stale_ids = [row["id"] for row in existing_rows if row["id"] not in new_ids]
+        if stale_ids:
+            store.delete_ids(stale_ids)
+    except Exception as exc:
+        return ProcessResult(status="error", error=str(exc))
 
-    return drawers_added, room
+    status = "new" if not existing_rows else "updated"
+    return ProcessResult(status=status, drawers=len(new_rows), room_counts={room: len(new_rows)})
 
 
 # =============================================================================
@@ -559,7 +646,8 @@ def mine(
     print(f"  Wing:    {wing}")
     print(f"  Rooms:   {', '.join(r['name'] for r in rooms)}")
     print(f"  Files:   {len(files)}")
-    print(f"  Palace:  {palace_path}")
+    store = DrawerStore(palace_path=palace_path)
+    print(f"  Palace:  {store.palace_path}")
     if dry_run:
         print("  DRY RUN — nothing will be filed")
     if not respect_gitignore:
@@ -568,41 +656,63 @@ def mine(
         print(f"  Include: {', '.join(sorted(normalize_include_paths(include_ignored)))}")
     print(f"{'─' * 55}\n")
 
-    if not dry_run:
-        collection = get_collection(palace_path)
-    else:
-        collection = None
-
     total_drawers = 0
-    files_skipped = 0
+    total_cleared = 0
+    status_counts = defaultdict(int)
     room_counts = defaultdict(int)
 
     for i, filepath in enumerate(files, 1):
-        drawers, room = process_file(
+        result = process_file(
             filepath=filepath,
             project_path=project_path,
-            collection=collection,
+            store=store,
             wing=wing,
             rooms=rooms,
             agent=agent,
             dry_run=dry_run,
         )
-        if drawers == 0 and not dry_run:
-            files_skipped += 1
-        else:
-            total_drawers += drawers
-            room_counts[room] += 1
-            if not dry_run:
-                print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
+        status_counts[result.status] += 1
+        total_drawers += result.drawers
+        total_cleared += result.cleared
+        for room, count in result.room_counts.items():
+            room_counts[room] += count
+
+        if dry_run:
+            detail = []
+            if result.drawers:
+                detail.append(f"{result.drawers} drawers")
+            if result.cleared:
+                detail.append(f"clear {result.cleared}")
+            suffix = f" ({', '.join(detail)})" if detail else ""
+            print(f"    [DRY RUN] {filepath.name} → {result.status}{suffix}")
+            continue
+
+        if result.status in ("new", "updated"):
+            print(
+                f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} "
+                f"{result.status:7} +{result.drawers}"
+            )
+        elif result.status == "cleared":
+            print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} cleared  -{result.cleared}")
+        elif result.status == "error":
+            print(f"  ! [{i:4}/{len(files)}] {filepath.name[:50]:50} error    {result.error}")
 
     print(f"\n{'=' * 55}")
     print("  Done.")
-    print(f"  Files processed: {len(files) - files_skipped}")
-    print(f"  Files skipped (already filed): {files_skipped}")
+    print(f"  Files scanned: {len(files)}")
+    print(f"  Files new: {status_counts['new']}")
+    print(f"  Files updated: {status_counts['updated']}")
+    print(f"  Files unchanged: {status_counts['unchanged']}")
+    print(f"  Files cleared: {status_counts['cleared']}")
+    print(f"  Files errored: {status_counts['error']}")
+    if status_counts["ignored"]:
+        print(f"  Files ignored (no usable content): {status_counts['ignored']}")
     print(f"  Drawers filed: {total_drawers}")
-    print("\n  By room:")
-    for room, count in sorted(room_counts.items(), key=lambda x: x[1], reverse=True):
-        print(f"    {room:20} {count} files")
+    print(f"  Drawers cleared: {total_cleared}")
+    if room_counts:
+        print("\n  Drawers filed by room:")
+        for room, count in sorted(room_counts.items(), key=lambda x: x[1], reverse=True):
+            print(f"    {room:20} {count} drawers")
     print('\n  Next: mempalace search "what you\'re looking for"')
     print(f"{'=' * 55}\n")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ mempalace imports — so that module-level initialisations (e.g.
 instead of the real user profile.
 """
 
+import hashlib
+import math
 import os
 import shutil
 import tempfile
@@ -29,9 +31,32 @@ os.environ["HOMEPATH"] = os.path.splitdrive(_session_tmp)[1] or _session_tmp
 # Now it is safe to import mempalace modules that trigger initialisation.
 import chromadb  # noqa: E402
 import pytest  # noqa: E402
+import chromadb.api.types as chroma_types  # noqa: E402
 
 from mempalace.config import MempalaceConfig  # noqa: E402
 from mempalace.knowledge_graph import KnowledgeGraph  # noqa: E402
+
+os.environ.setdefault("CHROMA_TELEMETRY", "FALSE")
+
+
+def _embed_text(text: str) -> list[float]:
+    vector = [0.0] * 8
+    tokens = text.lower().split() or [text.lower()]
+    for token in tokens:
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        for index in range(len(vector)):
+            vector[index] += digest[index] / 255.0
+
+    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
+    return [value / norm for value in vector]
+
+
+class TestDefaultEmbeddingFunction(chroma_types.DefaultEmbeddingFunction):
+    def __call__(self, input):
+        return [_embed_text(document) for document in input]
+
+
+chroma_types.DefaultEmbeddingFunction = TestDefaultEmbeddingFunction
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -256,6 +256,12 @@ class TestWriteTools:
         assert result["room"] == "test_room"
         assert result["drawer_id"].startswith("drawer_test_wing_test_room_")
 
+        _client, collection = _get_collection(palace_path)
+        row = collection.get(ids=[result["drawer_id"]], include=["metadatas"])
+        metadata = row["metadatas"][0]
+        assert metadata["ingest_mode"] == "manual"
+        assert metadata["refresh_owner"] == "manual"
+
     def test_add_drawer_duplicate_detection(self, monkeypatch, config, palace_path, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         _client, _col = _get_collection(palace_path, create=True)

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import chromadb
 import yaml
@@ -19,6 +20,42 @@ def write_file(path: Path, content: str):
 def scanned_files(project_root: Path, **kwargs):
     files = scan_project(str(project_root), **kwargs)
     return sorted(path.relative_to(project_root).as_posix() for path in files)
+
+
+def write_project_config(project_root: Path, wing: str = "test_project"):
+    with open(project_root / "mempalace.yaml", "w") as f:
+        yaml.dump(
+            {
+                "wing": wing,
+                "rooms": [
+                    {
+                        "name": "billing",
+                        "description": "Billing work",
+                        "keywords": ["invoice", "billing", "payment"],
+                    },
+                    {
+                        "name": "auth",
+                        "description": "Authentication work",
+                        "keywords": ["auth", "oauth", "token"],
+                    },
+                    {"name": "general", "description": "General"},
+                ],
+            },
+            f,
+        )
+
+
+def get_collection(palace_path: Path):
+    client = chromadb.PersistentClient(path=str(palace_path))
+    return client.get_collection("mempalace_drawers")
+
+
+def get_source_rows(col, source_file: Path, wing: str):
+    results = col.get(
+        where={"$and": [{"source_file": str(source_file.resolve())}, {"wing": wing}]},
+        include=["documents", "metadatas"],
+    )
+    return list(zip(results["ids"], results["documents"], results["metadatas"]))
 
 
 def test_project_mining():
@@ -257,5 +294,229 @@ def test_file_already_mined_check_mtime():
             metadatas=[{"source_file": "/fake/no_mtime.txt"}],
         )
         assert file_already_mined(col, "/fake/no_mtime.txt", check_mtime=True) is False
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_project_mining_refreshes_without_duplicates_and_reports_unchanged(capsys):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        write_project_config(project_root)
+        source = project_root / "notes.txt"
+        write_file(source, ("billing invoice payment details\n" * 40).strip())
+        palace_path = project_root / "palace"
+
+        mine(str(project_root), str(palace_path))
+        col = get_collection(palace_path)
+        first_rows = get_source_rows(col, source, "test_project")
+        assert first_rows
+        assert {meta["room"] for _, _, meta in first_rows} == {"billing"}
+        assert all(meta["ingest_mode"] == "projects" for _, _, meta in first_rows)
+        assert all(meta["refresh_owner"] == "projects" for _, _, meta in first_rows)
+        assert all(meta["source_signature"] for _, _, meta in first_rows)
+        assert all(meta["pipeline_fingerprint"] for _, _, meta in first_rows)
+
+        capsys.readouterr()
+        mine(str(project_root), str(palace_path))
+        output = capsys.readouterr().out
+        second_rows = get_source_rows(col, source, "test_project")
+
+        assert "Files unchanged: 1" in output
+        assert {row[0] for row in second_rows} == {row[0] for row in first_rows}
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_project_mining_updates_changed_files_and_replaces_stale_room_rows(capsys):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        write_project_config(project_root)
+        source = project_root / "notes.txt"
+        write_file(source, ("billing invoice payment details\n" * 40).strip())
+        palace_path = project_root / "palace"
+
+        mine(str(project_root), str(palace_path))
+        col = get_collection(palace_path)
+        first_rows = get_source_rows(col, source, "test_project")
+
+        write_file(source, ("auth oauth token login flow\n" * 40).strip())
+        capsys.readouterr()
+        mine(str(project_root), str(palace_path))
+        output = capsys.readouterr().out
+        updated_rows = get_source_rows(col, source, "test_project")
+
+        assert "Files updated: 1" in output
+        assert {meta["room"] for _, _, meta in updated_rows} == {"auth"}
+        assert {row[0] for row in updated_rows}.isdisjoint({row[0] for row in first_rows})
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_project_mining_keeps_namespaces_per_wing():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        write_project_config(project_root, wing="alpha")
+        source = project_root / "notes.txt"
+        write_file(source, ("billing invoice payment details\n" * 40).strip())
+        palace_path = project_root / "palace"
+
+        mine(str(project_root), str(palace_path), wing_override="alpha")
+        mine(str(project_root), str(palace_path), wing_override="beta")
+
+        col = get_collection(palace_path)
+        results = col.get(where={"source_file": str(source.resolve())}, include=["metadatas"])
+
+        assert col.count() > 0
+        assert {meta["wing"] for meta in results["metadatas"]} == {"alpha", "beta"}
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_project_mining_clears_empty_content_only_for_that_namespace(capsys):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        write_project_config(project_root)
+        source = project_root / "notes.txt"
+        write_file(source, ("billing invoice payment details\n" * 40).strip())
+        palace_path = project_root / "palace"
+
+        mine(str(project_root), str(palace_path), wing_override="alpha")
+        mine(str(project_root), str(palace_path), wing_override="beta")
+        col = get_collection(palace_path)
+
+        write_file(source, "")
+        capsys.readouterr()
+        mine(str(project_root), str(palace_path), wing_override="alpha")
+        output = capsys.readouterr().out
+
+        alpha_rows = get_source_rows(col, source, "alpha")
+        beta_rows = get_source_rows(col, source, "beta")
+        assert "Files cleared: 1" in output
+        assert alpha_rows == []
+        assert beta_rows
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_project_mining_preserves_old_drawers_on_read_error(monkeypatch, capsys):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        write_project_config(project_root)
+        source = project_root / "notes.txt"
+        write_file(source, ("billing invoice payment details\n" * 40).strip())
+        palace_path = project_root / "palace"
+
+        mine(str(project_root), str(palace_path))
+        col = get_collection(palace_path)
+        first_rows = get_source_rows(col, source, "test_project")
+
+        original_read_text = Path.read_text
+
+        def broken_read_text(self, *args, **kwargs):
+            if self.resolve() == source.resolve():
+                raise OSError("boom")
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", broken_read_text)
+        capsys.readouterr()
+        mine(str(project_root), str(palace_path))
+        output = capsys.readouterr().out
+
+        assert "Files errored: 1" in output
+        assert {row[0] for row in get_source_rows(col, source, "test_project")} == {
+            row[0] for row in first_rows
+        }
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_legacy_project_rows_are_upgraded_on_first_refresh():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        write_project_config(project_root)
+        source = project_root / "notes.txt"
+        content = ("billing invoice payment details\n" * 40).strip()
+        write_file(source, content)
+        palace_path = project_root / "palace"
+
+        from mempalace.miner import build_drawer_id, chunk_text
+
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_or_create_collection("mempalace_drawers")
+        chunks = chunk_text(content, str(source.resolve()))
+        col.upsert(
+            ids=[
+                build_drawer_id("test_project", "billing", str(source.resolve()), chunk["chunk_index"])
+                for chunk in chunks
+            ],
+            documents=[chunk["content"] for chunk in chunks],
+            metadatas=[
+                {
+                    "wing": "test_project",
+                    "room": "billing",
+                    "source_file": str(source.resolve()),
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": "legacy",
+                    "filed_at": "2026-01-01T00:00:00",
+                }
+                for chunk in chunks
+            ],
+        )
+
+        mine(str(project_root), str(palace_path))
+        rows = get_source_rows(col, source, "test_project")
+
+        assert rows
+        assert all(meta["ingest_mode"] == "projects" for _, _, meta in rows)
+        assert all(meta["refresh_owner"] == "projects" for _, _, meta in rows)
+        assert all(meta["source_signature"] for _, _, meta in rows)
+        assert all(meta["pipeline_fingerprint"] for _, _, meta in rows)
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_manual_drawers_with_same_source_file_survive_project_refresh(monkeypatch):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        write_project_config(project_root)
+        source = project_root / "notes.txt"
+        write_file(source, ("billing invoice payment details\n" * 40).strip())
+        palace_path = project_root / "palace"
+
+        from mempalace import mcp_server
+        from mempalace.mcp_server import tool_add_drawer
+
+        monkeypatch.setattr(
+            mcp_server,
+            "_config",
+            SimpleNamespace(
+                palace_path=str(palace_path),
+                collection_name="mempalace_drawers",
+            ),
+        )
+
+        result = tool_add_drawer(
+            wing="test_project",
+            room="manual_notes",
+            content="Remember the migration checklist.",
+            source_file=str(source.resolve()),
+            added_by="test",
+        )
+        assert result["success"] is True
+
+        mine(str(project_root), str(palace_path))
+        col = get_collection(palace_path)
+        rows = get_source_rows(col, source, "test_project")
+
+        assert any(doc == "Remember the migration checklist." for _, doc, _ in rows)
+        assert any(meta.get("ingest_mode") == "manual" for _, _, meta in rows)
+        assert any(meta.get("ingest_mode") == "projects" for _, _, meta in rows)
     finally:
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
## Summary
- replace project-file skip-once behavior with safe refresh semantics
- keep refresh scoped to the same `(wing, source_file, ingest_mode=projects)` namespace
- protect manual MCP-filed drawers and improve mine/status reporting

## What changed
- read each source file before deciding whether it is unchanged
- compute source + pipeline metadata for source-backed project drawers
- treat reruns as `new`, `updated`, `unchanged`, `cleared`, or `error` instead of silently skipping forever
- upsert new drawers before deleting stale drawer ids from the same namespace
- preserve old drawers on read failure and avoid deleting across wings or manual drawers

## Tests
- `./.venv/bin/python -m pytest tests/test_miner.py tests/test_mcp_server.py -q`
- `./.venv/bin/python -m pytest -q`
- `./.venv/bin/ruff check .`

Part 1 of the split follow-up to the closed oversized refresh PR.