### PR TITLE
Skip hooks in projects without initialized wing

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -57,9 +57,24 @@ MEMPAL_DIR=""
 # Read JSON input from stdin
 INPUT=$(cat)
 
+# Skip if project has no initialized mempalace wing (no mempalace.yaml found)
+WORKING_DIR=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd', ''))" 2>/dev/null)
+[ -z "$WORKING_DIR" ] && WORKING_DIR="$(pwd)"
+
+check_dir="$WORKING_DIR"
+while [ "$check_dir" != "/" ]; do
+    [ -f "$check_dir/mempalace.yaml" ] && break
+    check_dir="$(dirname "$check_dir")"
+done
+
+if [ ! -f "$check_dir/mempalace.yaml" ]; then
+    echo "{}"
+    exit 0
+fi
+
 SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
 
-echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
+echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID in $WORKING_DIR" >> "$STATE_DIR/hook.log"
 
 # Optional: run mempalace ingest synchronously so memories land before compaction
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -82,6 +82,21 @@ if [ "$STOP_HOOK_ACTIVE" = "True" ] || [ "$STOP_HOOK_ACTIVE" = "true" ]; then
     exit 0
 fi
 
+# Skip if project has no initialized mempalace wing (no mempalace.yaml found)
+WORKING_DIR=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd', ''))" 2>/dev/null)
+[ -z "$WORKING_DIR" ] && WORKING_DIR="$(pwd)"
+
+check_dir="$WORKING_DIR"
+while [ "$check_dir" != "/" ]; do
+    [ -f "$check_dir/mempalace.yaml" ] && break
+    check_dir="$(dirname "$check_dir")"
+done
+
+if [ ! -f "$check_dir/mempalace.yaml" ]; then
+    echo "{}"
+    exit 0
+fi
+
 # Count human messages in the JSONL transcript
 if [ -f "$TRANSCRIPT_PATH" ]; then
     EXCHANGE_COUNT=$(python3 - "$TRANSCRIPT_PATH" <<'PYEOF'


### PR DESCRIPTION
## Summary
- Both hook scripts now check for a `mempalace.yaml` by walking up from the working directory
- If no `mempalace.yaml` is found, hooks return `{}` (no-op) instead of blocking
- Prevents unnecessary save prompts in projects that don't use mempalace

## Motivation
When hooks are installed in user-level settings (`~/.claude/settings.json`), they fire for every project. Projects without a mempalace wing shouldn't trigger save/compaction blocks — there's nothing to save to.

## Test plan
- [ ] Run Claude Code in a project **with** `mempalace.yaml` — hooks should fire normally
- [ ] Run Claude Code in a project **without** `mempalace.yaml` — hooks should no-op