### PR TITLE
fix: lower check_duplicate default threshold from 0.9 to 0.5 (fixes #…

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -209,7 +209,7 @@ def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
     )
 
 
-def tool_check_duplicate(content: str, threshold: float = 0.9):
+def tool_check_duplicate(content: str, threshold: float = 0.5):
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -635,7 +635,12 @@ TOOLS = {
                 "content": {"type": "string", "description": "Content to check"},
                 "threshold": {
                     "type": "number",
-                    "description": "Similarity threshold 0-1 (default 0.9)",
+                    "description": (
+                        "Minimum similarity score to flag as duplicate (0-1, default 0.5). "
+                        "Similarity is 1 - cosine_distance: 1.0 = identical, ~0.7 = partial "
+                        "overlap, ~0.5 = semantically related. The previous default of 0.9 "
+                        "only caught near-exact copies and missed partial duplicates."
+                    ),
                 },
             },
             "required": ["content"],


### PR DESCRIPTION
Fixes #247

The previous default of 0.9 only caught near-exact copies. Real-world testing (reported in #247) showed:

- full stored chunk: similarity `1.0`
- half chunk: `~0.74`  
- quarter chunk: `~0.59`

`similarity = 1 - cosine_distance`, so 0.9 missed everything except exact matches.

**New default: 0.5** — catches partial overlaps and semantically related content while remaining tuneable. Also updates the tool description to explain what the similarity scale means so callers can make informed threshold choices.

## What does this PR do?

## How to test

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
