### PR TITLE
Respect .gitignore, support C/C++ sources, and silence Chroma telemetry noise on Windows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.0.14",
+      "version": "3.0.15",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.0.15",
+      "version": "3.0.16",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.0.16",
+      "version": "3.0.17",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.0.17",
+      "version": "3.0.18",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.0.18",
+      "version": "3.0.19",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.0.19",
+      "version": "3.0.20",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/mempalace/chroma_client.py
+++ b/mempalace/chroma_client.py
@@ -1,0 +1,26 @@
+"""
+Shared ChromaDB client helpers for MemPalace.
+"""
+
+import chromadb
+from chromadb.config import Settings
+from chromadb.telemetry.product import ProductTelemetryClient, ProductTelemetryEvent
+from overrides import override
+
+
+class NoOpProductTelemetryClient(ProductTelemetryClient):
+    """Disable Chroma product telemetry entirely."""
+
+    @override
+    def capture(self, event: ProductTelemetryEvent) -> None:
+        return
+
+
+def get_persistent_client(path: str):
+    """Create a persistent Chroma client with anonymized telemetry disabled."""
+    settings = Settings(
+        anonymized_telemetry=False,
+        chroma_product_telemetry_impl="mempalace.chroma_client.NoOpProductTelemetryClient",
+        chroma_telemetry_impl="mempalace.chroma_client.NoOpProductTelemetryClient",
+    )
+    return chromadb.PersistentClient(path=path, settings=settings)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -32,6 +32,7 @@ import argparse
 from pathlib import Path
 
 from .config import MempalaceConfig
+from .chroma_client import get_persistent_client
 
 
 def cmd_init(args):
@@ -157,7 +158,6 @@ def cmd_status(args):
 
 def cmd_repair(args):
     """Rebuild palace vector index from SQLite metadata."""
-    import chromadb
     import shutil
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
@@ -173,7 +173,7 @@ def cmd_repair(args):
 
     # Try to read existing drawers
     try:
-        client = chromadb.PersistentClient(path=palace_path)
+        client = get_persistent_client(path=palace_path)
         col = client.get_collection("mempalace_drawers")
         total = col.count()
         print(f"  Drawers found: {total}")
@@ -228,7 +228,6 @@ def cmd_repair(args):
 
 def cmd_compress(args):
     """Compress drawers in a wing using AAAK Dialect."""
-    import chromadb
     from .dialect import Dialect
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
@@ -249,7 +248,7 @@ def cmd_compress(args):
 
     # Connect to palace
     try:
-        client = chromadb.PersistentClient(path=palace_path)
+        client = get_persistent_client(path=palace_path)
         col = client.get_collection("mempalace_drawers")
     except Exception:
         print(f"\n  No palace found at {palace_path}")

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -15,8 +15,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-import chromadb
-
+from .chroma_client import get_persistent_client
 from .normalize import normalize
 
 
@@ -213,7 +212,7 @@ def detect_convo_room(content: str) -> str:
 
 def get_collection(palace_path: str):
     os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
+    client = get_persistent_client(path=palace_path)
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -21,9 +21,8 @@ import sys
 from pathlib import Path
 from collections import defaultdict
 
-import chromadb
-
 from .config import MempalaceConfig
+from .chroma_client import get_persistent_client
 
 
 # ---------------------------------------------------------------------------
@@ -91,7 +90,7 @@ class Layer1:
     def generate(self) -> str:
         """Pull top drawers from ChromaDB and format as compact L1 text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
+            client = get_persistent_client(path=self.palace_path)
             col = client.get_collection("mempalace_drawers")
         except Exception:
             return "## L1 — No palace found. Run: mempalace mine <dir>"
@@ -196,7 +195,7 @@ class Layer2:
     def retrieve(self, wing: str = None, room: str = None, n_results: int = 10) -> str:
         """Retrieve drawers filtered by wing and/or room."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
+            client = get_persistent_client(path=self.palace_path)
             col = client.get_collection("mempalace_drawers")
         except Exception:
             return "No palace found."
@@ -260,7 +259,7 @@ class Layer3:
     def search(self, query: str, wing: str = None, room: str = None, n_results: int = 5) -> str:
         """Semantic search, returns compact result text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
+            client = get_persistent_client(path=self.palace_path)
             col = client.get_collection("mempalace_drawers")
         except Exception:
             return "No palace found."
@@ -316,7 +315,7 @@ class Layer3:
     ) -> list:
         """Return raw dicts instead of formatted text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
+            client = get_persistent_client(path=self.palace_path)
             col = client.get_collection("mempalace_drawers")
         except Exception:
             return []
@@ -437,7 +436,7 @@ class MemoryStack:
 
         # Count drawers
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
+            client = get_persistent_client(path=self.palace_path)
             col = client.get_collection("mempalace_drawers")
             count = col.count()
             result["total_drawers"] = count

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -27,7 +27,7 @@ from .config import MempalaceConfig
 from .version import __version__
 from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
-import chromadb
+from .chroma_client import get_persistent_client
 
 from .knowledge_graph import KnowledgeGraph
 
@@ -42,7 +42,7 @@ _config = MempalaceConfig()
 def _get_collection(create=False):
     """Return the ChromaDB collection, or None on failure."""
     try:
-        client = chromadb.PersistentClient(path=_config.palace_path)
+        client = get_persistent_client(path=_config.palace_path)
         if create:
             return client.get_or_create_collection(_config.collection_name)
         return client.get_collection(_config.collection_name)

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,9 +15,12 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-import chromadb
+from .chroma_client import get_persistent_client
 
 READABLE_EXTENSIONS = {
+    ".c",
+    ".cc",
+    ".cpp",
     ".txt",
     ".md",
     ".py",
@@ -30,6 +33,13 @@ READABLE_EXTENSIONS = {
     ".yml",
     ".html",
     ".css",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".cxx",
+    ".inl",
+    ".ixx",
     ".java",
     ".go",
     ".rs",
@@ -395,7 +405,7 @@ def chunk_text(content: str, source_file: str) -> list:
 
 def get_collection(palace_path: str):
     os.makedirs(palace_path, exist_ok=True)
-    client = chromadb.PersistentClient(path=palace_path)
+    client = get_persistent_client(path=palace_path)
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
@@ -540,7 +550,6 @@ def scan_project(
             filepath = root_path / filename
             force_include = is_force_included(filepath, project_path, include_paths)
             exact_force_include = is_exact_force_include(filepath, project_path, include_paths)
-
             if not force_include and filename in SKIP_FILENAMES:
                 continue
             if filepath.suffix.lower() not in READABLE_EXTENSIONS and not exact_force_include:
@@ -596,7 +605,7 @@ def mine(
         print("  .gitignore: DISABLED")
     if include_ignored:
         print(f"  Include: {', '.join(sorted(normalize_include_paths(include_ignored)))}")
-    print(f"{'─' * 55}\n")
+    print(f"{'-' * 55}\n")
 
     if not dry_run:
         collection = get_collection(palace_path)
@@ -646,7 +655,7 @@ def mine(
 def status(palace_path: str):
     """Show what's been filed in the palace."""
     try:
-        client = chromadb.PersistentClient(path=palace_path)
+        client = get_persistent_client(path=palace_path)
         col = client.get_collection("mempalace_drawers")
     except Exception:
         print(f"\n  No palace found at {palace_path}")

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -17,14 +17,13 @@ No external graph DB needed — built from ChromaDB metadata.
 
 from collections import defaultdict, Counter
 from .config import MempalaceConfig
-
-import chromadb
+from .chroma_client import get_persistent_client
 
 
 def _get_collection(config=None):
     config = config or MempalaceConfig()
     try:
-        client = chromadb.PersistentClient(path=config.palace_path)
+        client = get_persistent_client(path=config.palace_path)
         return client.get_collection(config.collection_name)
     except Exception:
         return None

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 
 from .chroma_client import get_persistent_client
+
 logger = logging.getLogger("mempalace_mcp")
 
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -9,8 +9,7 @@ Returns verbatim text — the actual words, never summaries.
 import logging
 from pathlib import Path
 
-import chromadb
-
+from .chroma_client import get_persistent_client
 logger = logging.getLogger("mempalace_mcp")
 
 
@@ -24,7 +23,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     Optionally filter by wing (project) or room (aspect).
     """
     try:
-        client = chromadb.PersistentClient(path=palace_path)
+        client = get_persistent_client(path=palace_path)
         col = client.get_collection("mempalace_drawers")
     except Exception:
         print(f"\n  No palace found at {palace_path}")
@@ -98,7 +97,7 @@ def search_memories(
     Used by the MCP server and other callers that need data.
     """
     try:
-        client = chromadb.PersistentClient(path=palace_path)
+        client = get_persistent_client(path=palace_path)
         col = client.get_collection("mempalace_drawers")
     except Exception as e:
         logger.error("No palace found at %s: %s", palace_path, e)

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.0.15"
+__version__ = "3.0.16"

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.0.14"
+__version__ = "3.0.15"

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.0.17"
+__version__ = "3.0.18"

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.0.16"
+__version__ = "3.0.17"

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.0.19"
+__version__ = "3.0.20"

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.0.18"
+__version__ = "3.0.19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.0.14"
+version = "3.0.15"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.0.15"
+version = "3.0.16"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.0.18"
+version = "3.0.19"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.0.17"
+version = "3.0.18"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.0.16"
+version = "3.0.17"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.0.19"
+version = "3.0.20"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ os.environ["HOMEPATH"] = os.path.splitdrive(_session_tmp)[1] or _session_tmp
 import chromadb  # noqa: E402
 import pytest  # noqa: E402
 
+from mempalace.chroma_client import get_persistent_client  # noqa: E402
 from mempalace.config import MempalaceConfig  # noqa: E402
 from mempalace.knowledge_graph import KnowledgeGraph  # noqa: E402
 
@@ -100,7 +101,7 @@ def config(tmp_dir, palace_path):
 @pytest.fixture
 def collection(palace_path):
     """A ChromaDB collection pre-seeded in the temp palace."""
-    client = chromadb.PersistentClient(path=palace_path)
+    client = get_persistent_client(path=palace_path)
     col = client.get_or_create_collection("mempalace_drawers")
     yield col
     client.delete_collection("mempalace_drawers")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,6 @@ os.environ["HOMEDRIVE"] = os.path.splitdrive(_session_tmp)[0] or "C:"
 os.environ["HOMEPATH"] = os.path.splitdrive(_session_tmp)[1] or _session_tmp
 
 # Now it is safe to import mempalace modules that trigger initialisation.
-import chromadb  # noqa: E402
 import pytest  # noqa: E402
 
 from mempalace.chroma_client import get_persistent_client  # noqa: E402

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -386,8 +386,7 @@ def test_main_compress_dispatches():
 def test_cmd_repair_no_palace(mock_config_cls, tmp_path, capsys):
     mock_config_cls.return_value.palace_path = str(tmp_path / "nonexistent")
     args = argparse.Namespace(palace=None)
-    mock_chromadb = MagicMock()
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with patch("mempalace.cli.get_persistent_client", side_effect=Exception("no palace")):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "No palace found" in out
@@ -399,11 +398,9 @@ def test_cmd_repair_error_reading(mock_config_cls, tmp_path, capsys):
     palace_dir.mkdir()
     mock_config_cls.return_value.palace_path = str(palace_dir)
     args = argparse.Namespace(palace=None)
-    mock_chromadb = MagicMock()
     mock_client = MagicMock()
     mock_client.get_collection.side_effect = Exception("corrupt db")
-    mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with patch("mempalace.cli.get_persistent_client", return_value=mock_client):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "Error reading palace" in out
@@ -415,13 +412,11 @@ def test_cmd_repair_zero_drawers(mock_config_cls, tmp_path, capsys):
     palace_dir.mkdir()
     mock_config_cls.return_value.palace_path = str(palace_dir)
     args = argparse.Namespace(palace=None)
-    mock_chromadb = MagicMock()
     mock_col = MagicMock()
     mock_col.count.return_value = 0
     mock_client = MagicMock()
     mock_client.get_collection.return_value = mock_col
-    mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with patch("mempalace.cli.get_persistent_client", return_value=mock_client):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "Nothing to repair" in out
@@ -433,7 +428,6 @@ def test_cmd_repair_success(mock_config_cls, tmp_path, capsys):
     palace_dir.mkdir()
     mock_config_cls.return_value.palace_path = str(palace_dir)
     args = argparse.Namespace(palace=None)
-    mock_chromadb = MagicMock()
     mock_col = MagicMock()
     mock_col.count.return_value = 2
     mock_col.get.return_value = {
@@ -445,8 +439,7 @@ def test_cmd_repair_success(mock_config_cls, tmp_path, capsys):
     mock_client.get_collection.return_value = mock_col
     mock_new_col = MagicMock()
     mock_client.create_collection.return_value = mock_new_col
-    mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with patch("mempalace.cli.get_persistent_client", return_value=mock_client):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "Repair complete" in out
@@ -460,10 +453,8 @@ def test_cmd_repair_success(mock_config_cls, tmp_path, capsys):
 def test_cmd_compress_no_palace(mock_config_cls, capsys):
     mock_config_cls.return_value.palace_path = "/fake/palace"
     args = argparse.Namespace(palace=None, wing=None, dry_run=False, config=None)
-    mock_chromadb = MagicMock()
-    mock_chromadb.PersistentClient.side_effect = Exception("no palace")
     with (
-        patch.dict("sys.modules", {"chromadb": mock_chromadb}),
+        patch("mempalace.cli.get_persistent_client", side_effect=Exception("no palace")),
         pytest.raises(SystemExit),
     ):
         cmd_compress(args)
@@ -473,13 +464,11 @@ def test_cmd_compress_no_palace(mock_config_cls, capsys):
 def test_cmd_compress_no_drawers(mock_config_cls, capsys):
     mock_config_cls.return_value.palace_path = "/fake/palace"
     args = argparse.Namespace(palace=None, wing="mywing", dry_run=False, config=None)
-    mock_chromadb = MagicMock()
     mock_col = MagicMock()
     mock_col.get.return_value = {"documents": [], "metadatas": [], "ids": []}
     mock_client = MagicMock()
     mock_client.get_collection.return_value = mock_col
-    mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with patch("mempalace.cli.get_persistent_client", return_value=mock_client):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "No drawers found" in out
@@ -498,7 +487,6 @@ def _make_mock_dialect_module(dialect_instance):
 def test_cmd_compress_dry_run(mock_config_cls, capsys):
     mock_config_cls.return_value.palace_path = "/fake/palace"
     args = argparse.Namespace(palace=None, wing=None, dry_run=True, config=None)
-    mock_chromadb = MagicMock()
     mock_col = MagicMock()
     mock_col.get.side_effect = [
         {
@@ -510,7 +498,6 @@ def test_cmd_compress_dry_run(mock_config_cls, capsys):
     ]
     mock_client = MagicMock()
     mock_client.get_collection.return_value = mock_col
-    mock_chromadb.PersistentClient.return_value = mock_client
 
     mock_dialect = MagicMock()
     mock_dialect.compress.return_value = "compressed"
@@ -526,10 +513,9 @@ def test_cmd_compress_dry_run(mock_config_cls, capsys):
     with patch.dict(
         "sys.modules",
         {
-            "chromadb": mock_chromadb,
             "mempalace.dialect": mock_dialect_mod,
         },
-    ):
+    ), patch("mempalace.cli.get_persistent_client", return_value=mock_client):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "dry run" in out.lower()
@@ -542,12 +528,10 @@ def test_cmd_compress_with_config(mock_config_cls, tmp_path, capsys):
     config_file = tmp_path / "entities.json"
     config_file.write_text('{"people": [], "projects": []}')
     args = argparse.Namespace(palace=None, wing=None, dry_run=True, config=str(config_file))
-    mock_chromadb = MagicMock()
     mock_col = MagicMock()
     mock_col.get.return_value = {"documents": [], "metadatas": [], "ids": []}
     mock_client = MagicMock()
     mock_client.get_collection.return_value = mock_col
-    mock_chromadb.PersistentClient.return_value = mock_client
 
     mock_dialect = MagicMock()
     mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
@@ -555,10 +539,9 @@ def test_cmd_compress_with_config(mock_config_cls, tmp_path, capsys):
     with patch.dict(
         "sys.modules",
         {
-            "chromadb": mock_chromadb,
             "mempalace.dialect": mock_dialect_mod,
         },
-    ):
+    ), patch("mempalace.cli.get_persistent_client", return_value=mock_client):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "Loaded entity config" in out
@@ -569,7 +552,6 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     """Non-dry-run compress stores to mempalace_compressed collection."""
     mock_config_cls.return_value.palace_path = "/fake/palace"
     args = argparse.Namespace(palace=None, wing=None, dry_run=False, config=None)
-    mock_chromadb = MagicMock()
     mock_col = MagicMock()
     mock_col.get.side_effect = [
         {
@@ -583,7 +565,6 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     mock_client.get_collection.return_value = mock_col
     mock_comp_col = MagicMock()
     mock_client.get_or_create_collection.return_value = mock_comp_col
-    mock_chromadb.PersistentClient.return_value = mock_client
 
     mock_dialect = MagicMock()
     mock_dialect.compress.return_value = "compressed"
@@ -599,10 +580,9 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     with patch.dict(
         "sys.modules",
         {
-            "chromadb": mock_chromadb,
             "mempalace.dialect": mock_dialect_mod,
         },
-    ):
+    ), patch("mempalace.cli.get_persistent_client", return_value=mock_client):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "Stored" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -510,12 +510,15 @@ def test_cmd_compress_dry_run(mock_config_cls, capsys):
     }
     mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
 
-    with patch.dict(
-        "sys.modules",
-        {
-            "mempalace.dialect": mock_dialect_mod,
-        },
-    ), patch("mempalace.cli.get_persistent_client", return_value=mock_client):
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "mempalace.dialect": mock_dialect_mod,
+            },
+        ),
+        patch("mempalace.cli.get_persistent_client", return_value=mock_client),
+    ):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "dry run" in out.lower()
@@ -536,12 +539,15 @@ def test_cmd_compress_with_config(mock_config_cls, tmp_path, capsys):
     mock_dialect = MagicMock()
     mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
 
-    with patch.dict(
-        "sys.modules",
-        {
-            "mempalace.dialect": mock_dialect_mod,
-        },
-    ), patch("mempalace.cli.get_persistent_client", return_value=mock_client):
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "mempalace.dialect": mock_dialect_mod,
+            },
+        ),
+        patch("mempalace.cli.get_persistent_client", return_value=mock_client),
+    ):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "Loaded entity config" in out
@@ -577,12 +583,15 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     }
     mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
 
-    with patch.dict(
-        "sys.modules",
-        {
-            "mempalace.dialect": mock_dialect_mod,
-        },
-    ), patch("mempalace.cli.get_persistent_client", return_value=mock_client):
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "mempalace.dialect": mock_dialect_mod,
+            },
+        ),
+        patch("mempalace.cli.get_persistent_client", return_value=mock_client),
+    ):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "Stored" in out

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import shutil
-import chromadb
+from mempalace.chroma_client import get_persistent_client
 from mempalace.convo_miner import mine_convos
 
 
@@ -15,7 +15,7 @@ def test_convo_mining():
     palace_path = os.path.join(tmpdir, "palace")
     mine_convos(tmpdir, palace_path, wing="test_convos")
 
-    client = chromadb.PersistentClient(path=palace_path)
+    client = get_persistent_client(path=palace_path)
     col = client.get_collection("mempalace_drawers")
     assert col.count() >= 2
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -105,7 +105,7 @@ def test_layer1_generates_essential_story():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -123,7 +123,7 @@ def test_layer1_empty_palace():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -139,7 +139,7 @@ def test_layer1_with_wing_filter():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake", wing="project_x")
@@ -158,7 +158,7 @@ def test_layer1_truncates_long_snippets():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -175,7 +175,7 @@ def test_layer1_respects_max_chars():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -197,7 +197,7 @@ def test_layer1_importance_from_various_keys():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -218,7 +218,7 @@ def test_layer1_batch_exception_breaks():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -249,7 +249,7 @@ def test_layer2_retrieve_with_wing():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -270,7 +270,7 @@ def test_layer2_retrieve_with_room():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -290,7 +290,7 @@ def test_layer2_retrieve_wing_and_room():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -309,7 +309,7 @@ def test_layer2_retrieve_empty():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -326,7 +326,7 @@ def test_layer2_retrieve_no_filter():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -345,7 +345,7 @@ def test_layer2_retrieve_error():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -365,7 +365,7 @@ def test_layer2_truncates_long_snippets():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -413,7 +413,7 @@ def test_layer3_search_with_results():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -432,7 +432,7 @@ def test_layer3_search_no_results():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -453,7 +453,7 @@ def test_layer3_search_with_wing_filter():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -475,7 +475,7 @@ def test_layer3_search_with_room_filter():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -497,7 +497,7 @@ def test_layer3_search_with_wing_and_room():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -515,7 +515,7 @@ def test_layer3_search_error():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -536,7 +536,7 @@ def test_layer3_search_truncates_long_docs():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -557,7 +557,7 @@ def test_layer3_search_raw_returns_dicts():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -582,7 +582,7 @@ def test_layer3_search_raw_with_filters():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -600,7 +600,7 @@ def test_layer3_search_raw_error():
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -706,7 +706,7 @@ def test_memory_stack_status_with_palace(tmp_path):
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_persistent_client", return_value=mock_client),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         stack = MemoryStack(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,6 +8,8 @@ via monkeypatch to avoid touching real data.
 
 import json
 
+from mempalace.chroma_client import get_persistent_client
+
 
 def _patch_mcp_server(monkeypatch, config, kg):
     """Patch the mcp_server module globals to use test fixtures."""
@@ -23,9 +25,7 @@ def _get_collection(palace_path, create=False):
     Returns (client, collection) so callers can clean up the client
     when they are done.
     """
-    import chromadb
-
-    client = chromadb.PersistentClient(path=palace_path)
+    client = get_persistent_client(path=palace_path)
     if create:
         return client, client.get_or_create_collection("mempalace_drawers")
     return client, client.get_collection("mempalace_drawers")

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -4,9 +4,9 @@ import tempfile
 import time
 from pathlib import Path
 
-import chromadb
 import yaml
 
+from mempalace.chroma_client import get_persistent_client
 from mempalace.miner import mine, scan_project
 from mempalace.palace import file_already_mined
 
@@ -45,7 +45,7 @@ def test_project_mining():
         palace_path = project_root / "palace"
         mine(str(project_root), str(palace_path))
 
-        client = chromadb.PersistentClient(path=str(palace_path))
+        client = get_persistent_client(path=str(palace_path))
         col = client.get_collection("mempalace_drawers")
         assert col.count() > 0
     finally:
@@ -64,7 +64,7 @@ def test_scan_project_respects_gitignore():
 
         assert scanned_files(project_root) == ["src/app.py"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_respects_nested_gitignore():
@@ -80,7 +80,7 @@ def test_scan_project_respects_nested_gitignore():
 
         assert scanned_files(project_root) == ["subrepo/src/main.py"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_allows_nested_gitignore_override():
@@ -95,7 +95,7 @@ def test_scan_project_allows_nested_gitignore_override():
 
         assert scanned_files(project_root) == ["subrepo/keep.csv"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_allows_gitignore_negation_when_parent_dir_is_visible():
@@ -109,7 +109,7 @@ def test_scan_project_allows_gitignore_negation_when_parent_dir_is_visible():
 
         assert scanned_files(project_root) == ["generated/keep.py"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_does_not_reinclude_file_from_ignored_directory():
@@ -123,7 +123,7 @@ def test_scan_project_does_not_reinclude_file_from_ignored_directory():
 
         assert scanned_files(project_root) == []
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_can_disable_gitignore():
@@ -136,7 +136,7 @@ def test_scan_project_can_disable_gitignore():
 
         assert scanned_files(project_root, respect_gitignore=False) == ["data/stuff.csv"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_can_include_ignored_directory():
@@ -149,7 +149,7 @@ def test_scan_project_can_include_ignored_directory():
 
         assert scanned_files(project_root, include_ignored=["docs"]) == ["docs/guide.md"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_can_include_specific_ignored_file():
@@ -165,7 +165,7 @@ def test_scan_project_can_include_specific_ignored_file():
             "generated/keep.py"
         ]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_can_include_exact_file_without_known_extension():
@@ -178,7 +178,7 @@ def test_scan_project_can_include_exact_file_without_known_extension():
 
         assert scanned_files(project_root, include_ignored=["README"]) == ["README"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_include_override_beats_skip_dirs():
@@ -194,7 +194,7 @@ def test_scan_project_include_override_beats_skip_dirs():
             include_ignored=[".pytest_cache"],
         ) == [".pytest_cache/cache.py"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_scan_project_skip_dirs_still_apply_without_override():
@@ -207,15 +207,16 @@ def test_scan_project_skip_dirs_still_apply_without_override():
 
         assert scanned_files(project_root, respect_gitignore=False) == ["main.py"]
     finally:
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_file_already_mined_check_mtime():
     tmpdir = tempfile.mkdtemp()
+    client = None
     try:
         palace_path = os.path.join(tmpdir, "palace")
         os.makedirs(palace_path)
-        client = chromadb.PersistentClient(path=palace_path)
+        client = get_persistent_client(path=palace_path)
         col = client.get_or_create_collection("mempalace_drawers")
 
         test_file = os.path.join(tmpdir, "test.txt")
@@ -258,4 +259,11 @@ def test_file_already_mined_check_mtime():
         )
         assert file_already_mined(col, "/fake/no_mtime.txt", check_mtime=True) is False
     finally:
-        shutil.rmtree(tmpdir)
+        if client is not None:
+            try:
+                client.delete_collection("mempalace_drawers")
+            except Exception:
+                pass
+            del client
+        shutil.rmtree(tmpdir, ignore_errors=True)
+

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -269,4 +269,3 @@ def test_file_already_mined_check_mtime():
                 pass
             del client
         shutil.rmtree(tmpdir, ignore_errors=True)
-

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -123,4 +123,3 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         # Should have output with at least one result block
         assert "[1]" in captured.out
-

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -59,7 +59,7 @@ class TestSearchMemories:
         mock_client = MagicMock()
         mock_client.get_collection.return_value = mock_col
 
-        with patch("mempalace.searcher.chromadb.PersistentClient", return_value=mock_client):
+        with patch("mempalace.searcher.get_persistent_client", return_value=mock_client):
             result = search_memories("test", "/fake/path")
         assert "error" in result
         assert "query failed" in result["error"]
@@ -114,7 +114,7 @@ class TestSearchCLI:
         mock_client = MagicMock()
         mock_client.get_collection.return_value = mock_col
 
-        with patch("mempalace.searcher.chromadb.PersistentClient", return_value=mock_client):
+        with patch("mempalace.searcher.get_persistent_client", return_value=mock_client):
             with pytest.raises(SearchError, match="Search error"):
                 search("test", "/fake/path")
 
@@ -123,3 +123,4 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         # Should have output with at least one result block
         assert "[1]" in captured.out
+


### PR DESCRIPTION
## Summary

This PR fixes a few issues I ran into while using MemPalace on a large C++ project on Windows.

The main problems were:

- `mempalace mine` was still indexing ignored build artifacts because the active mining path needed to respect `.gitignore`
- C/C++ source files were not being indexed because common extensions like `.cpp` and `.h` were missing from `READABLE_EXTENSIONS`
- Chroma was emitting broken telemetry warnings on every run

## What changed

- added a shared Chroma client helper in [`mempalace/chroma_client.py`](mempalace/chroma_client.py)
- routed existing Chroma client creation through that helper in:
  - [`mempalace/cli.py`](mempalace/cli.py)
  - [`mempalace/convo_miner.py`](mempalace/convo_miner.py)
  - [`mempalace/layers.py`](mempalace/layers.py)
  - [`mempalace/mcp_server.py`](mempalace/mcp_server.py)
  - [`mempalace/miner.py`](mempalace/miner.py)
  - [`mempalace/palace_graph.py`](mempalace/palace_graph.py)
  - [`mempalace/searcher.py`](mempalace/searcher.py)
- disabled Chroma product telemetry via a no-op telemetry client so repeated `capture() takes 1 positional argument but 3 were given` warnings no longer appear
- added C/C++-related extensions to the project miner:
  - `.c`, `.cc`, `.cpp`, `.cxx`
  - `.h`, `.hh`, `.hpp`, `.hxx`
  - `.inl`, `.ixx`
- replaced a couple of Unicode progress characters in [`mempalace/miner.py`](mempalace/miner.py) with ASCII-safe equivalents so the command runs cleanly in a standard Windows PowerShell console

## Why

I tested this against a local C++ codebase. Before these changes:

- generated files under ignored directories were still being picked up
- source and header files were missing from indexing entirely
- every run printed Chroma telemetry errors even though the actual indexing still worked

After the changes:

- ignored build output is skipped properly
- C/C++ code is included in scanning
- the CLI runs without the telemetry noise
- the miner output is Windows-console safe

## Notes

I did not add tests in this pass. I verified the behavior manually against a local project and confirmed that:

- ignored files under `Intermediate/...` are no longer included
- `.cpp` / `.h` files are now discovered during scanning
- the telemetry warnings are gone during `mempalace mine`
