### PR TITLE
fix: allow mempalace init to default to the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ The 96.6% raw score is the highest published LongMemEval result requiring no API
 
 ```bash
 # Setup
-mempalace init <dir>                              # guided onboarding + AAAK bootstrap
+mempalace init [dir]                              # guided onboarding + AAAK bootstrap (default: current dir)
 
 # Mining
 mempalace mine <dir>                              # mine project files

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -19,6 +19,7 @@ Commands:
     mempalace status                      Show what's been filed
 
 Examples:
+    mempalace init                        # init current directory
     mempalace init ~/projects/my_app
     mempalace mine ~/projects/my_app
     mempalace mine ~/chats/claude-sessions --mode convos
@@ -41,8 +42,9 @@ def cmd_init(args):
     from .room_detector_local import detect_rooms_local
 
     # Pass 1: auto-detect people and projects from file content
-    print(f"\n  Scanning for entities in: {args.dir}")
-    files = scan_for_detection(args.dir)
+    project_dir = Path(args.dir).expanduser().resolve()
+    print(f"\n  Scanning for entities in: {project_dir}")
+    files = scan_for_detection(str(project_dir))
     if files:
         print(f"  Reading {len(files)} files...")
         detected = detect_entities(files)
@@ -51,7 +53,7 @@ def cmd_init(args):
             confirmed = confirm_entities(detected, yes=getattr(args, "yes", False))
             # Save confirmed entities to <project>/entities.json for the miner
             if confirmed["people"] or confirmed["projects"]:
-                entities_path = Path(args.dir).expanduser().resolve() / "entities.json"
+                entities_path = project_dir / "entities.json"
                 with open(entities_path, "w") as f:
                     json.dump(confirmed, f, indent=2)
                 print(f"  Entities saved: {entities_path}")
@@ -59,7 +61,7 @@ def cmd_init(args):
             print("  No entities detected — proceeding with directory-based rooms.")
 
     # Pass 2: detect rooms from folder structure
-    detect_rooms_local(project_dir=args.dir, yes=getattr(args, "yes", False))
+    detect_rooms_local(project_dir=str(project_dir), yes=getattr(args, "yes", False))
     MempalaceConfig().init()
 
 

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -9,7 +9,7 @@ Two ways to ingest:
 Same palace. Same search. Different ingest strategies.
 
 Commands:
-    mempalace init <dir>                  Detect rooms from folder structure
+    mempalace init [dir]                  Detect rooms from folder structure
     mempalace split <dir>                 Split concatenated mega-files into per-session files
     mempalace mine <dir>                  Mine project files (default)
     mempalace mine <dir> --mode convos    Mine conversation exports
@@ -347,7 +347,7 @@ def cmd_compress(args):
         print("  (dry run -- nothing stored)")
 
 
-def main():
+def build_parser():
     parser = argparse.ArgumentParser(
         description="MemPalace — Give your AI a memory. No API key required.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -363,7 +363,12 @@ def main():
 
     # init
     p_init = sub.add_parser("init", help="Detect rooms from your folder structure")
-    p_init.add_argument("dir", help="Project directory to set up")
+    p_init.add_argument(
+        "dir",
+        nargs="?",
+        default=".",
+        help="Project directory to set up (default: current directory)",
+    )
     p_init.add_argument(
         "--yes", action="store_true", help="Auto-accept all detected entities (non-interactive)"
     )
@@ -460,7 +465,12 @@ def main():
     # status
     sub.add_parser("status", help="Show what's been filed")
 
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
 
     if not args.command:
         parser.print_help()

--- a/mempalace/onboarding.py
+++ b/mempalace/onboarding.py
@@ -13,7 +13,7 @@ from minute one — before a single session is indexed.
 
 Usage:
     python3 -m mempalace.onboarding
-    or: mempalace init
+    or: mempalace init [dir]
 """
 
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,21 @@
+from mempalace.cli import build_parser
+
+
+def test_init_defaults_to_current_directory():
+    parser = build_parser()
+
+    args = parser.parse_args(["init"])
+
+    assert args.command == "init"
+    assert args.dir == "."
+    assert args.yes is False
+
+
+def test_init_accepts_explicit_directory():
+    parser = build_parser()
+
+    args = parser.parse_args(["init", "~/projects/demo", "--yes"])
+
+    assert args.command == "init"
+    assert args.dir == "~/projects/demo"
+    assert args.yes is True


### PR DESCRIPTION
## Summary
- make the init directory argument optional and default it to the current directory
- expose a parser builder so the CLI behavior can be tested directly
- update docs to show the optional init directory form and add regression coverage

Closes #210.

## Validation
- PYTHONPATH=/Users/anita/mempalace pytest --noconftest tests/test_cli.py -q
- python3 -m compileall mempalace