### PR TITLE
feat: add opt-in Cursor source filtering for mempalace_search

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -170,13 +170,20 @@ def tool_get_taxonomy():
     return {"taxonomy": taxonomy}
 
 
-def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+def tool_search(
+    query: str,
+    limit: int = 5,
+    wing: str = None,
+    room: str = None,
+    cursor_source_filter: bool = False,
+):
     return search_memories(
         query,
         palace_path=_config.palace_path,
         wing=wing,
         room=room,
         n_results=limit,
+        cursor_source_filter=cursor_source_filter,
     )
 
 
@@ -594,6 +601,10 @@ TOOLS = {
                 "limit": {"type": "integer", "description": "Max results (default 5)"},
                 "wing": {"type": "string", "description": "Filter by wing (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "cursor_source_filter": {
+                    "type": "boolean",
+                    "description": "Enable Cursor transcript quality filtering (optional, default false)",
+                },
             },
             "required": ["query"],
         },

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -4,10 +4,17 @@ searcher.py — Find anything. Exact words.
 
 Semantic search against the palace.
 Returns verbatim text — the actual words, never summaries.
+
+When ``cursor_source_filter`` is enabled, ``search_memories`` requests extra
+candidates from Chroma before post-filtering. Tune how many with the environment
+variable ``MEMPALACE_CURSOR_SEARCH_FETCH_MULTIPLIER`` (integer, default 12, max 48),
+or pass ``cursor_fetch_multiplier`` for programmatic overrides.
 """
 
 import logging
+import os
 from pathlib import Path
+from typing import Optional
 
 import chromadb
 
@@ -16,6 +23,27 @@ CHAT_SOURCE_MARKER = "/agent-transcripts/"
 SUBAGENT_SOURCE_MARKER = "/subagents/"
 MIN_SIMILARITY = 0.15
 FETCH_MULTIPLIER = 12
+_CURSOR_FETCH_MULTIPLIER_ENV = "MEMPALACE_CURSOR_SEARCH_FETCH_MULTIPLIER"
+_MAX_CURSOR_FETCH_MULTIPLIER = 48
+
+
+def _cursor_fetch_multiplier() -> int:
+    """Default multiplier when ``cursor_fetch_multiplier`` is not passed explicitly."""
+    raw = os.environ.get(_CURSOR_FETCH_MULTIPLIER_ENV, "").strip()
+    if not raw:
+        return FETCH_MULTIPLIER
+    try:
+        n = int(raw)
+    except ValueError:
+        return FETCH_MULTIPLIER
+    return max(1, min(n, _MAX_CURSOR_FETCH_MULTIPLIER))
+
+
+def _effective_cursor_fetch_multiplier(explicit: Optional[int]) -> int:
+    """Multiplier for Chroma fetch size when cursor post-filtering is on."""
+    if explicit is not None:
+        return max(1, min(int(explicit), _MAX_CURSOR_FETCH_MULTIPLIER))
+    return _cursor_fetch_multiplier()
 
 
 class SearchError(Exception):
@@ -47,8 +75,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     try:
         kwargs = {
             "query_texts": [query],
-            # Fetch more candidates so we can post-filter low quality hits.
-            "n_results": max(n_results * FETCH_MULTIPLIER, n_results),
+            "n_results": n_results,
             "include": ["documents", "metadatas", "distances"],
         }
         if where:
@@ -102,10 +129,16 @@ def search_memories(
     room: str = None,
     n_results: int = 5,
     cursor_source_filter: bool = False,
+    cursor_fetch_multiplier: Optional[int] = None,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
     Used by the MCP server and other callers that need data.
+
+    If ``cursor_source_filter`` is True, Chroma is queried with
+    ``n_results * multiplier`` rows so weak or duplicate transcript chunks can be
+    dropped; ``multiplier`` comes from ``cursor_fetch_multiplier``, else from
+    ``MEMPALACE_CURSOR_SEARCH_FETCH_MULTIPLIER`` (default 12).
     """
     try:
         client = chromadb.PersistentClient(path=palace_path)
@@ -127,7 +160,11 @@ def search_memories(
         where = {"room": room}
 
     try:
-        fetch_n = max(n_results * FETCH_MULTIPLIER, n_results) if cursor_source_filter else n_results
+        if cursor_source_filter:
+            mult = _effective_cursor_fetch_multiplier(cursor_fetch_multiplier)
+            fetch_n = n_results * mult
+        else:
+            fetch_n = n_results
         kwargs = {
             "query_texts": [query],
             "n_results": fetch_n,

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -12,6 +12,10 @@ from pathlib import Path
 import chromadb
 
 logger = logging.getLogger("mempalace_mcp")
+CHAT_SOURCE_MARKER = "/agent-transcripts/"
+SUBAGENT_SOURCE_MARKER = "/subagents/"
+MIN_SIMILARITY = 0.15
+FETCH_MULTIPLIER = 12
 
 
 class SearchError(Exception):
@@ -43,7 +47,8 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     try:
         kwargs = {
             "query_texts": [query],
-            "n_results": n_results,
+            # Fetch more candidates so we can post-filter low quality hits.
+            "n_results": max(n_results * FETCH_MULTIPLIER, n_results),
             "include": ["documents", "metadatas", "distances"],
         }
         if where:
@@ -91,7 +96,12 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: str,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    cursor_source_filter: bool = False,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
@@ -117,9 +127,10 @@ def search_memories(
         where = {"room": room}
 
     try:
+        fetch_n = max(n_results * FETCH_MULTIPLIER, n_results) if cursor_source_filter else n_results
         kwargs = {
             "query_texts": [query],
-            "n_results": n_results,
+            "n_results": fetch_n,
             "include": ["documents", "metadatas", "distances"],
         }
         if where:
@@ -134,16 +145,37 @@ def search_memories(
     dists = results["distances"][0]
 
     hits = []
+    seen_texts = set()
     for doc, meta, dist in zip(docs, metas, dists):
+        source_file = meta.get("source_file", "") or ""
+        similarity = round(1 - dist, 3)
+
+        if cursor_source_filter:
+            # Keep primary chat transcript chunks, drop known noisy sources.
+            if CHAT_SOURCE_MARKER not in source_file or SUBAGENT_SOURCE_MARKER in source_file:
+                continue
+
+            # Avoid weak matches that often produce irrelevant suggestions.
+            if similarity < MIN_SIMILARITY:
+                continue
+
+            # Deduplicate repeated text chunks.
+            doc_key = doc.strip()
+            if doc_key in seen_texts:
+                continue
+            seen_texts.add(doc_key)
+
         hits.append(
             {
                 "text": doc,
                 "wing": meta.get("wing", "unknown"),
                 "room": meta.get("room", "unknown"),
-                "source_file": Path(meta.get("source_file", "?")).name,
-                "similarity": round(1 - dist, 3),
+                "source_file": Path(source_file or "?").name,
+                "similarity": similarity,
             }
         )
+        if len(hits) >= n_results:
+            break
 
     return {
         "query": query,

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -4,7 +4,7 @@ test_searcher.py — Tests for the programmatic search_memories API.
 Tests the library-facing search interface (not the CLI print variant).
 """
 
-from mempalace.searcher import CHAT_SOURCE_MARKER, FETCH_MULTIPLIER, search_memories
+from mempalace.searcher import CHAT_SOURCE_MARKER, FETCH_MULTIPLIER, search, search_memories
 
 
 class TestSearchMemories:
@@ -138,9 +138,51 @@ class TestSearchMemories:
                 return FakeCollection()
 
         monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", lambda path: FakeClient())
+        monkeypatch.delenv("MEMPALACE_CURSOR_SEARCH_FETCH_MULTIPLIER", raising=False)
 
         search_memories("query", "/tmp/palace", n_results=3, cursor_source_filter=True)
         assert captured["n_results"] == 3 * FETCH_MULTIPLIER
+
+    def test_expands_respects_env_fetch_multiplier(self, monkeypatch):
+        captured = {}
+
+        class FakeCollection:
+            def query(self, **kwargs):
+                captured.update(kwargs)
+                return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+        class FakeClient:
+            def get_collection(self, _name):
+                return FakeCollection()
+
+        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", lambda path: FakeClient())
+        monkeypatch.setenv("MEMPALACE_CURSOR_SEARCH_FETCH_MULTIPLIER", "4")
+
+        search_memories("query", "/tmp/palace", n_results=3, cursor_source_filter=True)
+        assert captured["n_results"] == 12
+
+    def test_expands_respects_explicit_fetch_multiplier(self, monkeypatch):
+        captured = {}
+
+        class FakeCollection:
+            def query(self, **kwargs):
+                captured.update(kwargs)
+                return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+        class FakeClient:
+            def get_collection(self, _name):
+                return FakeCollection()
+
+        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", lambda path: FakeClient())
+
+        search_memories(
+            "query",
+            "/tmp/palace",
+            n_results=3,
+            cursor_source_filter=True,
+            cursor_fetch_multiplier=6,
+        )
+        assert captured["n_results"] == 18
 
     def test_cursor_source_filter_returns_result_fields(self, monkeypatch):
         class FakeCollection:
@@ -165,3 +207,22 @@ class TestSearchMemories:
         assert "source_file" in hit
         assert "similarity" in hit
         assert isinstance(hit["similarity"], float)
+
+
+def test_cli_search_requests_exact_n_results(monkeypatch):
+    """CLI ``search()`` must not expand n_results; only search_memories post-filter path does."""
+    captured = {}
+
+    class FakeCollection:
+        def query(self, **kwargs):
+            captured.update(kwargs)
+            return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+    class FakeClient:
+        def get_collection(self, _name):
+            return FakeCollection()
+
+    monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", lambda path: FakeClient())
+
+    search("q", "/tmp/palace", n_results=5)
+    assert captured["n_results"] == 5

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -4,7 +4,7 @@ test_searcher.py — Tests for the programmatic search_memories API.
 Tests the library-facing search interface (not the CLI print variant).
 """
 
-from mempalace.searcher import search_memories
+from mempalace.searcher import CHAT_SOURCE_MARKER, FETCH_MULTIPLIER, search_memories
 
 
 class TestSearchMemories:
@@ -36,6 +36,128 @@ class TestSearchMemories:
 
     def test_result_fields(self, palace_path, seeded_collection):
         result = search_memories("authentication", palace_path)
+        hit = result["results"][0]
+        assert "text" in hit
+        assert "wing" in hit
+        assert "room" in hit
+        assert "source_file" in hit
+        assert "similarity" in hit
+        assert isinstance(hit["similarity"], float)
+
+    def test_filters_non_transcript_sources(self, monkeypatch):
+        class FakeCollection:
+            def query(self, **kwargs):
+                return {
+                    "documents": [["good hit", "bad hit"]],
+                    "metadatas": [
+                        [
+                            {
+                                "wing": "cursor",
+                                "room": "technical",
+                                "source_file": "/tmp/agent-transcripts/abc.jsonl",
+                            },
+                            {
+                                "wing": "cursor",
+                                "room": "technical",
+                                "source_file": "/tmp/notes/manual.md",
+                            },
+                        ]
+                    ],
+                    "distances": [[0.2, 0.05]],
+                }
+
+        class FakeClient:
+            def get_collection(self, _name):
+                return FakeCollection()
+
+        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", lambda path: FakeClient())
+
+        result = search_memories("query", "/tmp/palace", cursor_source_filter=True)
+        assert len(result["results"]) == 1
+        assert result["results"][0]["text"] == "good hit"
+
+    def test_filters_subagent_and_low_similarity_and_duplicates(self, monkeypatch):
+        repeated = "same chunk"
+
+        class FakeCollection:
+            def query(self, **kwargs):
+                return {
+                    "documents": [[repeated, repeated, "subagent", "too weak", "valid"]],
+                    "metadatas": [
+                        [
+                            {
+                                "wing": "cursor",
+                                "room": "technical",
+                                "source_file": "/tmp/agent-transcripts/a.jsonl",
+                            },
+                            {
+                                "wing": "cursor",
+                                "room": "technical",
+                                "source_file": "/tmp/agent-transcripts/b.jsonl",
+                            },
+                            {
+                                "wing": "cursor",
+                                "room": "technical",
+                                "source_file": "/tmp/agent-transcripts/subagents/c.jsonl",
+                            },
+                            {
+                                "wing": "cursor",
+                                "room": "technical",
+                                "source_file": "/tmp/agent-transcripts/d.jsonl",
+                            },
+                            {
+                                "wing": "cursor",
+                                "room": "technical",
+                                "source_file": "/tmp/agent-transcripts/e.jsonl",
+                            },
+                        ]
+                    ],
+                    "distances": [[0.1, 0.1, 0.1, 0.95, 0.2]],
+                }
+
+        class FakeClient:
+            def get_collection(self, _name):
+                return FakeCollection()
+
+        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", lambda path: FakeClient())
+
+        result = search_memories("query", "/tmp/palace", n_results=5, cursor_source_filter=True)
+        texts = [hit["text"] for hit in result["results"]]
+        assert texts == [repeated, "valid"]
+
+    def test_expands_query_candidates_for_post_filtering(self, monkeypatch):
+        captured = {}
+
+        class FakeCollection:
+            def query(self, **kwargs):
+                captured.update(kwargs)
+                return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+        class FakeClient:
+            def get_collection(self, _name):
+                return FakeCollection()
+
+        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", lambda path: FakeClient())
+
+        search_memories("query", "/tmp/palace", n_results=3, cursor_source_filter=True)
+        assert captured["n_results"] == 3 * FETCH_MULTIPLIER
+
+    def test_cursor_source_filter_returns_result_fields(self, monkeypatch):
+        class FakeCollection:
+            def query(self, **kwargs):
+                return {
+                    "documents": [["hello"]],
+                    "metadatas": [[{"wing": "cursor", "room": "general", "source_file": f"/tmp{CHAT_SOURCE_MARKER}a.jsonl"}]],
+                    "distances": [[0.1]],
+                }
+
+        class FakeClient:
+            def get_collection(self, _name):
+                return FakeCollection()
+
+        monkeypatch.setattr("mempalace.searcher.chromadb.PersistentClient", lambda path: FakeClient())
+
+        result = search_memories("authentication", "/tmp/palace", cursor_source_filter=True)
         hit = result["results"][0]
         assert "text" in hit
         assert "wing" in hit


### PR DESCRIPTION
## Summary
- add optional \`cursor_source_filter\` for \`search_memories\` (default off)
- wire optional \`cursor_source_filter\` through MCP \`mempalace_search\`
- add focused tests for source filtering, dedupe, and candidate expansion

## Linked issue
Closes #245

## Test plan
- [x] run targeted searcher tests for new filtering mode
- [x] verify default search behavior remains unchanged when filter is disabled
