### PR TITLE
feat: add iOS/Swift file extensions to READABLE_EXTENSIONS

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -40,6 +40,16 @@ READABLE_EXTENSIONS = {
     ".csv",
     ".sql",
     ".toml",
+    ".swift",
+    ".m",
+    ".h",
+    ".mm",
+    ".plist",
+    ".entitlements",
+    ".strings",
+    ".stringsdict",
+    ".xcstrings",
+    ".xcconfig",
 }
 
 SKIP_FILENAMES = {


### PR DESCRIPTION
## Problem

`mempalace mine` on an Xcode project silently skips all Swift and iOS source files because `.swift` and related extensions are not in `READABLE_EXTENSIONS`. Only `.md`, `.json`, `.sql` etc. are picked up, missing the actual source code.

## Changes

Added the following extensions to `READABLE_EXTENSIONS` in `miner.py`:

- `.swift` — primary iOS/macOS source language
- `.m` / `.h` / `.mm` — Objective-C (legacy projects still common)
- `.plist` — app configuration and permissions (Info.plist etc.)
- `.entitlements` — app capabilities and signing
- `.strings` / `.stringsdict` / `.xcstrings` — localization files
- `.xcconfig` — build configuration

## Result

Tested on a real Xcode project (MindBuy iOS):
- **Before:** 99 files found (only docs and config)
- **After:** 279 files found (includes all Swift source)

## Future improvement

A configurable `file_extensions` key in `~/.mempalace/config.json` would allow users to add extensions without patching source — useful for any language not currently covered (Swift, Kotlin, Dart, etc.).