### PR TITLE
fix(mcp): redirect stdout to stderr to prevent JSON-RPC stream corruption (#225)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -18,6 +18,15 @@ Tools (write):
 """
 
 import sys
+
+# MCP communicates over stdio: stdout MUST carry only JSON-RPC messages.
+# Some imports below (chromadb, onnxruntime, etc.) print banners/warnings to
+# stdout from native code, which corrupts the protocol stream and breaks
+# Claude Desktop's JSON parser. Capture the real stdout for protocol writes,
+# then redirect sys.stdout to stderr for the rest of the process.
+_real_stdout = sys.stdout
+sys.stdout = sys.stderr
+
 import json
 import logging
 import hashlib
@@ -772,8 +781,8 @@ def main():
             request = json.loads(line)
             response = handle_request(request)
             if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
-                sys.stdout.flush()
+                _real_stdout.write(json.dumps(response) + "\n")
+                _real_stdout.flush()
         except KeyboardInterrupt:
             break
         except Exception as e:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -336,3 +336,46 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+
+class TestStdioHygiene:
+    """Regression tests for issue #225: MCP must not write non-JSON to stdout."""
+
+    def test_import_does_not_pollute_stdout(self):
+        """Importing mcp_server must redirect sys.stdout away from real stdout
+        so that native libraries (chromadb/onnxruntime) cannot corrupt the
+        JSON-RPC stream that Claude Desktop reads."""
+        import sys
+        from mempalace import mcp_server
+
+        assert hasattr(mcp_server, "_real_stdout")
+        # After import, sys.stdout must no longer be the real stdout — it
+        # should be redirected to stderr to swallow stray prints.
+        assert sys.stdout is not mcp_server._real_stdout
+        assert sys.stdout is sys.stderr or sys.stdout is mcp_server.sys.stderr
+
+    def test_main_writes_responses_to_real_stdout(self, monkeypatch, config, palace_path, kg):
+        """The main loop must write JSON-RPC responses to the captured real
+        stdout, not to the redirected sys.stdout."""
+        import io
+        import json as _json
+        from mempalace import mcp_server
+
+        _patch_mcp_server(monkeypatch, config, palace_path, kg)
+
+        fake_stdout = io.StringIO()
+        fake_stderr = io.StringIO()
+        request = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+        fake_stdin = io.StringIO(_json.dumps(request) + "\n")
+
+        monkeypatch.setattr(mcp_server, "_real_stdout", fake_stdout)
+        monkeypatch.setattr(mcp_server.sys, "stdin", fake_stdin)
+        monkeypatch.setattr(mcp_server.sys, "stdout", fake_stderr)
+
+        mcp_server.main()
+
+        # Real stdout must contain valid JSON, stderr must not.
+        out = fake_stdout.getvalue().strip()
+        assert out, "main() wrote nothing to real stdout"
+        for line in out.splitlines():
+            _json.loads(line)  # must parse


### PR DESCRIPTION
Fixes #225.

## Problem
When Claude Desktop launches `python -m mempalace.mcp_server`, it gets repeated JSON parse errors:

```
MCP mempalace: Unexpected token '*', "**********"... is not valid JSON
MCP mempalace: Unexpected token 'E', "EP Error D"... is not valid JSON
MCP mempalace: Unexpected token 'F', "Falling ba"... is not valid JSON
```

The MCP server itself uses `logging` to stderr, but native libraries imported at module load (chromadb, onnxruntime) print banners and ExecutionProvider warnings directly to stdout from C code. Any non-JSON byte on stdout corrupts the JSON-RPC stream.

## Fix
- Capture the real stdout into `_real_stdout` before any other imports.
- Redirect `sys.stdout = sys.stderr` for the rest of the process so stray prints (Python or native) land harmlessly on stderr.
- Write JSON-RPC responses in `main()` to `_real_stdout` instead of `sys.stdout`.

This is the minimal change that keeps the protocol stream clean without having to hunt down every offending print or set library-specific env vars.

## Tests
Added `TestStdioHygiene` in `tests/test_mcp_server.py`:
- `test_import_does_not_pollute_stdout` — verifies `sys.stdout` is no longer the real stdout after import.
- `test_main_writes_responses_to_real_stdout` — drives `main()` with a fake stdin/stdout/stderr and asserts every line written to the captured real stdout is valid JSON.