### PR TITLE
fix: harmonize query_entity direction default with MCP wrapper

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -185,7 +185,7 @@ class KnowledgeGraph:
 
     # ── Query operations ──────────────────────────────────────────────────
 
-    def query_entity(self, name: str, as_of: str = None, direction: str = "outgoing"):
+    def query_entity(self, name: str, as_of: str = None, direction: str = "both"):
         """
         Get all relationships for an entity.
 

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -63,6 +63,13 @@ class TestQueries:
         assert "outgoing" in directions
         assert "incoming" in directions
 
+    def test_query_default_direction_returns_both(self, seeded_kg):
+        """Default direction should be 'both', matching the MCP wrapper."""
+        results = seeded_kg.query_entity("Max")
+        directions = {r["direction"] for r in results}
+        assert "outgoing" in directions, "Default should include outgoing results"
+        assert "incoming" in directions, "Default should include incoming results"
+
     def test_query_as_of_filters_expired(self, seeded_kg):
         results = seeded_kg.query_entity("Alice", as_of="2023-06-01", direction="outgoing")
         employers = [r["object"] for r in results if r["predicate"] == "works_at"]


### PR DESCRIPTION
## Summary

`KnowledgeGraph.query_entity()` defaults `direction="outgoing"`, but the MCP wrapper `tool_kg_query()` defaults `direction="both"`. This means MCP users and library users get different behavior when no direction is specified.

This aligns the library default to `"both"` to match the MCP interface.

## Changes

- `mempalace/knowledge_graph.py` — Change `query_entity()` default from `"outgoing"` to `"both"`

One-line change. No new dependencies.

## Test plan

- [x] Ruff format and lint clean
- [x] No behavioral change for MCP users (already defaulted to "both" via the wrapper)
- [x] Library users now get the complete picture by default (both directions)