### PR TITLE
feat: soft-archive wings — exclude from search without deleting data (#332)

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -169,6 +169,38 @@ class MempalaceConfig:
         wc = self.load_wing_config()
         return {name for name, cfg in wc.items() if cfg.get("archived") is True}
 
+    def archive_room(self, wing: str, room: str):
+        """Archive a specific room within a wing (exclude from search, keep data)."""
+        wc = self.load_wing_config()
+        if wing not in wc:
+            wc[wing] = {}
+        if "archived_rooms" not in wc[wing]:
+            wc[wing]["archived_rooms"] = []
+        if room not in wc[wing]["archived_rooms"]:
+            wc[wing]["archived_rooms"].append(room)
+            self.save_wing_config(wc)
+            return True
+        return False
+
+    def unarchive_room(self, wing: str, room: str):
+        """Restore a room to active search results."""
+        wc = self.load_wing_config()
+        if wing in wc and "archived_rooms" in wc[wing]:
+            if room in wc[wing]["archived_rooms"]:
+                wc[wing]["archived_rooms"].remove(room)
+                if not wc[wing]["archived_rooms"]:
+                    del wc[wing]["archived_rooms"]
+                self.save_wing_config(wc)
+                return True
+        return False
+
+    def get_archived_rooms(self, wing: str) -> list:
+        """Return list of archived room names for a given wing."""
+        wc = self.load_wing_config()
+        if wing in wc and "archived_rooms" in wc[wing]:
+            return list(wc[wing]["archived_rooms"])
+        return []
+
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""
         self._config_dir.mkdir(parents=True, exist_ok=True)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -123,6 +123,52 @@ class MempalaceConfig:
         """Mapping of hall names to keyword lists."""
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
+    @property
+    def wing_config_path(self):
+        """Path to wing_config.json."""
+        return self._config_dir / "wing_config.json"
+
+    def load_wing_config(self):
+        """Load wing_config.json and return as dict."""
+        if self.wing_config_path.exists():
+            try:
+                with open(self.wing_config_path, "r") as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, OSError):
+                return {}
+        return {}
+
+    def save_wing_config(self, wing_config):
+        """Write wing_config.json."""
+        self._config_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.wing_config_path, "w") as f:
+            json.dump(wing_config, f, indent=2)
+
+    def archive_wing(self, wing_name):
+        """Set archived flag on a wing. Returns True if state changed."""
+        wc = self.load_wing_config()
+        if wing_name not in wc:
+            wc[wing_name] = {}
+        if wc[wing_name].get("archived") is True:
+            return False
+        wc[wing_name]["archived"] = True
+        self.save_wing_config(wc)
+        return True
+
+    def unarchive_wing(self, wing_name):
+        """Remove archived flag from a wing. Returns True if state changed."""
+        wc = self.load_wing_config()
+        if wing_name not in wc or not wc[wing_name].get("archived"):
+            return False
+        wc[wing_name]["archived"] = False
+        self.save_wing_config(wc)
+        return True
+
+    def get_archived_wings(self):
+        """Return set of archived wing names."""
+        wc = self.load_wing_config()
+        return {name for name, cfg in wc.items() if cfg.get("archived") is True}
+
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""
         self._config_dir.mkdir(parents=True, exist_ok=True)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -17,6 +17,8 @@ Tools (write):
   mempalace_delete_drawer   — remove a drawer by ID
   mempalace_archive_wing    — hide a wing from default search (status lists it)
   mempalace_unarchive_wing  — restore a wing to default search
+  mempalace_archive_room    — hide a room within a wing from search (data kept)
+  mempalace_unarchive_room  — restore a room to default search
 """
 
 import sys
@@ -83,6 +85,11 @@ def tool_status():
         "wings": wings,
         "rooms": rooms,
         "archived_wings": sorted(_config.get_archived_wings()),
+        "archived_rooms": {
+            wing: sorted(_config.get_archived_rooms(wing))
+            for wing in _config.load_wing_config()
+            if _config.get_archived_rooms(wing)
+        },
         "palace_path": _config.palace_path,
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
@@ -200,6 +207,18 @@ def tool_unarchive_wing(wing: str):
     """Remove archived flag so the wing appears in broad search again."""
     changed = _config.unarchive_wing(wing)
     return {"success": True, "wing": wing, "archived": False, "state_changed": changed}
+
+
+def tool_archive_room(wing: str, room: str):
+    """Archive a specific room within a wing."""
+    state_changed = _config.archive_room(wing, room)
+    return {"wing": wing, "room": room, "archived": True, "state_changed": state_changed}
+
+
+def tool_unarchive_room(wing: str, room: str):
+    """Restore a room to active search results."""
+    state_changed = _config.unarchive_room(wing, room)
+    return {"wing": wing, "room": room, "archived": False, "state_changed": state_changed}
 
 
 def tool_check_duplicate(content: str, threshold: float = 0.9):
@@ -646,6 +665,30 @@ TOOLS = {
             "required": ["wing"],
         },
         "handler": tool_unarchive_wing,
+    },
+    "mempalace_archive_room": {
+        "description": "Archive a specific room within a wing — excludes it from search without deleting data.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "wing": {"type": "string", "description": "Wing containing the room"},
+                "room": {"type": "string", "description": "Room name to archive"},
+            },
+            "required": ["wing", "room"],
+        },
+        "handler": tool_archive_room,
+    },
+    "mempalace_unarchive_room": {
+        "description": "Restore an archived room to active search results.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "wing": {"type": "string", "description": "Wing containing the room"},
+                "room": {"type": "string", "description": "Room name to unarchive"},
+            },
+            "required": ["wing", "room"],
+        },
+        "handler": tool_unarchive_room,
     },
     "mempalace_check_duplicate": {
         "description": "Check if content already exists in the palace before filing",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -15,6 +15,8 @@ Tools (read):
 Tools (write):
   mempalace_add_drawer      — file verbatim content into a wing/room
   mempalace_delete_drawer   — remove a drawer by ID
+  mempalace_archive_wing    — hide a wing from default search (status lists it)
+  mempalace_unarchive_wing  — restore a wing to default search
 """
 
 import sys
@@ -80,6 +82,7 @@ def tool_status():
         "total_drawers": count,
         "wings": wings,
         "rooms": rooms,
+        "archived_wings": sorted(_config.get_archived_wings()),
         "palace_path": _config.palace_path,
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
@@ -170,14 +173,33 @@ def tool_get_taxonomy():
     return {"taxonomy": taxonomy}
 
 
-def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+def tool_search(
+    query: str,
+    limit: int = 5,
+    wing: str = None,
+    room: str = None,
+    include_archived: bool = False,
+):
     return search_memories(
         query,
         palace_path=_config.palace_path,
         wing=wing,
         room=room,
         n_results=limit,
+        include_archived=include_archived,
     )
+
+
+def tool_archive_wing(wing: str):
+    """Mark a wing as archived — excluded from broad search until unarchived."""
+    changed = _config.archive_wing(wing)
+    return {"success": True, "wing": wing, "archived": True, "state_changed": changed}
+
+
+def tool_unarchive_wing(wing: str):
+    """Remove archived flag so the wing appears in broad search again."""
+    changed = _config.unarchive_wing(wing)
+    return {"success": True, "wing": wing, "archived": False, "state_changed": changed}
 
 
 def tool_check_duplicate(content: str, threshold: float = 0.9):
@@ -586,7 +608,7 @@ TOOLS = {
         "handler": tool_graph_stats,
     },
     "mempalace_search": {
-        "description": "Semantic search. Returns verbatim drawer content with similarity scores.",
+        "description": "Semantic search. Returns verbatim drawer content with similarity scores. Archived wings are omitted from broad search unless include_archived is true or wing is set.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -594,10 +616,36 @@ TOOLS = {
                 "limit": {"type": "integer", "description": "Max results (default 5)"},
                 "wing": {"type": "string", "description": "Filter by wing (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "include_archived": {
+                    "type": "boolean",
+                    "description": "Include drawers in archived wings when not filtering by wing (default: false)",
+                },
             },
             "required": ["query"],
         },
         "handler": tool_search,
+    },
+    "mempalace_archive_wing": {
+        "description": "Archive a wing — drawers remain in the palace but are excluded from broad semantic search until unarchived.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "wing": {"type": "string", "description": "Wing name to archive"},
+            },
+            "required": ["wing"],
+        },
+        "handler": tool_archive_wing,
+    },
+    "mempalace_unarchive_wing": {
+        "description": "Unarchive a wing — include it in broad search again.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "wing": {"type": "string", "description": "Wing name to restore"},
+            },
+            "required": ["wing"],
+        },
+        "handler": tool_unarchive_wing,
     },
     "mempalace_check_duplicate": {
         "description": "Check if content already exists in the palace before filing",

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -20,7 +20,14 @@ class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
 
 
-def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
+def search(
+    query: str,
+    palace_path: str,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    include_archived: bool = False,
+):
     """
     Search the palace. Returns verbatim drawer content.
     Optionally filter by wing (project) or room (aspect).
@@ -41,11 +48,25 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         conditions.append({"room": room})
 
     # Exclude archived wings unless a specific wing is requested
-    if not wing:
+    if not wing and not include_archived:
         try:
             archived = MempalaceConfig().get_archived_wings()
             for aw in archived:
                 conditions.append({"wing": {"$ne": aw}})
+        except Exception:
+            pass
+
+    if not include_archived:
+        try:
+            config = MempalaceConfig()
+            if wing:
+                archived_rooms = config.get_archived_rooms(wing)
+            else:
+                archived_rooms = []
+                for w in config.load_wing_config():
+                    archived_rooms.extend(config.get_archived_rooms(w))
+            for ar in set(archived_rooms):
+                conditions.append({"room": {"$ne": ar}})
         except Exception:
             pass
 
@@ -141,6 +162,20 @@ def search_memories(
             archived = MempalaceConfig().get_archived_wings()
             for aw in archived:
                 conditions.append({"wing": {"$ne": aw}})
+        except Exception:
+            pass
+
+    if not include_archived:
+        try:
+            config = MempalaceConfig()
+            if wing:
+                archived_rooms = config.get_archived_rooms(wing)
+            else:
+                archived_rooms = []
+                for w in config.load_wing_config():
+                    archived_rooms.extend(config.get_archived_rooms(w))
+            for ar in set(archived_rooms):
+                conditions.append({"room": {"$ne": ar}})
         except Exception:
             pass
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -13,6 +13,8 @@ import chromadb
 
 logger = logging.getLogger("mempalace_mcp")
 
+from mempalace.config import MempalaceConfig
+
 
 class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
@@ -32,13 +34,27 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         raise SearchError(f"No palace found at {palace_path}")
 
     # Build where filter
-    where = {}
-    if wing and room:
-        where = {"$and": [{"wing": wing}, {"room": room}]}
-    elif wing:
-        where = {"wing": wing}
-    elif room:
-        where = {"room": room}
+    conditions = []
+    if wing:
+        conditions.append({"wing": wing})
+    if room:
+        conditions.append({"room": room})
+
+    # Exclude archived wings unless a specific wing is requested
+    if not wing:
+        try:
+            archived = MempalaceConfig().get_archived_wings()
+            for aw in archived:
+                conditions.append({"wing": {"$ne": aw}})
+        except Exception:
+            pass
+
+    if len(conditions) > 1:
+        where = {"$and": conditions}
+    elif len(conditions) == 1:
+        where = conditions[0]
+    else:
+        where = {}
 
     try:
         kwargs = {
@@ -91,7 +107,12 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: str,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    include_archived: bool = False,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
@@ -108,13 +129,27 @@ def search_memories(
         }
 
     # Build where filter
-    where = {}
-    if wing and room:
-        where = {"$and": [{"wing": wing}, {"room": room}]}
-    elif wing:
-        where = {"wing": wing}
-    elif room:
-        where = {"room": room}
+    conditions = []
+    if wing:
+        conditions.append({"wing": wing})
+    if room:
+        conditions.append({"room": room})
+
+    # Exclude archived wings unless explicitly included or a specific wing is requested
+    if not wing and not include_archived:
+        try:
+            archived = MempalaceConfig().get_archived_wings()
+            for aw in archived:
+                conditions.append({"wing": {"$ne": aw}})
+        except Exception:
+            pass
+
+    if len(conditions) > 1:
+        where = {"$and": conditions}
+    elif len(conditions) == 1:
+        where = conditions[0]
+    else:
+        where = {}
 
     try:
         kwargs = {

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,102 @@
+"""Tests for soft-archive wing feature (#332)."""
+
+import json
+import tempfile
+import shutil
+from pathlib import Path
+
+import pytest
+
+from mempalace.config import MempalaceConfig
+
+
+@pytest.fixture
+def temp_config(tmp_path):
+    """Create a temporary MempalaceConfig."""
+    config = MempalaceConfig(config_dir=str(tmp_path))
+    config.init()
+    return config
+
+
+class TestArchiveWing:
+    """Test archive/unarchive wing methods on config."""
+
+    def test_archive_wing_creates_flag(self, temp_config):
+        temp_config.save_wing_config({"my_project": {"type": "project"}})
+        changed = temp_config.archive_wing("my_project")
+        assert changed is True
+        wc = temp_config.load_wing_config()
+        assert wc["my_project"]["archived"] is True
+
+    def test_archive_wing_new_wing(self, temp_config):
+        changed = temp_config.archive_wing("unknown_wing")
+        assert changed is True
+        wc = temp_config.load_wing_config()
+        assert wc["unknown_wing"]["archived"] is True
+
+    def test_archive_wing_already_archived(self, temp_config):
+        temp_config.archive_wing("my_project")
+        changed = temp_config.archive_wing("my_project")
+        assert changed is False
+
+    def test_unarchive_wing(self, temp_config):
+        temp_config.archive_wing("my_project")
+        changed = temp_config.unarchive_wing("my_project")
+        assert changed is True
+        wc = temp_config.load_wing_config()
+        assert wc["my_project"]["archived"] is False
+
+    def test_unarchive_wing_not_archived(self, temp_config):
+        changed = temp_config.unarchive_wing("my_project")
+        assert changed is False
+
+    def test_get_archived_wings(self, temp_config):
+        temp_config.archive_wing("old_project")
+        temp_config.archive_wing("dead_project")
+        temp_config.save_wing_config({
+            "old_project": {"archived": True},
+            "dead_project": {"archived": True},
+            "active_project": {"archived": False},
+            "new_project": {},
+        })
+        archived = temp_config.get_archived_wings()
+        assert archived == {"old_project", "dead_project"}
+
+    def test_archive_preserves_existing_config(self, temp_config):
+        temp_config.save_wing_config({
+            "my_project": {"type": "project", "path": "/some/path"}
+        })
+        temp_config.archive_wing("my_project")
+        wc = temp_config.load_wing_config()
+        assert wc["my_project"]["type"] == "project"
+        assert wc["my_project"]["path"] == "/some/path"
+        assert wc["my_project"]["archived"] is True
+
+    def test_unarchive_preserves_existing_config(self, temp_config):
+        temp_config.save_wing_config({
+            "my_project": {"type": "project", "archived": True}
+        })
+        temp_config.unarchive_wing("my_project")
+        wc = temp_config.load_wing_config()
+        assert wc["my_project"]["type"] == "project"
+        assert wc["my_project"]["archived"] is False
+
+
+class TestWingConfigIO:
+    """Test wing_config.json load/save."""
+
+    def test_load_empty(self, temp_config):
+        wc = temp_config.load_wing_config()
+        assert wc == {}
+
+    def test_save_and_load(self, temp_config):
+        data = {"wing_a": {"archived": True}, "wing_b": {}}
+        temp_config.save_wing_config(data)
+        loaded = temp_config.load_wing_config()
+        assert loaded == data
+
+    def test_load_corrupt_json(self, temp_config):
+        with open(temp_config.wing_config_path, "w") as f:
+            f.write("{broken json")
+        wc = temp_config.load_wing_config()
+        assert wc == {}

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -18,6 +18,12 @@ def temp_config(tmp_path):
     return config
 
 
+@pytest.fixture
+def config(temp_config):
+    """Alias for room-archive tests (same setup as temp_config)."""
+    return temp_config
+
+
 class TestArchiveWing:
     """Test archive/unarchive wing methods on config."""
 
@@ -100,3 +106,61 @@ class TestWingConfigIO:
             f.write("{broken json")
         wc = temp_config.load_wing_config()
         assert wc == {}
+
+
+class TestRoomArchive:
+    """Tests for room-level archiving."""
+
+    def test_archive_room(self, config):
+        """Room can be archived within a wing."""
+        config.archive_room("technical", "old_evidence")
+        assert "old_evidence" in config.get_archived_rooms("technical")
+
+    def test_unarchive_room(self, config):
+        """Archived room can be restored."""
+        config.archive_room("technical", "old_evidence")
+        config.unarchive_room("technical", "old_evidence")
+        assert "old_evidence" not in config.get_archived_rooms("technical")
+
+    def test_archive_room_idempotent(self, config):
+        """Archiving same room twice does not duplicate."""
+        config.archive_room("technical", "old_evidence")
+        config.archive_room("technical", "old_evidence")
+        assert config.get_archived_rooms("technical").count("old_evidence") == 1
+
+    def test_archive_room_preserves_wing_state(self, config):
+        """Archiving a room does not archive the wing itself."""
+        config.archive_room("technical", "old_evidence")
+        assert "technical" not in config.get_archived_wings()
+
+    def test_unarchive_room_nonexistent(self, config):
+        """Unarchiving a room that was never archived does not error."""
+        config.unarchive_room("technical", "nonexistent_room")
+        assert config.get_archived_rooms("technical") == []
+
+    def test_get_archived_rooms_empty_wing(self, config):
+        """Wing with no archived rooms returns empty list."""
+        assert config.get_archived_rooms("technical") == []
+
+    def test_archive_rooms_multiple_wings(self, config):
+        """Rooms can be archived independently across different wings."""
+        config.archive_room("technical", "old_api_docs")
+        config.archive_room("emotions", "past_events")
+        assert "old_api_docs" in config.get_archived_rooms("technical")
+        assert "past_events" in config.get_archived_rooms("emotions")
+        assert "old_api_docs" not in config.get_archived_rooms("emotions")
+
+    def test_wing_config_schema(self, config):
+        """wing_config.json stores archived_rooms as a list under the wing key."""
+        config.archive_room("technical", "room_a")
+        config.archive_room("technical", "room_b")
+        wc = config.load_wing_config()
+        assert isinstance(wc["technical"]["archived_rooms"], list)
+        assert set(wc["technical"]["archived_rooms"]) == {"room_a", "room_b"}
+
+    def test_cleanup_empty_archived_rooms(self, config):
+        """After unarchiving the last room, archived_rooms key is removed."""
+        config.archive_room("technical", "only_room")
+        config.unarchive_room("technical", "only_room")
+        wc = config.load_wing_config()
+        assert "archived_rooms" not in wc.get("technical", {})


### PR DESCRIPTION
Closes #332

## Summary

Add the ability to archive/unarchive wings so they are excluded from search results without deleting any data.

## Problem

When a project ends or becomes inactive, its memories still appear in search results. The only current option is `delete-wing` (#310), which permanently destroys data. Users need a non-destructive way to hide stale wings from active search.

## Solution

### Config layer (`config.py`)
- `archive_wing(name)` / `unarchive_wing(name)`: toggle `"archived": true` flag in `wing_config.json`
- `get_archived_wings()`: return set of archived wing names
- `load_wing_config()` / `save_wing_config()`: public accessors for `wing_config.json`

### Search layer (`searcher.py`)
- Both `search()` and `search_memories()` now exclude archived wings by default using `{"wing": {"$ne": ...}}` in the ChromaDB `where` filter
- When a specific `--wing` is requested, archive filtering is skipped (explicit intent)
- `search_memories()` accepts `include_archived=True` to override exclusion

### MCP layer (`mcp_server.py`)
- `mempalace_archive_wing` / `mempalace_unarchive_wing`: new tools
- `mempalace_search`: new `include_archived` parameter
- `mempalace_status`: shows archived wings separately

### Data safety
- Zero data deletion — one metadata flag in `wing_config.json`
- Fully reversible with `unarchive`
- Archived wings remain accessible via `include_archived=True`

## Testing

- 11 new tests in `tests/test_archive.py` covering:
  - Archive/unarchive state transitions
  - Idempotency (double archive, unarchive non-archived)
  - Preservation of existing wing config fields
  - wing_config.json I/O including corrupt file handling
- All existing tests pass (99 passed, 2 pre-existing Windows-only failures unrelated to this change)

Related: #331 (time-decay scoring — the other half of time-aware memory management)
