### PR TITLE
fix: mitigate shell injection risk in hooks (#110)

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -58,6 +58,9 @@ MEMPAL_DIR=""
 INPUT=$(cat)
 
 SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+# Sanitize SESSION_ID to prevent shell injection — only allow alnum, dash, underscore
+SESSION_ID=$(echo "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-')
+[ -z "$SESSION_ID" ] && SESSION_ID="unknown"
 
 echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
 


### PR DESCRIPTION
fixes #110 by correctly sanitizing the session ID. The python calls already handle their system args, but the SESSION_ID variable required defensive bounds checking to ensure it only captures `a-zA-Z0-9_-` rather than unescaped json strings which might interpolate.