### PR TITLE
feat: time-decay scoring for search results — prioritize recent memories (#331)

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -123,6 +123,11 @@ class MempalaceConfig:
         """Mapping of hall names to keyword lists."""
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
+    @property
+    def time_decay_half_life_days(self):
+        """Half-life in days for time-decay scoring. 0 = disabled."""
+        return self._file_config.get("time_decay_half_life_days", 90)
+
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""
         self._config_dir.mkdir(parents=True, exist_ok=True)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -170,13 +170,14 @@ def tool_get_taxonomy():
     return {"taxonomy": taxonomy}
 
 
-def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None, time_decay: bool = True):
     return search_memories(
         query,
         palace_path=_config.palace_path,
         wing=wing,
         room=room,
         n_results=limit,
+        time_decay=time_decay,
     )
 
 
@@ -594,6 +595,7 @@ TOOLS = {
                 "limit": {"type": "integer", "description": "Max results (default 5)"},
                 "wing": {"type": "string", "description": "Filter by wing (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "time_decay": {"type": "boolean", "description": "Apply time-decay to rank recent memories higher (default true)"},
             },
             "required": ["query"],
         },

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -193,16 +193,18 @@ def search_memories(
         )
 
     # Apply time-decay scoring
+    half_life_days = None
     if time_decay:
         try:
-            half_life = MempalaceConfig().time_decay_half_life_days
+            half_life_days = MempalaceConfig().time_decay_half_life_days
         except Exception:
-            half_life = 90
-        hits = _apply_time_decay(hits, half_life)
+            half_life_days = 90
+        hits = _apply_time_decay(hits, half_life_days)
 
     return {
         "query": query,
         "filters": {"wing": wing, "room": room},
         "time_decay": time_decay,
+        "half_life_days": half_life_days if time_decay else None,
         "results": hits,
     }

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -7,11 +7,52 @@ Returns verbatim text — the actual words, never summaries.
 """
 
 import logging
+from datetime import datetime, timezone
+import math
 from pathlib import Path
 
 import chromadb
 
 logger = logging.getLogger("mempalace_mcp")
+
+from mempalace.config import MempalaceConfig
+
+
+def _apply_time_decay(hits, half_life_days):
+    """Re-rank hits by applying exponential time-decay to similarity scores.
+
+    Args:
+        hits: list of dicts with 'similarity' and 'filed_at' keys.
+        half_life_days: half-life in days. If 0 or negative, no decay applied.
+
+    Returns:
+        Sorted list of hits with 'decay', 'original_similarity', and updated 'similarity'.
+    """
+    if not half_life_days or half_life_days <= 0:
+        return hits
+
+    now = datetime.now(timezone.utc)
+
+    for hit in hits:
+        filed_at_str = hit.get("filed_at", "")
+        if filed_at_str:
+            try:
+                filed_at = datetime.fromisoformat(filed_at_str)
+                if filed_at.tzinfo is None:
+                    filed_at = filed_at.replace(tzinfo=timezone.utc)
+                age_days = max((now - filed_at).total_seconds() / 86400, 0)
+            except (ValueError, TypeError):
+                age_days = 0
+        else:
+            age_days = 0
+
+        decay = math.pow(0.5, age_days / half_life_days)
+        hit["original_similarity"] = hit["similarity"]
+        hit["decay"] = round(decay, 4)
+        hit["similarity"] = round(hit["similarity"] * decay, 4)
+
+    hits.sort(key=lambda h: h["similarity"], reverse=True)
+    return hits
 
 
 class SearchError(Exception):
@@ -91,7 +132,12 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: str,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    time_decay: bool = True,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
@@ -142,11 +188,21 @@ def search_memories(
                 "room": meta.get("room", "unknown"),
                 "source_file": Path(meta.get("source_file", "?")).name,
                 "similarity": round(1 - dist, 3),
+                "filed_at": meta.get("filed_at", ""),
             }
         )
+
+    # Apply time-decay scoring
+    if time_decay:
+        try:
+            half_life = MempalaceConfig().time_decay_half_life_days
+        except Exception:
+            half_life = 90
+        hits = _apply_time_decay(hits, half_life)
 
     return {
         "query": query,
         "filters": {"wing": wing, "room": room},
+        "time_decay": time_decay,
         "results": hits,
     }

--- a/tests/test_time_decay.py
+++ b/tests/test_time_decay.py
@@ -1,0 +1,111 @@
+"""Tests for time-decay scoring feature (#331)."""
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from mempalace.searcher import _apply_time_decay
+
+
+class TestApplyTimeDecay:
+    """Test the _apply_time_decay helper function."""
+
+    def _make_hit(self, similarity, days_ago):
+        """Create a hit dict with filed_at set to days_ago days in the past."""
+        filed_at = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        return {
+            "text": f"content from {days_ago} days ago",
+            "wing": "test",
+            "room": "test",
+            "source_file": "test.md",
+            "similarity": similarity,
+            "filed_at": filed_at.isoformat(),
+        }
+
+    def test_recent_beats_old_when_similarity_close(self):
+        """A recent hit with slightly lower similarity should outrank an older hit."""
+        hits = [
+            self._make_hit(0.85, days_ago=180),  # old, higher similarity
+            self._make_hit(0.82, days_ago=1),     # recent, lower similarity
+        ]
+        result = _apply_time_decay(hits, half_life_days=90)
+        assert result[0]["text"] == "content from 1 days ago"
+
+    def test_half_life_halves_score_at_exact_half_life(self):
+        """At exactly half_life_days, decay should be ~0.5."""
+        hits = [self._make_hit(1.0, days_ago=90)]
+        result = _apply_time_decay(hits, half_life_days=90)
+        assert abs(result[0]["decay"] - 0.5) < 0.01
+
+    def test_zero_age_no_decay(self):
+        """A hit from today should have decay ~1.0."""
+        hits = [self._make_hit(0.9, days_ago=0)]
+        result = _apply_time_decay(hits, half_life_days=90)
+        assert result[0]["decay"] >= 0.99
+
+    def test_disabled_when_half_life_zero(self):
+        """half_life_days=0 should skip decay entirely."""
+        hits = [
+            self._make_hit(0.85, days_ago=180),
+            self._make_hit(0.82, days_ago=1),
+        ]
+        result = _apply_time_decay(hits, half_life_days=0)
+        # Original order preserved, no decay field added
+        assert result[0]["similarity"] == 0.85
+        assert "decay" not in result[0]
+
+    def test_disabled_when_half_life_negative(self):
+        """Negative half_life_days should skip decay."""
+        hits = [self._make_hit(0.9, days_ago=30)]
+        result = _apply_time_decay(hits, half_life_days=-1)
+        assert result[0]["similarity"] == 0.9
+        assert "decay" not in result[0]
+
+    def test_preserves_original_similarity(self):
+        """Original similarity should be saved in original_similarity field."""
+        hits = [self._make_hit(0.9, days_ago=90)]
+        result = _apply_time_decay(hits, half_life_days=90)
+        assert result[0]["original_similarity"] == 0.9
+        assert result[0]["similarity"] < 0.9
+
+    def test_missing_filed_at_gets_zero_decay(self):
+        """Hits without filed_at should get age=0 (no penalty)."""
+        hits = [{
+            "text": "no timestamp",
+            "wing": "test",
+            "room": "test",
+            "source_file": "test.md",
+            "similarity": 0.8,
+            "filed_at": "",
+        }]
+        result = _apply_time_decay(hits, half_life_days=90)
+        assert result[0]["decay"] >= 0.99
+
+    def test_invalid_filed_at_gets_zero_decay(self):
+        """Hits with invalid filed_at should get age=0 (no penalty)."""
+        hits = [{
+            "text": "bad timestamp",
+            "wing": "test",
+            "room": "test",
+            "source_file": "test.md",
+            "similarity": 0.8,
+            "filed_at": "not-a-date",
+        }]
+        result = _apply_time_decay(hits, half_life_days=90)
+        assert result[0]["decay"] >= 0.99
+
+    def test_sort_order_after_decay(self):
+        """Results should be sorted by decayed similarity, descending."""
+        hits = [
+            self._make_hit(0.95, days_ago=365),  # very old
+            self._make_hit(0.70, days_ago=1),     # recent but low similarity
+            self._make_hit(0.85, days_ago=30),    # middle
+        ]
+        result = _apply_time_decay(hits, half_life_days=90)
+        scores = [h["similarity"] for h in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_empty_hits(self):
+        """Empty list should return empty list."""
+        result = _apply_time_decay([], half_life_days=90)
+        assert result == []

--- a/tests/test_time_decay.py
+++ b/tests/test_time_decay.py
@@ -1,10 +1,11 @@
 """Tests for time-decay scoring feature (#331)."""
 
 from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock
 
 import pytest
 
-from mempalace.searcher import _apply_time_decay
+from mempalace.searcher import _apply_time_decay, search_memories
 
 
 class TestApplyTimeDecay:
@@ -109,3 +110,57 @@ class TestApplyTimeDecay:
         """Empty list should return empty list."""
         result = _apply_time_decay([], half_life_days=90)
         assert result == []
+
+
+class TestSearchMemoriesResponse:
+    """search_memories() response metadata for time decay."""
+
+    def test_response_includes_half_life_days_when_decay_enabled(self, monkeypatch):
+        """When time_decay is True, response includes half_life_days as the configured value."""
+        mock_col = MagicMock()
+        mock_col.query.return_value = {
+            "documents": [["hello"]],
+            "metadatas": [
+                [
+                    {
+                        "wing": "w",
+                        "room": "r",
+                        "source_file": "test.md",
+                        "filed_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                ]
+            ],
+            "distances": [[0.1]],
+        }
+        mock_client = MagicMock()
+        mock_client.get_collection.return_value = mock_col
+        monkeypatch.setattr(
+            "mempalace.searcher.chromadb.PersistentClient", lambda path: mock_client
+        )
+
+        cfg = MagicMock()
+        cfg.time_decay_half_life_days = 90
+        monkeypatch.setattr("mempalace.searcher.MempalaceConfig", lambda: cfg)
+
+        result = search_memories("q", "/fake/path", time_decay=True)
+        assert "half_life_days" in result
+        assert result["time_decay"] is True
+        assert result["half_life_days"] == 90
+
+    def test_half_life_days_none_when_decay_disabled(self, monkeypatch):
+        """When time_decay is False, half_life_days is None."""
+        mock_col = MagicMock()
+        mock_col.query.return_value = {
+            "documents": [["hello"]],
+            "metadatas": [[{"wing": "w", "room": "r", "source_file": "test.md"}]],
+            "distances": [[0.1]],
+        }
+        mock_client = MagicMock()
+        mock_client.get_collection.return_value = mock_col
+        monkeypatch.setattr(
+            "mempalace.searcher.chromadb.PersistentClient", lambda path: mock_client
+        )
+
+        result = search_memories("q", "/fake/path", time_decay=False)
+        assert result["time_decay"] is False
+        assert result["half_life_days"] is None


### PR DESCRIPTION
Closes #331

## Summary

Add time-decay scoring so recent memories rank higher than older ones in search results.

## Problem

`mempalace_search` ranks results purely by ChromaDB vector similarity. A tech-stack decision from six months ago and a discussion from yesterday are treated with equal weight. AI agents retrieving outdated decisions as top results can act on stale context without realizing it.

## Solution

### Decay formula

decay = 0.5 ^ (age_days / half_life_days) final_score = similarity * decay


With the default 90-day half-life: yesterday's memory keeps ~99% of its score, 90-day-old memory drops to 50%, 180-day-old drops to 25%.

### Config layer (`config.py`)
- `time_decay_half_life_days` property (default: 90, set to 0 to disable)

### Search layer (`searcher.py`)
- `_apply_time_decay()`: standalone function that re-ranks hits by applying exponential decay to similarity scores using the `filed_at` metadata timestamp
- `search_memories()` accepts `time_decay=True` (default) to enable/disable
- Results include `decay`, `original_similarity`, and adjusted `similarity` fields
- Missing or invalid `filed_at` timestamps receive zero penalty (decay=1.0)

### MCP layer (`mcp_server.py`)
- `mempalace_search`: new `time_decay` boolean parameter (default true)
- Agents can pass `time_decay=false` for historical research queries

### Non-breaking
- Default behavior changes ranking order but returns the same data
- `time_decay=false` restores exact previous behavior
- No schema migration needed — uses existing `filed_at` metadata

## Testing

- 10 new tests in `tests/test_time_decay.py` covering:
  - Recent vs old ranking reversal
  - Half-life precision (decay ≈ 0.5 at exactly half_life_days)
  - Zero/negative half-life disables decay
  - Missing and invalid `filed_at` handling
  - `original_similarity` preservation
  - Sort order correctness
  - Empty results
- All existing tests pass (99 passed, 2 pre-existing Windows-only failures unrelated to this change)

Related: #332 (soft-archive wings — the other half of time-aware memory management)
