### PR TITLE
fix: detect conflicting active KG facts

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -43,6 +43,23 @@ from datetime import date, datetime
 from pathlib import Path
 
 
+class KnowledgeConflictError(ValueError):
+    def __init__(self, conflicts):
+        super().__init__("Conflicting active fact exists")
+        self.conflicts = conflicts
+
+
+# Predicates modeled as having a single current value at a time.
+# Multi-valued relationships such as knows/likes/does are intentionally excluded.
+SINGLE_VALUED_PREDICATES = {
+    "works_at",
+    "assigned_to",
+    "married_to",
+    "is_partner_of",
+    "is_pet_of",
+}
+
+
 DEFAULT_KG_PATH = os.path.expanduser("~/.mempalace/knowledge_graph.sqlite3")
 
 
@@ -109,6 +126,34 @@ class KnowledgeGraph:
         conn.close()
         return eid
 
+    def _find_active_conflicts(self, conn, sub_id: str, pred: str, obj_id: str):
+        """Return conflicting active facts for single-valued predicates."""
+        if pred not in SINGLE_VALUED_PREDICATES:
+            return []
+
+        rows = conn.execute(
+            """
+            SELECT t.id, s.name as subject_name, t.predicate, o.name as object_name, t.valid_from, t.source_closet
+            FROM triples t
+            JOIN entities s ON t.subject = s.id
+            JOIN entities o ON t.object = o.id
+            WHERE t.subject = ? AND t.predicate = ? AND t.valid_to IS NULL AND t.object != ?
+            """,
+            (sub_id, pred, obj_id),
+        ).fetchall()
+
+        return [
+            {
+                "triple_id": row[0],
+                "subject": row[1],
+                "predicate": row[2],
+                "object": row[3],
+                "valid_from": row[4],
+                "source_closet": row[5],
+            }
+            for row in rows
+        ]
+
     def add_triple(
         self,
         subject: str,
@@ -123,10 +168,10 @@ class KnowledgeGraph:
         """
         Add a relationship triple: subject → predicate → object.
 
-        Examples:
-            add_triple("Max", "child_of", "Alice", valid_from="2015-04-01")
-            add_triple("Max", "does", "swimming", valid_from="2025-01-01")
-            add_triple("Alice", "worried_about", "Max injury", valid_from="2026-01", valid_to="2026-02")
+        Returns the triple id string.
+
+        If a conflicting active fact exists for a single-valued predicate,
+        raises KnowledgeConflictError with conflict details.
         """
         sub_id = self._entity_id(subject)
         obj_id = self._entity_id(obj)
@@ -145,7 +190,12 @@ class KnowledgeGraph:
 
         if existing:
             conn.close()
-            return existing[0]  # Already exists and still valid
+            return existing[0]
+
+        conflicts = self._find_active_conflicts(conn, sub_id, pred, obj_id)
+        if conflicts:
+            conn.close()
+            raise KnowledgeConflictError(conflicts)
 
         triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.md5(f'{valid_from}{datetime.now().isoformat()}'.encode()).hexdigest()[:8]}"
 
@@ -340,7 +390,7 @@ class KnowledgeGraph:
 
     def seed_from_entity_facts(self, entity_facts: dict):
         """
-        Seed the knowledge graph from fact_checker.py ENTITY_FACTS.
+        Seed the knowledge graph from a provided entity facts mapping.
         This bootstraps the graph with known ground truth.
         """
         for key, facts in entity_facts.items():

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -168,6 +168,11 @@ class KnowledgeGraph:
         """
         Add a relationship triple: subject → predicate → object.
 
+        Examples:
+            add_triple("Max", "child_of", "Alice", valid_from="2015-04-01")
+            add_triple("Max", "does", "swimming", valid_from="2025-01-01")
+            add_triple("Alice", "worried_about", "Max injury", valid_from="2026-01", valid_to="2026-02")
+
         Returns the triple id string.
 
         If a conflicting active fact exists for a single-valued predicate,
@@ -393,6 +398,14 @@ class KnowledgeGraph:
         Seed the knowledge graph from a provided entity facts mapping.
         This bootstraps the graph with known ground truth.
         """
+
+        def _seed_triple(*args, **kwargs):
+            try:
+                self.add_triple(*args, **kwargs)
+            except KnowledgeConflictError:
+                return None
+            return True
+
         for key, facts in entity_facts.items():
             name = facts.get("full_name", key.capitalize())
             etype = facts.get("type", "person")
@@ -408,30 +421,28 @@ class KnowledgeGraph:
             # Relationships
             parent = facts.get("parent")
             if parent:
-                self.add_triple(
-                    name, "child_of", parent.capitalize(), valid_from=facts.get("birthday")
-                )
+                _seed_triple(name, "child_of", parent.capitalize(), valid_from=facts.get("birthday"))
 
             partner = facts.get("partner")
             if partner:
-                self.add_triple(name, "married_to", partner.capitalize())
+                _seed_triple(name, "married_to", partner.capitalize())
 
             relationship = facts.get("relationship", "")
             if relationship == "daughter":
-                self.add_triple(
+                _seed_triple(
                     name,
                     "is_child_of",
                     facts.get("parent", "").capitalize() or name,
                     valid_from=facts.get("birthday"),
                 )
             elif relationship == "husband":
-                self.add_triple(name, "is_partner_of", facts.get("partner", name).capitalize())
+                _seed_triple(name, "is_partner_of", facts.get("partner", name).capitalize())
             elif relationship == "brother":
-                self.add_triple(name, "is_sibling_of", facts.get("sibling", name).capitalize())
+                _seed_triple(name, "is_sibling_of", facts.get("sibling", name).capitalize())
             elif relationship == "dog":
-                self.add_triple(name, "is_pet_of", facts.get("owner", name).capitalize())
+                _seed_triple(name, "is_pet_of", facts.get("owner", name).capitalize())
                 self.add_entity(name, "animal")
 
             # Interests
             for interest in facts.get("interests", []):
-                self.add_triple(name, "loves", interest.capitalize(), valid_from="2025-01-01")
+                _seed_triple(name, "loves", interest.capitalize(), valid_from="2025-01-01")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -29,7 +29,7 @@ from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
 import chromadb
 
-from .knowledge_graph import KnowledgeGraph
+from .knowledge_graph import KnowledgeGraph, KnowledgeConflictError
 
 _kg = KnowledgeGraph()
 
@@ -316,9 +316,18 @@ def tool_kg_add(
     subject: str, predicate: str, object: str, valid_from: str = None, source_closet: str = None
 ):
     """Add a relationship to the knowledge graph."""
-    triple_id = _kg.add_triple(
-        subject, predicate, object, valid_from=valid_from, source_closet=source_closet
-    )
+    try:
+        triple_id = _kg.add_triple(
+            subject, predicate, object, valid_from=valid_from, source_closet=source_closet
+        )
+    except KnowledgeConflictError as exc:
+        return {
+            "success": False,
+            "reason": "conflict",
+            "fact": f"{subject} → {predicate} → {object}",
+            "conflicts": exc.conflicts,
+            "hint": "Invalidate the old fact first if it is no longer true.",
+        }
     return {"success": True, "triple_id": triple_id, "fact": f"{subject} → {predicate} → {object}"}
 
 

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -5,6 +5,8 @@ Covers: entity CRUD, triple CRUD, temporal queries, invalidation,
 timeline, stats, and edge cases (duplicate triples, ID collisions).
 """
 
+from mempalace.knowledge_graph import KnowledgeConflictError
+
 
 class TestEntityOperations:
     def test_add_entity(self, kg):
@@ -39,11 +41,26 @@ class TestTripleOperations:
         tid2 = kg.add_triple("Alice", "knows", "Bob")
         assert tid1 == tid2
 
+    def test_conflicting_single_value_triple_raises(self, kg):
+        tid = kg.add_triple("Alice", "works_at", "Acme")
+        assert tid.startswith("t_alice_works_at_acme_")
+        try:
+            kg.add_triple("Alice", "works_at", "NewCo")
+            assert False, "Expected KnowledgeConflictError"
+        except KnowledgeConflictError as exc:
+            assert exc.conflicts[0]["object"] == "Acme"
+
     def test_invalidated_triple_allows_re_add(self, kg):
         tid1 = kg.add_triple("Alice", "works_at", "Acme")
         kg.invalidate("Alice", "works_at", "Acme", ended="2025-01-01")
         tid2 = kg.add_triple("Alice", "works_at", "Acme")
         assert tid1 != tid2  # new triple since old one was closed
+
+    def test_multi_value_predicate_does_not_conflict(self, kg):
+        tid1 = kg.add_triple("Alice", "knows", "Bob")
+        tid2 = kg.add_triple("Alice", "knows", "Carol")
+        assert tid1.startswith("t_alice_knows_bob_")
+        assert tid2.startswith("t_alice_knows_carol_")
 
 
 class TestQueries:

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -5,6 +5,8 @@ Covers: entity CRUD, triple CRUD, temporal queries, invalidation,
 timeline, stats, and edge cases (duplicate triples, ID collisions).
 """
 
+import pytest
+
 from mempalace.knowledge_graph import KnowledgeConflictError
 
 
@@ -44,11 +46,9 @@ class TestTripleOperations:
     def test_conflicting_single_value_triple_raises(self, kg):
         tid = kg.add_triple("Alice", "works_at", "Acme")
         assert tid.startswith("t_alice_works_at_acme_")
-        try:
+        with pytest.raises(KnowledgeConflictError) as exc_info:
             kg.add_triple("Alice", "works_at", "NewCo")
-            assert False, "Expected KnowledgeConflictError"
-        except KnowledgeConflictError as exc:
-            assert exc.conflicts[0]["object"] == "Acme"
+        assert exc_info.value.conflicts[0]["object"] == "Acme"
 
     def test_invalidated_triple_allows_re_add(self, kg):
         tid1 = kg.add_triple("Alice", "works_at", "Acme")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -272,6 +272,21 @@ class TestKGTools:
             valid_from="2025-01-01",
         )
         assert result["success"] is True
+        assert result["triple_id"].startswith("t_alice_likes_coffee_")
+
+    def test_kg_add_conflict(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, palace_path, seeded_kg)
+        from mempalace.mcp_server import tool_kg_add
+
+        result = tool_kg_add(
+            subject="Alice",
+            predicate="works_at",
+            object="AnotherCo",
+            valid_from="2025-02-01",
+        )
+        assert result["success"] is False
+        assert result["reason"] == "conflict"
+        assert result["conflicts"][0]["object"] == "NewCo"
 
     def test_kg_query(self, monkeypatch, config, palace_path, seeded_kg):
         _patch_mcp_server(monkeypatch, config, palace_path, seeded_kg)


### PR DESCRIPTION
  ## What does this PR do?

  Add conflict detection for knowledge graph writes on single-valued predicates.

  ### Changes
  - add `KnowledgeConflictError` in `mempalace/knowledge_graph.py`
  - detect conflicting active facts before inserting new triples for single-valued predicates like `works_at`, `assigned_to`, and `married_to`
  - keep `KnowledgeGraph.add_triple()` compatible by still returning the triple id on success
  - return a structured conflict response from `mempalace_kg_add`
  - add tests for duplicate, conflict, and invalidation flows

  ### Notes
  Conflict detection is intentionally limited to a small set of single-valued predicates. Multi-valued predicates like `knows`, `likes`, and `does` are excluded.

  ## How to test

  - `uv run pytest tests/test_knowledge_graph.py tests/test_mcp_server.py`
  - `uv run ruff check mempalace/knowledge_graph.py mempalace/mcp_server.py tests/test_knowledge_graph.py tests/test_mcp_server.py`

  ## Checklist
  - [x] Tests pass (`uv run pytest tests/test_knowledge_graph.py tests/test_mcp_server.py`)
  - [x] No hardcoded paths
  - [x] Linter passes (`uv run ruff check mempalace/knowledge_graph.py mempalace/mcp_server.py tests/test_knowledge_graph.py tests/test_mcp_server.py`)