### PR TITLE
docs: add OpenCode + Oh-My-OpenAgent integration guide

### DIFF
--- a/examples/agents_md_snippet.md
+++ b/examples/agents_md_snippet.md
@@ -1,0 +1,36 @@
+<!-- Copy this section into your project's AGENTS.md -->
+
+## MemPalace Memory Protocol
+
+This project uses MemPalace for persistent AI memory across sessions. The MCP server is configured globally — all agents have access to 19 memory tools automatically.
+
+### When to Save Memories
+- **After completing a significant task**: Save what was done, decisions made, and why
+- **After debugging sessions**: Save the root cause, fix, and patterns observed
+- **When making architectural decisions**: Save the decision, alternatives considered, and rationale
+- **Before ending a long session**: Save key context that the next session will need
+
+### How to Save
+Use `mempalace_add_drawer` with:
+- `wing`: "{your-project-name}" (this project's wing)
+- `room`: Appropriate topic slug (e.g., "auth-migration", "deploy-config", "bug-fixes")
+- `content`: Verbatim content — exact words, decisions, code snippets. Never summarize.
+
+### How to Recall
+- **Before starting work**: Call `mempalace_search` with the topic you're working on
+- **When unsure about past decisions**: Search for the decision topic
+- **When context seems missing**: Check `mempalace_kg_query` for entity relationships
+
+### Agent Diary
+Each agent can maintain a personal diary via `mempalace_diary_write` / `mempalace_diary_read`. Use this for session-level notes, observations, and learnings.
+
+### Available Tools (19 total)
+- Palace read: `mempalace_status`, `mempalace_search`, `mempalace_list_wings`, `mempalace_list_rooms`, `mempalace_get_taxonomy`, `mempalace_check_duplicate`, `mempalace_get_aaak_spec`
+- Palace write: `mempalace_add_drawer`, `mempalace_delete_drawer`
+- Knowledge Graph: `mempalace_kg_query`, `mempalace_kg_add`, `mempalace_kg_invalidate`, `mempalace_kg_timeline`, `mempalace_kg_stats`
+- Navigation: `mempalace_traverse`, `mempalace_find_tunnels`, `mempalace_graph_stats`
+- Diary: `mempalace_diary_write`, `mempalace_diary_read`
+
+## Oh-My-OpenAgent Note
+
+No changes to `oh-my-openagent.json` are needed — MCPs from `opencode.json` are inherited automatically.

--- a/examples/opencode_install.sh
+++ b/examples/opencode_install.sh
@@ -171,21 +171,7 @@ install_with_pip() {
 }
 
 run_mempalace() {
-    case "$RUNNER_KIND" in
-        uv)
-            "$RESOLVED_PYTHON" -m mempalace "$@"
-            ;;
-        pipx)
-            "$RESOLVED_PYTHON" -m mempalace "$@"
-            ;;
-        pip)
-            "$RESOLVED_PYTHON" -m mempalace "$@"
-            ;;
-        *)
-            error "Unknown runner kind: $RUNNER_KIND"
-            exit 1
-            ;;
-    esac
+    "$RESOLVED_PYTHON" -m mempalace "$@"
 }
 
 update_opencode_config() {
@@ -198,7 +184,7 @@ update_opencode_config() {
     success "Created backup: $BACKUP_FILE"
 
     # Merge only the mempalace MCP entry so existing keys stay intact.
-    python3 - <<'PY' "$CONFIG_FILE" "$RESOLVED_PYTHON"
+    "$DETECTED_PYTHON" - <<'PY' "$CONFIG_FILE" "$RESOLVED_PYTHON"
 import json
 import sys
 from pathlib import Path

--- a/examples/opencode_install.sh
+++ b/examples/opencode_install.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+PROJECT_DIR="${1:-$(pwd)}"
+CONFIG_DIR="$HOME/.config/opencode"
+CONFIG_FILE="$CONFIG_DIR/opencode.json"
+BACKUP_FILE="$CONFIG_FILE.bak"
+
+# Only enable ANSI output when writing to a real terminal.
+if [ -t 1 ]; then
+    COLOR_GREEN='\033[0;32m'
+    COLOR_YELLOW='\033[1;33m'
+    COLOR_RED='\033[0;31m'
+    COLOR_RESET='\033[0m'
+else
+    COLOR_GREEN=''
+    COLOR_YELLOW=''
+    COLOR_RED=''
+    COLOR_RESET=''
+fi
+
+usage() {
+    cat <<EOF
+Usage: ./$SCRIPT_NAME [project-dir]
+  project-dir: Directory to initialize mempalace for (default: current directory)
+EOF
+}
+
+info() {
+    printf '%s\n' "$1"
+}
+
+success() {
+    printf '%b\n' "${COLOR_GREEN}✓${COLOR_RESET} $1"
+}
+
+warn() {
+    printf '%b\n' "${COLOR_YELLOW}⚠${COLOR_RESET} $1"
+}
+
+error() {
+    printf '%b\n' "${COLOR_RED}✗${COLOR_RESET} $1" >&2
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+if [ ! -d "$PROJECT_DIR" ]; then
+    error "Project directory does not exist: $PROJECT_DIR"
+    exit 1
+fi
+
+detect_python() {
+    local candidate
+    for candidate in python3.12 python3.11 python3.10 python3.9; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    error "Python 3.9+ not found. Install Python 3.12, 3.11, 3.10, or 3.9 first."
+    if command -v brew >/dev/null 2>&1; then
+        warn "macOS hint: brew install python@3.12"
+    else
+        warn "Linux hint: install python3.12 (or 3.11/3.10/3.9) with your distro package manager."
+    fi
+    exit 1
+}
+
+detect_package_manager() {
+    if command -v uv >/dev/null 2>&1; then
+        printf '%s\n' "uv"
+    elif command -v pipx >/dev/null 2>&1; then
+        printf '%s\n' "pipx"
+    else
+        printf '%s\n' "pip"
+    fi
+}
+
+resolve_uv_python() {
+    local tool_dir tool_python
+    tool_dir="$(uv tool dir)"
+    tool_python="$tool_dir/mempalace/bin/python"
+    if [ -x "$tool_python" ]; then
+        printf '%s\n' "$tool_python"
+        return 0
+    fi
+    return 1
+}
+
+resolve_pipx_python() {
+    local pipx_home
+    pipx_home="$(pipx environment --value PIPX_HOME 2>/dev/null || true)"
+    if [ -n "$pipx_home" ] && [ -x "$pipx_home/venvs/mempalace/bin/python" ]; then
+        printf '%s\n' "$pipx_home/venvs/mempalace/bin/python"
+        return 0
+    fi
+
+    # Fall back to common pipx locations when environment metadata is unavailable.
+    if [ -x "$HOME/.local/pipx/venvs/mempalace/bin/python" ]; then
+        printf '%s\n' "$HOME/.local/pipx/venvs/mempalace/bin/python"
+        return 0
+    fi
+
+    if [ -x "$HOME/.local/share/pipx/venvs/mempalace/bin/python" ]; then
+        printf '%s\n' "$HOME/.local/share/pipx/venvs/mempalace/bin/python"
+        return 0
+    fi
+
+    return 1
+}
+
+install_with_uv() {
+    local detected_python="$1"
+    local tool_python
+
+    if tool_python="$(resolve_uv_python 2>/dev/null)"; then
+        success "MemPalace already installed with uv; skipping install"
+        RESOLVED_PYTHON="$tool_python"
+        RUNNER_KIND="uv"
+        return 0
+    fi
+
+    info "Installing MemPalace with uv using $detected_python"
+    uv tool install --python "$detected_python" mempalace
+    RESOLVED_PYTHON="$(resolve_uv_python)"
+    RUNNER_KIND="uv"
+    success "Installed MemPalace with uv"
+}
+
+install_with_pipx() {
+    local detected_python="$1"
+    local tool_python
+
+    if pipx list 2>/dev/null | grep -q 'package mempalace'; then
+        tool_python="$(resolve_pipx_python || true)"
+        if [ -n "$tool_python" ]; then
+            success "MemPalace already installed with pipx; skipping install"
+            RESOLVED_PYTHON="$tool_python"
+            RUNNER_KIND="pipx"
+            return 0
+        fi
+    fi
+
+    info "Installing MemPalace with pipx using $detected_python"
+    pipx install --python "$detected_python" mempalace
+    RESOLVED_PYTHON="$(resolve_pipx_python)"
+    RUNNER_KIND="pipx"
+    success "Installed MemPalace with pipx"
+}
+
+install_with_pip() {
+    local detected_python="$1"
+
+    if "$detected_python" -m pip show mempalace >/dev/null 2>&1; then
+        success "MemPalace already installed for $detected_python; skipping install"
+        RESOLVED_PYTHON="$detected_python"
+        RUNNER_KIND="pip"
+        return 0
+    fi
+
+    info "Installing MemPalace with pip using $detected_python --user"
+    "$detected_python" -m pip install --user mempalace
+    RESOLVED_PYTHON="$detected_python"
+    RUNNER_KIND="pip"
+    success "Installed MemPalace with pip"
+}
+
+run_mempalace() {
+    case "$RUNNER_KIND" in
+        uv)
+            "$RESOLVED_PYTHON" -m mempalace "$@"
+            ;;
+        pipx)
+            "$RESOLVED_PYTHON" -m mempalace "$@"
+            ;;
+        pip)
+            "$RESOLVED_PYTHON" -m mempalace "$@"
+            ;;
+        *)
+            error "Unknown runner kind: $RUNNER_KIND"
+            exit 1
+            ;;
+    esac
+}
+
+update_opencode_config() {
+    if [ ! -f "$CONFIG_FILE" ]; then
+        warn "OpenCode config does not exist at $CONFIG_FILE; skipping MCP config update"
+        return 0
+    fi
+
+    cp "$CONFIG_FILE" "$BACKUP_FILE"
+    success "Created backup: $BACKUP_FILE"
+
+    # Merge only the mempalace MCP entry so existing keys stay intact.
+    python3 - <<'PY' "$CONFIG_FILE" "$RESOLVED_PYTHON"
+import json
+import sys
+from pathlib import Path
+
+config_path = Path(sys.argv[1])
+resolved_python = sys.argv[2]
+
+with config_path.open() as handle:
+    data = json.load(handle)
+
+if not isinstance(data, dict):
+    raise SystemExit("opencode.json must contain a JSON object")
+
+mcp = data.get("mcp")
+if mcp is None:
+    mcp = {}
+    data["mcp"] = mcp
+elif not isinstance(mcp, dict):
+    raise SystemExit("opencode.json field 'mcp' must be an object")
+
+mcp["mempalace"] = {
+    "type": "local",
+    "command": [resolved_python, "-m", "mempalace.mcp_server"],
+    "environment": {"PYTHONUNBUFFERED": "1"},
+    "enabled": True,
+    "timeout": 10000,
+}
+
+with config_path.open("w") as handle:
+    json.dump(data, handle, indent=2)
+    handle.write("\n")
+PY
+
+    success "Updated existing OpenCode MCP config"
+}
+
+verify_server() {
+    local response
+    response="$(printf '%s\n' '{"jsonrpc":"2.0","method":"tools/list","id":1}' | "$RESOLVED_PYTHON" -m mempalace.mcp_server 2>/dev/null || true)"
+    if [ -z "$response" ]; then
+        error "MemPalace MCP server did not respond to tools/list"
+        exit 1
+    fi
+    success "Verified MemPalace MCP server startup"
+}
+
+DETECTED_PYTHON="$(detect_python)"
+PACKAGE_MANAGER="$(detect_package_manager)"
+RESOLVED_PYTHON=""
+RUNNER_KIND=""
+
+info "Using project directory: $PROJECT_DIR"
+info "Detected Python: $DETECTED_PYTHON"
+info "Preferred installer: $PACKAGE_MANAGER"
+
+case "$PACKAGE_MANAGER" in
+    uv)
+        install_with_uv "$DETECTED_PYTHON"
+        ;;
+    pipx)
+        install_with_pipx "$DETECTED_PYTHON"
+        ;;
+    pip)
+        install_with_pip "$DETECTED_PYTHON"
+        ;;
+esac
+
+if [ -f "$PROJECT_DIR/mempalace.yaml" ]; then
+    success "mempalace.yaml already exists; skipping init"
+else
+    info "Initializing MemPalace for $PROJECT_DIR"
+    if run_mempalace init --help 2>&1 | grep -q -- '--yes'; then
+        run_mempalace init "$PROJECT_DIR" --yes
+    else
+        printf 'y\n' | run_mempalace init "$PROJECT_DIR"
+    fi
+    success "Initialized MemPalace project"
+fi
+
+update_opencode_config
+verify_server
+
+printf '\n'
+success "OpenCode + MemPalace setup complete"
+info "Next steps:"
+info "  1. Start OpenCode and confirm the mempalace MCP is enabled"
+info "  2. Run: mempalace mine \"$PROJECT_DIR\""

--- a/examples/opencode_setup.md
+++ b/examples/opencode_setup.md
@@ -1,0 +1,125 @@
+# OpenCode + Oh-My-OpenAgent Integration Guide
+
+This guide explains how to set up MemPalace as a persistent memory layer for [OpenCode](https://opencode.ai) with the [oh-my-openagent](https://github.com/oh-my-opencode/oh-my-openagent) plugin.
+
+## Prerequisites
+
+- Python 3.9+ (3.12 recommended for ChromaDB compatibility)
+- [uv](https://docs.astral.sh/uv/) or pip
+- [OpenCode](https://opencode.ai) installed and configured
+- [oh-my-openagent](https://github.com/oh-my-opencode/oh-my-openagent) plugin active
+
+## 1. Install MemPalace
+
+```bash
+# Recommended: install via uv (isolated tool environment)
+uv tool install mempalace
+
+# Fallback: pip
+pip install mempalace
+```
+
+## 2. Initialize Your Project
+
+MemPalace requires per-project initialization before mining. This creates `mempalace.yaml` in the project directory and updates `~/.mempalace/config.json` globally.
+
+```bash
+# Run from your project root (or pass the path)
+mempalace init /path/to/your/project
+```
+
+*Note: `mempalace status` will report "No palace found" until you run `mempalace mine` — this is expected.*
+
+### Identity Configuration (Optional but Recommended)
+
+Define your role and projects by editing files in `~/.mempalace/`:
+
+- **`~/.mempalace/identity.txt`**: Plain text description of your role and focus.
+- **`~/.mempalace/wing_config.json`**: JSON mapping projects and name variants to "Wings".
+
+## 3. Connect to OpenCode (MCP)
+
+Add MemPalace to your `~/.config/opencode/opencode.json`:
+
+```bash
+# Find your uv tools directory
+uv tool dir
+# Example output: /home/youruser/.local/share/uv/tools
+```
+
+Edit `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["oh-my-openagent@latest"],
+  "mcp": {
+    "mempalace": {
+      "type": "local",
+      "command": ["$(uv tool dir)/mempalace/bin/python", "-m", "mempalace.mcp_server"],
+      "environment": { "PYTHONUNBUFFERED": "1" },
+      "enabled": true,
+      "timeout": 10000
+    }
+  }
+}
+```
+
+Replace `$(uv tool dir)` with the actual path from `uv tool dir`. For example:
+```
+~/.local/share/uv/tools/mempalace/bin/python
+```
+
+*Note: oh-my-openagent inherits all MCPs from `opencode.json` automatically — no separate plugin config needed.*
+
+## 4. Mine Your Projects
+
+Run the miner to ingest code and documentation into your palace. `mempalace init` must be run first for each project.
+
+```bash
+# Mine a single project
+mempalace mine /path/to/your/project
+
+# Mine multiple projects
+for dir in ~/projects/*/; do
+  mempalace init "$dir"
+  mempalace mine "$dir"
+done
+```
+
+## 5. Memory Protocol (AGENTS.md)
+
+Add a memory section to your project's `AGENTS.md` so agents know when and how to use MemPalace:
+
+```markdown
+## Memory (MemPalace)
+
+- Search before starting: `mempalace_search` for related past work, decisions, patterns
+- Save after significant work: `mempalace_save_memory` with context and key findings
+- Tag memories with project name and date for retrieval
+```
+
+## 6. Verify
+
+Start OpenCode and confirm MemPalace is connected:
+
+```bash
+# In an OpenCode session, check MCP status
+/mcp list
+# Expected: mempalace  CONNECTED  19 tools
+```
+
+If not connected, verify the python path is correct:
+```bash
+ls $(uv tool dir)/mempalace/bin/python
+```
+
+## 7. Usage
+
+Once connected, OpenCode agents automatically have access to 19 MemPalace tools. Example queries that trigger memory lookups:
+
+- *"What decisions did we make about the auth module?"* → `mempalace_search`
+- *"Save what we decided about the API structure"* → `mempalace_save_memory`
+- *"What patterns have we used for error handling?"* → `mempalace_search`
+
+Agents using oh-my-openagent will call these tools proactively based on skill instructions — no explicit prompting required.

--- a/examples/opencode_setup.md
+++ b/examples/opencode_setup.md
@@ -56,7 +56,7 @@ Edit `~/.config/opencode/opencode.json`:
   "mcp": {
     "mempalace": {
       "type": "local",
-      "command": ["$(uv tool dir)/mempalace/bin/python", "-m", "mempalace.mcp_server"],
+      "command": ["<UV_TOOL_DIR>/mempalace/bin/python", "-m", "mempalace.mcp_server"],
       "environment": { "PYTHONUNBUFFERED": "1" },
       "enabled": true,
       "timeout": 10000
@@ -95,8 +95,8 @@ Add a memory section to your project's `AGENTS.md` so agents know when and how t
 ## Memory (MemPalace)
 
 - Search before starting: `mempalace_search` for related past work, decisions, patterns
-- Save after significant work: `mempalace_save_memory` with context and key findings
-- Tag memories with project name and date for retrieval
+- Save after significant work: `mempalace_add_drawer` with wing, room, and verbatim content
+- Query entity relationships: `mempalace_kg_query` for linked concepts and decisions
 ```
 
 ## 6. Verify
@@ -119,7 +119,7 @@ ls $(uv tool dir)/mempalace/bin/python
 Once connected, OpenCode agents automatically have access to 19 MemPalace tools. Example queries that trigger memory lookups:
 
 - *"What decisions did we make about the auth module?"* → `mempalace_search`
-- *"Save what we decided about the API structure"* → `mempalace_save_memory`
+- *"Save what we decided about the API structure"* → `mempalace_add_drawer`
 - *"What patterns have we used for error handling?"* → `mempalace_search`
 
 Agents using oh-my-openagent will call these tools proactively based on skill instructions — no explicit prompting required.


### PR DESCRIPTION
## Summary
Adds a complete integration package for OpenCode (https://opencode.ai) users with Oh-My-OpenAgent plugin to set up mempalace as their AI memory system.

## Files Added
- `examples/opencode_setup.md` — Step-by-step guide (follows gemini_cli_setup.md pattern)
- `examples/opencode_install.sh` — Automated setup script (idempotent, cross-platform)
- `examples/agents_md_snippet.md` — Copy-paste memory protocol for AGENTS.md

## What This Enables
OpenCode users can:
1. Run the install script to get mempalace + MCP configured in one command
2. Follow the guide for manual setup or customization
3. Copy the AGENTS.md snippet to give their AI agents memory protocol instructions

## Testing
- All files tested on a real OpenCode + Oh-My-OpenAgent setup
- Install script passes `bash -n` syntax check (and `shellcheck` if available)
- Guide config matches OpenCode's McpLocalConfig schema
- MCP server verified with 19 tools via JSON-RPC