### PR TITLE
fix: Ignore wait_for_previous argument to support Gemini MCP clients

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -766,6 +766,7 @@ def handle_request(request):
             elif declared_type == "number" and not isinstance(value, (int, float)):
                 tool_args[key] = float(value)
         try:
+            tool_args.pop("wait_for_previous", None)
             result = TOOLS[tool_name]["handler"](**tool_args)
             return {
                 "jsonrpc": "2.0",


### PR DESCRIPTION
### Describe the bug
When using Mempalace with the Gemini CLI MCP client, the client automatically injects an undocumented wait_for_previous argument into the tool execution request. This causes a TypeError: unexpected keyword argument in mcp_server.py and crashes the tool execution.

### Solution
Added a safe .pop("wait_for_previous", None) before passing tool_args to the handler. This safely drops the non-standard argument and restores compatibility with Gemini clients without affecting other standard clients like Claude Desktop or Cursor.
