### PR TITLE
fix: eliminate sys.argv manipulation in split command (fixes #303)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -128,24 +128,14 @@ def cmd_wakeup(args):
 
 def cmd_split(args):
     """Split concatenated transcript mega-files into per-session files."""
-    from .split_mega_files import main as split_main
-    import sys
+    from .split_mega_files import run as split_run
 
-    # Rebuild argv for split_mega_files argparse
-    argv = ["--source", args.dir]
-    if args.output_dir:
-        argv += ["--output-dir", args.output_dir]
-    if args.dry_run:
-        argv.append("--dry-run")
-    if args.min_sessions != 2:
-        argv += ["--min-sessions", str(args.min_sessions)]
-
-    old_argv = sys.argv
-    sys.argv = ["mempalace split"] + argv
-    try:
-        split_main()
-    finally:
-        sys.argv = old_argv
+    split_run(
+        source=args.dir,
+        output_dir=args.output_dir,
+        dry_run=args.dry_run,
+        min_sessions=args.min_sessions,
+    )
 
 
 def cmd_status(args):

--- a/mempalace/split_mega_files.py
+++ b/mempalace/split_mega_files.py
@@ -227,6 +227,71 @@ def split_file(filepath, output_dir, dry_run=False):
     return written
 
 
+def run(
+    source: str = None,
+    output_dir: str = None,
+    dry_run: bool = False,
+    min_sessions: int = 2,
+    file: str = None,
+):
+    """
+    Split mega-files. Called directly by the CLI dispatcher and by main().
+
+    Args:
+        source:       Source directory (default: MEMPALACE_SOURCE_DIR or ~/Desktop/transcripts).
+        output_dir:   Output directory (default: same dir as each source file).
+        dry_run:      If True, print what would happen without writing anything.
+        min_sessions: Only split files containing at least this many sessions.
+        file:         If given, split this single file instead of scanning source.
+    """
+    src_dir = Path(source) if source else LUMI_DIR
+    out_dir = output_dir or None  # None = same dir as file
+
+    if file:
+        files = [Path(file)]
+    else:
+        files = sorted(src_dir.glob("*.txt"))
+
+    mega_files = []
+    for f in files:
+        lines = f.read_text(errors="replace").splitlines(keepends=True)
+        boundaries = find_session_boundaries(lines)
+        if len(boundaries) >= min_sessions:
+            mega_files.append((f, len(boundaries)))
+
+    if not mega_files:
+        print(f"No mega-files found in {src_dir} (min {min_sessions} sessions).")
+        return
+
+    print(f"\n{'=' * 60}")
+    print(f"  Mega-file splitter — {'DRY RUN' if dry_run else 'SPLITTING'}")
+    print(f"{'=' * 60}")
+    print(f"  Source:      {src_dir}")
+    print(f"  Output:      {out_dir or 'same dir as source'}")
+    print(f"  Mega-files:  {len(mega_files)}")
+    print(f"{'─' * 60}\n")
+
+    total_written = 0
+    for f, n_sessions in mega_files:
+        print(f"  {f.name}  ({n_sessions} sessions, {f.stat().st_size // 1024}KB)")
+        written = split_file(f, out_dir, dry_run=dry_run)
+        total_written += len(written)
+
+        if not dry_run and written:
+            backup = f.with_suffix(".mega_backup")
+            f.rename(backup)
+            print(f"  → Original renamed to {backup.name}\n")
+        else:
+            print()
+
+    print(f"{'─' * 60}")
+    if dry_run:
+        print(f"  DRY RUN — would create {total_written} files from {len(mega_files)} mega-files")
+    else:
+        print(f"  Done — created {total_written} files from {len(mega_files)} mega-files")
+    print()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Split concatenated transcript mega-files into per-session files"
@@ -256,53 +321,13 @@ def main():
         help="Split a single specific file instead of scanning dir",
     )
     args = parser.parse_args()
-
-    src_dir = Path(args.source) if args.source else LUMI_DIR
-    output_dir = args.output_dir or None  # None = same dir as file
-
-    if args.file:
-        files = [Path(args.file)]
-    else:
-        files = sorted(src_dir.glob("*.txt"))
-
-    mega_files = []
-    for f in files:
-        lines = f.read_text(errors="replace").splitlines(keepends=True)
-        boundaries = find_session_boundaries(lines)
-        if len(boundaries) >= args.min_sessions:
-            mega_files.append((f, len(boundaries)))
-
-    if not mega_files:
-        print(f"No mega-files found in {src_dir} (min {args.min_sessions} sessions).")
-        return
-
-    print(f"\n{'=' * 60}")
-    print(f"  Mega-file splitter — {'DRY RUN' if args.dry_run else 'SPLITTING'}")
-    print(f"{'=' * 60}")
-    print(f"  Source:      {src_dir}")
-    print(f"  Output:      {output_dir or 'same dir as source'}")
-    print(f"  Mega-files:  {len(mega_files)}")
-    print(f"{'─' * 60}\n")
-
-    total_written = 0
-    for f, n_sessions in mega_files:
-        print(f"  {f.name}  ({n_sessions} sessions, {f.stat().st_size // 1024}KB)")
-        written = split_file(f, output_dir, dry_run=args.dry_run)
-        total_written += len(written)
-
-        if not args.dry_run and written:
-            backup = f.with_suffix(".mega_backup")
-            f.rename(backup)
-            print(f"  → Original renamed to {backup.name}\n")
-        else:
-            print()
-
-    print(f"{'─' * 60}")
-    if args.dry_run:
-        print(f"  DRY RUN — would create {total_written} files from {len(mega_files)} mega-files")
-    else:
-        print(f"  Done — created {total_written} files from {len(mega_files)} mega-files")
-    print()
+    run(
+        source=args.source,
+        output_dir=args.output_dir,
+        dry_run=args.dry_run,
+        min_sessions=args.min_sessions,
+        file=args.file,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_split_mega_files.py
+++ b/tests/test_split_mega_files.py
@@ -290,3 +290,28 @@ def test_split_file_tiny_fragments_skipped(tmp_path):
     # The first chunk is very small, should be skipped
     for p in written:
         assert p.stat().st_size > 0
+
+
+def _make_run_input(path, n_sessions=2):
+    """Write a .txt file with n_sessions genuine Claude Code session headers."""
+    session = "Claude Code v1.0.0\n" + ("line of content\n" * 10)
+    path.write_text(session * n_sessions)
+
+
+def test_run_dry_run_does_not_write(tmp_path):
+    mega = tmp_path / "chat.txt"
+    _make_run_input(mega)
+    smf.run(source=str(tmp_path), dry_run=True, min_sessions=2)
+    # dry_run must not create new files or rename the original
+    assert list(tmp_path.glob("*.txt")) == [mega]
+    assert not list(tmp_path.glob("*.mega_backup"))
+
+
+def test_run_splits_and_renames_original(tmp_path):
+    mega = tmp_path / "chat.txt"
+    _make_run_input(mega, n_sessions=2)
+    smf.run(source=str(tmp_path), min_sessions=2)
+    # original renamed to .mega_backup
+    assert (tmp_path / "chat.mega_backup").exists()
+    # two split files created
+    assert len(list(tmp_path.glob("*.txt"))) == 2


### PR DESCRIPTION
cmd_split previously rebuilt sys.argv and called split_mega_files.main(), which re-parsed it via argparse. This is fragile — any extra content in sys.argv (pytest, Python 3.14 launcher flags, etc.) causes parse_args() to raise 'unrecognized arguments' and the command fails.

Fix: extract the split logic from main() into a new run() function that accepts direct parameters. cmd_split now calls split_run() directly — no sys.argv mutation, no second argparse invocation.

main() is unchanged from the user's perspective: it still parses the same flags (--source, --output-dir, --dry-run, --min-sessions, --file) and delegates to run(). The standalone script interface is unaffected.

## What does this PR do?

## How to test

## Checklist
- [X] Tests pass (`python -m pytest tests/ -v`)
- [X] No hardcoded paths
- [X] Linter passes (`ruff check .`)
