### PR TITLE
docs: Add STAN extension to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ results = search_memories("auth decisions", palace_path="~/.mempalace/palace")
 
 Either way — your entire memory stack runs offline. ChromaDB on your machine, Llama on your machine, AAAK for compression, zero cloud calls.
 
+### Community Extensions
+
+* [**MemPalace STAN Extension**](https://github.com/web3guru888/mempalace-stan-extension) — Stigmergic A* Navigation (STAN) with pheromone decay. Provides biologically-inspired causal traversal and optimal pathfinding between concepts in the MemPalace knowledge graph.
+
 ---
 
 ## The Problem


### PR DESCRIPTION
### Description

Following up on feedback in PR #272, this PR adds a link to the standalone STAN (Stigmergic A* Navigation) extension in a new **Community Extensions** section of the README.

The STAN algorithm (A* search with pheromone decay over the MemPalace knowledge graph) has been extracted into an opt-in plugin as suggested, keeping the core lean:

- **Extension repo**: https://github.com/web3guru888/mempalace-stan-extension
- **What it does**: Biologically-inspired causal traversal and optimal pathfinding between concepts in the knowledge graph
- **Install**: `pip install -e .` (works alongside existing MemPalace installation)

This PR only touches `README.md` — adds 4 lines for the Community Extensions section. No code changes, no dependency changes.

Thanks for the guidance on #272!