### PR TITLE
feat: add OpenCode auto-plugin for zero-config MemPalace integration

### DIFF
--- a/examples/opencode_auto_plugin.js
+++ b/examples/opencode_auto_plugin.js
@@ -63,6 +63,7 @@ const LOG_FILE = '/tmp/mempalace-auto.log';
 // Dedup across an entire opencode process lifetime.
 const initializedProjects = new Set();
 const initializingProjects = new Set();
+const miningProjects = new Set();
 
 function log(msg) {
   try {
@@ -115,7 +116,13 @@ function spawnDetached(cmd, args, tag) {
 }
 
 function ensureInitialized(projectRoot) {
-  if (initializedProjects.has(projectRoot) || initializingProjects.has(projectRoot)) return;
+  if (
+    initializedProjects.has(projectRoot) ||
+    initializingProjects.has(projectRoot) ||
+    miningProjects.has(projectRoot)
+  ) {
+    return;
+  }
   initializingProjects.add(projectRoot);
 
   log(`init: ${projectRoot}`);
@@ -131,9 +138,40 @@ function ensureInitialized(projectRoot) {
     settled = true;
     initializingProjects.delete(projectRoot);
     if (code === 0) {
-      initializedProjects.add(projectRoot);
       log(`init ok → mine: ${projectRoot}`);
-      spawnDetached('mempalace', ['mine', '--limit', '200', projectRoot], 'mine');
+      miningProjects.add(projectRoot);
+      const mine = spawnDetached('mempalace', ['mine', '--limit', '200', projectRoot], 'mine');
+      if (!mine) {
+        miningProjects.delete(projectRoot);
+        log(`mine failed error=spawn-error: ${projectRoot}`);
+        return;
+      }
+
+      let mineSettled = false;
+      const finalizeMine = (mineCode, mineReason) => {
+        if (mineSettled) return;
+        mineSettled = true;
+        miningProjects.delete(projectRoot);
+        if (mineCode === 0) {
+          initializedProjects.add(projectRoot);
+          log(`mine ok: ${projectRoot}`);
+        } else {
+          initializedProjects.delete(projectRoot);
+          log(`mine failed ${mineReason}=${mineCode}: ${projectRoot}`);
+        }
+      };
+
+      mine.on('error', (error) => {
+        finalizeMine(error?.code ?? error?.message ?? 'spawn-error', 'error');
+      });
+
+      mine.on('exit', (mineCode) => {
+        finalizeMine(mineCode, 'code');
+      });
+
+      mine.on('close', (mineCode) => {
+        finalizeMine(mineCode, 'close');
+      });
     } else {
       log(`init failed ${reason}=${code}: ${projectRoot}`);
     }

--- a/examples/opencode_auto_plugin.js
+++ b/examples/opencode_auto_plugin.js
@@ -62,6 +62,7 @@ const LOG_FILE = '/tmp/mempalace-auto.log';
 
 // Dedup across an entire opencode process lifetime.
 const initializedProjects = new Set();
+const initializingProjects = new Set();
 
 function log(msg) {
   try {
@@ -102,6 +103,8 @@ function spawnDetached(cmd, args, tag) {
       detached: true,
       stdio: ['ignore', out, err],
     });
+    closeSync(out);
+    closeSync(err);
     child.on('error', (e) => log(`[${tag}] spawn error: ${e.message}`));
     child.unref();
     return child;
@@ -112,15 +115,20 @@ function spawnDetached(cmd, args, tag) {
 }
 
 function ensureInitialized(projectRoot) {
-  if (initializedProjects.has(projectRoot)) return;
-  initializedProjects.add(projectRoot);
+  if (initializedProjects.has(projectRoot) || initializingProjects.has(projectRoot)) return;
+  initializingProjects.add(projectRoot);
 
   log(`init: ${projectRoot}`);
   const init = spawnDetached('mempalace', ['init', '--yes', projectRoot], 'init');
-  if (!init) return;
+  if (!init) {
+    initializingProjects.delete(projectRoot);
+    return;
+  }
 
   init.on('exit', (code) => {
+    initializingProjects.delete(projectRoot);
     if (code === 0) {
+      initializedProjects.add(projectRoot);
       log(`init ok → mine: ${projectRoot}`);
       spawnDetached('mempalace', ['mine', '--limit', '200', projectRoot], 'mine');
     } else {

--- a/examples/opencode_auto_plugin.js
+++ b/examples/opencode_auto_plugin.js
@@ -1,0 +1,154 @@
+/**
+ * mempalace-auto.js — Opencode plugin that auto-initializes MemPalace in every project.
+ *
+ * Behavior (once per project per opencode process):
+ *   1. On first `event` in an opencode session, detect the git repo root of ctx.directory.
+ *   2. Spawn `mempalace init --yes <root>` in the background (detached, unref).
+ *   3. After init succeeds, spawn `mempalace mine --limit 200 <root>` in the background.
+ *   4. Inject the MemPalace Memory Protocol section into the system prompt on every chat
+ *      via `experimental.chat.system.transform` — so every agent knows when/how to use it.
+ *
+ * Why this approach:
+ *   - No AGENTS.md patching — the protocol lives in memory, not on disk.
+ *   - No shell wrappers — uses native opencode plugin hooks.
+ *   - Idempotent — `mempalace init --yes` is safe to run multiple times.
+ *   - Skipped for non-git directories (~, /tmp, Downloads, etc.).
+ *   - Per-opencode-process dedup via in-memory Set.
+ *
+ * Install:
+ *   Drop this file into ~/.config/opencode/plugins/ and restart opencode.
+ *   No opencode.json change needed — local plugins are auto-loaded.
+ *
+ * Logs:
+ *   /tmp/mempalace-auto.log — stdout/stderr of spawned init/mine processes.
+ */
+
+import { spawn, execSync } from 'node:child_process';
+import { openSync, writeSync, closeSync } from 'node:fs';
+
+const MEMPALACE_PROTOCOL = `## MemPalace Memory Protocol
+
+This project uses MemPalace for persistent AI memory across sessions. The MCP server is configured globally — all agents have access to 19 memory tools automatically.
+
+### When to Save Memories
+- **After completing a significant task**: Save what was done, decisions made, and why
+- **After debugging sessions**: Save the root cause, fix, and patterns observed
+- **When making architectural decisions**: Save the decision, alternatives considered, and rationale
+- **Before ending a long session**: Save key context that the next session will need
+
+### How to Save
+Use \`mempalace_add_drawer\` with:
+- \`wing\`: "{your-project-name}" (this project's wing)
+- \`room\`: Appropriate topic slug (e.g., "auth-migration", "deploy-config", "bug-fixes")
+- \`content\`: Verbatim content — exact words, decisions, code snippets. Never summarize.
+
+### How to Recall
+- **Before starting work**: Call \`mempalace_search\` with the topic you're working on
+- **When unsure about past decisions**: Search for the decision topic
+- **When context seems missing**: Check \`mempalace_kg_query\` for entity relationships
+
+### Agent Diary
+Each agent can maintain a personal diary via \`mempalace_diary_write\` / \`mempalace_diary_read\`. Use this for session-level notes, observations, and learnings.
+
+### Available Tools (19 total)
+- Palace read: \`mempalace_status\`, \`mempalace_search\`, \`mempalace_list_wings\`, \`mempalace_list_rooms\`, \`mempalace_get_taxonomy\`, \`mempalace_check_duplicate\`, \`mempalace_get_aaak_spec\`
+- Palace write: \`mempalace_add_drawer\`, \`mempalace_delete_drawer\`
+- Knowledge Graph: \`mempalace_kg_query\`, \`mempalace_kg_add\`, \`mempalace_kg_invalidate\`, \`mempalace_kg_timeline\`, \`mempalace_kg_stats\`
+- Navigation: \`mempalace_traverse\`, \`mempalace_find_tunnels\`, \`mempalace_graph_stats\`
+- Diary: \`mempalace_diary_write\`, \`mempalace_diary_read\`
+`;
+
+const LOG_FILE = '/tmp/mempalace-auto.log';
+
+// Dedup across an entire opencode process lifetime.
+const initializedProjects = new Set();
+
+function log(msg) {
+  try {
+    // Append a timestamped line to the log file without blocking.
+    const line = `[${new Date().toISOString()}] ${msg}\n`;
+    // We intentionally use sync append here — it's ~1 syscall per line and only fires
+    // on init/mine transitions, not on every event.
+    // writeSync/closeSync imported at module top.
+    const fd = openSync(LOG_FILE, 'a');
+    writeSync(fd, line);
+    closeSync(fd);
+  } catch {
+    // Logging must never crash the plugin.
+  }
+}
+
+function findGitRoot(startDir) {
+  if (!startDir) return null;
+  try {
+    const root = execSync('git rev-parse --show-toplevel', {
+      cwd: startDir,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    })
+      .toString()
+      .trim();
+    return root || null;
+  } catch {
+    return null;
+  }
+}
+
+function spawnDetached(cmd, args, tag) {
+  try {
+    const out = openSync(LOG_FILE, 'a');
+    const err = openSync(LOG_FILE, 'a');
+    const child = spawn(cmd, args, {
+      detached: true,
+      stdio: ['ignore', out, err],
+    });
+    child.on('error', (e) => log(`[${tag}] spawn error: ${e.message}`));
+    child.unref();
+    return child;
+  } catch (e) {
+    log(`[${tag}] spawn threw: ${e?.message ?? e}`);
+    return null;
+  }
+}
+
+function ensureInitialized(projectRoot) {
+  if (initializedProjects.has(projectRoot)) return;
+  initializedProjects.add(projectRoot);
+
+  log(`init: ${projectRoot}`);
+  const init = spawnDetached('mempalace', ['init', '--yes', projectRoot], 'init');
+  if (!init) return;
+
+  init.on('exit', (code) => {
+    if (code === 0) {
+      log(`init ok → mine: ${projectRoot}`);
+      spawnDetached('mempalace', ['mine', '--limit', '200', projectRoot], 'mine');
+    } else {
+      log(`init failed code=${code}: ${projectRoot}`);
+    }
+  });
+}
+
+export const MempalaceAutoPlugin = async (ctx) => {
+  const projectRoot = findGitRoot(ctx?.directory);
+  if (projectRoot) {
+    log(`plugin loaded, project=${projectRoot}`);
+  } else {
+    log(`plugin loaded, no git repo at ${ctx?.directory ?? '?'} — passive mode`);
+  }
+
+  return {
+    event: async () => {
+      if (projectRoot) ensureInitialized(projectRoot);
+    },
+
+    'experimental.chat.system.transform': async (_input, output) => {
+      if (!projectRoot) return;
+      // Avoid double-injection if already present.
+      if (output.system.some((entry) => entry.includes('MemPalace Memory Protocol'))) return;
+      output.system.push(MEMPALACE_PROTOCOL);
+    },
+  };
+};
+
+export default MempalaceAutoPlugin;

--- a/examples/opencode_auto_plugin.js
+++ b/examples/opencode_auto_plugin.js
@@ -2,7 +2,7 @@
  * mempalace-auto.js — Opencode plugin that auto-initializes MemPalace in every project.
  *
  * Behavior (once per project per opencode process):
- *   1. On first `event` in an opencode session, detect the git repo root of ctx.directory.
+ *   1. On first `event` for a project in an opencode process, detect the git repo root of ctx.directory.
  *   2. Spawn `mempalace init --yes <root>` in the background (detached, unref).
  *   3. After init succeeds, spawn `mempalace mine --limit 200 <root>` in the background.
  *   4. Inject the MemPalace Memory Protocol section into the system prompt on every chat
@@ -125,15 +125,30 @@ function ensureInitialized(projectRoot) {
     return;
   }
 
-  init.on('exit', (code) => {
+  let settled = false;
+  const finalize = (code, reason) => {
+    if (settled) return;
+    settled = true;
     initializingProjects.delete(projectRoot);
     if (code === 0) {
       initializedProjects.add(projectRoot);
       log(`init ok → mine: ${projectRoot}`);
       spawnDetached('mempalace', ['mine', '--limit', '200', projectRoot], 'mine');
     } else {
-      log(`init failed code=${code}: ${projectRoot}`);
+      log(`init failed ${reason}=${code}: ${projectRoot}`);
     }
+  };
+
+  init.on('error', (error) => {
+    finalize(error?.code ?? error?.message ?? 'spawn-error', 'error');
+  });
+
+  init.on('exit', (code) => {
+    finalize(code, 'code');
+  });
+
+  init.on('close', (code) => {
+    finalize(code, 'close');
   });
 }
 

--- a/examples/opencode_auto_plugin_setup.md
+++ b/examples/opencode_auto_plugin_setup.md
@@ -67,9 +67,9 @@ tail -f /tmp/mempalace-auto.log
 You should see lines like:
 
 ```
-[2025-04-08T14:32:01.234Z] plugin loaded, project=/Users/you/coding/my-project
-[2025-04-08T14:32:01.456Z] init: /Users/you/coding/my-project
-[2025-04-08T14:32:02.789Z] init ok → mine: /Users/you/coding/my-project
+[2026-04-08T14:32:01.234Z] plugin loaded, project=/Users/you/coding/my-project
+[2026-04-08T14:32:01.456Z] init: /Users/you/coding/my-project
+[2026-04-08T14:32:02.789Z] init ok → mine: /Users/you/coding/my-project
 ```
 
 Inside OpenCode, ask the agent:
@@ -78,13 +78,13 @@ Inside OpenCode, ask the agent:
 
 The agent should describe the protocol — proof that the system-prompt injection worked.
 
-Also verify that the wing was created:
+Also verify that MemPalace now has content for the project:
 
 ```bash
-mempalace list-wings
+mempalace status
 ```
 
-Your project should appear as a new wing.
+You should see the palace summary update after init/mine completes.
 
 ## How It Works
 

--- a/examples/opencode_auto_plugin_setup.md
+++ b/examples/opencode_auto_plugin_setup.md
@@ -3,7 +3,7 @@
 This guide explains how to set up the **MemPalace Auto-Plugin** for [OpenCode](https://github.com/sst/opencode) — a zero-config integration that automatically initializes MemPalace in every project and injects the Memory Protocol into every agent session.
 
 **What it does:**
-1. On first event of every OpenCode session, detects the current git repo root.
+1. On first event for a project in an OpenCode process, detects the current git repo root.
 2. Runs `mempalace init --yes <root>` in the background (idempotent — safe to re-run).
 3. After init succeeds, runs `mempalace mine --limit 200 <root>` in the background.
 4. Injects the **MemPalace Memory Protocol** section into the system prompt of every chat — so every agent automatically knows when and how to save memories.
@@ -91,7 +91,7 @@ You should see the palace summary update after init/mine completes.
 The plugin uses two OpenCode plugin hooks:
 
 ### `event` hook
-Fires on every OpenCode event. On the first event per session, the plugin:
+Fires on every OpenCode event. The first time a given project emits an event in an OpenCode process, the plugin:
 1. Walks up from `ctx.directory` to find the nearest `.git` directory.
 2. If a git root is found AND this process hasn't initialized it yet, spawns `mempalace init --yes <root>` detached with `unref()`.
 3. On init success, spawns `mempalace mine --limit 200 <root>` detached.

--- a/examples/opencode_auto_plugin_setup.md
+++ b/examples/opencode_auto_plugin_setup.md
@@ -1,0 +1,151 @@
+# OpenCode Auto-Plugin Integration Guide
+
+This guide explains how to set up the **MemPalace Auto-Plugin** for [OpenCode](https://github.com/sst/opencode) — a zero-config integration that automatically initializes MemPalace in every project and injects the Memory Protocol into every agent session.
+
+**What it does:**
+1. On first event of every OpenCode session, detects the current git repo root.
+2. Runs `mempalace init --yes <root>` in the background (idempotent — safe to re-run).
+3. After init succeeds, runs `mempalace mine --limit 200 <root>` in the background.
+4. Injects the **MemPalace Memory Protocol** section into the system prompt of every chat — so every agent automatically knows when and how to save memories.
+
+**What it does NOT do:**
+- No `AGENTS.md` file patching — the protocol lives in the system prompt at runtime.
+- No opencode.json changes — local plugins are auto-loaded.
+- No hooks to install — pure OpenCode plugin API.
+
+## Prerequisites
+
+- Python 3.9+ with MemPalace installed (`pip install mempalace` or editable install)
+- `mempalace` CLI on `$PATH` (verify with `mempalace --help`)
+- [OpenCode](https://github.com/sst/opencode) installed and working
+- MemPalace MCP server already configured in OpenCode (see [mcp_setup.md](mcp_setup.md))
+
+## 1. Install the Plugin
+
+Drop the plugin file into your global OpenCode plugins directory:
+
+```bash
+mkdir -p ~/.config/opencode/plugins
+curl -fsSL https://raw.githubusercontent.com/milla-jovovich/mempalace/main/examples/opencode_auto_plugin.js \
+  -o ~/.config/opencode/plugins/mempalace-auto.js
+```
+
+Or copy from a local clone:
+
+```bash
+cp examples/opencode_auto_plugin.js ~/.config/opencode/plugins/mempalace-auto.js
+```
+
+## 2. Enable ES Modules (if not already)
+
+OpenCode plugins use ES module syntax (`import`/`export`). Make sure your `~/.config/opencode/package.json` declares `"type": "module"`:
+
+```bash
+cat ~/.config/opencode/package.json 2>/dev/null || echo "{}" > ~/.config/opencode/package.json
+```
+
+Edit to ensure it contains:
+
+```json
+{
+  "type": "module"
+}
+```
+
+## 3. Restart OpenCode
+
+Close and reopen OpenCode. The plugin loads automatically — no `opencode.json` changes needed.
+
+## 4. Verify
+
+Open OpenCode in any git-tracked project, then check the log:
+
+```bash
+tail -f /tmp/mempalace-auto.log
+```
+
+You should see lines like:
+
+```
+[2025-04-08T14:32:01.234Z] plugin loaded, project=/Users/you/coding/my-project
+[2025-04-08T14:32:01.456Z] init: /Users/you/coding/my-project
+[2025-04-08T14:32:02.789Z] init ok → mine: /Users/you/coding/my-project
+```
+
+Inside OpenCode, ask the agent:
+
+> What does the MemPalace Memory Protocol tell you to do?
+
+The agent should describe the protocol — proof that the system-prompt injection worked.
+
+Also verify that the wing was created:
+
+```bash
+mempalace list-wings
+```
+
+Your project should appear as a new wing.
+
+## How It Works
+
+The plugin uses two OpenCode plugin hooks:
+
+### `event` hook
+Fires on every OpenCode event. On the first event per session, the plugin:
+1. Walks up from `ctx.directory` to find the nearest `.git` directory.
+2. If a git root is found AND this process hasn't initialized it yet, spawns `mempalace init --yes <root>` detached with `unref()`.
+3. On init success, spawns `mempalace mine --limit 200 <root>` detached.
+4. All subsequent events in the same OpenCode process are a no-op (dedup via in-memory `Set`).
+
+**Why detached + unref?** So OpenCode never waits for or blocks on these commands. They run fully in the background.
+
+### `experimental.chat.system.transform` hook
+Fires before every chat message. Pushes the MemPalace Memory Protocol section onto `output.system` — but only once per message (dedup check prevents duplicates if multiple plugins inject similar content).
+
+## Customization
+
+The plugin has three knobs you may want to tune (edit the top of `mempalace-auto.js`):
+
+| Knob | Default | What to change |
+|------|---------|---------------|
+| `MEMPALACE_PROTOCOL` | Standard protocol text | Add project-specific memory guidelines |
+| `LOG_FILE` | `/tmp/mempalace-auto.log` | Change to `~/Library/Logs/...` on macOS if you prefer |
+| `mine --limit 200` | 200 files | Increase for large repos, decrease for fast init |
+
+## Troubleshooting
+
+**Nothing happens in the log:**
+- Verify `~/.config/opencode/package.json` has `"type": "module"`.
+- Check OpenCode startup logs for plugin load errors.
+- Run `node --check ~/.config/opencode/plugins/mempalace-auto.js` to check syntax.
+
+**`mempalace: command not found` in the log:**
+- Add the mempalace binary path to OpenCode's environment.
+- Or edit `spawnDetached('mempalace', ...)` to use an absolute path.
+
+**Protocol not injected into the system prompt:**
+- Verify the plugin loaded: check `/tmp/mempalace-auto.log` for `"plugin loaded"`.
+- Ensure the project directory is inside a git repo — the plugin skips non-git dirs by design.
+- Ask the agent directly: "Do you see the MemPalace Memory Protocol in your system prompt?"
+
+**Mine runs too long / too much:**
+- Lower the `--limit` value in the `spawnDetached('mempalace', ['mine', '--limit', '200', ...])` call.
+
+## Security Notes
+
+- The plugin only spawns `mempalace` (your already-trusted CLI). No other commands.
+- It only activates inside git repos, preventing accidental initialization of `~`, `/tmp`, or unrelated directories.
+- Log file is at `/tmp/mempalace-auto.log` — no sensitive content beyond project paths.
+
+## Comparison with Other Integration Methods
+
+| Method | Pros | Cons |
+|--------|------|------|
+| **This plugin** | Zero per-project config, automatic, opencode-native | Requires OpenCode plugin support (built-in) |
+| Shell wrapper (`opencode` → `init-and-launch.sh`) | Works with any tool | Extra script to maintain, fragile |
+| `direnv` / `chpwd` hook | Outside AI context | Fires on every `cd`, not session-bound |
+| Manual `mempalace init` per project | Explicit control | Easy to forget, defeats automation |
+
+---
+
+**Questions?** File an issue at [milla-jovovich/mempalace](https://github.com/milla-jovovich/mempalace/issues).

--- a/examples/opencode_auto_plugin_setup.md
+++ b/examples/opencode_auto_plugin_setup.md
@@ -17,6 +17,7 @@ This guide explains how to set up the **MemPalace Auto-Plugin** for [OpenCode](h
 
 - Python 3.9+ with MemPalace installed (`pip install mempalace` or editable install)
 - `mempalace` CLI on `$PATH` (verify with `mempalace --help`)
+- `git` on `$PATH` (the plugin uses `git rev-parse --show-toplevel` to detect repo roots)
 - [OpenCode](https://github.com/sst/opencode) installed and working
 - MemPalace MCP server already configured in OpenCode (see [mcp_setup.md](mcp_setup.md))
 
@@ -95,7 +96,8 @@ Fires on every OpenCode event. The first time a given project emits an event in 
 1. Walks up from `ctx.directory` to find the nearest `.git` directory.
 2. If a git root is found AND this process hasn't initialized it yet, spawns `mempalace init --yes <root>` detached with `unref()`.
 3. On init success, spawns `mempalace mine --limit 200 <root>` detached.
-4. All subsequent events in the same OpenCode process are a no-op (dedup via in-memory `Set`).
+4. While init/mine is in flight, subsequent events are a no-op (dedup via in-memory `Set`s).
+5. The project is marked initialized only after `mempalace mine` succeeds; failed mine runs are retried on later events.
 
 **Why detached + unref?** So OpenCode never waits for or blocks on these commands. They run fully in the background.
 
@@ -133,9 +135,9 @@ The plugin has three knobs you may want to tune (edit the top of `mempalace-auto
 
 ## Security Notes
 
-- The plugin only spawns `mempalace` (your already-trusted CLI). No other commands.
+- The plugin executes `git rev-parse --show-toplevel` to detect repo roots, then spawns `mempalace` for init/mine.
 - It only activates inside git repos, preventing accidental initialization of `~`, `/tmp`, or unrelated directories.
-- Log file is at `/tmp/mempalace-auto.log` — no sensitive content beyond project paths.
+- Log file is at `/tmp/mempalace-auto.log` and captures stdout/stderr from `mempalace init` and `mempalace mine`; treat it as local diagnostic output, not as sanitized audit logs.
 
 ## Comparison with Other Integration Methods
 


### PR DESCRIPTION
## Summary

- Adds `examples/opencode_auto_plugin.js` — a drop-in OpenCode plugin that auto-initializes MemPalace in every git-tracked project
- Adds `examples/opencode_auto_plugin_setup.md` — full setup guide matching the existing docs style (cf. `gemini_cli_setup.md`, `mcp_setup.md`)

## What the Plugin Does

1. **On first event** of each OpenCode session → detects git root → spawns `mempalace init --yes <root>` in background
2. **After init succeeds** → spawns `mempalace mine --limit 200 <root>` in background
3. **On every chat** → injects the MemPalace Memory Protocol into the system prompt via `experimental.chat.system.transform`

Zero per-project config needed. Drop the file into `~/.config/opencode/plugins/` and restart OpenCode.

## Key Design Decisions

| Decision | Why |
|----------|-----|
| System-prompt injection, NOT AGENTS.md patching | No disk writes, no conflicts with other tools, idempotent |
| Detached + unref spawns | OpenCode never blocks on init/mine |
| Git-only scope | Prevents accidental init in `~`, `/tmp`, etc. |
| In-memory dedup Set | `mempalace init` runs at most once per project per process |
| Log to `/tmp/mempalace-auto.log` | Easy debugging, no sensitive data beyond paths |

## Complementary to PR #268

PR #268 adds the manual `opencode_setup.md` integration guide. This plugin **automates** what that guide describes — users install it once and MemPalace works in every project automatically.

## Verification

- `node --check examples/opencode_auto_plugin.js` ✅
- Smoke-tested: factory → hooks returned, system.transform → protocol injected, dedup → no duplicates ✅
- No Python code modified — tests not affected