### PR TITLE
fix(chromadb): create mempalace_drawers with hnsw:space=cosine (#218)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -210,7 +210,9 @@ def cmd_repair(args):
 
     print("  Rebuilding collection...")
     client.delete_collection("mempalace_drawers")
-    new_col = client.create_collection("mempalace_drawers")
+    new_col = client.create_collection(
+        "mempalace_drawers", metadata={"hnsw:space": "cosine"}
+    )
 
     filed = 0
     for i in range(0, len(all_ids), batch_size):

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -217,7 +217,9 @@ def get_collection(palace_path: str):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        return client.create_collection("mempalace_drawers")
+        return client.create_collection(
+            "mempalace_drawers", metadata={"hnsw:space": "cosine"}
+        )
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -44,7 +44,9 @@ def _get_collection(create=False):
     try:
         client = chromadb.PersistentClient(path=_config.palace_path)
         if create:
-            return client.get_or_create_collection(_config.collection_name)
+            return client.get_or_create_collection(
+                _config.collection_name, metadata={"hnsw:space": "cosine"}
+            )
         return client.get_collection(_config.collection_name)
     except Exception:
         return None

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -399,7 +399,9 @@ def get_collection(palace_path: str):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        return client.create_collection("mempalace_drawers")
+        return client.create_collection(
+            "mempalace_drawers", metadata={"hnsw:space": "cosine"}
+        )
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -206,3 +206,30 @@ def test_scan_project_skip_dirs_still_apply_without_override():
         assert scanned_files(project_root, respect_gitignore=False) == ["main.py"]
     finally:
         shutil.rmtree(tmpdir)
+
+
+def test_get_collection_uses_cosine_space():
+    """Regression for #218: collection must be created with hnsw:space=cosine
+    so that searcher's `1 - dist` similarity scoring stays in [-1, 1] (not L2)."""
+    from mempalace.miner import get_collection
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        col = get_collection(tmpdir)
+        assert col.metadata is not None
+        assert col.metadata.get("hnsw:space") == "cosine"
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_convo_get_collection_uses_cosine_space():
+    """Regression for #218: convos mine path must also use cosine."""
+    from mempalace.convo_miner import get_collection
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        col = get_collection(tmpdir)
+        assert col.metadata is not None
+        assert col.metadata.get("hnsw:space") == "cosine"
+    finally:
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
Fixes #218.

## Problem
ChromaDB defaults to **L2** distance when no metric is specified, but `searcher.py` computes:

\`\`\`python
similarity = round(1 - dist, 3)
\`\`\`

That formula only makes sense for **cosine** distance (where `dist ∈ [0, 2]`). With L2, every similarity score comes out negative regardless of relevance — exactly the symptom in the bug report (`-0.174`, `-0.43`, `-0.707`).

## Fix
Add `metadata={"hnsw:space": "cosine"}` to **every** code path that can create the `mempalace_drawers` collection:

- `mempalace/miner.py` — `get_collection` (projects mine path)
- `mempalace/convo_miner.py` — `get_collection` (convos mine path)
- `mempalace/cli.py` — `cmd_repair` rebuild after wipe
- `mempalace/mcp_server.py` — `_get_collection(create=True)` (used by `mempalace_add_drawer`)

## Tests
Added two regression tests in `tests/test_miner.py`:
- `test_get_collection_uses_cosine_space`
- `test_convo_get_collection_uses_cosine_space`

Both create a temp palace, call `get_collection`, and assert `col.metadata["hnsw:space"] == "cosine"`.

## Migration
Existing collections are unaffected — the metric is set at creation time. Users with an already-mined palace need to wipe and re-mine (or run `mempalace repair`) to benefit from the fix. Worth a note in the next release.