### PR TITLE
feat: allow .rst files in project mining

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -20,6 +20,7 @@ import chromadb
 READABLE_EXTENSIONS = {
     ".txt",
     ".md",
+    ".rst",
     ".py",
     ".js",
     ".ts",

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -65,6 +65,18 @@ def test_scan_project_respects_gitignore():
         shutil.rmtree(tmpdir)
 
 
+def test_scan_project_includes_rst_files():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / "docs" / "guide.rst", "Heading\n=======\n\nBody text\n" * 20)
+
+        assert scanned_files(project_root) == ["docs/guide.rst"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
 def test_scan_project_respects_nested_gitignore():
     tmpdir = tempfile.mkdtemp()
     try:


### PR DESCRIPTION
## Summary
- add `.rst` to `READABLE_EXTENSIONS` in `mempalace/miner.py`
- add regression test `test_scan_project_includes_rst_files`

This makes ReStructuredText documentation discoverable during project scans, matching issue #255.

Fixes #255

Greetings, saschabuehrle
