### PR TITLE
fix: silence ChromaDB telemetry warnings and CoreML segfault on Apple Silicon

### DIFF
--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -1,6 +1,21 @@
 """MemPalace — Give your AI a memory. No API key required."""
 
-from .cli import main
-from .version import __version__
+import logging
+import os
+import platform
+
+from .cli import main  # noqa: E402
+from .version import __version__  # noqa: E402
+
+# ChromaDB 0.6.x ships a Posthog telemetry client whose capture() signature is
+# incompatible with the bundled posthog library, producing noisy stderr warnings
+# on every client operation ("Failed to send telemetry event … capture() takes
+# 1 positional argument but 3 were given").  Silence just that logger.
+logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
+
+# ONNX Runtime's CoreML provider segfaults during vector queries on Apple Silicon.
+# Force CPU execution unless the user has explicitly set a preference.
+if platform.machine() == "arm64" and platform.system() == "Darwin":
+    os.environ.setdefault("ORT_DISABLE_COREML", "1")
 
 __all__ = ["main", "__version__"]


### PR DESCRIPTION
## Summary

Fixes two ChromaDB compatibility issues in a single 10-line change to `mempalace/__init__.py`:

- **Telemetry spam**: ChromaDB 0.6.x bundles a Posthog telemetry client whose `capture()` signature is incompatible with the installed posthog library, producing `Failed to send telemetry event ... capture() takes 1 positional argument but 3 were given` on every operation. Fixed by raising the `chromadb.telemetry.product.posthog` logger threshold to `CRITICAL`.

- **CoreML segfault on Apple Silicon** (#74): ONNX Runtime's CoreML execution provider crashes with SIGSEGV during vector queries on macOS ARM64. Fixed by auto-setting `ORT_DISABLE_COREML=1` via `os.environ.setdefault()` so it forces CPU execution while still respecting any user-provided override.

## Root cause

The telemetry error originates in `chromadb/telemetry/product/posthog.py:61` where `posthog.capture(user_id, event_name, properties)` is called with 3 positional args, but the bundled posthog library's `capture()` only accepts 1. Setting `anonymized_telemetry=False` in ChromaDB Settings does not prevent the call — it only sets `posthog.disabled = True`, which the broken posthog stub doesn't honor.

## Changes

| File | Change |
|------|--------|
| `mempalace/__init__.py` | Silence telemetry logger + auto-set `ORT_DISABLE_COREML=1` on ARM64 macOS |

## Test plan

- [x] All 101 tests pass
- [x] Zero lint errors
- [x] `mempalace search` produces clean output with no telemetry warnings
- [x] `mempalace search` no longer segfaults on macOS ARM64 (tested on M-series Mac)

Relates to #74