### PR TITLE
fix(normalize): fail closed on invalid ChatGPT mapping trees

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-from .normalize import normalize
+from .normalize import ChatGPTNormalizeError, normalize
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -294,6 +294,49 @@ def scan_convos(convo_dir: str) -> list:
     return files
 
 
+def _normalize_convo_file(filepath: Path, index: int, total_files: int):
+    """Normalize one conversation file and classify recoverable failures."""
+    try:
+        return normalize(str(filepath)), False
+    except ChatGPTNormalizeError as e:
+        print(f"  ! [{index:4}/{total_files}] {filepath.name[:50]:50} skipped: {e}")
+        return None, True
+    except (OSError, ValueError):
+        return None, False
+
+
+def _chunk_convo_content(content: str, extract_mode: str) -> list:
+    """Chunk normalized conversation content for the selected extraction mode."""
+    if extract_mode == "general":
+        from .general_extractor import extract_memories
+
+        return extract_memories(content)
+    return chunk_exchanges(content)
+
+
+def _room_for_convo_content(content: str, extract_mode: str):
+    """Detect a room unless general extraction assigns rooms per memory."""
+    if extract_mode == "general":
+        return None
+    return detect_convo_room(content)
+
+
+def _record_dry_run_convo_file(filepath: Path, chunks: list, room, extract_mode: str, room_counts):
+    """Print dry-run output and update room counts for one file."""
+    if extract_mode == "general":
+        from collections import Counter
+
+        type_counts = Counter(c.get("memory_type", "general") for c in chunks)
+        types_str = ", ".join(f"{t}:{n}" for t, n in type_counts.most_common())
+        print(f"    [DRY RUN] {filepath.name} → {len(chunks)} memories ({types_str})")
+        for c in chunks:
+            room_counts[c.get("memory_type", "general")] += 1
+    else:
+        print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
+        room_counts[room] += 1
+    return len(chunks)
+
+
 # =============================================================================
 # MINE CONVERSATIONS
 # =============================================================================
@@ -395,6 +438,8 @@ def mine_convos(
 
     total_drawers = 0
     files_skipped = 0
+    normalize_failed_files = 0
+    files_processed = 0
     room_counts = defaultdict(int)
 
     for i, filepath in enumerate(files, 1):
@@ -406,12 +451,16 @@ def mine_convos(
             continue
 
         # Normalize format
-        try:
-            content = normalize(str(filepath))
-        except (OSError, ValueError):
+        content, normalize_failed = _normalize_convo_file(filepath, i, len(files))
+        if normalize_failed:
+            normalize_failed_files += 1
+            continue
+        if content is None:
             if not dry_run:
                 _register_file(collection, source_file, wing, agent)
             continue
+
+        files_processed += 1
 
         if not content or len(content.strip()) < MIN_CHUNK_SIZE:
             if not dry_run:
@@ -419,13 +468,7 @@ def mine_convos(
             continue
 
         # Chunk — either exchange pairs or general extraction
-        if extract_mode == "general":
-            from .general_extractor import extract_memories
-
-            chunks = extract_memories(content)
-            # Each chunk already has memory_type; use it as the room name
-        else:
-            chunks = chunk_exchanges(content)
+        chunks = _chunk_convo_content(content, extract_mode)
 
         if not chunks:
             if not dry_run:
@@ -433,27 +476,12 @@ def mine_convos(
             continue
 
         # Detect room from content (general mode uses memory_type instead)
-        if extract_mode != "general":
-            room = detect_convo_room(content)
-        else:
-            room = None  # set per-chunk below
+        room = _room_for_convo_content(content, extract_mode)
 
         if dry_run:
-            if extract_mode == "general":
-                from collections import Counter
-
-                type_counts = Counter(c.get("memory_type", "general") for c in chunks)
-                types_str = ", ".join(f"{t}:{n}" for t, n in type_counts.most_common())
-                print(f"    [DRY RUN] {filepath.name} → {len(chunks)} memories ({types_str})")
-            else:
-                print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-            total_drawers += len(chunks)
-            # Track room counts
-            if extract_mode == "general":
-                for c in chunks:
-                    room_counts[c.get("memory_type", "general")] += 1
-            else:
-                room_counts[room] += 1
+            total_drawers += _record_dry_run_convo_file(
+                filepath, chunks, room, extract_mode, room_counts
+            )
             continue
 
         if extract_mode != "general":
@@ -475,8 +503,10 @@ def mine_convos(
 
     print(f"\n{'=' * 55}")
     print("  Done.")
-    print(f"  Files processed: {len(files) - files_skipped}")
+    print(f"  Files processed: {files_processed}")
     print(f"  Files skipped (already filed): {files_skipped}")
+    if normalize_failed_files:
+        print(f"  Files skipped (invalid ChatGPT exports): {normalize_failed_files}")
     print(f"  Drawers filed: {total_drawers}")
     if room_counts:
         print("\n  By room:")

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -109,6 +109,14 @@ def strip_noise(text: str) -> str:
     return text.strip()
 
 
+class ChatGPTNormalizeError(ValueError):
+    """Raised when a ChatGPT export cannot be safely normalized."""
+
+
+class ChatGPTBranchAmbiguityError(ChatGPTNormalizeError):
+    """Raised when a ChatGPT mapping tree has multiple candidate branches."""
+
+
 def normalize(filepath: str) -> str:
     """
     Load a file and normalize to transcript format if it's a chat export.
@@ -334,40 +342,152 @@ def _try_chatgpt_json(data) -> Optional[str]:
     if not isinstance(data, dict) or "mapping" not in data:
         return None
     mapping = data["mapping"]
+    if not isinstance(mapping, dict):
+        raise ChatGPTNormalizeError("Invalid ChatGPT export: mapping must be an object")
+
+    root_id = _find_chatgpt_root_id(mapping)
+    if not root_id:
+        raise ChatGPTNormalizeError("Invalid ChatGPT export: could not find mapping root")
+
+    reachable_ids = _collect_chatgpt_reachable_ids(mapping, root_id)
+    active_node_id = _resolve_chatgpt_active_node_id(data, mapping, root_id)
+    path_ids = _build_chatgpt_path(mapping, active_node_id, root_id, reachable_ids)
+    if not path_ids:
+        raise ChatGPTNormalizeError(
+            "Invalid ChatGPT export: could not resolve active conversation path"
+        )
+
     messages = []
-    # Find root: prefer node with parent=None AND no message (synthetic root)
+    for node_id in path_ids:
+        node = mapping.get(node_id, {})
+        msg = node.get("message")
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("author", {}).get("role", "")
+        text = _extract_chatgpt_text(msg.get("content", {}))
+        if role == "user" and text:
+            messages.append(("user", text))
+        elif role == "assistant" and text:
+            messages.append(("assistant", text))
+    if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    raise ChatGPTNormalizeError(
+        "Invalid ChatGPT export: active conversation path did not yield enough messages"
+    )
+
+
+def _find_chatgpt_root_id(mapping: dict) -> Optional[str]:
+    """Prefer the synthetic root; fall back to any parent-less node."""
     root_id = None
     fallback_root = None
     for node_id, node in mapping.items():
+        if not isinstance(node, dict):
+            continue
         if node.get("parent") is None:
             if node.get("message") is None:
                 root_id = node_id
                 break
-            elif fallback_root is None:
+            if fallback_root is None:
                 fallback_root = node_id
+    return root_id or fallback_root
+
+
+def _resolve_chatgpt_active_node_id(
+    data: dict, mapping: dict, root_id: Optional[str]
+) -> Optional[str]:
+    """Use the export's active node when available; otherwise require a single path."""
+    if "current_node" in data:
+        current_node = data.get("current_node")
+        if current_node in mapping:
+            return current_node
+        raise ChatGPTNormalizeError(
+            "Invalid ChatGPT export: current_node does not reference a mapping node"
+        )
     if not root_id:
-        root_id = fallback_root
-    if root_id:
-        current_id = root_id
-        visited = set()
-        while current_id and current_id not in visited:
-            visited.add(current_id)
-            node = mapping.get(current_id, {})
-            msg = node.get("message")
-            if msg:
-                role = msg.get("author", {}).get("role", "")
-                content = msg.get("content", {})
-                parts = content.get("parts", []) if isinstance(content, dict) else []
-                text = " ".join(str(p) for p in parts if isinstance(p, str) and p).strip()
-                if role == "user" and text:
-                    messages.append(("user", text))
-                elif role == "assistant" and text:
-                    messages.append(("assistant", text))
-            children = node.get("children", [])
-            current_id = children[0] if children else None
-    if len(messages) >= 2:
-        return _messages_to_transcript(messages)
-    return None
+        return None
+
+    leaf_ids = _collect_chatgpt_leaf_ids(mapping, root_id)
+    if len(leaf_ids) == 1:
+        return leaf_ids[0]
+    if len(leaf_ids) > 1:
+        raise ChatGPTBranchAmbiguityError(
+            "Ambiguous ChatGPT mapping tree: multiple candidate conversation branches without current_node"
+        )
+    return root_id
+
+
+def _collect_chatgpt_leaf_ids(mapping: dict, root_id: str) -> list[str]:
+    """Return reachable leaves from root using only valid child references."""
+    leaf_ids = []
+    for node_id in _collect_chatgpt_reachable_ids(mapping, root_id):
+        node = mapping.get(node_id, {})
+        if not isinstance(node, dict):
+            continue
+        child_ids = [child_id for child_id in node.get("children", []) if child_id in mapping]
+        if not child_ids:
+            leaf_ids.append(node_id)
+
+    return leaf_ids
+
+
+def _collect_chatgpt_reachable_ids(mapping: dict, root_id: str) -> list[str]:
+    """Return nodes reachable from root following children edges only."""
+    reachable_ids = []
+    stack = [root_id]
+    visited = set()
+
+    while stack:
+        node_id = stack.pop()
+        if node_id in visited:
+            continue
+        visited.add(node_id)
+        reachable_ids.append(node_id)
+
+        node = mapping.get(node_id, {})
+        if not isinstance(node, dict):
+            continue
+        child_ids = [child_id for child_id in node.get("children", []) if child_id in mapping]
+        stack.extend(reversed(child_ids))
+
+    return reachable_ids
+
+
+def _build_chatgpt_path(
+    mapping: dict, active_node_id: Optional[str], root_id: Optional[str], reachable_ids: list[str]
+) -> list[str]:
+    """Walk from the active node back to root and return the ordered path."""
+    if not active_node_id or active_node_id not in mapping:
+        return []
+
+    path_ids = []
+    current_id = active_node_id
+    visited = set()
+
+    while current_id and current_id not in visited:
+        visited.add(current_id)
+        path_ids.append(current_id)
+        node = mapping.get(current_id, {})
+        if not isinstance(node, dict):
+            break
+        parent_id = node.get("parent")
+        current_id = parent_id if parent_id in mapping else None
+
+    path_ids.reverse()
+    if root_id and (not path_ids or path_ids[0] != root_id):
+        return []
+    reachable_id_set = set(reachable_ids)
+    if any(node_id not in reachable_id_set for node_id in path_ids):
+        return []
+    return path_ids
+
+
+def _extract_chatgpt_text(content) -> str:
+    """Extract plain text from ChatGPT message content blocks."""
+    if isinstance(content, dict):
+        parts = content.get("parts", [])
+        if isinstance(parts, list):
+            return " ".join(str(part) for part in parts if isinstance(part, str) and part).strip()
+    return ""
 
 
 def _try_slack_json(data) -> Optional[str]:

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import shutil
 from pathlib import Path
-
+import json
 import chromadb
 
 from mempalace.convo_miner import mine_convos
@@ -156,5 +156,137 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         for meta in rebuilt["metadatas"]:
             assert meta.get("normalize_version") == NORMALIZE_VERSION
         del col, client
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_convo_mining_warns_on_ambiguous_chatgpt_branches(capsys):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(tmpdir, "ambiguous.json"), "w") as f:
+            json.dump(
+                {
+                    "mapping": {
+                        "root": {"parent": None, "message": None, "children": ["u1"]},
+                        "u1": {
+                            "parent": "root",
+                            "message": {
+                                "author": {"role": "user"},
+                                "content": {"parts": ["Tell me a slogan"]},
+                            },
+                            "children": ["a_old", "a_new"],
+                        },
+                        "a_old": {
+                            "parent": "u1",
+                            "message": {
+                                "author": {"role": "assistant"},
+                                "content": {"parts": ["Old answer"]},
+                            },
+                            "children": [],
+                        },
+                        "a_new": {
+                            "parent": "u1",
+                            "message": {
+                                "author": {"role": "assistant"},
+                                "content": {"parts": ["New regenerated answer"]},
+                            },
+                            "children": [],
+                        },
+                    }
+                },
+                f,
+            )
+
+        palace_path = os.path.join(tmpdir, "palace")
+        mine_convos(tmpdir, palace_path, wing="test_convos", dry_run=True)
+
+        output = capsys.readouterr().out
+        assert "multiple candidate conversation branches without current_node" in output
+        assert "ambiguous.json" in output
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_convo_mining_warns_on_invalid_chatgpt_export(capsys):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(tmpdir, "invalid.json"), "w") as f:
+            json.dump(
+                {
+                    "current_node": "missing",
+                    "mapping": {
+                        "root": {"parent": None, "message": None, "children": ["u1"]},
+                        "u1": {
+                            "parent": "root",
+                            "message": {
+                                "author": {"role": "user"},
+                                "content": {"parts": ["Tell me a slogan"]},
+                            },
+                            "children": ["a1"],
+                        },
+                        "a1": {
+                            "parent": "u1",
+                            "message": {
+                                "author": {"role": "assistant"},
+                                "content": {"parts": ["A better answer"]},
+                            },
+                            "children": [],
+                        },
+                    },
+                },
+                f,
+            )
+
+        palace_path = os.path.join(tmpdir, "palace")
+        mine_convos(tmpdir, palace_path, wing="test_convos", dry_run=True)
+
+        output = capsys.readouterr().out
+        assert "current_node does not reference a mapping node" in output
+        assert "invalid.json" in output
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_convo_mining_reports_invalid_chatgpt_skip_summary(capsys):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(tmpdir, "invalid.json"), "w") as f:
+            json.dump(
+                {
+                    "current_node": "missing",
+                    "mapping": {
+                        "root": {"parent": None, "message": None, "children": ["u1"]},
+                        "u1": {
+                            "parent": "root",
+                            "message": {
+                                "author": {"role": "user"},
+                                "content": {"parts": ["Tell me a slogan"]},
+                            },
+                            "children": ["a1"],
+                        },
+                        "a1": {
+                            "parent": "u1",
+                            "message": {
+                                "author": {"role": "assistant"},
+                                "content": {"parts": ["A better answer"]},
+                            },
+                            "children": [],
+                        },
+                    },
+                },
+                f,
+            )
+        with open(os.path.join(tmpdir, "chat.txt"), "w") as f:
+            f.write(
+                "> What is memory?\nMemory is persistence.\n\n> Why does it matter?\nIt enables continuity.\n\n> How do we build it?\nWith structured storage.\n"
+            )
+
+        palace_path = os.path.join(tmpdir, "palace")
+        mine_convos(tmpdir, palace_path, wing="test_convos", dry_run=True)
+
+        output = capsys.readouterr().out
+        assert "Files processed: 1" in output
+        assert "Files skipped (invalid ChatGPT exports): 1" in output
+        assert "Files skipped (ambiguous ChatGPT branches)" not in output
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,8 +1,11 @@
 import json
 from unittest.mock import patch
+import pytest
 
 from mempalace.normalize import (
     _SLACK_PROVENANCE_FOOTER,
+    ChatGPTBranchAmbiguityError,
+    ChatGPTNormalizeError,
     _extract_content,
     _format_tool_result,
     _format_tool_use,
@@ -735,8 +738,241 @@ def test_chatgpt_json_too_few_messages():
             },
         }
     }
+    with pytest.raises(ChatGPTNormalizeError, match="enough messages"):
+        _try_chatgpt_json(data)
+
+
+def test_chatgpt_json_uses_current_node_branch():
+    data = {
+        "current_node": "a_new",
+        "mapping": {
+            "root": {"parent": None, "message": None, "children": ["u1"]},
+            "u1": {
+                "parent": "root",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Tell me a slogan"]}},
+                "children": ["a_old", "a_new"],
+            },
+            "a_old": {
+                "parent": "u1",
+                "message": {"author": {"role": "assistant"}, "content": {"parts": ["Old answer"]}},
+                "children": [],
+            },
+            "a_new": {
+                "parent": "u1",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["New regenerated answer"]},
+                },
+                "children": [],
+            },
+        },
+    }
+
     result = _try_chatgpt_json(data)
-    assert result is None
+
+    assert "New regenerated answer" in result
+    assert "Old answer" not in result
+
+
+def test_chatgpt_json_without_current_node_rejects_ambiguous_branches():
+    data = {
+        "mapping": {
+            "root": {"parent": None, "message": None, "children": ["u1"]},
+            "u1": {
+                "parent": "root",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Tell me a slogan"]}},
+                "children": ["a_old", "a_new"],
+            },
+            "a_old": {
+                "parent": "u1",
+                "message": {"author": {"role": "assistant"}, "content": {"parts": ["Old answer"]}},
+                "children": [],
+            },
+            "a_new": {
+                "parent": "u1",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["New regenerated answer"]},
+                },
+                "children": [],
+            },
+        },
+    }
+
+    with pytest.raises(ChatGPTBranchAmbiguityError):
+        _try_chatgpt_json(data)
+
+
+def test_chatgpt_json_with_invalid_current_node_fails_explicitly():
+    data = {
+        "current_node": "missing",
+        "mapping": {
+            "root": {"parent": None, "message": None, "children": ["u1"]},
+            "u1": {
+                "parent": "root",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Tell me a slogan"]}},
+                "children": ["a1"],
+            },
+            "a1": {
+                "parent": "u1",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["A better answer"]},
+                },
+                "children": [],
+            },
+        },
+    }
+
+    with pytest.raises(ChatGPTNormalizeError, match="current_node"):
+        _try_chatgpt_json(data)
+
+
+def test_chatgpt_json_rejects_current_node_outside_rooted_tree():
+    data = {
+        "current_node": "orphan_a",
+        "mapping": {
+            "root": {"parent": None, "message": None, "children": ["u1"]},
+            "u1": {
+                "parent": "root",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Real question"]}},
+                "children": ["a1"],
+            },
+            "a1": {
+                "parent": "u1",
+                "message": {"author": {"role": "assistant"}, "content": {"parts": ["Real answer"]}},
+                "children": [],
+            },
+            "orphan_u": {
+                "parent": None,
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Orphan question"]}},
+                "children": ["orphan_a"],
+            },
+            "orphan_a": {
+                "parent": "orphan_u",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["Orphan answer"]},
+                },
+                "children": [],
+            },
+        },
+    }
+
+    with pytest.raises(ChatGPTNormalizeError, match="active conversation path"):
+        _try_chatgpt_json(data)
+
+
+def test_chatgpt_json_rejects_current_node_not_reachable_from_children():
+    data = {
+        "current_node": "hidden_a",
+        "mapping": {
+            "root": {"parent": None, "message": None, "children": ["u1"]},
+            "u1": {
+                "parent": "root",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Real question"]}},
+                "children": ["a1"],
+            },
+            "a1": {
+                "parent": "u1",
+                "message": {"author": {"role": "assistant"}, "content": {"parts": ["Real answer"]}},
+                "children": [],
+            },
+            "hidden_a": {
+                "parent": "u1",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["Hidden answer"]},
+                },
+                "children": [],
+            },
+        },
+    }
+
+    with pytest.raises(ChatGPTNormalizeError, match="active conversation path"):
+        _try_chatgpt_json(data)
+
+
+def test_chatgpt_json_without_current_node_accepts_single_branch():
+    data = {
+        "mapping": {
+            "root": {"parent": None, "message": None, "children": ["u1"]},
+            "u1": {
+                "parent": "root",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Tell me a slogan"]}},
+                "children": ["a1"],
+            },
+            "a1": {
+                "parent": "u1",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["A better answer"]},
+                },
+                "children": [],
+            },
+        },
+    }
+
+    result = _try_chatgpt_json(data)
+
+    assert "A better answer" in result
+
+
+def test_chatgpt_json_uses_active_edit_branch_path():
+    data = {
+        "current_node": "a2_new",
+        "mapping": {
+            "root": {"parent": None, "message": None, "children": ["u1"]},
+            "u1": {
+                "parent": "root",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Draft an email"]}},
+                "children": ["a1"],
+            },
+            "a1": {
+                "parent": "u1",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["Sure, here's a draft."]},
+                },
+                "children": ["u2_old", "u2_new"],
+            },
+            "u2_old": {
+                "parent": "a1",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Make it formal"]}},
+                "children": ["a2_old"],
+            },
+            "a2_old": {
+                "parent": "u2_old",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["Formal revision"]},
+                },
+                "children": [],
+            },
+            "u2_new": {
+                "parent": "a1",
+                "message": {"author": {"role": "user"}, "content": {"parts": ["Make it warmer"]}},
+                "children": ["a2_new"],
+            },
+            "a2_new": {
+                "parent": "u2_new",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["Warmer revision"]},
+                },
+                "children": [],
+            },
+        },
+    }
+
+    result = _try_chatgpt_json(data)
+
+    assert "Draft an email" in result
+    assert "Sure, here's a draft." in result
+    assert "Make it warmer" in result
+    assert "Warmer revision" in result
+    assert "Make it formal" not in result
+    assert "Formal revision" not in result
 
 
 # ── _try_slack_json ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #330

## What does this PR do?

Fix ChatGPT `mapping` normalization so imports fail closed instead of silently ingesting the wrong transcript or raw invalid JSON.

This PR:
- stops walking `children[0]` and resolves the transcript from the active node path instead
- uses `current_node` when present, and rejects ambiguous multi-branch trees without it
- rejects invalid ChatGPT exports when `mapping` is malformed, `current_node` is invalid, the resolved path does not connect back to the detected root, or the path is not reachable from the root via `children`
- prevents `mine_convos()` from silently passing invalid ChatGPT exports downstream as plain text
- updates ingest reporting so skipped invalid ChatGPT exports are counted and labeled correctly
- adds regression tests for regenerated branches, edited branches, invalid `current_node`, orphaned subtrees, unreachable hidden nodes, and ingest skip reporting

## How to test

```bash
uv run pytest /Users/mrbrain/code/mempalace/tests/test_normalize.py -q
uv run pytest /Users/mrbrain/code/mempalace/tests/test_convo_miner.py -q -k "ambiguous or invalid or summary"
uv run ruff check .
```

## Checklist
 Tests pass (python -m pytest tests/ -v)
 No hardcoded paths
 Linter passes (ruff check .)