### PR TITLE
build: add a Nix wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ venv/
 # ChromaDB local data
 *.sqlite3-journal
 .envrc
+
+# Nix
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -181,6 +181,36 @@ No API key is required for the core benchmark path.
 - Release notes → [CHANGELOG.md](CHANGELOG.md)
 - Corrections and public notices → [docs/HISTORY.md](docs/HISTORY.md)
 
+### Nix
+
+A Nix flake is provided for reproducible builds and development.
+
+If you don't have Nix installed, the [Determinate Nix Installer](https://determinate.systems/nix-installer/) is the easiest way to get started (flakes work out of the box):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+```
+
+Then:
+
+```bash
+# Run directly without installing
+nix run github:milla-jovovich/mempalace -- search "why did we switch to GraphQL"
+
+# Install into your profile
+nix profile install github:milla-jovovich/mempalace
+
+# Development shell with all dependencies (Python, uv, ruff, pytest)
+nix develop
+
+# Run tests (one-liner)
+nix develop --command python -m pytest tests/
+
+# Build the package & run the result
+nix build
+./result/bin/mempalace --help
+```
+
 ## Contributing
 
 PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773870109,
+        "narHash": "sha256-ZoTdqZP03DcdoyxvpFHCAek4bkPUTUPUF3oCCgc3dP4=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "b6e74f433b02fa4b8a7965ee24680f4867e2926f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775439158,
+        "narHash": "sha256-NHY9SJNU019n+8NCabBDtmuzRFeE2gZlYKHowp9bV24=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "fb6b728260f3f32761367e9fd1e1a25b4245bcd0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775614466,
+        "narHash": "sha256-cjFEkDKw2CjhPvKqWBW4yDHevsWekw7C2BhvabRTLXs=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "f77ef8e55effbe879851a640bae2dc277cc0f525",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,116 @@
+{
+  description = "MemPalace - Give your AI a memory";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      pyproject-nix,
+      uv2nix,
+      pyproject-build-systems,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+
+      workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./.; };
+
+      overlay = workspace.mkPyprojectOverlay {
+        sourcePreference = "wheel";
+      };
+
+      # sdist-only packages that need explicit build deps
+      pyprojectOverrides = final: prev: {
+        chroma-hnswlib = prev.chroma-hnswlib.overrideAttrs (old: {
+          nativeBuildInputs =
+            (old.nativeBuildInputs or [ ])
+            ++ (final.resolveBuildSystem {
+              setuptools = [ ];
+              pybind11 = [ ];
+              numpy = [ ];
+            });
+        });
+        autocorrect = prev.autocorrect.overrideAttrs (old: {
+          nativeBuildInputs =
+            (old.nativeBuildInputs or [ ])
+            ++ (final.resolveBuildSystem {
+              setuptools = [ ];
+            });
+        });
+      };
+
+      mkPythonSet =
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        (pkgs.callPackage pyproject-nix.build.packages {
+          python = pkgs.python312;
+        }).overrideScope
+          (
+            lib.composeManyExtensions [
+              pyproject-build-systems.overlays.wheel
+              overlay
+              pyprojectOverrides
+            ]
+          );
+    in
+    {
+      packages = forAllSystems (system: {
+        default = ((mkPythonSet system).mkVirtualEnv "mempalace-env" workspace.deps.default).overrideAttrs {
+          meta.mainProgram = "mempalace";
+        };
+      });
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          pythonSet = mkPythonSet system;
+          # Exclude hardware-specific ONNX extras (gpu/dml/coreml)
+          devDeps = builtins.mapAttrs (_: builtins.filter (e: !builtins.elem e [ "dml" "gpu" "coreml" ])) workspace.deps.all;
+          virtualenv = pythonSet.mkVirtualEnv "mempalace-dev-env" devDeps;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              virtualenv
+              pkgs.uv
+            ];
+            env = {
+              UV_NO_SYNC = "1";
+              UV_PYTHON = pythonSet.python.interpreter;
+              UV_PYTHON_DOWNLOADS = "never";
+            };
+            shellHook = ''
+              unset PYTHONPATH
+            '';
+          };
+        }
+      );
+
+    };
+}


### PR DESCRIPTION
## What does this PR do?

[Nix](https://nix.dev/) is a package manager that builds stuff in isolation so "works on my machine" actually means it works on every machine.
The flake pins every dependency down to the hash, so two years from now nix build produces the exact same thing.

For users: `nix run` is a oneliner that lets one run mempalace without touching your system Python.
For contributors: `nix develop` drops you into a shell with everything one needs without any virtualenv setup, or "install ruff and pytest first".

## How to test

```bash
# Check the build works
nix build && ./result/bin/mempalace --help
# Check the tests
nix develop -- command python -m pytest tests/ -v
# Check the linter
nix develop --command ruff check .
```

I also verified it works functionally (just used the memory system as supposed to).
I am getting these errors, but I think they are caused by https://github.com/milla-jovovich/mempalace/issues/163
`Failed to send telemetry event ClientStartEvent: capture() takes 1 positional argument but 3 were given`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
