### PR TITLE
feat: smart wing auto-detection when mining conversations

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -8,7 +8,9 @@ Normalizes format, chunks by exchange pair (Q+A = one unit), files to palace.
 Same palace as project mining. Different ingest strategy.
 """
 
+import json
 import os
+import re
 import sys
 import hashlib
 from pathlib import Path
@@ -44,6 +46,166 @@ SKIP_DIRS = {
 }
 
 MIN_CHUNK_SIZE = 30
+
+
+# =============================================================================
+# WING DETECTION — 3-tier auto-detect project from conversations
+# =============================================================================
+
+# Anchors: common parent directories that sit above project folders.
+_PATH_ANCHORS = {"projects", "developer", "code", "repos", "src", "workspace"}
+
+# Regex for project directory references inside conversation text.
+_PROJECT_PATH_RE = re.compile(
+    r"(?:^|[\s\"'(])"           # boundary before the path
+    r"/(?:Users|home)/[^/]+/"   # home directory
+    r"(?:[Pp]rojects|[Dd]eveloper|code|repos|src|workspace)/"  # anchor dir
+    r"([a-zA-Z0-9][a-zA-Z0-9._-]{1,50})"  # project name (capture group)
+)
+
+
+def detect_wing(filepath: str, convo_dir: str, content: str = None,
+                 raw_content: str = None) -> str:
+    """Infer the wing (project) name from a conversation file.
+
+    Uses a 3-tier detection strategy:
+
+    1. **Path-based** — Claude Code encodes project paths in directory names.
+       e.g., ``-Users-name-Projects-myapp`` → ``myapp``.
+
+    2. **JSONL cwd-based** — Claude Code JSONL entries contain a ``cwd`` field
+       recording the agent's working directory. The most-referenced project
+       directory (excluding the bare anchor) is used as the wing.
+
+    3. **Content-based** — Scan conversation text for project directory paths
+       like ``/Users/name/Projects/myapp/src/...``. The most-referenced project
+       name wins.
+
+    Falls back to ``"general"`` when no project can be determined.
+
+    Pass ``raw_content`` to avoid a redundant file read when the caller has
+    already loaded the file (e.g., ``mine_convos``).
+    """
+    # Tier 1: path-based
+    wing = _detect_wing_from_path(filepath, convo_dir)
+    if wing != "general":
+        return wing
+
+    # Tier 2: JSONL cwd field (needs raw file, not normalized transcript)
+    if raw_content is None:
+        try:
+            with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+                raw_content = f.read()
+        except OSError:
+            raw_content = ""
+
+    if raw_content:
+        wing = _detect_wing_from_cwd(raw_content)
+        if wing != "general":
+            return wing
+
+    # Tier 3: content path references (works on either raw or normalized)
+    search_text = raw_content or content or ""
+    wing = _detect_wing_from_content(search_text)
+    if wing != "general":
+        return wing
+
+    return "general"
+
+
+# Keep the old name as an alias for backwards compatibility and tests.
+detect_wing_from_path = detect_wing
+
+
+def _detect_wing_from_path(filepath: str, convo_dir: str) -> str:
+    """Tier 1: infer wing from the encoded project directory in the file path."""
+    filepath_str = str(filepath)
+    convo_dir_resolved = str(Path(convo_dir).expanduser().resolve())
+
+    if not filepath_str.startswith(convo_dir_resolved):
+        # Not under the convo dir — use parent directory name
+        parent = Path(filepath).parent.name
+        if parent:
+            return _clean_wing(parent)
+        return "general"
+
+    relative = filepath_str[len(convo_dir_resolved):].lstrip(os.sep)
+    project_dir = relative.split(os.sep)[0] if os.sep in relative else ""
+    if not project_dir:
+        return "general"
+
+    # Claude Code encoded paths: -Users-name-Projects-myapp
+    segments = [s for s in project_dir.split("-") if s]
+    for i, seg in enumerate(segments):
+        if seg.lower() in _PATH_ANCHORS:
+            remaining = segments[i + 1:]
+            if remaining:
+                return _clean_wing("-".join(remaining))
+            return "general"
+
+    # No anchor found — likely a home directory or other non-project path
+    return "general"
+
+
+def _detect_wing_from_cwd(content: str) -> str:
+    """Tier 2: extract project from cwd fields in Claude Code JSONL entries."""
+    # Only parse JSONL — skip if content doesn't look like it
+    if not content.strip().startswith("{"):
+        return "general"
+
+    project_counts = {}
+    for line in content.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        cwd = entry.get("cwd", "")
+        if not cwd:
+            continue
+
+        # Extract project name from cwd path
+        proj = _project_from_path(cwd)
+        if proj:
+            project_counts[proj] = project_counts.get(proj, 0) + 1
+
+    if project_counts:
+        return _clean_wing(max(project_counts, key=project_counts.get))
+    return "general"
+
+
+def _detect_wing_from_content(content: str) -> str:
+    """Tier 3: scan conversation text for project directory references."""
+    project_counts = {}
+    for match in _PROJECT_PATH_RE.finditer(content[:50000]):
+        proj = match.group(1)
+        if proj and len(proj) > 2:
+            project_counts[proj] = project_counts.get(proj, 0) + 1
+
+    if project_counts:
+        return _clean_wing(max(project_counts, key=project_counts.get))
+    return "general"
+
+
+def _project_from_path(path: str) -> str:
+    """Extract project name from an absolute path, or return empty string."""
+    parts = path.replace("\\", "/").split("/")
+    for i, part in enumerate(parts):
+        if part.lower() in _PATH_ANCHORS and i + 1 < len(parts):
+            candidate = parts[i + 1]
+            if candidate and len(candidate) > 1:
+                return candidate
+    return ""
+
+
+def _clean_wing(name: str) -> str:
+    """Normalize a project name into a valid wing name."""
+    return name.lower().replace("-", "_").replace(".", "_").replace(" ", "_").strip("_")
 
 
 # =============================================================================
@@ -270,6 +432,7 @@ def mine_convos(
     """
 
     convo_path = Path(convo_dir).expanduser().resolve()
+    auto_wing = wing is None
     if not wing:
         wing = convo_path.name.lower().replace(" ", "_").replace("-", "_")
 
@@ -280,7 +443,10 @@ def mine_convos(
     print(f"\n{'=' * 55}")
     print("  MemPalace Mine — Conversations")
     print(f"{'=' * 55}")
-    print(f"  Wing:    {wing}")
+    if auto_wing:
+        print("  Wing:    (auto-detect per file)")
+    else:
+        print(f"  Wing:    {wing}")
     print(f"  Source:  {convo_path}")
     print(f"  Files:   {len(files)}")
     print(f"  Palace:  {palace_path}")
@@ -294,12 +460,21 @@ def mine_convos(
     files_skipped = 0
     room_counts = defaultdict(int)
 
+    wing_counts = defaultdict(int)
+
     for i, filepath in enumerate(files, 1):
         source_file = str(filepath)
 
         # Skip if already filed
         if not dry_run and file_already_mined(collection, source_file):
             files_skipped += 1
+            continue
+
+        # Read raw content once — shared by normalize and detect_wing
+        try:
+            with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+                raw_content = f.read()
+        except OSError:
             continue
 
         # Normalize format
@@ -310,6 +485,12 @@ def mine_convos(
 
         if not content or len(content.strip()) < MIN_CHUNK_SIZE:
             continue
+
+        # Auto-detect wing from file path + content when no explicit --wing given
+        file_wing = wing
+        if auto_wing:
+            file_wing = detect_wing(filepath, str(convo_path), content,
+                                    raw_content=raw_content)
 
         # Chunk — either exchange pairs or general extraction
         if extract_mode == "general":
@@ -329,15 +510,23 @@ def mine_convos(
         else:
             room = None  # set per-chunk below
 
+        wing_counts[file_wing] = wing_counts.get(file_wing, 0) + 1
+
         if dry_run:
             if extract_mode == "general":
                 from collections import Counter
 
                 type_counts = Counter(c.get("memory_type", "general") for c in chunks)
                 types_str = ", ".join(f"{t}:{n}" for t, n in type_counts.most_common())
-                print(f"    [DRY RUN] {filepath.name} → {len(chunks)} memories ({types_str})")
+                print(
+                    f"    [DRY RUN] {filepath.name} → wing:{file_wing} "
+                    f"{len(chunks)} memories ({types_str})"
+                )
             else:
-                print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
+                print(
+                    f"    [DRY RUN] {filepath.name} → wing:{file_wing} "
+                    f"room:{room} ({len(chunks)} drawers)"
+                )
             total_drawers += len(chunks)
             # Track room counts
             if extract_mode == "general":
@@ -356,14 +545,17 @@ def mine_convos(
             chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
             if extract_mode == "general":
                 room_counts[chunk_room] += 1
-            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.md5((source_file + str(chunk['chunk_index'])).encode(), usedforsecurity=False).hexdigest()[:16]}"
+            drawer_id = (
+                f"drawer_{file_wing}_{chunk_room}_"
+                f"{hashlib.md5((source_file + str(chunk['chunk_index'])).encode(), usedforsecurity=False).hexdigest()[:16]}"
+            )
             try:
                 collection.add(
                     documents=[chunk["content"]],
                     ids=[drawer_id],
                     metadatas=[
                         {
-                            "wing": wing,
+                            "wing": file_wing,
                             "room": chunk_room,
                             "source_file": source_file,
                             "chunk_index": chunk["chunk_index"],
@@ -380,13 +572,18 @@ def mine_convos(
                     raise
 
         total_drawers += drawers_added
-        print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+        wing_label = f" [{file_wing}]" if auto_wing else ""
+        print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}{wing_label}")
 
     print(f"\n{'=' * 55}")
     print("  Done.")
     print(f"  Files processed: {len(files) - files_skipped}")
     print(f"  Files skipped (already filed): {files_skipped}")
     print(f"  Drawers filed: {total_drawers}")
+    if wing_counts and auto_wing:
+        print("\n  By wing:")
+        for w, count in sorted(wing_counts.items(), key=lambda x: x[1], reverse=True):
+            print(f"    {w:20} {count} files")
     if room_counts:
         print("\n  By room:")
         for room, count in sorted(room_counts.items(), key=lambda x: x[1], reverse=True):

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,8 +1,9 @@
+import json
 import os
 import tempfile
 import shutil
 import chromadb
-from mempalace.convo_miner import mine_convos
+from mempalace.convo_miner import mine_convos, detect_wing, detect_wing_from_path
 
 
 def test_convo_mining():
@@ -22,5 +23,210 @@ def test_convo_mining():
     # Verify search works
     results = col.query(query_texts=["memory persistence"], n_results=1)
     assert len(results["documents"][0]) > 0
+
+    shutil.rmtree(tmpdir)
+
+
+# =============================================================================
+# Wing auto-detection tests
+# =============================================================================
+
+
+def test_detect_wing_claude_code_project():
+    """Tier 1: Claude Code project path extracts the project name as wing."""
+    convo_dir = "/Users/alice/.claude/projects"
+    filepath = (
+        "/Users/alice/.claude/projects/"
+        "-Users-alice-Projects-my-cool-app/"
+        "abc-123/subagents/agent-xyz.jsonl"
+    )
+    assert detect_wing(filepath, convo_dir) == "my_cool_app"
+
+
+def test_detect_wing_claude_code_single_word_project():
+    """Tier 1: single-word project name."""
+    convo_dir = "/Users/bob/.claude/projects"
+    filepath = (
+        "/Users/bob/.claude/projects/"
+        "-Users-bob-Projects-webapp/"
+        "session-1/subagents/agent-a.jsonl"
+    )
+    assert detect_wing(filepath, convo_dir) == "webapp"
+
+
+def test_detect_wing_claude_code_root_projects():
+    """Tier 1: sessions from ~/Projects root → general (no path signal)."""
+    convo_dir = "/Users/alice/.claude/projects"
+    filepath = (
+        "/Users/alice/.claude/projects/"
+        "-Users-alice-Projects/"
+        "session-uuid/subagents/agent-xyz.jsonl"
+    )
+    # With no content, path-only returns general
+    assert detect_wing(filepath, convo_dir, content="no project info") == "general"
+
+
+def test_detect_wing_claude_code_home_dir():
+    """Tier 1: sessions from home directory (no anchor) → general."""
+    convo_dir = "/Users/alice/.claude/projects"
+    filepath = (
+        "/Users/alice/.claude/projects/"
+        "-Users-alice/"
+        "session-uuid/subagents/agent-xyz.jsonl"
+    )
+    assert detect_wing(filepath, convo_dir, content="no project info") == "general"
+
+
+def test_detect_wing_developer_anchor():
+    """Tier 1: paths with Developer as anchor directory."""
+    convo_dir = "/Users/carol/.claude/projects"
+    filepath = (
+        "/Users/carol/.claude/projects/"
+        "-Users-carol-Developer-side-project/"
+        "session/subagents/agent.jsonl"
+    )
+    assert detect_wing(filepath, convo_dir) == "side_project"
+
+
+def test_detect_wing_fallback_parent():
+    """Tier 1: non-Claude-Code paths fall back to parent directory name."""
+    convo_dir = "/tmp/chats"
+    filepath = "/tmp/chats/work-stuff/transcript.txt"
+    assert detect_wing(filepath, convo_dir, content="no project info") == "work_stuff"
+
+
+def test_detect_wing_from_cwd():
+    """Tier 2: detect project from cwd fields in JSONL content."""
+    convo_dir = "/Users/alice/.claude/projects"
+    filepath = (
+        "/Users/alice/.claude/projects/"
+        "-Users-alice-Projects/"
+        "session-uuid/subagents/agent.jsonl"
+    )
+    # Simulate Claude Code JSONL with cwd pointing to a project
+    lines = [
+        json.dumps({"type": "user", "cwd": "/Users/alice/Projects", "message": {"content": "hi"}}),
+        json.dumps({"type": "assistant", "cwd": "/Users/alice/Projects/myapp", "message": {"content": "hello"}}),
+        json.dumps({"type": "user", "cwd": "/Users/alice/Projects/myapp", "message": {"content": "help"}}),
+        json.dumps({"type": "assistant", "cwd": "/Users/alice/Projects/myapp", "message": {"content": "sure"}}),
+    ]
+    content = "\n".join(lines)
+    # Tier 1 returns general (root Projects dir), tier 2 should find myapp from cwd
+    assert detect_wing(filepath, convo_dir, content=content) == "myapp"
+
+
+def test_detect_wing_from_content_paths():
+    """Tier 3: detect project from path references in conversation text."""
+    convo_dir = "/Users/alice/.claude/projects"
+    filepath = (
+        "/Users/alice/.claude/projects/"
+        "-Users-alice-Projects/"
+        "session-uuid/subagents/agent.jsonl"
+    )
+    # Normalized transcript — no cwd fields, but content mentions project paths
+    content = (
+        "> Help me fix the scoring bug\n"
+        "Looking at /Users/alice/Projects/cabra/src/game/scoring.ts\n\n"
+        "> What about the synergy system?\n"
+        "Reading /Users/alice/Projects/cabra/src/game/synergy.ts now.\n"
+    )
+    assert detect_wing(filepath, convo_dir, content=content) == "cabra"
+
+
+def test_detect_wing_cwd_beats_content():
+    """Tier 2 (cwd) takes priority over tier 3 (content references)."""
+    convo_dir = "/Users/alice/.claude/projects"
+    filepath = (
+        "/Users/alice/.claude/projects/"
+        "-Users-alice-Projects/"
+        "session/agent.jsonl"
+    )
+    # cwd points to appA, but content mentions appB more
+    lines = [
+        json.dumps({"type": "user", "cwd": "/Users/alice/Projects/appA", "message": {"content": "hi"}}),
+        json.dumps({"type": "assistant", "cwd": "/Users/alice/Projects/appA", "message": {"content": "hello"}}),
+    ]
+    content = "\n".join(lines)
+    # Even though content is JSONL (no path refs to other projects), cwd wins
+    assert detect_wing(filepath, convo_dir, content=content) == "appa"
+
+
+def test_detect_wing_backwards_compat():
+    """detect_wing_from_path is an alias for detect_wing."""
+    assert detect_wing_from_path is detect_wing
+
+
+def test_clean_wing_normalizes_dots():
+    """Dots in project names (e.g., zachtime.xyz) become underscores."""
+    convo_dir = "/Users/alice/.claude/projects"
+    filepath = (
+        "/Users/alice/.claude/projects/"
+        "-Users-alice-Projects/"
+        "session/agent.jsonl"
+    )
+    content = (
+        "> Deploy the site\n"
+        "Deploying /Users/alice/Projects/zachtime.xyz/dist to CloudFront.\n\n"
+        "> Check the build\n"
+        "Reading /Users/alice/Projects/zachtime.xyz/package.json.\n"
+    )
+    assert detect_wing(filepath, convo_dir, content=content) == "zachtime_xyz"
+
+
+def test_detect_wing_auto_mine_creates_per_project_wings():
+    """When no --wing is given, mine_convos files drawers with per-file wings."""
+    tmpdir = tempfile.mkdtemp()
+    # Simulate Claude Code structure: two "projects"
+    proj_a = os.path.join(tmpdir, "-Users-test-Projects-alpha", "session1", "subagents")
+    proj_b = os.path.join(tmpdir, "-Users-test-Projects-beta", "session1", "subagents")
+    os.makedirs(proj_a)
+    os.makedirs(proj_b)
+
+    convo = "> What is X?\nX is a thing.\n\n> Tell me more\nMore details here.\n"
+    with open(os.path.join(proj_a, "agent-a.txt"), "w") as f:
+        f.write(convo)
+    with open(os.path.join(proj_b, "agent-b.txt"), "w") as f:
+        f.write(convo)
+
+    palace_path = os.path.join(tmpdir, "palace")
+    # No --wing: auto-detect
+    mine_convos(tmpdir, palace_path, wing=None)
+
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_collection("mempalace_drawers")
+    all_meta = col.get(include=["metadatas"])["metadatas"]
+
+    wings = {m["wing"] for m in all_meta}
+    assert "alpha" in wings
+    assert "beta" in wings
+
+    shutil.rmtree(tmpdir)
+
+
+def test_explicit_wing_overrides_auto_detect():
+    """When --wing is given, all files use that wing regardless of path."""
+    tmpdir = tempfile.mkdtemp()
+    proj = os.path.join(tmpdir, "-Users-test-Projects-alpha", "session1", "subagents")
+    os.makedirs(proj)
+    convo = (
+        "> What is the meaning of software architecture and why does it matter?\n"
+        "Software architecture defines the high-level structure of a system.\n\n"
+        "> Can you explain the difference between monoliths and microservices?\n"
+        "Monoliths deploy as a single unit while microservices are distributed.\n\n"
+        "> What about serverless architecture patterns?\n"
+        "Serverless lets you focus on business logic without managing servers.\n"
+    )
+    with open(os.path.join(proj, "agent.txt"), "w") as f:
+        f.write(convo)
+
+    palace_path = os.path.join(tmpdir, "palace")
+    mine_convos(tmpdir, palace_path, wing="my_custom_wing")
+
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_collection("mempalace_drawers")
+    all_meta = col.get(include=["metadatas"])["metadatas"]
+
+    wings = {m["wing"] for m in all_meta}
+    assert wings == {"my_custom_wing"}
 
     shutil.rmtree(tmpdir)


### PR DESCRIPTION
## Summary

- Adds 3-tier wing auto-detection when `--wing` is not specified during `mempalace mine --mode convos`
- **Tier 1 (path):** Decodes Claude Code encoded directory names (e.g., `-Users-alice-Projects-myapp` → `myapp`)
- **Tier 2 (cwd):** Extracts most-referenced project from JSONL `cwd` fields
- **Tier 3 (content):** Scans conversation text for project directory path references
- Falls back to `"general"` when no project can be determined
- Explicit `--wing` overrides all auto-detection (fully backwards compatible)

Closes #318

## Test plan

- [x] 13 new tests covering all 3 tiers, priority ordering, backwards compat, and integration with `mine_convos()`
- [x] All existing tests pass
- [ ] Verify on real Claude Code conversation directories with mixed projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)