### PR TITLE
feat: parallel file processing and batched upserts in mine()

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .normalize import normalize
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import SKIP_DIRS, get_collection
 
 
 # File types that might contain conversations
@@ -369,7 +369,9 @@ def mine_convos(
     # ------------------------------------------------------------------
     else:
         print(f"  Checking {len(files)} files for changes...")
-        pending = [fp for fp in files if not file_already_mined(collection, str(fp))]
+        from .miner import build_mined_cache
+        mined_cache = build_mined_cache(collection)
+        pending = [fp for fp in files if str(fp) not in mined_cache]
         already_mined = len(files) - len(pending)
 
         batch_ids, batch_docs, batch_metas = [], [], []

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -14,6 +14,7 @@ import hashlib
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .normalize import normalize
 from .palace import SKIP_DIRS, get_collection, file_already_mined
@@ -28,6 +29,8 @@ CONVO_EXTENSIONS = {
 }
 
 MIN_CHUNK_SIZE = 30
+BATCH_SIZE = 128  # chunks per upsert call (matches miner.py)
+MAX_WORKERS = min(32, (os.cpu_count() or 4) * 2)
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
 
 
@@ -229,6 +232,76 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
+def process_convo_file_cpu(
+    filepath: Path,
+    wing: str,
+    agent: str,
+    extract_mode: str,
+) -> "tuple | None":
+    """
+    Pure CPU worker: normalize, chunk, detect room, build drawer records.
+    Thread-safe — no ChromaDB calls, no shared state.
+
+    Returns (source_file, room, records, room_counts_delta) or None if skipped.
+    """
+    source_file = str(filepath)
+
+    try:
+        content = normalize(source_file)
+    except (OSError, ValueError):
+        return None
+
+    if not content or len(content.strip()) < MIN_CHUNK_SIZE:
+        return None
+
+    if extract_mode == "general":
+        from .general_extractor import extract_memories
+
+        chunks = extract_memories(content)
+    else:
+        chunks = chunk_exchanges(content)
+
+    if not chunks:
+        return None
+
+    if extract_mode != "general":
+        room = detect_convo_room(content)
+    else:
+        room = None
+
+    now = datetime.now().isoformat()
+    records = []
+    room_counts_delta = defaultdict(int)
+
+    if extract_mode != "general":
+        room_counts_delta[room] = 1
+
+    for chunk in chunks:
+        chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
+        if extract_mode == "general":
+            room_counts_delta[chunk_room] += 1
+
+        drawer_id = (
+            f"drawer_{wing}_{chunk_room}_"
+            + hashlib.sha256(
+                (source_file + str(chunk["chunk_index"])).encode()
+            ).hexdigest()[:24]
+        )
+        meta = {
+            "wing": wing,
+            "room": chunk_room,
+            "source_file": source_file,
+            "chunk_index": chunk["chunk_index"],
+            "added_by": agent,
+            "filed_at": now,
+            "ingest_mode": "convos",
+            "extract_mode": extract_mode,
+        }
+        records.append((drawer_id, chunk["content"], meta))
+
+    return source_file, room, records, dict(room_counts_delta)
+
+
 def mine_convos(
     convo_dir: str,
     palace_path: str,
@@ -270,93 +343,84 @@ def mine_convos(
     files_skipped = 0
     room_counts = defaultdict(int)
 
-    for i, filepath in enumerate(files, 1):
-        source_file = str(filepath)
-
-        # Skip if already filed
-        if not dry_run and file_already_mined(collection, source_file):
-            files_skipped += 1
-            continue
-
-        # Normalize format
-        try:
-            content = normalize(str(filepath))
-        except (OSError, ValueError):
-            continue
-
-        if not content or len(content.strip()) < MIN_CHUNK_SIZE:
-            continue
-
-        # Chunk — either exchange pairs or general extraction
-        if extract_mode == "general":
-            from .general_extractor import extract_memories
-
-            chunks = extract_memories(content)
-            # Each chunk already has memory_type; use it as the room name
-        else:
-            chunks = chunk_exchanges(content)
-
-        if not chunks:
-            continue
-
-        # Detect room from content (general mode uses memory_type instead)
-        if extract_mode != "general":
-            room = detect_convo_room(content)
-        else:
-            room = None  # set per-chunk below
-
-        if dry_run:
+    # ------------------------------------------------------------------
+    # DRY RUN: sequential, no writes
+    # ------------------------------------------------------------------
+    if dry_run:
+        for i, filepath in enumerate(files, 1):
+            result = process_convo_file_cpu(filepath, wing, agent, extract_mode)
+            if result is None:
+                continue
+            _, room, records, room_counts_delta = result
             if extract_mode == "general":
                 from collections import Counter
 
-                type_counts = Counter(c.get("memory_type", "general") for c in chunks)
+                type_counts = Counter(meta["room"] for (_, _, meta) in records)
                 types_str = ", ".join(f"{t}:{n}" for t, n in type_counts.most_common())
-                print(f"    [DRY RUN] {filepath.name} → {len(chunks)} memories ({types_str})")
+                print(f"    [DRY RUN] {filepath.name} → {len(records)} memories ({types_str})")
             else:
-                print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-            total_drawers += len(chunks)
-            # Track room counts
-            if extract_mode == "general":
-                for c in chunks:
-                    room_counts[c.get("memory_type", "general")] += 1
-            else:
-                room_counts[room] += 1
-            continue
+                print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(records)} drawers)")
+            total_drawers += len(records)
+            for r, c in room_counts_delta.items():
+                room_counts[r] += c
 
-        if extract_mode != "general":
-            room_counts[room] += 1
+    # ------------------------------------------------------------------
+    # REAL MINE: parallel file processing + batched upserts
+    # ------------------------------------------------------------------
+    else:
+        print(f"  Checking {len(files)} files for changes...")
+        pending = [fp for fp in files if not file_already_mined(collection, str(fp))]
+        already_mined = len(files) - len(pending)
 
-        # File each chunk
-        drawers_added = 0
-        for chunk in chunks:
-            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-            if extract_mode == "general":
-                room_counts[chunk_room] += 1
-            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
-            try:
-                collection.add(
-                    documents=[chunk["content"]],
-                    ids=[drawer_id],
-                    metadatas=[
-                        {
-                            "wing": wing,
-                            "room": chunk_room,
-                            "source_file": source_file,
-                            "chunk_index": chunk["chunk_index"],
-                            "added_by": agent,
-                            "filed_at": datetime.now().isoformat(),
-                            "ingest_mode": "convos",
-                            "extract_mode": extract_mode,
-                        }
-                    ],
-                )
-                drawers_added += 1
-            except Exception as e:
-                if "already exists" not in str(e).lower():
-                    raise
+        batch_ids, batch_docs, batch_metas = [], [], []
+        completed = 0
+        skipped_small = 0
 
-        total_drawers += drawers_added
-        print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+        def flush_batch(ids, docs, metas):
+            if ids:
+                collection.upsert(documents=docs, ids=ids, metadatas=metas)
+                ids.clear()
+                docs.clear()
+                metas.clear()
+
+        try:
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {
+                    executor.submit(
+                        process_convo_file_cpu, fp, wing, agent, extract_mode
+                    ): fp
+                    for fp in pending
+                }
+                for future in as_completed(futures):
+                    filepath = futures[future]
+                    try:
+                        result = future.result()
+                    except Exception as e:
+                        print(f"  ! [ERROR] {filepath.name}: {e}")
+                        completed += 1
+                        continue
+                    completed += 1
+                    if result is None:
+                        skipped_small += 1
+                        continue
+                    source_file, room, records, room_counts_delta = result
+                    for drawer_id, chunk_content, meta in records:
+                        batch_ids.append(drawer_id)
+                        batch_docs.append(chunk_content)
+                        batch_metas.append(meta)
+                        if len(batch_ids) >= BATCH_SIZE:
+                            flush_batch(batch_ids, batch_docs, batch_metas)
+                    total_drawers += len(records)
+                    for r, c in room_counts_delta.items():
+                        room_counts[r] += c
+                    print(
+                        f"  ✓ [{completed:4}/{len(pending)}] "
+                        f"{Path(source_file).name[:50]:50} +{len(records)}"
+                    )
+        finally:
+            flush_batch(batch_ids, batch_docs, batch_metas)
+
+        files_skipped = already_mined + skipped_small
 
     print(f"\n{'=' * 55}")
     print("  Done.")

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -238,12 +238,7 @@ def process_convo_file_cpu(
     agent: str,
     extract_mode: str,
 ) -> "tuple | None":
-    """
-    Pure CPU worker: normalize, chunk, detect room, build drawer records.
-    Thread-safe — no ChromaDB calls, no shared state.
-
-    Returns (source_file, room, records, room_counts_delta) or None if skipped.
-    """
+    """Normalize, chunk, and build drawer records. Thread-safe, no ChromaDB calls."""
     source_file = str(filepath)
 
     try:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -637,10 +637,8 @@ def mine(
                 total_drawers += drawers
                 room_counts[room] += 1
     else:
-        # Issue 6: show progress during pre-filter so large repos don't appear to hang
         print(f"  Checking {len(files)} files for changes...")
         pending = [fp for fp in files if not file_already_mined(collection, str(fp), check_mtime=True)]
-        # Issue 5: files_skipped = already-mined + too-small/unreadable (result is None)
         already_mined = len(files) - len(pending)
 
         batch_ids, batch_docs, batch_metas = [], [], []
@@ -654,7 +652,7 @@ def mine(
                 batch_docs.clear()
                 batch_metas.clear()
 
-        # Issue 3: use try/finally so flush_batch() always runs even if a future raises
+        # flush_batch() runs even if a future raises
         try:
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                 futures = {

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -698,7 +698,13 @@ def mine(
                     for fp in pending
                 }
                 for future in as_completed(futures):
-                    result = future.result()
+                    fp = futures[future]
+                    try:
+                        result = future.result()
+                    except Exception as e:
+                        print(f"  ! [ERROR] {fp.name}: {e}")
+                        completed += 1
+                        continue
                     completed += 1
                     if result is None:
                         skipped_small += 1

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -499,6 +499,44 @@ def process_file(
 
 
 # =============================================================================
+# MINED FILE CACHE
+# =============================================================================
+
+
+def build_mined_cache(collection) -> dict:
+    """Fetch all mined file mtimes in one query.
+
+    Returns {source_file: mtime_float} where mtime is None if not stored.
+    Replaces per-file file_already_mined() calls during the pre-filter scan.
+    """
+    try:
+        results = collection.get(include=["metadatas"])
+    except Exception:
+        return {}
+    cache = {}
+    for meta in results.get("metadatas") or []:
+        sf = meta.get("source_file")
+        if sf and sf not in cache:
+            mt = meta.get("source_mtime")
+            cache[sf] = float(mt) if mt is not None else None
+    return cache
+
+
+def is_stale(filepath: Path, mined_cache: dict) -> bool:
+    """Return True if the file needs to be (re-)mined."""
+    sf = str(filepath)
+    if sf not in mined_cache:
+        return True
+    mt = mined_cache[sf]
+    if mt is None:
+        return True
+    try:
+        return os.path.getmtime(sf) != mt
+    except OSError:
+        return True
+
+
+# =============================================================================
 # SCAN PROJECT
 # =============================================================================
 
@@ -638,7 +676,8 @@ def mine(
                 room_counts[room] += 1
     else:
         print(f"  Checking {len(files)} files for changes...")
-        pending = [fp for fp in files if not file_already_mined(collection, str(fp), check_mtime=True)]
+        mined_cache = build_mined_cache(collection)
+        pending = [fp for fp in files if is_stale(fp, mined_cache)]
         already_mined = len(files) - len(pending)
 
         batch_ids, batch_docs, batch_metas = [], [], []

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -645,14 +645,13 @@ def mine(
         completed = 0
         skipped_small = 0
 
-        def flush_batch():
-            if batch_ids:
-                collection.upsert(documents=batch_docs, ids=batch_ids, metadatas=batch_metas)
-                batch_ids.clear()
-                batch_docs.clear()
-                batch_metas.clear()
+        def flush_batch(ids, docs, metas):
+            if ids:
+                collection.upsert(documents=docs, ids=ids, metadatas=metas)
+                ids.clear()
+                docs.clear()
+                metas.clear()
 
-        # flush_batch() runs even if a future raises
         try:
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                 futures = {
@@ -671,12 +670,12 @@ def mine(
                         batch_docs.append(chunk_content)
                         batch_metas.append(meta)
                         if len(batch_ids) >= BATCH_SIZE:
-                            flush_batch()
+                            flush_batch(batch_ids, batch_docs, batch_metas)
                     total_drawers += len(records)
                     room_counts[room] += 1
                     print(f"  ✓ [{completed:4}/{len(pending)}] {Path(source_file).name[:50]:50} +{len(records)}")
         finally:
-            flush_batch()
+            flush_batch(batch_ids, batch_docs, batch_metas)
 
         files_skipped = already_mined + skipped_small
 

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -14,6 +14,7 @@ import fnmatch
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import chromadb
 
@@ -55,6 +56,8 @@ CHUNK_SIZE = 800  # chars per drawer
 CHUNK_OVERLAP = 100  # overlap between chunks
 MIN_CHUNK_SIZE = 50  # skip tiny chunks
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
+BATCH_SIZE = 128  # chunks per upsert call
+MAX_WORKERS = min(32, (os.cpu_count() or 4) * 2)
 
 
 # =============================================================================
@@ -404,6 +407,56 @@ def add_drawer(
 # =============================================================================
 
 
+def process_file_cpu(
+    filepath: Path,
+    project_path: Path,
+    wing: str,
+    rooms: list,
+    agent: str,
+) -> "tuple | None":
+    """Read, chunk, and route a file without touching ChromaDB. Safe to run in threads."""
+    source_file = str(filepath)
+    try:
+        content = filepath.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    content = content.strip()
+    if len(content) < MIN_CHUNK_SIZE:
+        return None
+
+    room = detect_room(filepath, content, rooms, project_path)
+    chunks = chunk_text(content, source_file)
+    if not chunks:
+        return None
+
+    now = datetime.now().isoformat()
+    try:
+        mtime = os.path.getmtime(source_file)
+    except OSError:
+        mtime = None
+
+    drawer_id_prefix = f"drawer_{wing}_{room}_"
+    records = []
+    for chunk in chunks:
+        drawer_id = drawer_id_prefix + hashlib.sha256(
+            (source_file + str(chunk["chunk_index"])).encode()
+        ).hexdigest()[:24]
+        meta = {
+            "wing": wing,
+            "room": room,
+            "source_file": source_file,
+            "chunk_index": chunk["chunk_index"],
+            "added_by": agent,
+            "filed_at": now,
+        }
+        if mtime is not None:
+            meta["source_mtime"] = mtime
+        records.append((drawer_id, chunk["content"], meta))
+
+    return source_file, room, records
+
+
 def process_file(
     filepath: Path,
     project_path: Path,
@@ -577,23 +630,56 @@ def mine(
     files_skipped = 0
     room_counts = defaultdict(int)
 
-    for i, filepath in enumerate(files, 1):
-        drawers, room = process_file(
-            filepath=filepath,
-            project_path=project_path,
-            collection=collection,
-            wing=wing,
-            rooms=rooms,
-            agent=agent,
-            dry_run=dry_run,
-        )
-        if drawers == 0 and not dry_run:
-            files_skipped += 1
-        else:
-            total_drawers += drawers
-            room_counts[room] += 1
-            if not dry_run:
-                print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
+    if dry_run:
+        for i, filepath in enumerate(files, 1):
+            drawers, room = process_file(
+                filepath=filepath,
+                project_path=project_path,
+                collection=collection,
+                wing=wing,
+                rooms=rooms,
+                agent=agent,
+                dry_run=True,
+            )
+            if drawers > 0:
+                total_drawers += drawers
+                room_counts[room] += 1
+    else:
+        pending = [fp for fp in files if not file_already_mined(collection, str(fp), check_mtime=True)]
+        files_skipped = len(files) - len(pending)
+
+        batch_ids, batch_docs, batch_metas = [], [], []
+        completed = 0
+
+        def flush_batch():
+            if batch_ids:
+                collection.upsert(documents=batch_docs, ids=batch_ids, metadatas=batch_metas)
+                batch_ids.clear()
+                batch_docs.clear()
+                batch_metas.clear()
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {
+                executor.submit(process_file_cpu, fp, project_path, wing, rooms, agent): fp
+                for fp in pending
+            }
+            for future in as_completed(futures):
+                result = future.result()
+                completed += 1
+                if result is None:
+                    continue
+                source_file, room, records = result
+                for drawer_id, content, meta in records:
+                    batch_ids.append(drawer_id)
+                    batch_docs.append(content)
+                    batch_metas.append(meta)
+                    if len(batch_ids) >= BATCH_SIZE:
+                        flush_batch()
+                total_drawers += len(records)
+                room_counts[room] += 1
+                print(f"  ✓ [{completed:4}/{len(pending)}] {Path(source_file).name[:50]:50} +{len(records)}")
+
+        flush_batch()
 
     print(f"\n{'=' * 55}")
     print("  Done.")

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -414,7 +414,7 @@ def process_file_cpu(
     rooms: list,
     agent: str,
 ) -> "tuple | None":
-    """Read, chunk, and route a file without touching ChromaDB. Safe to run in threads."""
+    """Read, chunk, and route a file. Thread-safe, no ChromaDB calls."""
     source_file = str(filepath)
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")
@@ -504,11 +504,7 @@ def process_file(
 
 
 def build_mined_cache(collection) -> dict:
-    """Fetch all mined file mtimes in one query.
-
-    Returns {source_file: mtime_float} where mtime is None if not stored.
-    Replaces per-file file_already_mined() calls during the pre-filter scan.
-    """
+    """Fetch all mined file mtimes in one query. Returns {source_file: mtime}."""
     try:
         results = collection.get(include=["metadatas"])
     except Exception:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -467,37 +467,29 @@ def process_file(
     dry_run: bool,
 ) -> tuple:
     """Read, chunk, route, and file one file. Returns (drawer_count, room_name)."""
-
-    # Skip if already filed
     source_file = str(filepath)
     if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
         return 0, None
 
-    try:
-        content = filepath.read_text(encoding="utf-8", errors="replace")
-    except OSError:
+    result = process_file_cpu(filepath, project_path, wing, rooms, agent)
+    if result is None:
         return 0, None
 
-    content = content.strip()
-    if len(content) < MIN_CHUNK_SIZE:
-        return 0, None
-
-    room = detect_room(filepath, content, rooms, project_path)
-    chunks = chunk_text(content, source_file)
+    _, room, records = result
 
     if dry_run:
-        print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-        return len(chunks), room
+        print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(records)} drawers)")
+        return len(records), room
 
     drawers_added = 0
-    for chunk in chunks:
+    for drawer_id, chunk_content, meta in records:
         added = add_drawer(
             collection=collection,
             wing=wing,
             room=room,
-            content=chunk["content"],
+            content=chunk_content,
             source_file=source_file,
-            chunk_index=chunk["chunk_index"],
+            chunk_index=meta["chunk_index"],
             agent=agent,
         )
         if added:
@@ -645,11 +637,15 @@ def mine(
                 total_drawers += drawers
                 room_counts[room] += 1
     else:
+        # Issue 6: show progress during pre-filter so large repos don't appear to hang
+        print(f"  Checking {len(files)} files for changes...")
         pending = [fp for fp in files if not file_already_mined(collection, str(fp), check_mtime=True)]
-        files_skipped = len(files) - len(pending)
+        # Issue 5: files_skipped = already-mined + too-small/unreadable (result is None)
+        already_mined = len(files) - len(pending)
 
         batch_ids, batch_docs, batch_metas = [], [], []
         completed = 0
+        skipped_small = 0
 
         def flush_batch():
             if batch_ids:
@@ -658,28 +654,33 @@ def mine(
                 batch_docs.clear()
                 batch_metas.clear()
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = {
-                executor.submit(process_file_cpu, fp, project_path, wing, rooms, agent): fp
-                for fp in pending
-            }
-            for future in as_completed(futures):
-                result = future.result()
-                completed += 1
-                if result is None:
-                    continue
-                source_file, room, records = result
-                for drawer_id, content, meta in records:
-                    batch_ids.append(drawer_id)
-                    batch_docs.append(content)
-                    batch_metas.append(meta)
-                    if len(batch_ids) >= BATCH_SIZE:
-                        flush_batch()
-                total_drawers += len(records)
-                room_counts[room] += 1
-                print(f"  ✓ [{completed:4}/{len(pending)}] {Path(source_file).name[:50]:50} +{len(records)}")
+        # Issue 3: use try/finally so flush_batch() always runs even if a future raises
+        try:
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {
+                    executor.submit(process_file_cpu, fp, project_path, wing, rooms, agent): fp
+                    for fp in pending
+                }
+                for future in as_completed(futures):
+                    result = future.result()
+                    completed += 1
+                    if result is None:
+                        skipped_small += 1
+                        continue
+                    source_file, room, records = result
+                    for drawer_id, chunk_content, meta in records:
+                        batch_ids.append(drawer_id)
+                        batch_docs.append(chunk_content)
+                        batch_metas.append(meta)
+                        if len(batch_ids) >= BATCH_SIZE:
+                            flush_batch()
+                    total_drawers += len(records)
+                    room_counts[room] += 1
+                    print(f"  ✓ [{completed:4}/{len(pending)}] {Path(source_file).name[:50]:50} +{len(records)}")
+        finally:
+            flush_batch()
 
-        flush_batch()
+        files_skipped = already_mined + skipped_small
 
     print(f"\n{'=' * 55}")
     print("  Done.")

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,8 +1,46 @@
 import os
 import tempfile
 import shutil
+from pathlib import Path
 import chromadb
-from mempalace.convo_miner import mine_convos
+from mempalace.convo_miner import mine_convos, process_convo_file_cpu
+
+
+def test_process_convo_file_cpu_returns_records():
+    """process_convo_file_cpu returns records without touching ChromaDB."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        filepath = Path(tmpdir) / "chat.txt"
+        filepath.write_text(
+            "> What is memory?\nMemory is persistence.\n\n"
+            "> Why does it matter?\nIt enables continuity.\n\n"
+            "> How do we build it?\nWith structured storage.\n",
+            encoding="utf-8",
+        )
+        result = process_convo_file_cpu(filepath, wing="testwing", agent="testbot", extract_mode="exchange")
+        assert result is not None
+        source_file, room, records, room_counts_delta = result
+        assert source_file == str(filepath)
+        assert len(records) > 0
+        drawer_id, content, meta = records[0]
+        assert drawer_id.startswith("drawer_testwing_")
+        assert meta["wing"] == "testwing"
+        assert meta["added_by"] == "testbot"
+        assert meta["ingest_mode"] == "convos"
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_process_convo_file_cpu_returns_none_for_empty():
+    """process_convo_file_cpu returns None for empty/tiny files."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        filepath = Path(tmpdir) / "empty.txt"
+        filepath.write_text("", encoding="utf-8")
+        result = process_convo_file_cpu(filepath, wing="testwing", agent="testbot", extract_mode="exchange")
+        assert result is None
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_convo_mining():

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -260,3 +260,107 @@ def test_file_already_mined_check_mtime():
         # Release ChromaDB file handles before cleanup (required on Windows)
         del col, client
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_process_file_cpu_returns_records():
+    """process_file_cpu returns (source_file, room, records) without touching ChromaDB."""
+    from mempalace.miner import process_file_cpu
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "src")
+        filepath = project_root / "src" / "app.py"
+        write_file(filepath, "def main():\n    print('hello')\n" * 20)
+
+        rooms = [{"name": "src", "description": "Source code"}]
+        result = process_file_cpu(filepath, project_root, "testwing", rooms, "testbot")
+
+        assert result is not None
+        source_file, room, records = result
+        assert source_file == str(filepath)
+        assert room == "src"
+        assert len(records) > 0
+        drawer_id, content, meta = records[0]
+        assert drawer_id.startswith("drawer_testwing_src_")
+        assert "def main" in content
+        assert meta["wing"] == "testwing"
+        assert meta["room"] == "src"
+        assert meta["added_by"] == "testbot"
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_process_file_cpu_returns_none_for_empty_file():
+    from mempalace.miner import process_file_cpu
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        filepath = project_root / "empty.py"
+        write_file(filepath, "")
+
+        result = process_file_cpu(filepath, project_root, "testwing", [], "testbot")
+        assert result is None
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_parallel_produces_same_result_as_serial():
+    """Parallel mine indexes the same files and drawer count as the original serial path."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "src")
+
+        for i in range(5):
+            write_file(
+                project_root / "src" / f"module_{i}.py",
+                f"# module {i}\ndef func_{i}():\n    pass\n" * 20,
+            )
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {"wing": "test_parallel", "rooms": [{"name": "src", "description": "Source"}]},
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        mine(str(project_root), str(palace_path))
+
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() > 0
+
+        results = col.get(where={"wing": "test_parallel"})
+        source_files = {m["source_file"] for m in results["metadatas"]}
+        assert len(source_files) == 5
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_skips_already_mined_files_on_rerun():
+    """Re-running mine skips unchanged files (incremental behaviour preserved)."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        filepath = project_root / "notes.md"
+        write_file(filepath, "# Notes\n\nSome content here.\n" * 20)
+
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump({"wing": "test_incr", "rooms": [{"name": "general", "description": "General"}]}, f)
+
+        palace_path = project_root / "palace"
+        mine(str(project_root), str(palace_path))
+
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_collection("mempalace_drawers")
+        count_after_first = col.count()
+        del col, client
+
+        mine(str(project_root), str(palace_path))
+
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() == count_after_first
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -329,11 +329,19 @@ def test_mine_parallel_produces_same_result_as_serial():
 
         client = chromadb.PersistentClient(path=str(palace_path))
         col = client.get_collection("mempalace_drawers")
-        assert col.count() > 0
+        first_count = col.count()
+        assert first_count > 0
 
         results = col.get(where={"wing": "test_parallel"})
         source_files = {m["source_file"] for m in results["metadatas"]}
         assert len(source_files) == 5
+        del col, client
+
+        # Re-mine: idempotent — count must not change
+        mine(str(project_root), str(palace_path))
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() == first_count
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 


### PR DESCRIPTION
## Problem

`mine()` processes files sequentially and calls `collection.upsert()` once per chunk. On large codebases this is slow — file I/O stalls the CPU, and the ONNX embedder runs one vector at a time instead of batching.

## Solution

Two changes that compound:

**1. Thread pool for file reading + chunking**

Extracted the ChromaDB-free part of `process_file()` into a new `process_file_cpu()` function (read → chunk → detect room → build metadata records). This has no shared state and is safe to run concurrently. `mine()` now dispatches these via `ThreadPoolExecutor`, overlapping file I/O across files while the main thread handles upserts.

**2. Batched upserts**

Instead of `collection.upsert([1 chunk])` N times, records from completed futures are accumulated and flushed every `BATCH_SIZE` (128) chunks. ChromaDB's ONNX backend processes a batch as a single matrix operation, which is significantly faster than N sequential single-vector calls.

## Constants added

```python
BATCH_SIZE = 128          # chunks per upsert call
MAX_WORKERS = min(32, (os.cpu_count() or 4) * 2)
```

## Compatibility

- `dry_run` path is unchanged (still uses original `process_file()`).
- Already-mined files are pre-filtered before the thread pool to avoid redundant ChromaDB reads from worker threads.
- No new dependencies.