### PR TITLE
fix: skip tool_result messages in _count_human_messages

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -57,6 +57,12 @@ def _count_human_messages(transcript_path: str) -> int:
                             if "<command-message>" in content:
                                 continue
                         elif isinstance(content, list):
+                            if all(
+                                b.get("type") == "tool_result"
+                                for b in content
+                                if isinstance(b, dict)
+                            ):
+                                continue
                             text = " ".join(
                                 b.get("text", "") for b in content if isinstance(b, dict)
                             )

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -82,6 +82,43 @@ def test_count_handles_list_content(tmp_path):
     assert _count_human_messages(str(transcript)) == 1
 
 
+def test_count_skips_tool_result_messages(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            {"message": {"role": "user", "content": "real question"}},
+            {
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "x", "content": "result"}],
+                }
+            },
+        ],
+    )
+    assert _count_human_messages(str(transcript)) == 1
+
+
+def test_count_mixed_content_with_tool_result_counts(tmp_path):
+    """Messages with tool_result alongside other block types are counted."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            {
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "x", "content": "result"},
+                        {"type": "text", "text": "also some text"},
+                    ],
+                }
+            },
+        ],
+    )
+    assert _count_human_messages(str(transcript)) == 1
+
+
 def test_count_missing_file():
     assert _count_human_messages("/nonexistent/path.jsonl") == 0
 


### PR DESCRIPTION
## What does this PR do?

`_count_human_messages()` in `hooks_cli.py` was counting tool result messages as human turns. In Claude Code's transcript format, tool results arrive as `role: "user"` messages with content blocks of `type: "tool_result"`. This inflated the message counter and triggered the AUTO-SAVE stop hook too frequently.

The fix adds a check inside the `elif isinstance(content, list)` branch to skip messages where all blocks are `tool_result` type.

## How to test

```bash
pytest tests/test_hooks_cli.py -v
```

Two new tests cover the fix:
- `test_count_skips_tool_result_messages` — pure tool_result messages are not counted
- `test_count_mixed_content_with_tool_result_counts` — mixed content (tool_result + text) still counts

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)