### PR TITLE
Fixed broken link reference for AAAK Dialect in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Other memory systems try to fix this by letting AI decide what's worth rememberi
 
 <br>
 
-[Quick Start](#quick-start) · [The Palace](#the-palace) · [AAAK Dialect](#aaak-compression) · [Benchmarks](#benchmarks) · [MCP Tools](#mcp-server)
+[Quick Start](#quick-start) · [The Palace](#the-palace) · [AAAK Dialect](#aaak-dialect-experimental) · [Benchmarks](#benchmarks) · [MCP Tools](#mcp-server)
 
 <br>
 


### PR DESCRIPTION
## What does this PR do?

On the repo main page
https://github.com/milla-jovovich/mempalace

Clicking on the `AAAK Dialect` link, points to the anchor `#aaak-compression`, which is a dead link.
https://github.com/milla-jovovich/mempalace#aaak-compression

The working anchor is `#aaak-dialect-experimental`.
https://github.com/milla-jovovich/mempalace#aaak-dialect-experimental


## How to test

Click on the working anchor, and verify that the browser jumps to the `AAAK Dialect (experimental)` section.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
