### PR TITLE
feat: add native Cursor SQLite convo ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ mempalace init ~/projects/myapp
 
 # Mine your data
 mempalace mine ~/projects/myapp                    # projects — code, docs, notes
-mempalace mine ~/chats/ --mode convos              # convos — Claude, ChatGPT, Slack exports
+mempalace mine ~/chats/ --mode convos              # convos — Claude, ChatGPT, Slack, Cursor state.vscdb
 mempalace mine ~/chats/ --mode convos --extract general  # general — classifies into decisions, milestones, problems
 
 # Search anything you've ever discussed
@@ -564,7 +564,7 @@ mempalace init <dir>                              # guided onboarding + AAAK boo
 
 # Mining
 mempalace mine <dir>                              # mine project files
-mempalace mine <dir> --mode convos                # mine conversation exports
+mempalace mine <dir> --mode convos                # mine conversation exports (incl. Cursor state.vscdb)
 mempalace mine <dir> --mode convos --wing myapp   # tag with a wing name
 
 # Splitting

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -4,7 +4,7 @@ MemPalace — Give your AI a memory. No API key required.
 
 Two ways to ingest:
   Projects:      mempalace mine ~/projects/my_app          (code, docs, notes)
-  Conversations: mempalace mine ~/chats/ --mode convos     (Claude, ChatGPT, Slack)
+  Conversations: mempalace mine ~/chats/ --mode convos     (Claude, ChatGPT, Slack, Cursor)
 
 Same palace. Same search. Different ingest strategies.
 

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -26,7 +26,12 @@ CONVO_EXTENSIONS = {
     ".md",
     ".json",
     ".jsonl",
+    ".vscdb",
+    ".sqlite",
+    ".db",
 }
+
+SQLITE_CONVO_EXTENSIONS = {".vscdb", ".sqlite", ".db"}
 
 SKIP_DIRS = {
     ".git",
@@ -233,6 +238,20 @@ def file_already_mined(collection, source_file: str) -> bool:
 # =============================================================================
 
 
+def _is_cursor_sqlite_candidate(filepath: Path) -> bool:
+    """Heuristic to avoid ingesting arbitrary DB files as conversations."""
+    suffix = filepath.suffix.lower()
+    if suffix not in SQLITE_CONVO_EXTENSIONS:
+        return False
+
+    name = filepath.name.lower()
+    if name.startswith("state.vscdb"):
+        return True
+
+    parts = [part.lower() for part in filepath.parts]
+    return "cursor" in parts and "workspacestorage" in parts
+
+
 def scan_convos(convo_dir: str) -> list:
     """Find all potential conversation files."""
     convo_path = Path(convo_dir).expanduser().resolve()
@@ -243,8 +262,14 @@ def scan_convos(convo_dir: str) -> list:
             if filename.endswith(".meta.json"):
                 continue
             filepath = Path(root) / filename
-            if filepath.suffix.lower() in CONVO_EXTENSIONS:
-                files.append(filepath)
+            suffix = filepath.suffix.lower()
+            if suffix not in CONVO_EXTENSIONS:
+                continue
+
+            if suffix in SQLITE_CONVO_EXTENSIONS and not _is_cursor_sqlite_candidate(filepath):
+                continue
+
+            files.append(filepath)
     return files
 
 

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -9,6 +9,7 @@ Supported:
     - Claude Code JSONL
     - OpenAI Codex CLI JSONL
     - Slack JSON export
+    - Cursor SQLite workspace DB (state.vscdb / ItemTable composer.composerData)
     - Plain text (pass through for paragraph chunking)
 
 No API key. No internet. Everything local.
@@ -16,6 +17,7 @@ No API key. No internet. Everything local.
 
 import json
 import os
+import sqlite3
 from pathlib import Path
 from typing import Optional
 
@@ -25,6 +27,16 @@ def normalize(filepath: str) -> str:
     Load a file and normalize to transcript format if it's a chat export.
     Plain text files pass through unchanged.
     """
+    path = Path(filepath)
+
+    # Cursor and other local chat tooling can persist sessions in SQLite.
+    # Handle DB files before text decode to avoid binary garbage ingestion.
+    if _looks_like_sqlite(path):
+        normalized = _try_cursor_sqlite(path)
+        if normalized:
+            return normalized
+        return ""
+
     try:
         with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             content = f.read()
@@ -40,13 +52,132 @@ def normalize(filepath: str) -> str:
         return content
 
     # Try JSON normalization
-    ext = Path(filepath).suffix.lower()
+    ext = path.suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
         if normalized:
             return normalized
 
     return content
+
+
+def _looks_like_sqlite(path: Path) -> bool:
+    """Detect SQLite files by signature to support Cursor workspace DB ingestion."""
+    try:
+        with open(path, "rb") as f:
+            return f.read(16) == b"SQLite format 3\x00"
+    except OSError:
+        return False
+
+
+def _try_cursor_sqlite(path: Path) -> Optional[str]:
+    """
+    Cursor stores composer chats in state.vscdb (SQLite), typically under:
+    .../Cursor/User/workspaceStorage/<hash>/state.vscdb
+
+    We read ItemTable[key='composer.composerData'] and normalize all discovered
+    user/assistant turns into transcript format.
+    """
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return None
+
+    try:
+        cursor = conn.cursor()
+        rows = cursor.execute(
+            "SELECT value FROM ItemTable WHERE key = ?",
+            ("composer.composerData",),
+        ).fetchall()
+    except sqlite3.Error:
+        return None
+    finally:
+        conn.close()
+
+    messages = []
+    for (raw_value,) in rows:
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            continue
+        try:
+            payload = json.loads(raw_value)
+        except json.JSONDecodeError:
+            continue
+
+        messages.extend(_extract_cursor_messages(payload))
+
+    # Remove adjacent duplicates caused by overlapping nested structures.
+    deduped = []
+    for role, text in messages:
+        item = (role, text.strip())
+        if not item[1]:
+            continue
+        if not deduped or deduped[-1] != item:
+            deduped.append(item)
+
+    if len(deduped) >= 2:
+        return _messages_to_transcript(deduped)
+    return None
+
+
+def _extract_cursor_messages(payload) -> list:
+    """Extract (role, text) pairs from Cursor composer payloads."""
+
+    messages = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            role = _cursor_role(node)
+            text = _cursor_text(node)
+            if role and text:
+                messages.append((role, text))
+
+            for value in node.values():
+                walk(value)
+
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    # Prefer explicit composer sessions first when present.
+    all_composers = payload.get("allComposers") if isinstance(payload, dict) else None
+    if isinstance(all_composers, list) and all_composers:
+        for composer in all_composers:
+            walk(composer)
+    else:
+        walk(payload)
+
+    return messages
+
+
+def _cursor_role(node: dict) -> Optional[str]:
+    """Best-effort role normalization for Cursor composer message shapes."""
+    raw_role = node.get("role")
+    if isinstance(raw_role, dict):
+        raw_role = raw_role.get("type") or raw_role.get("role")
+
+    for key in (raw_role, node.get("type"), node.get("sender"), node.get("speaker")):
+        if not isinstance(key, str):
+            continue
+        role = key.lower()
+        if any(token in role for token in ("user", "human", "prompt", "request")):
+            return "user"
+        if any(token in role for token in ("assistant", "ai", "model", "agent", "bot")):
+            return "assistant"
+
+    return None
+
+
+def _cursor_text(node: dict) -> str:
+    """Extract textual content from Cursor message-like dicts."""
+    for key in ("text", "message", "markdown", "prompt", "response", "body", "content"):
+        if key not in node:
+            continue
+        value = node.get(key)
+        text = _extract_content(value)
+        if text:
+            return text
+
+    return ""
 
 
 def _try_normalize_json(content: str) -> Optional[str]:

--- a/tests/test_convo_scan.py
+++ b/tests/test_convo_scan.py
@@ -1,0 +1,24 @@
+from mempalace.convo_miner import scan_convos
+
+
+def test_scan_convos_includes_cursor_state_vscdb(tmp_path):
+    workspace = tmp_path / "Cursor" / "User" / "workspaceStorage" / "abc123"
+    workspace.mkdir(parents=True)
+    db_path = workspace / "state.vscdb"
+    db_path.write_bytes(b"SQLite format 3\x00dummy")
+
+    files = scan_convos(str(tmp_path))
+    assert db_path in files
+
+
+def test_scan_convos_skips_unrelated_db_files(tmp_path):
+    keep = tmp_path / "chat.json"
+    keep.write_text('[{"role":"user","content":"hello"}]', encoding="utf-8")
+
+    skip_db = tmp_path / "analytics.db"
+    skip_db.write_bytes(b"SQLite format 3\x00dummy")
+
+    files = scan_convos(str(tmp_path))
+
+    assert keep in files
+    assert skip_db not in files

--- a/tests/test_normalize_cursor.py
+++ b/tests/test_normalize_cursor.py
@@ -1,0 +1,54 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from mempalace.normalize import normalize
+
+
+def _make_cursor_db(path: Path, payload: dict):
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute(
+        "INSERT INTO ItemTable(key, value) VALUES (?, ?)",
+        ("composer.composerData", json.dumps(payload)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_normalize_cursor_sqlite_workspace_db(tmp_path):
+    db_path = tmp_path / "state.vscdb"
+    payload = {
+        "allComposers": [
+            {
+                "messages": [
+                    {"role": "user", "content": "How do I fix auth timeout?"},
+                    {"role": "assistant", "content": "Start with token expiry checks."},
+                    {"role": "user", "text": "Give me exact steps."},
+                    {
+                        "role": "assistant",
+                        "markdown": "1) reproduce\n2) inspect refresh flow\n3) patch",
+                    },
+                ]
+            }
+        ]
+    }
+    _make_cursor_db(db_path, payload)
+
+    normalized = normalize(str(db_path))
+
+    assert "> How do I fix auth timeout?" in normalized
+    assert "Start with token expiry checks." in normalized
+    assert "> Give me exact steps." in normalized
+    assert "inspect refresh flow" in normalized
+
+
+def test_normalize_non_cursor_sqlite_returns_empty(tmp_path):
+    db_path = tmp_path / "random.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE foo (id INTEGER PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO foo(value) VALUES ('hello')")
+    conn.commit()
+    conn.close()
+
+    assert normalize(str(db_path)) == ""


### PR DESCRIPTION
## Summary
This PR adds **native Cursor SQLite conversation ingestion** so users can point `mempalace mine --mode convos` directly at Cursor workspace storage and ingest composer chats without manual export.

### What changed
- `normalize.py`
  - detect SQLite files by signature (`SQLite format 3`)
  - read Cursor `ItemTable` rows where `key = 'composer.composerData'`
  - parse `allComposers` payloads and normalize user/assistant turns into transcript format
  - safely return empty content for non-conversation SQLite DBs (so they are skipped)
- `convo_miner.py`
  - include SQLite suffixes in convo scan (`.vscdb`, `.sqlite`, `.db`)
  - add guardrail heuristics to avoid arbitrary DB ingestion
  - detect Cursor workspace DB candidates (`state.vscdb`, Cursor `workspaceStorage` paths)
- docs
  - updated CLI/README examples to mention Cursor conversation ingestion

## Why
Implements issue #274 by enabling local-first, verbatim extraction of Cursor composer history from `state.vscdb`.

## Tests
Added:
- `tests/test_normalize_cursor.py`
  - verifies Cursor SQLite payload normalization from `composer.composerData`
  - verifies non-Cursor SQLite DBs are skipped
- `tests/test_convo_scan.py`
  - verifies scan includes Cursor `state.vscdb`
  - verifies scan skips unrelated `.db` files

Run locally:
- `ruff check mempalace/normalize.py mempalace/convo_miner.py mempalace/cli.py tests/test_normalize_cursor.py tests/test_convo_scan.py`
- `pytest tests/test_normalize.py tests/test_normalize_cursor.py tests/test_convo_scan.py tests/test_convo_miner.py -q` ✅

Note: full `pytest tests/ -v` currently fails on this machine in existing search/mcp tests due an upstream ONNX/CoreML runtime provider error, unrelated to these changes.

Fixes #274

Greetings, saschabuehrle
