### PR TITLE
docs: add Cursor memory-first MCP workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,8 +490,7 @@ claude mcp add mempalace -- python -m mempalace.mcp_server
 
 The AI learns AAAK and the memory protocol automatically from the `mempalace_status` response. No manual configuration.
 
-For a practical Cursor workflow (memory-first when needed, token-aware defaults, and chat storage
-patterns), see [examples/mcp_setup.md](examples/mcp_setup.md).
+For a practical Cursor workflow (memory-first when needed, token-aware defaults, and chat storage patterns), see [examples/mcp_setup.md](examples/mcp_setup.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -490,6 +490,9 @@ claude mcp add mempalace -- python -m mempalace.mcp_server
 
 The AI learns AAAK and the memory protocol automatically from the `mempalace_status` response. No manual configuration.
 
+For a practical Cursor workflow (memory-first when needed, token-aware defaults, and chat storage
+patterns), see [examples/mcp_setup.md](examples/mcp_setup.md).
+
 ---
 
 ## Auto-Save Hooks

--- a/examples/mcp_setup.md
+++ b/examples/mcp_setup.md
@@ -25,3 +25,62 @@ The server exposes the full MemPalace MCP toolset. Common entry points include:
 ## Usage in Claude Code
 
 Once configured, Claude Code can search your memories directly during conversations.
+
+## Cursor Memory-First Workflow (Token-Aware)
+
+This is a practical setup for Cursor users who want memory when it helps, but avoid extra token
+spend on generic questions.
+
+### 1) Save durable chat outcomes
+
+Store important outcomes verbatim so future searches can quote exact context:
+
+```text
+tool: mempalace_add_drawer
+wing: cursor
+room: technical | decisions | problems | general
+content: full user/assistant snippet (verbatim)
+source_file: chat-YYYY-MM-DD-topic
+added_by: cursor-agent
+```
+
+Also save a compact timeline note:
+
+```text
+tool: mempalace_diary_write
+agent_name: cursor-agent
+topic: short-tag
+entry: SESSION:YYYY-MM-DD|TOPIC:...|DECISION:...|NEXT:...|★★★
+```
+
+### 2) Query policy (reduce wasted tokens)
+
+Use **memory-first** only when the user asks about prior context:
+
+- "remember"
+- "before"
+- "you said"
+- "last time"
+- "our project setup"
+
+Skip memory lookup for generic one-off questions (for example, "what is nginx?").
+
+### 3) Retrieval pattern
+
+```text
+1. mempalace_search(query, wing="cursor", room=<best room>, limit=3-5)
+2. If empty, optionally broaden (remove room filter, then wing filter)
+3. Answer from retrieved memory only
+4. If still empty, say "No stored memory yet" and answer normally
+```
+
+### 4) Suggested room mapping for chat memory
+
+- `technical` - tooling, infra, implementation notes
+- `decisions` - architectural/product decisions
+- `problems` - incidents, bugs, blockers
+- `planning` - next steps and work plans
+- `general` - preferences and non-technical context
+
+Tip: if you expect a room like `networking`, create a consistent convention in content tags
+(for example `Topic: networking`) and keep storage in the closest existing room (`technical`).

--- a/examples/mcp_setup.md
+++ b/examples/mcp_setup.md
@@ -1,6 +1,8 @@
-# MCP Integration — Claude Code
+# MCP Integration
 
-## Setup
+Claude Code setup below; see [Cursor Memory-First Workflow](#cursor-memory-first-workflow-token-aware) for Cursor.
+
+## Setup (Claude Code)
 
 Run the MCP server:
 
@@ -40,9 +42,10 @@ tool: mempalace_add_drawer
 wing: cursor
 room: technical | decisions | problems | general
 content: full user/assistant snippet (verbatim)
-source_file: chat-YYYY-MM-DD-topic
-added_by: cursor-agent
+source_file: cursor-agent/chat-YYYY-MM-DD-topic
 ```
+
+(`mempalace_add_drawer` checks for near-duplicates before filing; you do not need to call `mempalace_check_duplicate` first.)
 
 Also save a compact timeline note:
 
@@ -54,6 +57,8 @@ entry: SESSION:YYYY-MM-DD|TOPIC:...|DECISION:...|NEXT:...|★★★
 ```
 
 ### 2) Query policy (reduce wasted tokens)
+
+The same pattern applies in any MCP-capable editor, not only Cursor.
 
 Use **memory-first** only when the user asks about prior context:
 
@@ -75,6 +80,8 @@ Skip memory lookup for generic one-off questions (for example, "what is nginx?")
 ```
 
 ### 4) Suggested room mapping for chat memory
+
+These names are a **convention for chat memory** you choose when filing drawers; they are separate from rooms MemPalace may infer from project structure elsewhere.
 
 - `technical` - tooling, infra, implementation notes
 - `decisions` - architectural/product decisions


### PR DESCRIPTION
## Summary
- add a practical Cursor memory-first, token-aware MCP workflow to `examples/mcp_setup.md`
- document when to query memory vs skip lookup to avoid unnecessary token usage
- link the workflow from the README MCP section for discoverability

## Test plan
- [x] docs-only change (`README.md`, `examples/mcp_setup.md`)
- [x] markdown renders for added sections and examples
- [x] README link points to the new guide