### PR TITLE
fix: expand ~ in split command directory argument

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -132,7 +132,8 @@ def cmd_split(args):
     import sys
 
     # Rebuild argv for split_mega_files argparse
-    argv = ["--source", args.dir]
+    # Expand ~ and resolve to absolute path so split_mega_files sees a real path
+    argv = ["--source", str(Path(args.dir).expanduser().resolve())]
     if args.output_dir:
         argv += ["--output-dir", args.output_dir]
     if args.dry_run:

--- a/mempalace/split_mega_files.py
+++ b/mempalace/split_mega_files.py
@@ -257,7 +257,7 @@ def main():
     )
     args = parser.parse_args()
 
-    src_dir = Path(args.source) if args.source else LUMI_DIR
+    src_dir = Path(args.source).expanduser().resolve() if args.source else LUMI_DIR
     output_dir = args.output_dir or None  # None = same dir as file
 
     if args.file:


### PR DESCRIPTION
## Problem

`mempalace split ~/some/dir` silently finds no files because `Path("~/foo")` does **not** expand the tilde — it treats `~` as a literal directory name.

## Root cause

In `split_mega_files.py`:
```python
# before
src_dir = Path(args.source) if args.source else LUMI_DIR
```

`Path` does not call `os.path.expanduser` automatically, so any `~`-prefixed path is never resolved to the real home directory.

## Fix

Two one-line changes:

**`mempalace/split_mega_files.py`** (root cause):
```python
src_dir = Path(args.source).expanduser().resolve() if args.source else LUMI_DIR
```

**`mempalace/cli.py`** (defensive fix at the CLI boundary):
```python
argv = ["--source", str(Path(args.dir).expanduser().resolve())]
```

`.resolve()` is added alongside `.expanduser()` so relative paths (e.g. `mempalace split .`) also work correctly.

## Reproduction

```bash
# Before — finds nothing, no error
mempalace split ~/Desktop/transcripts

# After — works as expected
mempalace split ~/Desktop/transcripts
```