### PR TITLE
fix: improve Windows test compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,18 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11", "3.13"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.11"
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,21 @@ from mempalace.config import MempalaceConfig  # noqa: E402
 from mempalace.knowledge_graph import KnowledgeGraph  # noqa: E402
 
 
+def close_chroma_client(client):
+    """Best-effort cleanup for Chroma clients, especially on Windows."""
+    try:
+        client.close()
+    except Exception:
+        pass
+
+    try:
+        server = getattr(client, "_server", None)
+        if server is not None and hasattr(server, "stop"):
+            server.stop()
+    except Exception:
+        pass
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _isolate_home():
     """Ensure HOME points to a temp dir for the entire test session.
@@ -84,7 +99,8 @@ def collection(palace_path):
     """A ChromaDB collection pre-seeded in the temp palace."""
     client = chromadb.PersistentClient(path=palace_path)
     col = client.get_or_create_collection("mempalace_drawers")
-    return col
+    yield col
+    close_chroma_client(client)
 
 
 @pytest.fixture

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -3,24 +3,29 @@ import tempfile
 import shutil
 import chromadb
 from mempalace.convo_miner import mine_convos
+from tests.conftest import close_chroma_client
 
 
 def test_convo_mining():
     tmpdir = tempfile.mkdtemp()
-    with open(os.path.join(tmpdir, "chat.txt"), "w") as f:
-        f.write(
-            "> What is memory?\nMemory is persistence.\n\n> Why does it matter?\nIt enables continuity.\n\n> How do we build it?\nWith structured storage.\n"
-        )
+    client = None
+    try:
+        with open(os.path.join(tmpdir, "chat.txt"), "w") as f:
+            f.write(
+                "> What is memory?\nMemory is persistence.\n\n> Why does it matter?\nIt enables continuity.\n\n> How do we build it?\nWith structured storage.\n"
+            )
 
-    palace_path = os.path.join(tmpdir, "palace")
-    mine_convos(tmpdir, palace_path, wing="test_convos")
+        palace_path = os.path.join(tmpdir, "palace")
+        mine_convos(tmpdir, palace_path, wing="test_convos")
 
-    client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_collection("mempalace_drawers")
-    assert col.count() >= 2
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() >= 2
 
-    # Verify search works
-    results = col.query(query_texts=["memory persistence"], n_results=1)
-    assert len(results["documents"][0]) > 0
-
-    shutil.rmtree(tmpdir)
+        # Verify search works
+        results = col.query(query_texts=["memory persistence"], n_results=1)
+        assert len(results["documents"][0]) > 0
+    finally:
+        if client is not None:
+            close_chroma_client(client)
+        shutil.rmtree(tmpdir)

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -7,6 +7,7 @@ import chromadb
 import yaml
 
 from mempalace.miner import mine, scan_project
+from tests.conftest import close_chroma_client
 
 
 def write_file(path: Path, content: str):
@@ -21,6 +22,7 @@ def scanned_files(project_root: Path, **kwargs):
 
 def test_project_mining():
     tmpdir = tempfile.mkdtemp()
+    client = None
     try:
         project_root = Path(tmpdir).resolve()
         os.makedirs(project_root / "backend")
@@ -47,6 +49,8 @@ def test_project_mining():
         col = client.get_collection("mempalace_drawers")
         assert col.count() > 0
     finally:
+        if client is not None:
+            close_chroma_client(client)
         shutil.rmtree(tmpdir)
 
 


### PR DESCRIPTION
﻿## What does this PR do?

- adds a lightweight Windows test job to CI
- explicitly closes Chroma clients in test teardown to avoid Windows file-lock cleanup failures
- keeps the change scoped to tests/CI only

Closes #275.

## How to test

- `python -m pytest tests/ -v`
- On Windows, specifically verify:
  - `python -m pytest tests/test_convo_miner.py tests/test_miner.py -v`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
