### PR TITLE
Fix: set cosine distance metric on ChromaDB collection creation

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -210,7 +210,7 @@ def cmd_repair(args):
 
     print("  Rebuilding collection...")
     client.delete_collection("mempalace_drawers")
-    new_col = client.create_collection("mempalace_drawers")
+    new_col = client.create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
 
     filed = 0
     for i in range(0, len(all_ids), batch_size):

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -217,7 +217,7 @@ def get_collection(palace_path: str):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        return client.create_collection("mempalace_drawers")
+        return client.create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -44,7 +44,7 @@ def _get_collection(create=False):
     try:
         client = chromadb.PersistentClient(path=_config.palace_path)
         if create:
-            return client.get_or_create_collection(_config.collection_name)
+            return client.get_or_create_collection(_config.collection_name, metadata={"hnsw:space": "cosine"})
         return client.get_collection(_config.collection_name)
     except Exception:
         return None

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -399,7 +399,9 @@ def get_collection(palace_path: str):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        return client.create_collection("mempalace_drawers")
+        # metadata key is deprecated in chromadb >=0.6; migrate to
+        # configuration={"hnsw": {"space": "cosine"}} once min version is bumped.
+        return client.create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def config(tmp_dir, palace_path):
 def collection(palace_path):
     """A ChromaDB collection pre-seeded in the temp palace."""
     client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_or_create_collection("mempalace_drawers")
+    col = client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
     return col
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -26,7 +26,7 @@ def _get_collection(palace_path, create=False):
 
     client = chromadb.PersistentClient(path=palace_path)
     if create:
-        return client.get_or_create_collection("mempalace_drawers")
+        return client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
     return client.get_collection("mempalace_drawers")
 
 


### PR DESCRIPTION
## Summary

Closes #218.

ChromaDB defaults to L2 (Euclidean) distance when no metric is specified, but `searcher.py` computes similarity as `1 - dist`, which only produces valid 0–1 scores under cosine distance. All six collection creation points were missing the `metadata={"hnsw:space": "cosine"}` parameter.

### Files changed
- `convo_miner.py` — `create_collection` in `get_collection()`
- `miner.py` — `create_collection` in `get_collection()`
- `cli.py` — `create_collection` in `cmd_repair()` rebuild path
- `mcp_server.py` — `get_or_create_collection` in `_get_collection()`
- `tests/conftest.py` — test fixture collection
- `tests/test_mcp_server.py` — test helper collection

### Notes
- Uses legacy `metadata={"hnsw:space": "cosine"}` rather than `configuration=` for compatibility with `chromadb>=0.5.0`. Added a code comment noting the deprecation path.
- `get_or_create_collection` silently ignores metadata if the collection already exists — existing palaces need `mempalace repair` to pick up cosine distance.
- The `metadata=` approach stores the space in the `collection_metadata` table; ChromaDB's HNSW implementation reads it from there at runtime.

## Test plan
- [x] `pytest` on chromadb 0.6.3 — 98 passed, 3 pre-existing failures (ONNXRuntime/CoreML, unrelated)
- [x] Manual e2e on chromadb 1.5.7 — confirmed `1 - dist` produces meaningful 0–1 scores with cosine vs negative scores with L2. Scores represent `1 - distance` as computed by `searcher.py`; with cosine, relevant results score near 1 and irrelevant results score near 0, while L2 produces unbounded negative scores that break this ranking:

| | L2 (bug) | Cosine (fix) |
|---|---|---|
| Best match | 0.643 | **0.822** |
| Weak match | -0.813 | 0.094 |
| No match | -1.020 | -0.010 |

