### PR TITLE
chore(deps): pin chromadb to >=1.0,<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.0.14"
+version = "3.1.0"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ markers = [
 source = ["mempalace"]
 
 [tool.coverage.report]
-fail_under = 30
+fail_under = 85
 show_missing = true
 exclude_lines = [
     "if __name__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "chromadb>=1.0,<2",
-    "pyyaml>=6.0",
+    "pyyaml>=6.0,<7",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "chromadb>=0.5.0,<0.7",
+    "chromadb>=1.0,<2",
     "pyyaml>=6.0",
 ]
 


### PR DESCRIPTION
The previous constraint of chromadb>=0.5.0,<0.7 forces installs onto the 0.5/0.6 line, which uses an older on-disk format. Palaces created with chromadb 1.x (the current major) can't be opened by 0.6 — get_collection fails with KeyError: '_type' when reading collection config json.

Pin to the 1.x line so:
  - editable installs from this fork keep working with palaces built on 1.x
  - new installs land on the same major as the current chromadb release
  - we have a single supported major instead of straddling two on-disk formats

If we need to support 0.6.x palaces later we can add a migration path, but right now mixing the two breaks any palace.

## What does this PR do?

## How to test

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)
