### PR TITLE
fix: filter programming keywords from entity detection (#348)

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -395,6 +395,56 @@ STOPWORDS = {
     "inference",
 }
 
+# Programming language keywords, types, traits, and framework names
+# that should never be detected as entity candidates.
+CODE_KEYWORDS = {
+    # Rust types, traits, and derive macros
+    "string", "vec", "debug", "clone", "copy", "send", "sync",
+    "serialize", "deserialize", "display", "default", "hash",
+    "option", "result", "box", "arc", "mutex", "cell", "ref",
+    "impl", "trait", "struct", "enum", "match", "async", "await",
+    "tokio", "serde", "anyhow", "thiserror",
+    # Rust/C++ common
+    "iterator", "into", "from",
+    # JavaScript / TypeScript / React
+    "react", "vue", "angular", "svelte", "next", "nuxt",
+    "node", "deno", "bun", "express", "fetch", "promise",
+    "component", "props", "state", "hook", "context", "reducer",
+    "dispatch", "effect", "callback", "memo", "fragment",
+    "typescript", "javascript", "jquery",
+    # Python
+    "django", "flask", "fastapi", "pytest", "numpy", "pandas",
+    "pydantic", "dataclass", "decorator", "generator", "yield",
+    # Go
+    "goroutine", "channel", "defer", "panic", "recover",
+    # General programming
+    "tree", "graph", "queue", "stack", "array", "map", "set",
+    "index", "buffer", "stream", "socket", "thread", "process",
+    "handler", "middleware", "router", "controller", "service",
+    "schema", "query", "mutation", "resolver",
+    "config", "logger", "parser", "builder", "factory",
+    "event", "listener", "observer", "adapter", "wrapper",
+    "payload", "request", "response", "header", "body",
+    "token", "session", "cookie", "cache", "proxy",
+    # Language / runtime names (capitalized in prose)
+    "rust", "python", "golang", "kotlin", "swift", "scala",
+    "ruby", "java", "perl", "lua", "dart", "elixir",
+    # Build tools / package managers
+    "cargo", "npm", "yarn", "pnpm", "pip", "conda", "maven", "gradle",
+    # Frameworks / libraries commonly capitalized
+    "tauri", "electron", "vite", "webpack", "babel", "eslint",
+    "docker", "kubernetes", "redis", "postgres", "mongo", "sqlite",
+    # CSS / UI
+    "tailwind", "bootstrap", "material",
+    # Version control
+    "git", "github", "gitlab", "bitbucket",
+    # Common capitalized code patterns
+    "todo", "fixme", "hack", "note", "bug", "feature",
+    "phase", "flow", "step", "stage", "task", "action",
+    "view", "page", "layout", "modal", "dialog", "panel",
+    "table", "column", "row", "field", "form", "button",
+}
+
 # For entity detection — prose only, no code files
 # Code files have too many capitalized names (classes, functions) that aren't entities
 PROSE_EXTENSIONS = {
@@ -450,7 +500,7 @@ def extract_candidates(text: str) -> dict:
 
     counts = defaultdict(int)
     for word in raw:
-        if word.lower() not in STOPWORDS and len(word) > 1:
+        if word.lower() not in STOPWORDS and word.lower() not in CODE_KEYWORDS and len(word) > 1:
             counts[word] += 1
 
     # Also find multi-word proper nouns (e.g. "Memory Palace", "Claude Code")

--- a/tests/test_code_keywords.py
+++ b/tests/test_code_keywords.py
@@ -1,0 +1,102 @@
+"""Tests for entity detector CODE_KEYWORDS filtering (#348)."""
+
+from mempalace.entity_detector import extract_candidates, detect_entities, CODE_KEYWORDS, STOPWORDS
+
+
+class TestCodeKeywordsFiltering:
+    """Verify that programming keywords are excluded from entity candidates."""
+
+    def test_rust_types_excluded(self):
+        """Rust types like String, Vec, Debug should not be candidates."""
+        text = "String " * 10 + "Vec " * 10 + "Debug " * 10 + "Clone " * 10
+        candidates = extract_candidates(text)
+        for keyword in ["String", "Vec", "Debug", "Clone"]:
+            assert keyword not in candidates, f"{keyword} should be filtered by CODE_KEYWORDS"
+
+    def test_rust_derive_macros_excluded(self):
+        """Serialize, Deserialize should not be candidates."""
+        text = "Serialize " * 10 + "Deserialize " * 10
+        candidates = extract_candidates(text)
+        assert "Serialize" not in candidates
+        assert "Deserialize" not in candidates
+
+    def test_framework_names_excluded(self):
+        """React, Tauri, Node, Vue should not be candidates."""
+        text = "React " * 10 + "Tauri " * 10 + "Node " * 10 + "Vue " * 10
+        candidates = extract_candidates(text)
+        for name in ["React", "Tauri", "Node", "Vue"]:
+            assert name not in candidates, f"{name} should be filtered"
+
+    def test_language_names_excluded(self):
+        """Rust, Python, Kotlin etc should not be candidates."""
+        text = "Rust " * 10 + "Python " * 10 + "Kotlin " * 10
+        candidates = extract_candidates(text)
+        for name in ["Rust", "Python", "Kotlin"]:
+            assert name not in candidates, f"{name} should be filtered"
+
+    def test_common_code_patterns_excluded(self):
+        """Phase, Flow, Tree, Graph should not be candidates."""
+        text = "Phase " * 10 + "Flow " * 10 + "Tree " * 10 + "Graph " * 10
+        candidates = extract_candidates(text)
+        for name in ["Phase", "Flow", "Tree", "Graph"]:
+            assert name not in candidates, f"{name} should be filtered"
+
+    def test_real_project_names_not_excluded(self):
+        """Actual project names like CodeMAP, MalCheck should still be detected."""
+        # These are not in CODE_KEYWORDS or STOPWORDS
+        assert "codemap" not in CODE_KEYWORDS
+        assert "malcheck" not in CODE_KEYWORDS
+        assert "codemap" not in STOPWORDS
+        assert "malcheck" not in STOPWORDS
+
+    def test_real_person_names_not_excluded(self):
+        """Real person names should still be candidates."""
+        text = "Alice " * 10 + "Bob " * 10 + "Charlie " * 10
+        candidates = extract_candidates(text)
+        assert "Alice" in candidates
+        assert "Bob" in candidates
+        assert "Charlie" in candidates
+
+    def test_code_keywords_are_lowercase(self):
+        """All CODE_KEYWORDS entries should be lowercase for consistent matching."""
+        for keyword in CODE_KEYWORDS:
+            assert keyword == keyword.lower(), f"CODE_KEYWORDS entry '{keyword}' should be lowercase"
+
+    def test_no_overlap_with_stopwords(self):
+        """CODE_KEYWORDS should not duplicate STOPWORDS entries (keep sets clean)."""
+        overlap = CODE_KEYWORDS & STOPWORDS
+        # Some overlap is acceptable but flag it for awareness
+        # This test documents the current state rather than enforcing zero overlap
+        assert isinstance(overlap, set)  # just verify it runs
+
+    def test_detect_entities_with_code_heavy_content(self, tmp_path):
+        """Full pipeline: code-heavy files should not produce false project detections."""
+        # Create a fake Rust-like file
+        rust_content = """
+        use std::collections::HashMap;
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        struct Config {
+            name: String,
+            values: Vec<String>,
+        }
+        impl Default for Config {
+            fn default() -> Self { Config { name: String::new(), values: Vec::new() } }
+        }
+        """ * 5
+
+        test_file = tmp_path / "main.rs"
+        test_file.write_text(rust_content)
+
+        # Also create a prose file mentioning a real project
+        prose_file = tmp_path / "README.md"
+        prose_file.write_text("MyProject is a tool for data analysis. " * 10)
+
+        result = detect_entities([prose_file, test_file], max_files=10)
+
+        # Rust keywords should NOT appear as projects
+        project_names = [e["name"] for e in result["projects"]]
+        uncertain_names = [e["name"] for e in result["uncertain"]]
+        all_detected = project_names + uncertain_names
+
+        for keyword in ["String", "Vec", "Debug", "Clone", "Serialize", "Deserialize"]:
+            assert keyword not in all_detected, f"{keyword} should not be detected"


### PR DESCRIPTION
Closes #348

## Summary

Add a `CODE_KEYWORDS` blocklist to `entity_detector.py` so programming types, traits, frameworks, and language names are no longer misdetected as projects or uncertain entities during `mempalace init`.

## Problem

When `mempalace init` scans a directory containing code files (Rust, TypeScript, React, etc.), common programming keywords are detected as entities:

- **False projects:** React, Tauri, Rust, Node, Tree
- **False uncertain:** String (31×), Vec (19×), Debug (13×), Deserialize (12×), Serialize (12×), Clone (12×)

Users must manually remove every false entry. If they press Enter to accept all, Wing classification is polluted from the start.

## Solution

Add a `CODE_KEYWORDS` set (~120 terms) covering:
- Rust types/traits/derive macros (String, Vec, Debug, Clone, Serialize, Deserialize, ...)
- JS/TS/React keywords (React, Vue, Angular, Node, Component, Props, ...)
- Python framework names (Django, Flask, FastAPI, Pytest, ...)
- Go keywords (Goroutine, Channel, Defer, ...)
- General programming patterns (Tree, Graph, Queue, Handler, Middleware, ...)
- Language/runtime names (Rust, Python, Kotlin, Swift, ...)
- Build tools and frameworks (Cargo, Tauri, Electron, Docker, ...)

The check is applied in `extract_candidates()` alongside the existing `STOPWORDS` filter — one additional `not in` check per candidate word.

## What is NOT filtered

- Actual project names (CodeMAP, MalCheck, etc.)
- Actual person names (Alice, Bob, etc.)
- Any term not in the blocklist

## Testing

- 10 new tests in `tests/test_code_keywords.py` covering:
  - Rust types, derive macros, framework names, language names, common code patterns excluded
  - Real project and person names NOT excluded
  - All CODE_KEYWORDS entries are lowercase (consistency check)
  - Full pipeline test with code-heavy + prose files
- All existing tests pass (101 passed, 2 pre-existing Windows-only failures)
