### PR TITLE
fix: make file_already_mined wing-scoped; add .al .rst .xlf .ps1 exte…

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -274,7 +274,7 @@ def mine_convos(
         source_file = str(filepath)
 
         # Skip if already filed
-        if not dry_run and file_already_mined(collection, source_file):
+        if not dry_run and file_already_mined(collection, source_file, wing=wing):
             files_skipped += 1
             continue
 

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -41,7 +41,7 @@ READABLE_EXTENSIONS = {
     ".csv",
     ".sql",
     ".toml",
-    ".al",   # Microsoft Dynamics 365 / AL Language
+    ".al",  # Microsoft Dynamics 365 / AL Language
     ".xlf",  # XLIFF localisation files
     ".ps1",  # PowerShell scripts
 }

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -22,6 +22,7 @@ from .palace import SKIP_DIRS, get_collection, file_already_mined
 READABLE_EXTENSIONS = {
     ".txt",
     ".md",
+    ".rst",
     ".py",
     ".js",
     ".ts",
@@ -40,6 +41,9 @@ READABLE_EXTENSIONS = {
     ".csv",
     ".sql",
     ".toml",
+    ".al",   # Microsoft Dynamics 365 / AL Language
+    ".xlf",  # XLIFF localisation files
+    ".ps1",  # PowerShell scripts
 }
 
 SKIP_FILENAMES = {
@@ -417,7 +421,7 @@ def process_file(
 
     # Skip if already filed
     source_file = str(filepath)
-    if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
+    if not dry_run and file_already_mined(collection, source_file, check_mtime=True, wing=wing):
         return 0, None
 
     try:

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -48,15 +48,22 @@ def get_collection(palace_path: str, collection_name: str = "mempalace_drawers")
         return client.create_collection(collection_name)
 
 
-def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:
+def file_already_mined(
+    collection, source_file: str, check_mtime: bool = False, wing: str = ""
+) -> bool:
     """Check if a file has already been filed in the palace.
 
     When check_mtime=True (used by project miner), returns False if the file
     has been modified since it was last mined, so it gets re-mined.
     When check_mtime=False (used by convo miner), just checks existence.
+    When wing is provided, only records from that wing are considered.
     """
     try:
-        results = collection.get(where={"source_file": source_file}, limit=1)
+        where_filter = {"source_file": source_file}
+        if wing:
+            where_filter["wing"] = wing
+
+        results = collection.get(where=where_filter, limit=1)
         if not results.get("ids"):
             return False
         if check_mtime:

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -59,9 +59,10 @@ def file_already_mined(
     When wing is provided, only records from that wing are considered.
     """
     try:
-        where_filter = {"source_file": source_file}
         if wing:
-            where_filter["wing"] = wing
+            where_filter = {"$and": [{"source_file": source_file}, {"wing": wing}]}
+        else:
+            where_filter = {"source_file": source_file}
 
         results = collection.get(where=where_filter, limit=1)
         if not results.get("ids"):

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -180,6 +180,26 @@ def test_scan_project_can_include_exact_file_without_known_extension():
         shutil.rmtree(tmpdir)
 
 
+def test_scan_project_includes_added_readable_extensions():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / "automation.ps1", "Write-Host 'hello'\n" * 20)
+        write_file(project_root / "translations.xlf", "<xliff>hello</xliff>\n" * 20)
+        write_file(project_root / "page.al", "page 50100 CustomerCard {}\n" * 20)
+        write_file(project_root / "notes.rst", "Heading\n=======\n" * 20)
+
+        assert scanned_files(project_root, respect_gitignore=False) == [
+            "automation.ps1",
+            "notes.rst",
+            "page.al",
+            "translations.xlf",
+        ]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
 def test_scan_project_include_override_beats_skip_dirs():
     tmpdir = tempfile.mkdtemp()
     try:
@@ -258,5 +278,31 @@ def test_file_already_mined_check_mtime():
         assert file_already_mined(col, "/fake/no_mtime.txt", check_mtime=True) is False
     finally:
         # Release ChromaDB file handles before cleanup (required on Windows)
+        del col, client
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_file_already_mined_is_wing_scoped():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        palace_path = os.path.join(tmpdir, "palace")
+        os.makedirs(palace_path)
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_or_create_collection("mempalace_drawers")
+
+        test_file = os.path.join(tmpdir, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("hello world")
+
+        col.add(
+            ids=["d1"],
+            documents=["hello world"],
+            metadatas=[{"source_file": test_file, "wing": "alpha"}],
+        )
+
+        assert file_already_mined(col, test_file, wing="alpha") is True
+        assert file_already_mined(col, test_file, wing="beta") is False
+        assert file_already_mined(col, test_file) is True
+    finally:
         del col, client
         shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
Fixes #278

## Wing-aware dedup

`file_already_mined()` previously queried only by `source_file`, so mining the same repo into two wings (e.g. two git branches) would skip the second wing entirely — the first mine's mtime match short-circuits it.

Fix: adds an optional `wing` parameter. When provided, the `WHERE` filter includes `{"wing": wing}` so each wing tracks its own mined state. Default `wing=""` preserves the original behaviour for any callers that don't pass a wing.

## Extension additions

Added to `READABLE_EXTENSIONS`:
- `.rst` — reStructuredText documentation
- `.al` — Microsoft Dynamics 365 / AL Language (BC repos have 16k–18k `.al` files)
- `.xlf` — XLIFF localisation files  
- `.ps1` — PowerShell scripts


## What does this PR do?

## How to test

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
