### PR TITLE
fix(miner): count files with 0 drawers as skipped in dry-run summary

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1128,7 +1128,7 @@ def _mine_impl(
                 raise
             files_processed = i
             last_file = filepath.name
-            if drawers == 0 and not dry_run:
+            if drawers == 0:
                 files_skipped += 1
             else:
                 total_drawers += drawers

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -362,6 +362,40 @@ def test_mine_dry_run_with_tiny_file_no_crash():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_mine_dry_run_summary_counts_skipped_tiny_files(capsys):
+    """Dry-run 'Files processed' count must subtract files that returned 0 drawers.
+
+    Before the fix, ``files_skipped`` was only incremented in non-dry-run mode,
+    so the dry-run summary printed every file as processed even when some were
+    too small to file a single drawer.
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        # 1 substantive + 2 below MIN_CHUNK_SIZE
+        write_file(project_root / "good.py", "def main():\n    print('hello world')\n" * 20)
+        write_file(project_root / "tiny_a.txt", "x")
+        write_file(project_root / "tiny_b.txt", "y")
+
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "general", "description": "General"}],
+                },
+                f,
+            )
+
+        mine(str(project_root), str(project_root / "palace"), dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "Files processed: 1" in out, out
+        assert "Files skipped (already filed): 2" in out, out
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def test_status_missing_palace_does_not_create_empty_collection(tmp_path, capsys):
     palace_path = tmp_path / "missing-palace"
 


### PR DESCRIPTION
## Summary

Rebased onto `develop` (the prior base, `main`, predates the rename). Reframed since the original crash bgauryy reported in #165 review is gone — but the secondary concern from that same review is still live, and that's what this PR now fixes.

## What changed since the original review

Upstream's `process_file` now returns `(0, "general")` for tiny / unreadable files instead of `(0, None)`. So `room_counts[None]` never happens, and `f"{None:20}"` in the summary formatter never crashes. The original `TypeError` motivation is moot.

What's still broken on `develop`: the dry-run summary's "Files processed" / "Files skipped" counters.

## The remaining bug (bgauryy review item #2)

```python
# mempalace/miner.py — current develop HEAD
if drawers == 0 and not dry_run:
    files_skipped += 1
else:
    total_drawers += drawers
    room_counts[room] += 1
```

In dry-run mode, the `not dry_run` guard prevents `files_skipped` from ever incrementing. Tiny files fall to the `else` branch, where:

1. `total_drawers += 0` is a no-op.
2. `room_counts["general"] += 1` inflates the "general" room tally with files that don't actually file any drawer.

Then the summary prints:

```
Files processed: {len(files) - files_skipped}      # always reports ALL files
Files skipped (already filed): {files_skipped}     # always 0 in dry-run
By room:
    general              N files                   # N inflated by tiny files
```

For a 100-file project with 30 tiny files, dry-run says "Files processed: 100" instead of "Files processed: 70 / Files skipped: 30". Cosmetic but misleading — `mine --dry-run` is a planning tool and the numbers should match what `mine` will actually do.

## Fix

```python
if drawers == 0:
    files_skipped += 1
else:
    total_drawers += drawers
    room_counts[room] += 1
```

Drops the `not dry_run` guard. The non-dry-run path is unchanged — `files_skipped += 1` was already happening there. The dry-run path now matches.

## Test added

`test_mine_dry_run_summary_counts_skipped_tiny_files` (in `tests/test_miner.py`):

- Creates 1 substantive file + 2 below `MIN_CHUNK_SIZE`
- Calls `mine(dry_run=True)`
- Asserts `Files processed: 1` and `Files skipped (already filed): 2` appear in stdout

Verified the test fails on `develop` HEAD without the fix and passes with it.

## Files

- `mempalace/miner.py` — one-line conditional change
- `tests/test_miner.py` — one new test (~35 lines)

## Test plan

- [x] `pytest tests/test_miner.py -v` — 35 passed
- [x] `ruff check mempalace/miner.py tests/test_miner.py` — clean
- [x] New test fails on develop HEAD without the fix; passes with it

## Notes

- The original test from the v1 of this PR (`test_process_file_returns_room`) is dropped — it asserted `(0, None)` for tiny files, which is no longer the contract.
- The existing `test_mine_dry_run_with_tiny_file_no_crash` on develop verifies "no crash" but doesn't check summary numbers, so the new test is complementary, not redundant.

Closes the bgauryy review item #2 from #165.
