### PR TITLE
chore: bump version to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and guidelines.
 MIT — see [LICENSE](LICENSE).
 
 <!-- Link Definitions -->
-[version-shield]: https://img.shields.io/badge/version-3.0.0-4dc9f6?style=flat-square&labelColor=0a0e14
+[version-shield]: https://img.shields.io/badge/version-3.1.0-4dc9f6?style=flat-square&labelColor=0a0e14
 [release-link]: https://github.com/milla-jovovich/mempalace/releases
 [python-shield]: https://img.shields.io/badge/python-3.9+-7dd8f8?style=flat-square&labelColor=0a0e14&logo=python&logoColor=7dd8f8
 [python-link]: https://www.python.org/

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.0.14"
+__version__ = "3.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.0.14"
+version = "3.1.0"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Version bump from `3.0.14` → `3.1.0`. First PyPI cut since `v3.0.0` (2026-04-06) — covers 39 merged PRs. Closes the pip/plugin version drift that was causing #290 and #296.

## Files touched

- `pyproject.toml` — version string
- `mempalace/version.py` — `__version__`
- `README.md` — version shield badge

## Release notes (for GH release at `v3.1.0` tag)

---

# MemPalace v3.1.0

First PyPI cut since v3.0.0 on 2026-04-06 — **39 merged PRs**. This release closes the pip/plugin version drift (#290, #296) and lands the first-week community fixes.

## 🔒 Security
- **#387** Input validation at MCP entry points, shell-injection fix in save hook, file size guard + symlink skip, SQLite connection leak fix, WAL audit trail, hardened file perms
- **#141** Sanitize `SESSION_ID` in save hook
- **#139** Sanitize MCP error responses, remove `sys.exit` from library code

## 🐛 Bug fixes (highlights)
- **#399** MCP null args hang, `cmd_repair` infinite recursion, 500 MB OOM guard
- **#270** **Claude + Codex plugin packaging** — one-step install (closes #187)
- **#137** 10K safety cap on unbounded ChromaDB metadata fetches (closes #180)
- **#129** Windows Unicode crash fix (closes #47)
- **#123** `--yes` flag bypasses all init prompts (closes #179)
- **#78** Respect nested `.gitignore` rules during mining (closes #233)
- **#236** Silence ChromaDB telemetry + Apple Silicon CoreML segfault (closes #163)
- **#324** Negotiate MCP protocol version instead of hardcoding
- **#145** Room detection checks keywords against folder paths
- **#136** SQLite WAL mode + consistent LIMIT in KG timeline
- **#66** Batch ChromaDB reads to avoid SQLite variable limit
- **#140** Upsert + deterministic IDs prevent data stagnation
- Plus more — see full commit log

## ✨ Features
- **#61** OpenAI Codex CLI JSONL normalizer (first in the #59 import format umbrella)
- **#223** Scale benchmark suite (106 tests)
- **#135** Cache ChromaDB `PersistentClient` — big perf win

## 📊 Benchmarks (the honest version)
- **#147** Honest AAAK stats (word-based token estimator, lossy labels)
- Retired the `recall_any@5` headline — see the `aa10f8f` README correction and the ongoing methodology threads in #27, #29, #39, #214, #168

## 📦 Packaging
- **#142** Tightened chromadb range (`>=0.5.0,<0.7`) + `py.typed` marker
- **#281** Test coverage 30% → 85% + Windows encoding fixes
- **#131** Migrated tests to `uv`, 20 → 92 tests
- **#16** Unified package and MCP version reporting

## 🙏 Thanks

Massive thanks to everyone who ran audits, caught real bugs, and sent clean PRs in the first week — especially @lhl, @dial481, @gizmax, @rohithzr, @hugooconnor, @anthonyonazure, @fubak, @fuzzymoomoo, @vanachterjacob, @SethRosenthal100, @cktang88, @adv3nt3, @slapglif, @skuznetsov, @rusel95, @M0nkeyFl0wer, @EndeavorYen, @bobmatnyc, @kpulik, @kevgathuku, @mvalentsev, @mvanhorn, @jonashertner.

Closes #290 and #296.

## 📥 Install

```bash
pip install --upgrade mempalace
```

✨

---

## Test plan

- [ ] CI passes on Linux 3.9/3.11/3.13, Windows, macOS
- [ ] `mempalace --version` reports `3.1.0`
- [ ] `python -c "import mempalace; print(mempalace.__version__)"` reports `3.1.0`
- [ ] README version badge shows `3.1.0`
- [ ] After merge: tag `v3.1.0`, build wheel + sdist, `twine upload dist/*`
- [ ] Create GH release at the tag using the release notes above
