### PR TITLE
fix(hooks): use mempalace shim instead of bare `python3 -m mempalace`

### DIFF
--- a/.claude-plugin/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin/hooks/mempal-precompact-hook.sh
@@ -2,4 +2,4 @@
 # MemPalace PreCompact Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
 INPUT=$(cat)
-echo "$INPUT" | python3 -m mempalace hook run --hook precompact --harness claude-code
+echo "$INPUT" | mempalace hook run --hook precompact --harness claude-code

--- a/.claude-plugin/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin/hooks/mempal-stop-hook.sh
@@ -2,4 +2,4 @@
 # MemPalace Stop Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
 INPUT=$(cat)
-echo "$INPUT" | python3 -m mempalace hook run --hook stop --harness claude-code
+echo "$INPUT" | mempalace hook run --hook stop --harness claude-code

--- a/.codex-plugin/hooks/mempal-hook.sh
+++ b/.codex-plugin/hooks/mempal-hook.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 HOOK_NAME="${1:?Usage: mempal-hook.sh <hook-name>}"
 INPUT_FILE=$(mktemp) || { echo "Failed to create temp file" >&2; exit 1; }
 cat > "$INPUT_FILE"
-cat "$INPUT_FILE" | python3 -m mempalace hook run --hook "$HOOK_NAME" --harness codex
+cat "$INPUT_FILE" | mempalace hook run --hook "$HOOK_NAME" --harness codex
 EXIT_CODE=$?
 rm -f "$INPUT_FILE" 2>/dev/null
 exit $EXIT_CODE

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -65,7 +65,7 @@ echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     REPO_DIR="$(dirname "$SCRIPT_DIR")"
-    python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
+    mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
 # Always block — compaction = save everything

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -130,7 +130,7 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         REPO_DIR="$(dirname "$SCRIPT_DIR")"
-        python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
+        mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 
     # Block the AI and tell it to save


### PR DESCRIPTION
## Summary

Replaces `python3 -m mempalace` with the `mempalace` shim in all 5 hook scripts. This fixes silent auto-save failures on any machine where `$PATH` resolves `python3` to a venv that doesn't have mempalace installed.

## The Bug

Hook scripts invoke the CLI via:

```bash
echo "$INPUT" | python3 -m mempalace hook run --hook stop --harness claude-code
```

On any machine where a Python tool has been installed via `uv tool install` (e.g. `kimi-cli`, `llm`, `aider`), `~/.local/share/uv/tools/<tool>/bin` sits earlier in `$PATH` than `/opt/homebrew/bin` or `/usr/bin`. Bare `python3` then resolves to that tool's isolated venv, which has no mempalace, and every hook fires:

```
/Users/nynat/.local/share/uv/tools/kimi-cli/bin/python3: No module named mempalace
```

On Claude Code this shows up as a Stop hook error on every conversation exit, which silently breaks auto-save. I hit this on a Mac Mini with `kimi-cli` installed via `uv tool install kimi-cli`. I'd expect it to be common — `uv` is mainstream now and `uv tool` is the recommended install path for Python CLIs.

## The Fix

Call the `mempalace` shim directly. pipx, pip, and uv all install a wrapper at `~/.local/bin/mempalace` (or equivalent) that internally dispatches to the correct venv's Python — so it's immune to `$PATH` ordering for `python3` itself and survives Python version upgrades.

This also matches what the hook comments already document as the intended CLI:

```bash
# === MEMPALACE CLI ===
# This repo uses: mempalace mine <dir>
```

So the shell was diverging from its own documentation. The PR just brings them back into alignment.

## Files Changed

5 files, 5 lines — pure text substitution:

| File | What it runs |
|---|---|
| `.claude-plugin/hooks/mempal-stop-hook.sh` | `mempalace hook run --hook stop --harness claude-code` |
| `.claude-plugin/hooks/mempal-precompact-hook.sh` | `mempalace hook run --hook precompact --harness claude-code` |
| `.codex-plugin/hooks/mempal-hook.sh` | `mempalace hook run --hook "$HOOK_NAME" --harness codex` |
| `hooks/mempal_save_hook.sh` | `mempalace mine "$MEMPAL_DIR"` (optional auto-ingest block) |
| `hooks/mempal_precompact_hook.sh` | `mempalace mine "$MEMPAL_DIR"` (optional auto-ingest block) |

Intentionally left alone:
- `examples/gemini_cli_setup.md` — uses `.venv/bin/python3 -m mempalace`, an absolute path which is immune to the hijack
- `mempalace/onboarding.py` — the `python3 -m mempalace.onboarding` string is a user-facing hint in a docstring, not a runtime call
- Inline `python3 -c` calls in `hooks/mempal_*.sh` — these only need stdlib (`sys`, `json`), which any python3 has, so they're not affected by the hijack

## Compatibility

- **No behaviour change** on machines where bare `python3` already resolves to a python with mempalace installed.
- **Fixes the error** on machines where it doesn't.
- **Requires**: `mempalace` shim on `$PATH` — which is the case for anyone who installed via `pip install mempalace`, `pipx install mempalace`, `uv tool install mempalace`, or the Claude Code plugin's bundled install.

## Relates To

- #323 — `mempal-stop-hook.sh calls nonexistent hook subcommand`. That issue is a different failure mode (running against mempalace 3.0.0 from PyPI, which doesn't have the `hook` subcommand yet — 3.0.14+ does). This PR is orthogonal: it fixes the `$PATH` hijack that triggers *before* the subcommand even runs. Both need to be resolved for the plugin to work out of the box.
- #265 — `Bundle hook scripts in pip package`. That's the long-term architectural fix. This PR is a minimal stopgap that unblocks users today without touching package layout.

## Test Plan

- [x] `grep -r "python3 -m mempalace" .claude-plugin .codex-plugin hooks` returns no matches
- [x] Verified the fix live on the affected Mac Mini (re-ran the stop hook, now returns `{}` with exit 0 instead of the `No module named mempalace` error)
- [x] No Python code touched → `pytest tests/` irrelevant for this change, but happy to run it if CI requests

Thanks for mempalace — it's been great!