### PR TITLE
fix(status): paginate metadata reads so palaces over 10k drawers report  correctly

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -86,6 +86,28 @@ def _no_palace():
     }
 
 
+def _iter_all_metadatas(col, where=None, page_size=10000):
+    """Yield every metadata entry in the collection, paginating past the 10k cap.
+
+    ChromaDB's `col.get()` enforces a per-call limit, so a single fetch silently
+    truncates large palaces. This walks the collection in pages so callers see
+    every drawer.
+    """
+    total = col.count()
+    offset = 0
+    while offset < total:
+        kwargs = {"include": ["metadatas"], "limit": page_size, "offset": offset}
+        if where is not None:
+            kwargs["where"] = where
+        page = col.get(**kwargs)
+        metas = page.get("metadatas") or []
+        if not metas:
+            break
+        for m in metas:
+            yield m
+        offset += len(metas)
+
+
 # ==================== READ TOOLS ====================
 
 
@@ -97,8 +119,7 @@ def tool_status():
     wings = {}
     rooms = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
+        for m in _iter_all_metadatas(col):
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
             wings[w] = wings.get(w, 0) + 1
@@ -154,8 +175,7 @@ def tool_list_wings():
         return _no_palace()
     wings = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
+        for m in _iter_all_metadatas(col):
             w = m.get("wing", "unknown")
             wings[w] = wings.get(w, 0) + 1
     except Exception:
@@ -169,11 +189,8 @@ def tool_list_rooms(wing: str = None):
         return _no_palace()
     rooms = {}
     try:
-        kwargs = {"include": ["metadatas"], "limit": 10000}
-        if wing:
-            kwargs["where"] = {"wing": wing}
-        all_meta = col.get(**kwargs)["metadatas"]
-        for m in all_meta:
+        where = {"wing": wing} if wing else None
+        for m in _iter_all_metadatas(col, where=where):
             r = m.get("room", "unknown")
             rooms[r] = rooms.get(r, 0) + 1
     except Exception:
@@ -187,8 +204,7 @@ def tool_get_taxonomy():
         return _no_palace()
     taxonomy = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
+        for m in _iter_all_metadatas(col):
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
             if w not in taxonomy:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -666,16 +666,24 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
+    # Authoritative total from ChromaDB
+    total = col.count()
 
+    # Count by wing and room — paginate through all metadatas
+    page_size = 10000
     wing_rooms = defaultdict(lambda: defaultdict(int))
-    for m in metas:
-        wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
+    offset = 0
+    while offset < total:
+        r = col.get(limit=page_size, offset=offset, include=["metadatas"])
+        metas = r.get("metadatas") or []
+        if not metas:
+            break
+        for m in metas:
+            wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
+        offset += len(metas)
 
     print(f"\n{'=' * 55}")
-    print(f"  MemPalace Status — {len(metas)} drawers")
+    print(f"  MemPalace Status — {total} drawers")
     print(f"{'=' * 55}\n")
     for wing, rooms in sorted(wing_rooms.items()):
         print(f"  WING: {wing}")


### PR DESCRIPTION
## What does this PR do?

  Fixes a silent truncation bug where palaces with more than 10,000 drawers
  report `10000` as their total drawer count instead of the real number. Found
  this on a fresh palace with 39,334 drawers — `mempalace status` and the
  `mempalace_status` MCP tool both reported 10,000.

  Both `mempalace status` (CLI) and the `mempalace_status`,
  `mempalace_list_wings`, `mempalace_list_rooms`, and `mempalace_get_taxonomy`
  MCP tools called `col.get(limit=10000, ...)` and treated `len(metadatas)` as
  the total drawer count. Palaces larger than 10k silently truncated their stats.

  Use `col.count()` for the authoritative total and walk metadatas in 10k pages
  so per-room / per-wing breakdowns stay accurate. Adds an `_iter_all_metadatas`
  helper in `mcp_server.py` shared by all four read tools, and applies the same
  fix to `miner.status()`.

  The diary read path keeps its 10k limit since per-agent diary collections are
  small and the call is filtered by wing+room.

  ## How to test

  1. Mine a palace with more than 10k drawers (e.g. mine a directory of Claude
  Code JSONL transcripts, or run multiple `mempalace mine` passes).
  2. Verify the real count via ChromaDB directly:
     ```python
     import chromadb
     c = chromadb.PersistentClient(path="~/.mempalace/palace")
     col = c.get_collection("mempalace_drawers")
     print(col.count())
  3. Run mempalace status — total should match col.count(), not be capped at
  10000.
  4. Call mempalace_status MCP tool — total_drawers and the wings / rooms
  breakdowns should reflect the full collection.

  Checklist

  - Tests pass (python -m pytest tests/ -v)
  - No hardcoded paths
  - Linter passes (ruff check .)
