### PR TITLE
fix: honor configured drawer collection everywhere

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -34,6 +34,7 @@ import argparse
 from pathlib import Path
 
 from .config import MempalaceConfig
+from .palace import get_drawer_collection, resolve_drawer_context
 
 
 def cmd_init(args):
@@ -101,7 +102,8 @@ def cmd_mine(args):
 def cmd_search(args):
     from .searcher import search, SearchError
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    cfg = MempalaceConfig()
+    palace_path = os.path.expanduser(args.palace) if args.palace else cfg.palace_path
     try:
         search(
             query=args.query,
@@ -109,6 +111,7 @@ def cmd_search(args):
             wing=args.wing,
             room=args.room,
             n_results=args.results,
+            config=cfg,
         )
     except SearchError:
         sys.exit(1)
@@ -161,8 +164,9 @@ def cmd_migrate(args):
 def cmd_status(args):
     from .miner import status
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
-    status(palace_path=palace_path)
+    cfg = MempalaceConfig()
+    palace_path = os.path.expanduser(args.palace) if args.palace else cfg.palace_path
+    status(palace_path=palace_path, config=cfg)
 
 
 def cmd_repair(args):
@@ -170,7 +174,9 @@ def cmd_repair(args):
     import chromadb
     import shutil
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    cfg = MempalaceConfig()
+    palace_arg = os.path.expanduser(args.palace) if args.palace else cfg.palace_path
+    palace_path, collection_name = resolve_drawer_context(palace_path=palace_arg, config=cfg)
 
     if not os.path.isdir(palace_path):
         print(f"\n  No palace found at {palace_path}")
@@ -183,9 +189,13 @@ def cmd_repair(args):
 
     # Try to read existing drawers
     try:
+        col = get_drawer_collection(palace_path=palace_path, create=False, config=cfg)
+        if col is None:
+            print(f"\n  No palace found at {palace_path}")
+            return
         client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
         total = col.count()
+        print(f"  Collection: {collection_name}")
         print(f"  Drawers found: {total}")
     except Exception as e:
         print(f"  Error reading palace: {e}")
@@ -220,8 +230,8 @@ def cmd_repair(args):
     shutil.copytree(palace_path, backup_path)
 
     print("  Rebuilding collection...")
-    client.delete_collection("mempalace_drawers")
-    new_col = client.create_collection("mempalace_drawers")
+    client.delete_collection(collection_name)
+    new_col = client.create_collection(collection_name)
 
     filed = 0
     for i in range(0, len(all_ids), batch_size):
@@ -277,7 +287,9 @@ def cmd_compress(args):
     import chromadb
     from .dialect import Dialect
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    cfg = MempalaceConfig()
+    palace_arg = os.path.expanduser(args.palace) if args.palace else cfg.palace_path
+    palace_path, _ = resolve_drawer_context(palace_path=palace_arg, config=cfg)
 
     # Load dialect (with optional entity config)
     config_path = args.config
@@ -295,8 +307,10 @@ def cmd_compress(args):
 
     # Connect to palace
     try:
+        col = get_drawer_collection(palace_path=palace_path, create=False, config=cfg)
+        if col is None:
+            raise FileNotFoundError(palace_path)
         client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
     except Exception:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -61,6 +61,11 @@ def sanitize_content(value: str, max_length: int = 100_000) -> str:
 DEFAULT_PALACE_PATH = os.path.expanduser("~/.mempalace/palace")
 DEFAULT_COLLECTION_NAME = "mempalace_drawers"
 
+
+def _expand_path(path: str) -> str:
+    """Normalize user-home references without changing relative-path behavior."""
+    return os.path.expanduser(path)
+
 DEFAULT_TOPIC_WINGS = [
     "emotions",
     "consciousness",
@@ -144,8 +149,8 @@ class MempalaceConfig:
         """Path to the memory palace data directory."""
         env_val = os.environ.get("MEMPALACE_PALACE_PATH") or os.environ.get("MEMPAL_PALACE_PATH")
         if env_val:
-            return env_val
-        return self._file_config.get("palace_path", DEFAULT_PALACE_PATH)
+            return _expand_path(env_val)
+        return _expand_path(self._file_config.get("palace_path", DEFAULT_PALACE_PATH))
 
     @property
     def collection_name(self):

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -12,7 +12,7 @@ Load only what you need, when you need it.
 
 Wake-up cost: ~600-900 tokens (L0+L1). Leaves 95%+ of context free.
 
-Reads directly from ChromaDB (mempalace_drawers)
+Reads from the configured drawer collection
 and ~/.mempalace/identity.txt.
 """
 
@@ -21,9 +21,8 @@ import sys
 from pathlib import Path
 from collections import defaultdict
 
-import chromadb
-
 from .config import MempalaceConfig
+from .palace import get_drawer_collection
 
 
 # ---------------------------------------------------------------------------
@@ -84,16 +83,21 @@ class Layer1:
     MAX_CHARS = 3200  # hard cap on total L1 text (~800 tokens)
 
     def __init__(self, palace_path: str = None, wing: str = None):
-        cfg = MempalaceConfig()
-        self.palace_path = palace_path or cfg.palace_path
+        self._config = MempalaceConfig()
+        self.palace_path = palace_path or self._config.palace_path
         self.wing = wing
 
     def generate(self) -> str:
         """Pull top drawers from ChromaDB and format as compact L1 text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = get_drawer_collection(
+                palace_path=self.palace_path,
+                create=False,
+                config=self._config,
+            )
         except Exception:
+            return "## L1 — No palace found. Run: mempalace mine <dir>"
+        if col is None:
             return "## L1 — No palace found. Run: mempalace mine <dir>"
 
         # Fetch all drawers in batches to avoid SQLite variable limit (~999)
@@ -190,15 +194,20 @@ class Layer2:
     """
 
     def __init__(self, palace_path: str = None):
-        cfg = MempalaceConfig()
-        self.palace_path = palace_path or cfg.palace_path
+        self._config = MempalaceConfig()
+        self.palace_path = palace_path or self._config.palace_path
 
     def retrieve(self, wing: str = None, room: str = None, n_results: int = 10) -> str:
         """Retrieve drawers filtered by wing and/or room."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = get_drawer_collection(
+                palace_path=self.palace_path,
+                create=False,
+                config=self._config,
+            )
         except Exception:
+            return "No palace found."
+        if col is None:
             return "No palace found."
 
         where = {}
@@ -250,19 +259,24 @@ class Layer2:
 class Layer3:
     """
     Unlimited depth. Semantic search against the full palace.
-    Reuses searcher.py logic against mempalace_drawers.
+    Reuses searcher.py logic against the configured drawer collection.
     """
 
     def __init__(self, palace_path: str = None):
-        cfg = MempalaceConfig()
-        self.palace_path = palace_path or cfg.palace_path
+        self._config = MempalaceConfig()
+        self.palace_path = palace_path or self._config.palace_path
 
     def search(self, query: str, wing: str = None, room: str = None, n_results: int = 5) -> str:
         """Semantic search, returns compact result text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = get_drawer_collection(
+                palace_path=self.palace_path,
+                create=False,
+                config=self._config,
+            )
         except Exception:
+            return "No palace found."
+        if col is None:
             return "No palace found."
 
         where = {}
@@ -316,9 +330,14 @@ class Layer3:
     ) -> list:
         """Return raw dicts instead of formatted text."""
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
+            col = get_drawer_collection(
+                palace_path=self.palace_path,
+                create=False,
+                config=self._config,
+            )
         except Exception:
+            return []
+        if col is None:
             return []
 
         where = {}
@@ -377,8 +396,8 @@ class MemoryStack:
     """
 
     def __init__(self, palace_path: str = None, identity_path: str = None):
-        cfg = MempalaceConfig()
-        self.palace_path = palace_path or cfg.palace_path
+        self._config = MempalaceConfig()
+        self.palace_path = palace_path or self._config.palace_path
         self.identity_path = identity_path or os.path.expanduser("~/.mempalace/identity.txt")
 
         self.l0 = Layer0(self.identity_path)
@@ -437,10 +456,12 @@ class MemoryStack:
 
         # Count drawers
         try:
-            client = chromadb.PersistentClient(path=self.palace_path)
-            col = client.get_collection("mempalace_drawers")
-            count = col.count()
-            result["total_drawers"] = count
+            col = get_drawer_collection(
+                palace_path=self.palace_path,
+                create=False,
+                config=self._config,
+            )
+            result["total_drawers"] = col.count() if col else 0
         except Exception:
             result["total_drawers"] = 0
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from pathlib import Path
 
 from .config import MempalaceConfig, sanitize_name, sanitize_content
+from .palace import open_collection_on_client, iter_collection_metadatas, resolve_drawer_context
 from .version import __version__
 from .query_sanitizer import sanitize_query
 from .searcher import search_memories
@@ -55,7 +56,7 @@ def _parse_args():
 _args = _parse_args()
 
 if _args.palace:
-    os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(_args.palace)
+    os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(os.path.expanduser(_args.palace))
 
 _config = MempalaceConfig()
 if _args.palace:
@@ -65,7 +66,9 @@ else:
 
 
 _client_cache = None
+_client_cache_path = None
 _collection_cache = None
+_collection_cache_key = None
 
 
 # ==================== WRITE-AHEAD LOG ====================
@@ -101,30 +104,37 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         logger.error(f"WAL write failed: {e}")
 
 
-_client_cache = None
-_collection_cache = None
-
-
 def _get_client():
     """Return a singleton ChromaDB PersistentClient."""
-    global _client_cache
-    if _client_cache is None:
-        _client_cache = chromadb.PersistentClient(path=_config.palace_path)
+    global _client_cache, _client_cache_path, _collection_cache, _collection_cache_key
+    palace_path, _ = resolve_drawer_context(config=_config)
+    if _client_cache is None or _client_cache_path != palace_path:
+        _client_cache = chromadb.PersistentClient(path=palace_path)
+        _client_cache_path = palace_path
+        _collection_cache = None
+        _collection_cache_key = None
     return _client_cache
 
 
 def _get_collection(create=False):
     """Return the ChromaDB collection, caching the client between calls."""
-    global _collection_cache
+    global _collection_cache, _collection_cache_key
+    palace_path, collection_name = resolve_drawer_context(config=_config)
+    cache_key = (palace_path, collection_name)
+    if _collection_cache is not None and _collection_cache_key == cache_key:
+        return _collection_cache
+    if not create and not os.path.isdir(palace_path):
+        return None
     try:
         client = _get_client()
-        if create:
-            _collection_cache = client.get_or_create_collection(_config.collection_name)
-        elif _collection_cache is None:
-            _collection_cache = client.get_collection(_config.collection_name)
-        return _collection_cache
-    except Exception:
+        collection = open_collection_on_client(client, collection_name, create=create)
+    except chromadb.errors.NotFoundError:
         return None
+    if collection is None:
+        return None
+    _collection_cache = collection
+    _collection_cache_key = cache_key
+    return collection
 
 
 def _no_palace():
@@ -141,32 +151,24 @@ def tool_status():
     col = _get_collection()
     if not col:
         return _no_palace()
+    palace_path, _ = resolve_drawer_context(config=_config)
     count = col.count()
     wings = {}
     rooms = {}
-    batch_size = 5000
-    offset = 0
     error_info = None
-    while True:
-        try:
-            batch = col.get(include=["metadatas"], limit=batch_size, offset=offset)
-            rows = batch["metadatas"]
-            for m in rows:
-                w = m.get("wing", "unknown")
-                r = m.get("room", "unknown")
-                wings[w] = wings.get(w, 0) + 1
-                rooms[r] = rooms.get(r, 0) + 1
-            offset += len(rows)
-            if len(rows) < batch_size:
-                break
-        except Exception as e:
-            error_info = f"Partial result, failed at offset {offset}: {str(e)}"
-            break
+    try:
+        for m in iter_collection_metadatas(col):
+            w = m.get("wing", "unknown")
+            r = m.get("room", "unknown")
+            wings[w] = wings.get(w, 0) + 1
+            rooms[r] = rooms.get(r, 0) + 1
+    except Exception as e:
+        error_info = f"Partial result: {e}"
     result = {
         "total_drawers": count,
         "wings": wings,
         "rooms": rooms,
-        "palace_path": _config.palace_path,
+        "palace_path": palace_path,
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
     }
@@ -214,28 +216,12 @@ def tool_list_wings():
     if not col:
         return _no_palace()
     wings = {}
-    batch_size = 5000
-    offset = 0
     try:
-        col.count()  # verify collection is accessible
+        for m in iter_collection_metadatas(col):
+            w = m.get("wing", "unknown")
+            wings[w] = wings.get(w, 0) + 1
     except Exception as e:
-        return {"wings": {}, "error": str(e)}
-    while True:
-        try:
-            batch = col.get(include=["metadatas"], limit=batch_size, offset=offset)
-            rows = batch["metadatas"]
-            for m in rows:
-                w = m.get("wing", "unknown")
-                wings[w] = wings.get(w, 0) + 1
-            offset += len(rows)
-            if len(rows) < batch_size:
-                break
-        except Exception as e:
-            return {
-                "wings": wings,
-                "error": f"Partial result, failed at offset {offset}: {str(e)}",
-                "partial": True,
-            }
+        return {"wings": wings, "error": f"Partial result: {e}", "partial": True}
     return {"wings": wings}
 
 
@@ -244,33 +230,18 @@ def tool_list_rooms(wing: str = None):
     if not col:
         return _no_palace()
     rooms = {}
-    batch_size = 5000
-    offset = 0
     where = {"wing": wing} if wing else None
     try:
-        col.count()  # verify collection is accessible
+        for m in iter_collection_metadatas(col, where=where):
+            r = m.get("room", "unknown")
+            rooms[r] = rooms.get(r, 0) + 1
     except Exception as e:
-        return {"wing": wing or "all", "rooms": {}, "error": str(e)}
-    while True:
-        try:
-            kwargs = {"include": ["metadatas"], "limit": batch_size, "offset": offset}
-            if where:
-                kwargs["where"] = where
-            batch = col.get(**kwargs)
-            rows = batch["metadatas"]
-            for m in rows:
-                r = m.get("room", "unknown")
-                rooms[r] = rooms.get(r, 0) + 1
-            offset += len(rows)
-            if len(rows) < batch_size:
-                break
-        except Exception as e:
-            return {
-                "wing": wing or "all",
-                "rooms": rooms,
-                "error": f"Partial result, failed at offset {offset}: {str(e)}",
-                "partial": True,
-            }
+        return {
+            "wing": wing or "all",
+            "rooms": rooms,
+            "error": f"Partial result: {e}",
+            "partial": True,
+        }
     return {"wing": wing or "all", "rooms": rooms}
 
 
@@ -279,31 +250,15 @@ def tool_get_taxonomy():
     if not col:
         return _no_palace()
     taxonomy = {}
-    batch_size = 5000
-    offset = 0
     try:
-        col.count()  # verify collection is accessible
+        for m in iter_collection_metadatas(col):
+            w = m.get("wing", "unknown")
+            r = m.get("room", "unknown")
+            if w not in taxonomy:
+                taxonomy[w] = {}
+            taxonomy[w][r] = taxonomy[w].get(r, 0) + 1
     except Exception as e:
-        return {"taxonomy": {}, "error": str(e)}
-    while True:
-        try:
-            batch = col.get(include=["metadatas"], limit=batch_size, offset=offset)
-            rows = batch["metadatas"]
-            for m in rows:
-                w = m.get("wing", "unknown")
-                r = m.get("room", "unknown")
-                if w not in taxonomy:
-                    taxonomy[w] = {}
-                taxonomy[w][r] = taxonomy[w].get(r, 0) + 1
-            offset += len(rows)
-            if len(rows) < batch_size:
-                break
-        except Exception as e:
-            return {
-                "taxonomy": taxonomy,
-                "error": f"Partial result, failed at offset {offset}: {str(e)}",
-                "partial": True,
-            }
+        return {"taxonomy": taxonomy, "error": f"Partial result: {e}", "partial": True}
     return {"taxonomy": taxonomy}
 
 
@@ -318,6 +273,7 @@ def tool_search(
         wing=wing,
         room=room,
         n_results=limit,
+        config=_config,
     )
     # Attach sanitizer metadata for transparency
     if sanitized["was_sanitized"]:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,9 +15,13 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-import chromadb
-
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import (
+    SKIP_DIRS,
+    file_already_mined,
+    get_collection,
+    get_drawer_collection,
+    iter_collection_metadatas,
+)
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -622,26 +626,27 @@ def mine(
 # =============================================================================
 
 
-def status(palace_path: str):
+def status(palace_path: str, config=None):
     """Show what's been filed in the palace."""
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = get_drawer_collection(palace_path=palace_path, create=False, config=config)
     except Exception:
+        print(f"\n  No palace found at {palace_path}")
+        print("  Run: mempalace init <dir> then mempalace mine <dir>")
+        return
+    if col is None:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
     # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
-
     wing_rooms = defaultdict(lambda: defaultdict(int))
-    for m in metas:
+    for m in iter_collection_metadatas(col):
         wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
+    total_drawers = col.count()
 
     print(f"\n{'=' * 55}")
-    print(f"  MemPalace Status — {len(metas)} drawers")
+    print(f"  MemPalace Status — {total_drawers} drawers")
     print(f"{'=' * 55}\n")
     for wing, rooms in sorted(wing_rooms.items()):
         print(f"  WING: {wing}")

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -6,6 +6,9 @@ Consolidates ChromaDB access patterns used by both miners and the MCP server.
 
 import os
 import chromadb
+from chromadb.errors import NotFoundError
+
+from .config import MempalaceConfig
 
 SKIP_DIRS = {
     ".git",
@@ -34,18 +37,86 @@ SKIP_DIRS = {
 }
 
 
-def get_collection(palace_path: str, collection_name: str = "mempalace_drawers"):
-    """Get or create the palace ChromaDB collection."""
+def resolve_drawer_context(
+    palace_path: str = None,
+    collection_name: str = None,
+    config: MempalaceConfig = None,
+):
+    """Resolve the default drawer collection path and name."""
+    cfg = config or MempalaceConfig()
+    resolved_path = os.path.expanduser(os.fspath(palace_path)) if palace_path else cfg.palace_path
+    resolved_collection = collection_name or cfg.collection_name
+    return resolved_path, resolved_collection
+
+
+def open_collection_on_client(client, collection_name: str, create: bool):
+    """Open a collection on an existing client without hiding real failures."""
+    if create:
+        return client.get_or_create_collection(collection_name)
+    try:
+        return client.get_collection(collection_name)
+    except NotFoundError:
+        return None
+
+
+def get_drawer_collection(
+    palace_path: str = None,
+    collection_name: str = None,
+    *,
+    create: bool = False,
+    config: MempalaceConfig = None,
+):
+    """Open the configured drawer collection for reads or writes."""
+    palace_path, collection_name = resolve_drawer_context(
+        palace_path=palace_path,
+        collection_name=collection_name,
+        config=config,
+    )
+    if not create and not os.path.isdir(palace_path):
+        return None
+    if create:
+        _ensure_palace_dir(palace_path)
+    client = chromadb.PersistentClient(path=palace_path)
+    return open_collection_on_client(client, collection_name, create=create)
+
+
+def get_collection(palace_path: str, collection_name: str = None):
+    """Backward-compatible wrapper for write paths that need the drawer collection."""
+    return get_drawer_collection(
+        palace_path=palace_path,
+        collection_name=collection_name,
+        create=True,
+    )
+
+
+def iter_collection_metadatas(collection, *, where=None, batch_size: int = 1000):
+    """Yield collection metadata rows in pages without a hard cap."""
+    offset = 0
+    while True:
+        kwargs = {"include": ["metadatas"], "limit": batch_size, "offset": offset}
+        if where:
+            kwargs["where"] = where
+        batch = collection.get(**kwargs)
+        metadatas = batch.get("metadatas") or []
+        batch_ids = batch.get("ids")
+        batch_count = len(batch_ids) if batch_ids is not None else len(metadatas)
+        if batch_count == 0:
+            break
+        for metadata in metadatas:
+            if metadata:
+                yield metadata
+        offset += batch_count
+        if batch_count < batch_size:
+            break
+
+
+def _ensure_palace_dir(palace_path: str):
+    """Create the palace directory with best-effort owner-only permissions."""
     os.makedirs(palace_path, exist_ok=True)
     try:
         os.chmod(palace_path, 0o700)
     except (OSError, NotImplementedError):
         pass
-    client = chromadb.PersistentClient(path=palace_path)
-    try:
-        return client.get_collection(collection_name)
-    except Exception:
-        return client.create_collection(collection_name)
 
 
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -9,7 +9,8 @@ Returns verbatim text — the actual words, never summaries.
 import logging
 from pathlib import Path
 
-import chromadb
+from .config import MempalaceConfig
+from .palace import get_drawer_collection, resolve_drawer_context
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -18,18 +19,29 @@ class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
 
 
-def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
+def search(
+    query: str,
+    palace_path: str,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    config: MempalaceConfig = None,
+):
     """
     Search the palace. Returns verbatim drawer content.
     Optionally filter by wing (project) or room (aspect).
     """
+    cfg = config or MempalaceConfig()
+    resolved_path, _ = resolve_drawer_context(palace_path=palace_path, config=cfg)
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
-    except Exception:
-        print(f"\n  No palace found at {palace_path}")
+        col = get_drawer_collection(palace_path=palace_path, create=False, config=cfg)
+    except Exception as e:
+        print(f"\n  Search error: {e}")
+        raise SearchError(f"Search error: {e}") from e
+    if col is None:
+        print(f"\n  No palace found at {resolved_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
-        raise SearchError(f"No palace found at {palace_path}")
+        raise SearchError(f"No palace found at {resolved_path}")
 
     # Build where filter
     where = {}
@@ -91,17 +103,26 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: str,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    config: MempalaceConfig = None,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
     Used by the MCP server and other callers that need data.
     """
+    cfg = config or MempalaceConfig()
+    resolved_path, _ = resolve_drawer_context(palace_path=palace_path, config=cfg)
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = get_drawer_collection(palace_path=palace_path, create=False, config=cfg)
     except Exception as e:
-        logger.error("No palace found at %s: %s", palace_path, e)
+        logger.error("Search setup failed at %s: %s", resolved_path, e)
+        return {"error": f"Search error: {e}"}
+    if col is None:
+        logger.error("No palace found at %s", resolved_path)
         return {
             "error": "No palace found",
             "hint": "Run: mempalace init <dir> && mempalace mine <dir>",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,9 @@ def _reset_mcp_cache():
             from mempalace import mcp_server
 
             mcp_server._client_cache = None
+            mcp_server._client_cache_path = None
             mcp_server._collection_cache = None
+            mcp_server._collection_cache_key = None
         except (ImportError, AttributeError):
             pass
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,10 @@ def test_cmd_status_default_palace(mock_config_cls):
     mock_miner = MagicMock()
     with patch.dict("sys.modules", {"mempalace.miner": mock_miner}):
         cmd_status(args)
-        mock_miner.status.assert_called_once_with(palace_path="/fake/palace")
+        mock_miner.status.assert_called_once_with(
+            palace_path="/fake/palace",
+            config=mock_config_cls.return_value,
+        )
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -44,7 +47,10 @@ def test_cmd_status_custom_palace(mock_config_cls):
         import os
 
         expected = os.path.expanduser("~/my_palace")
-        mock_miner.status.assert_called_once_with(palace_path=expected)
+        mock_miner.status.assert_called_once_with(
+            palace_path=expected,
+            config=mock_config_cls.return_value,
+        )
 
 
 # ── cmd_search ─────────────────────────────────────────────────────────
@@ -64,6 +70,7 @@ def test_cmd_search_calls_search(mock_config_cls):
             wing="mywing",
             room="myroom",
             n_results=3,
+            config=mock_config_cls.return_value,
         )
 
 
@@ -416,9 +423,7 @@ def test_main_compress_dispatches():
 def test_cmd_repair_no_palace(mock_config_cls, tmp_path, capsys):
     mock_config_cls.return_value.palace_path = str(tmp_path / "nonexistent")
     args = argparse.Namespace(palace=None)
-    mock_chromadb = MagicMock()
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
-        cmd_repair(args)
+    cmd_repair(args)
     out = capsys.readouterr().out
     assert "No palace found" in out
 
@@ -429,11 +434,7 @@ def test_cmd_repair_error_reading(mock_config_cls, tmp_path, capsys):
     palace_dir.mkdir()
     mock_config_cls.return_value.palace_path = str(palace_dir)
     args = argparse.Namespace(palace=None)
-    mock_chromadb = MagicMock()
-    mock_client = MagicMock()
-    mock_client.get_collection.side_effect = Exception("corrupt db")
-    mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with patch("mempalace.cli.get_drawer_collection", side_effect=Exception("corrupt db")):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "Error reading palace" in out
@@ -445,13 +446,9 @@ def test_cmd_repair_zero_drawers(mock_config_cls, tmp_path, capsys):
     palace_dir.mkdir()
     mock_config_cls.return_value.palace_path = str(palace_dir)
     args = argparse.Namespace(palace=None)
-    mock_chromadb = MagicMock()
     mock_col = MagicMock()
     mock_col.count.return_value = 0
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-    mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with patch("mempalace.cli.get_drawer_collection", return_value=mock_col):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "Nothing to repair" in out
@@ -462,6 +459,7 @@ def test_cmd_repair_success(mock_config_cls, tmp_path, capsys):
     palace_dir = tmp_path / "palace"
     palace_dir.mkdir()
     mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "custom_drawers"
     args = argparse.Namespace(palace=None)
     mock_chromadb = MagicMock()
     mock_col = MagicMock()
@@ -472,15 +470,19 @@ def test_cmd_repair_success(mock_config_cls, tmp_path, capsys):
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
     }
     mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
     mock_new_col = MagicMock()
     mock_client.create_collection.return_value = mock_new_col
     mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with (
+        patch.dict("sys.modules", {"chromadb": mock_chromadb}),
+        patch("mempalace.cli.get_drawer_collection", return_value=mock_col),
+    ):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "Repair complete" in out
     assert "2 drawers rebuilt" in out
+    mock_client.delete_collection.assert_called_once_with("custom_drawers")
+    mock_client.create_collection.assert_called_once_with("custom_drawers")
 
 
 # ── cmd_compress ───────────────────────────────────────────────────────
@@ -490,10 +492,8 @@ def test_cmd_repair_success(mock_config_cls, tmp_path, capsys):
 def test_cmd_compress_no_palace(mock_config_cls, capsys):
     mock_config_cls.return_value.palace_path = "/fake/palace"
     args = argparse.Namespace(palace=None, wing=None, dry_run=False, config=None)
-    mock_chromadb = MagicMock()
-    mock_chromadb.PersistentClient.side_effect = Exception("no palace")
     with (
-        patch.dict("sys.modules", {"chromadb": mock_chromadb}),
+        patch("mempalace.cli.get_drawer_collection", return_value=None),
         pytest.raises(SystemExit),
     ):
         cmd_compress(args)
@@ -502,17 +502,21 @@ def test_cmd_compress_no_palace(mock_config_cls, capsys):
 @patch("mempalace.cli.MempalaceConfig")
 def test_cmd_compress_no_drawers(mock_config_cls, capsys):
     mock_config_cls.return_value.palace_path = "/fake/palace"
+    mock_config_cls.return_value.collection_name = "custom_drawers"
     args = argparse.Namespace(palace=None, wing="mywing", dry_run=False, config=None)
     mock_chromadb = MagicMock()
     mock_col = MagicMock()
     mock_col.get.return_value = {"documents": [], "metadatas": [], "ids": []}
     mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
     mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+    with (
+        patch.dict("sys.modules", {"chromadb": mock_chromadb}),
+        patch("mempalace.cli.get_drawer_collection", return_value=mock_col) as mock_get_drawers,
+    ):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "No drawers found" in out
+    assert mock_get_drawers.call_args.kwargs["config"].collection_name == "custom_drawers"
 
 
 def _make_mock_dialect_module(dialect_instance):
@@ -539,7 +543,6 @@ def test_cmd_compress_dry_run(mock_config_cls, capsys):
         {"documents": [], "metadatas": [], "ids": []},
     ]
     mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
     mock_chromadb.PersistentClient.return_value = mock_client
 
     mock_dialect = MagicMock()
@@ -559,7 +562,7 @@ def test_cmd_compress_dry_run(mock_config_cls, capsys):
             "chromadb": mock_chromadb,
             "mempalace.dialect": mock_dialect_mod,
         },
-    ):
+    ), patch("mempalace.cli.get_drawer_collection", return_value=mock_col):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "dry run" in out.lower()
@@ -576,7 +579,6 @@ def test_cmd_compress_with_config(mock_config_cls, tmp_path, capsys):
     mock_col = MagicMock()
     mock_col.get.return_value = {"documents": [], "metadatas": [], "ids": []}
     mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
     mock_chromadb.PersistentClient.return_value = mock_client
 
     mock_dialect = MagicMock()
@@ -588,7 +590,7 @@ def test_cmd_compress_with_config(mock_config_cls, tmp_path, capsys):
             "chromadb": mock_chromadb,
             "mempalace.dialect": mock_dialect_mod,
         },
-    ):
+    ), patch("mempalace.cli.get_drawer_collection", return_value=mock_col):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "Loaded entity config" in out
@@ -610,7 +612,6 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
         {"documents": [], "metadatas": [], "ids": []},
     ]
     mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
     mock_comp_col = MagicMock()
     mock_client.get_or_create_collection.return_value = mock_comp_col
     mock_chromadb.PersistentClient.return_value = mock_client
@@ -632,7 +633,7 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
             "chromadb": mock_chromadb,
             "mempalace.dialect": mock_dialect_mod,
         },
-    ):
+    ), patch("mempalace.cli.get_drawer_collection", return_value=mock_col):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "Stored" in out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,11 +18,28 @@ def test_config_from_file():
     assert cfg.palace_path == "/custom/palace"
 
 
+def test_config_from_file_expands_tilde():
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "config.json"), "w") as f:
+        json.dump({"palace_path": "~/custom/palace"}, f)
+    cfg = MempalaceConfig(config_dir=tmpdir)
+    assert cfg.palace_path == os.path.expanduser("~/custom/palace")
+
+
 def test_env_override():
     os.environ["MEMPALACE_PALACE_PATH"] = "/env/palace"
     cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
     assert cfg.palace_path == "/env/palace"
     del os.environ["MEMPALACE_PALACE_PATH"]
+
+
+def test_env_override_expands_tilde():
+    os.environ["MEMPALACE_PALACE_PATH"] = "~/env/palace"
+    try:
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        assert cfg.palace_path == os.path.expanduser("~/env/palace")
+    finally:
+        del os.environ["MEMPALACE_PALACE_PATH"]
 
 
 def test_init():

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,7 +1,11 @@
 import os
 import tempfile
 import shutil
+from types import SimpleNamespace
+
 import chromadb
+import pytest
+
 from mempalace.convo_miner import mine_convos
 
 
@@ -24,3 +28,30 @@ def test_convo_mining():
     assert len(results["documents"][0]) > 0
 
     shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_convo_mining_uses_configured_collection(monkeypatch):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(tmpdir, "chat.txt"), "w") as f:
+            f.write(
+                "> What changed?\nWe switched collections.\n\n> Why?\nTo honor config consistently.\n"
+            )
+
+        palace_path = os.path.join(tmpdir, "palace")
+        monkeypatch.setattr(
+            "mempalace.palace.MempalaceConfig",
+            lambda: SimpleNamespace(
+                palace_path=palace_path,
+                collection_name="custom_drawers",
+            ),
+        )
+
+        mine_convos(tmpdir, palace_path, wing="test_convos")
+
+        client = chromadb.PersistentClient(path=palace_path)
+        assert client.get_collection("custom_drawers").count() >= 1
+        with pytest.raises(chromadb.errors.NotFoundError):
+            client.get_collection("mempalace_drawers")
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,7 +1,10 @@
 """Tests for mempalace.layers — Layer0, Layer1, Layer2, Layer3, MemoryStack."""
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import chromadb
 
 from mempalace.layers import Layer0, Layer1, Layer2, Layer3, MemoryStack
 
@@ -71,16 +74,14 @@ def test_layer0_default_path():
 
 
 def _mock_chromadb_for_layer(docs, metas, monkeypatch=None):
-    """Return a mock PersistentClient whose collection.get returns docs/metas."""
+    """Return a mock collection whose get() paginates over docs/metas."""
     mock_col = MagicMock()
     # First batch returns data, second batch returns empty (end of pagination)
     mock_col.get.side_effect = [
         {"documents": docs, "metadatas": metas},
         {"documents": [], "metadatas": []},
     ]
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-    return mock_client
+    return mock_col
 
 
 def test_layer1_no_palace():
@@ -101,11 +102,11 @@ def test_layer1_generates_essential_story():
         {"room": "decisions", "source_file": "meeting.txt", "importance": 5},
         {"room": "architecture", "source_file": "design.txt", "importance": 4},
     ]
-    mock_client = _mock_chromadb_for_layer(docs, metas)
+    mock_col = _mock_chromadb_for_layer(docs, metas)
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -118,12 +119,10 @@ def test_layer1_generates_essential_story():
 def test_layer1_empty_palace():
     mock_col = MagicMock()
     mock_col.get.return_value = {"documents": [], "metadatas": []}
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -135,11 +134,11 @@ def test_layer1_empty_palace():
 def test_layer1_with_wing_filter():
     docs = ["Memory about project X"]
     metas = [{"room": "general", "source_file": "x.txt", "importance": 3}]
-    mock_client = _mock_chromadb_for_layer(docs, metas)
+    mock_col = _mock_chromadb_for_layer(docs, metas)
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake", wing="project_x")
@@ -147,18 +146,18 @@ def test_layer1_with_wing_filter():
 
     assert "ESSENTIAL STORY" in result
     # Verify wing filter was passed
-    call_kwargs = mock_client.get_collection.return_value.get.call_args_list[0][1]
+    call_kwargs = mock_col.get.call_args_list[0][1]
     assert call_kwargs.get("where") == {"wing": "project_x"}
 
 
 def test_layer1_truncates_long_snippets():
     docs = ["A" * 300]
     metas = [{"room": "general", "source_file": "long.txt"}]
-    mock_client = _mock_chromadb_for_layer(docs, metas)
+    mock_col = _mock_chromadb_for_layer(docs, metas)
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -171,11 +170,11 @@ def test_layer1_respects_max_chars():
     """L1 stops adding entries once MAX_CHARS is reached."""
     docs = [f"Memory number {i} with substantial content padding here" for i in range(30)]
     metas = [{"room": "general", "source_file": f"f{i}.txt", "importance": 5} for i in range(30)]
-    mock_client = _mock_chromadb_for_layer(docs, metas)
+    mock_col = _mock_chromadb_for_layer(docs, metas)
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -193,11 +192,11 @@ def test_layer1_importance_from_various_keys():
         {"room": "r", "weight": 1},
         {"room": "r"},  # no weight key, defaults to 3
     ]
-    mock_client = _mock_chromadb_for_layer(docs, metas)
+    mock_col = _mock_chromadb_for_layer(docs, metas)
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -213,12 +212,10 @@ def test_layer1_batch_exception_breaks():
         {"documents": ["doc1"], "metadatas": [{"room": "r"}]},
         RuntimeError("batch error"),
     ]
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer1(palace_path="/fake")
@@ -244,12 +241,10 @@ def test_layer2_retrieve_with_wing():
         "documents": ["Some memory about the project"],
         "metadatas": [{"room": "backend", "source_file": "notes.txt"}],
     }
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
 
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -265,12 +260,9 @@ def test_layer2_retrieve_with_room():
         "documents": ["Backend architecture notes"],
         "metadatas": [{"room": "architecture", "source_file": "arch.txt"}],
     }
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -285,12 +277,9 @@ def test_layer2_retrieve_wing_and_room():
         "documents": ["Filtered result"],
         "metadatas": [{"room": "backend", "source_file": "x.txt"}],
     }
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -304,12 +293,9 @@ def test_layer2_retrieve_wing_and_room():
 def test_layer2_retrieve_empty():
     mock_col = MagicMock()
     mock_col.get.return_value = {"documents": [], "metadatas": []}
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -321,12 +307,9 @@ def test_layer2_retrieve_empty():
 def test_layer2_retrieve_no_filter():
     mock_col = MagicMock()
     mock_col.get.return_value = {"documents": [], "metadatas": []}
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -340,12 +323,9 @@ def test_layer2_retrieve_no_filter():
 def test_layer2_retrieve_error():
     mock_col = MagicMock()
     mock_col.get.side_effect = RuntimeError("db error")
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -360,12 +340,9 @@ def test_layer2_truncates_long_snippets():
         "documents": ["B" * 400],
         "metadatas": [{"room": "r", "source_file": "s.txt"}],
     }
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer2(palace_path="/fake")
@@ -408,12 +385,9 @@ def test_layer3_search_with_results():
         [{"wing": "project", "room": "backend", "source_file": "notes.txt"}],
         [0.2],
     )
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -427,12 +401,9 @@ def test_layer3_search_with_results():
 def test_layer3_search_no_results():
     mock_col = MagicMock()
     mock_col.query.return_value = _mock_query_results([], [], [])
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -448,12 +419,9 @@ def test_layer3_search_with_wing_filter():
         [{"wing": "proj", "room": "r"}],
         [0.1],
     )
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -470,12 +438,9 @@ def test_layer3_search_with_room_filter():
         [{"wing": "w", "room": "backend"}],
         [0.1],
     )
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -492,12 +457,9 @@ def test_layer3_search_with_wing_and_room():
         [{"wing": "proj", "room": "backend"}],
         [0.1],
     )
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -510,12 +472,9 @@ def test_layer3_search_with_wing_and_room():
 def test_layer3_search_error():
     mock_col = MagicMock()
     mock_col.query.side_effect = RuntimeError("search failed")
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -531,12 +490,9 @@ def test_layer3_search_truncates_long_docs():
         [{"wing": "w", "room": "r", "source_file": "s.txt"}],
         [0.1],
     )
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -552,12 +508,9 @@ def test_layer3_search_raw_returns_dicts():
         [{"wing": "proj", "room": "backend", "source_file": "f.txt"}],
         [0.3],
     )
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -577,12 +530,9 @@ def test_layer3_search_raw_with_filters():
         [{"wing": "w", "room": "r"}],
         [0.1],
     )
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -595,12 +545,9 @@ def test_layer3_search_raw_with_filters():
 def test_layer3_search_raw_error():
     mock_col = MagicMock()
     mock_col.query.side_effect = RuntimeError("fail")
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         layer = Layer3(palace_path="/fake")
@@ -701,12 +648,9 @@ def test_memory_stack_status_with_palace(tmp_path):
 
     mock_col = MagicMock()
     mock_col.count.return_value = 42
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
-        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+        patch("mempalace.layers.get_drawer_collection", return_value=mock_col),
     ):
         mock_cfg.return_value.palace_path = "/fake"
         stack = MemoryStack(
@@ -717,3 +661,26 @@ def test_memory_stack_status_with_palace(tmp_path):
 
     assert result["total_drawers"] == 42
     assert result["L0_identity"]["exists"] is True
+
+
+def test_memory_stack_status_uses_configured_collection(tmp_path):
+    identity_file = tmp_path / "identity.txt"
+    identity_file.write_text("I am Atlas.")
+    palace_path = tmp_path / "palace"
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_or_create_collection("custom_drawers")
+    col.add(
+        ids=["drawer_1"],
+        documents=["Stored in the configured collection."],
+        metadatas=[{"wing": "project", "room": "backend", "source_file": "notes.txt"}],
+    )
+    cfg = SimpleNamespace(palace_path=str(palace_path), collection_name="custom_drawers")
+
+    with patch("mempalace.layers.MempalaceConfig", return_value=cfg):
+        stack = MemoryStack(
+            palace_path=str(palace_path),
+            identity_path=str(identity_file),
+        )
+        result = stack.status()
+
+    assert result["total_drawers"] == 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,6 +7,9 @@ via monkeypatch to avoid touching real data.
 """
 
 import json
+from types import SimpleNamespace
+
+import chromadb
 
 
 def _patch_mcp_server(monkeypatch, config, kg):
@@ -15,20 +18,45 @@ def _patch_mcp_server(monkeypatch, config, kg):
 
     monkeypatch.setattr(mcp_server, "_config", config)
     monkeypatch.setattr(mcp_server, "_kg", kg)
+    mcp_server._client_cache = None
+    mcp_server._client_cache_path = None
+    mcp_server._collection_cache = None
+    mcp_server._collection_cache_key = None
 
 
-def _get_collection(palace_path, create=False):
+def _get_collection(palace_path, create=False, collection_name="mempalace_drawers"):
     """Helper to get collection from test palace.
 
     Returns (client, collection) so callers can clean up the client
     when they are done.
     """
-    import chromadb
-
     client = chromadb.PersistentClient(path=palace_path)
     if create:
-        return client, client.get_or_create_collection("mempalace_drawers")
-    return client, client.get_collection("mempalace_drawers")
+        return client, client.get_or_create_collection(collection_name)
+    return client, client.get_collection(collection_name)
+
+
+class _PagedCollection:
+    def __init__(self, total):
+        self._metadatas = [
+            {"wing": "project" if i % 2 == 0 else "notes", "room": "backend" if i % 3 else "planning"}
+            for i in range(total)
+        ]
+
+    def count(self):
+        return len(self._metadatas)
+
+    def get(self, include, limit, offset, where=None):
+        del include
+        if where:
+            source = [m for m in self._metadatas if all(m.get(k) == v for k, v in where.items())]
+        else:
+            source = self._metadatas
+        batch = source[offset : offset + limit]
+        return {
+            "ids": [f"id{offset + i}" for i in range(len(batch))],
+            "metadatas": batch,
+        }
 
 
 # ── Protocol Layer ──────────────────────────────────────────────────────
@@ -181,6 +209,21 @@ class TestReadTools:
         assert "project" in result["wings"]
         assert "notes" in result["wings"]
 
+    def test_status_with_custom_collection(self, monkeypatch, palace_path, kg):
+        config = SimpleNamespace(palace_path=palace_path, collection_name="custom_drawers")
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, col = _get_collection(palace_path, create=True, collection_name="custom_drawers")
+        col.add(
+            ids=["drawer_custom"],
+            documents=["Custom collection drawer"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": "notes.txt"}],
+        )
+        del _client
+        from mempalace.mcp_server import tool_status
+
+        result = tool_status()
+        assert result["total_drawers"] == 1
+
     def test_list_wings(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_list_wings
@@ -221,6 +264,25 @@ class TestReadTools:
 
         result = tool_status()
         assert "error" in result
+
+    def test_read_tools_page_past_10000(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        fake_collection = _PagedCollection(10_005)
+        monkeypatch.setattr("mempalace.mcp_server._get_collection", lambda create=False: fake_collection)
+        from mempalace.mcp_server import tool_get_taxonomy, tool_list_rooms, tool_list_wings, tool_status
+
+        status_result = tool_status()
+        wings_result = tool_list_wings()
+        rooms_result = tool_list_rooms(wing="project")
+        taxonomy_result = tool_get_taxonomy()
+
+        assert status_result["total_drawers"] == 10_005
+        assert sum(status_result["wings"].values()) == 10_005
+        assert wings_result["wings"] == status_result["wings"]
+        assert sum(rooms_result["rooms"].values()) == status_result["wings"]["project"]
+        assert sum(
+            count for wing_rooms in taxonomy_result["taxonomy"].values() for count in wing_rooms.values()
+        ) == 10_005
 
 
 # ── Search Tool ─────────────────────────────────────────────────────────
@@ -320,6 +382,47 @@ class TestWriteTools:
             threshold=0.99,
         )
         assert result["is_duplicate"] is False
+
+
+class TestCollectionCache:
+    def test_get_collection_rekeys_when_context_changes(self, monkeypatch, tmp_path, kg):
+        from mempalace import mcp_server
+
+        palace_a = tmp_path / "palace-a"
+        palace_b = tmp_path / "palace-b"
+        config_a = SimpleNamespace(palace_path=str(palace_a), collection_name="col_a")
+        config_b = SimpleNamespace(palace_path=str(palace_a), collection_name="col_b")
+        config_c = SimpleNamespace(palace_path=str(palace_b), collection_name="col_b")
+
+        _patch_mcp_server(monkeypatch, config_a, kg)
+        col_a = mcp_server._get_collection(create=True)
+        assert col_a.name == "col_a"
+        assert mcp_server._collection_cache_key == (str(palace_a), "col_a")
+
+        monkeypatch.setattr(mcp_server, "_config", config_b)
+        col_b = mcp_server._get_collection(create=True)
+        assert col_b.name == "col_b"
+        assert mcp_server._collection_cache_key == (str(palace_a), "col_b")
+
+        monkeypatch.setattr(mcp_server, "_config", config_c)
+        col_c = mcp_server._get_collection(create=True)
+        assert col_c.name == "col_b"
+        assert mcp_server._client_cache_path == str(palace_b)
+        assert mcp_server._collection_cache_key == (str(palace_b), "col_b")
+
+    def test_create_false_miss_does_not_poison_later_create_true(self, monkeypatch, tmp_path, kg):
+        from mempalace import mcp_server
+
+        palace_path = tmp_path / "palace"
+        palace_path.mkdir()
+        config = SimpleNamespace(palace_path=str(palace_path), collection_name="custom_drawers")
+        _patch_mcp_server(monkeypatch, config, kg)
+
+        assert mcp_server._get_collection(create=False) is None
+        created = mcp_server._get_collection(create=True)
+        assert created is not None
+        assert created.name == "custom_drawers"
+        assert mcp_server._get_collection(create=False).name == "custom_drawers"
 
 
 # ── KG Tools ────────────────────────────────────────────────────────────

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -2,8 +2,10 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import chromadb
+import pytest
 import yaml
 
 from mempalace.miner import mine, scan_project
@@ -18,6 +20,25 @@ def write_file(path: Path, content: str):
 def scanned_files(project_root: Path, **kwargs):
     files = scan_project(str(project_root), **kwargs)
     return sorted(path.relative_to(project_root).as_posix() for path in files)
+
+
+class _PagedCollection:
+    def __init__(self, total):
+        self._metadatas = [
+            {"wing": "project" if i % 2 == 0 else "notes", "room": "backend" if i % 3 else "planning"}
+            for i in range(total)
+        ]
+
+    def count(self):
+        return len(self._metadatas)
+
+    def get(self, include, limit, offset, where=None):
+        del include, where
+        batch = self._metadatas[offset : offset + limit]
+        return {
+            "ids": [f"id{offset + i}" for i in range(len(batch))],
+            "metadatas": batch,
+        }
 
 
 def test_project_mining():
@@ -51,6 +72,40 @@ def test_project_mining():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_project_mining_uses_configured_collection(monkeypatch):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "backend")
+        write_file(project_root / "backend" / "app.py", "def main():\n    return 1\n" * 20)
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "backend", "description": "Backend code"}],
+                },
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        monkeypatch.setattr(
+            "mempalace.palace.MempalaceConfig",
+            lambda: SimpleNamespace(
+                palace_path=str(palace_path),
+                collection_name="custom_drawers",
+            ),
+        )
+
+        mine(str(project_root), str(palace_path))
+
+        client = chromadb.PersistentClient(path=str(palace_path))
+        assert client.get_collection("custom_drawers").count() > 0
+        with pytest.raises(chromadb.errors.NotFoundError):
+            client.get_collection("mempalace_drawers")
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def test_scan_project_respects_gitignore():
     tmpdir = tempfile.mkdtemp()
     try:
@@ -64,6 +119,19 @@ def test_scan_project_respects_gitignore():
         assert scanned_files(project_root) == ["src/app.py"]
     finally:
         shutil.rmtree(tmpdir)
+
+
+def test_status_pages_past_10000(monkeypatch, capsys):
+    from mempalace.miner import status
+
+    monkeypatch.setattr("mempalace.miner.get_drawer_collection", lambda *args, **kwargs: _PagedCollection(10_005))
+    status("/fake/palace")
+
+    out = capsys.readouterr().out
+    assert "10,005" not in out  # current output is plain int, keep shape unchanged
+    assert "10005 drawers" in out
+    assert "WING: project" in out
+    assert "WING: notes" in out
 
 
 def test_scan_project_respects_nested_gitignore():

--- a/tests/test_palace.py
+++ b/tests/test_palace.py
@@ -1,0 +1,33 @@
+"""Tests for shared palace access helpers."""
+
+from mempalace.palace import get_drawer_collection, iter_collection_metadatas
+
+
+class _PagedCollection:
+    def __init__(self, total):
+        self._metadatas = [{"wing": "w", "room": f"r{i % 3}"} for i in range(total)]
+
+    def get(self, include, limit, offset, where=None):
+        del include, where
+        batch = self._metadatas[offset : offset + limit]
+        return {
+            "ids": [f"id{offset + i}" for i in range(len(batch))],
+            "metadatas": batch,
+        }
+
+
+def test_get_drawer_collection_read_does_not_create_missing_dir(tmp_path):
+    missing = tmp_path / "missing-palace"
+
+    assert get_drawer_collection(palace_path=str(missing), create=False) is None
+    assert not missing.exists()
+
+
+def test_iter_collection_metadatas_pages_without_hard_cap():
+    collection = _PagedCollection(10_005)
+
+    rows = list(iter_collection_metadatas(collection, batch_size=1000))
+
+    assert len(rows) == 10_005
+    assert rows[0]["room"] == "r0"
+    assert rows[-1]["room"] == "r2"

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -5,8 +5,10 @@ Uses the real ChromaDB fixtures from conftest.py for integration tests,
 plus mock-based tests for error paths.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import chromadb
 import pytest
 
 from mempalace.searcher import SearchError, search, search_memories
@@ -38,6 +40,32 @@ class TestSearchMemories:
         result = search_memories("code", palace_path, n_results=2)
         assert len(result["results"]) <= 2
 
+    def test_search_memories_uses_explicit_path_and_configured_collection(self, tmp_path):
+        palace_path = tmp_path / "custom-palace"
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_or_create_collection("custom_drawers")
+        col.add(
+            ids=["drawer_1"],
+            documents=["JWT authentication now lives in the custom collection."],
+            metadatas=[
+                {
+                    "wing": "project",
+                    "room": "backend",
+                    "source_file": "auth.py",
+                    "chunk_index": 0,
+                }
+            ],
+        )
+        cfg = SimpleNamespace(
+            palace_path="/wrong/path",
+            collection_name="custom_drawers",
+        )
+
+        result = search_memories("JWT authentication", str(palace_path), config=cfg)
+
+        assert result["results"]
+        assert result["results"][0]["room"] == "backend"
+
     def test_no_palace_returns_error(self, tmp_path):
         result = search_memories("anything", str(tmp_path / "missing"))
         assert "error" in result
@@ -56,10 +84,8 @@ class TestSearchMemories:
         """search_memories returns error dict when query raises."""
         mock_col = MagicMock()
         mock_col.query.side_effect = RuntimeError("query failed")
-        mock_client = MagicMock()
-        mock_client.get_collection.return_value = mock_col
 
-        with patch("mempalace.searcher.chromadb.PersistentClient", return_value=mock_client):
+        with patch("mempalace.searcher.get_drawer_collection", return_value=mock_col):
             result = search_memories("test", "/fake/path")
         assert "error" in result
         assert "query failed" in result["error"]
@@ -111,10 +137,8 @@ class TestSearchCLI:
         """search raises SearchError when query fails."""
         mock_col = MagicMock()
         mock_col.query.side_effect = RuntimeError("boom")
-        mock_client = MagicMock()
-        mock_client.get_collection.return_value = mock_col
 
-        with patch("mempalace.searcher.chromadb.PersistentClient", return_value=mock_client):
+        with patch("mempalace.searcher.get_drawer_collection", return_value=mock_col):
             with pytest.raises(SearchError, match="Search error"):
                 search("test", "/fake/path")
 


### PR DESCRIPTION
## Summary

This fixes a trust problem in the current tool: different parts of MemPalace could look at different drawer collections, so a user could mine memories successfully and then have search, wake-up, status, repair, or MCP read from somewhere else.

In simple terms, this PR makes the tool use the same default drawer collection everywhere it already promises to use it.

## What changed

- mining, search, layers, CLI status, CLI repair, CLI compress, and MCP drawer tools now all resolve the same configured default drawer collection
- `palace_path` from config and env now expands `~`
- `python -m mempalace.mcp_server --palace ~/...` now resolves `~` correctly
- read paths no longer create a fake empty palace or collection when the palace is actually missing
- metadata-based readers now page instead of truncating at 10,000 drawers, so large-palace status and taxonomy counts stay correct
- MCP collection caching is now keyed by resolved `(palace_path, collection_name)` so context changes do not go stale

## What this does not change

- no new commands or flags
- no public collection override
- no knowledge-graph redesign
- no deleted-file cleanup or refresh redesign

## Tests

- added regressions for `~` expansion from config and env
- added regressions proving project and convo mining write to the configured collection
- added regressions proving search, layers, and MCP read from that same configured collection
- added regressions for exact counts above 10,000 drawers
- added regressions for MCP cache rekeying and create-false/create-true behavior

Validation run locally:
- `.venv/bin/pytest tests/test_config.py tests/test_palace.py tests/test_miner.py tests/test_convo_miner.py tests/test_searcher.py tests/test_layers.py tests/test_mcp_server.py tests/test_cli.py`
- `.venv/bin/ruff check mempalace tests`
- `.venv/bin/python -m pytest`
