### PR TITLE
fix: add ensure_ascii=False to json.dumps in MCP server

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -904,7 +904,11 @@ def handle_request(request):
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "result": {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]},
+                "result": {
+                    "content": [
+                        {"type": "text", "text": json.dumps(result, indent=2, ensure_ascii=False)}
+                    ]
+                },
             }
         except Exception:
             logger.exception(f"Tool error in {tool_name}")
@@ -934,7 +938,7 @@ def main():
             request = json.loads(line)
             response = handle_request(request)
             if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
+                sys.stdout.write(json.dumps(response, ensure_ascii=False) + "\n")
                 sys.stdout.flush()
         except KeyboardInterrupt:
             break

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -403,3 +403,55 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+
+# ── Unicode / non-ASCII handling ───────────────────────────────────────
+
+
+class TestUnicodeHandling:
+    """Verify json.dumps uses ensure_ascii=False so non-ASCII characters
+    survive round-trip through the MCP JSON-RPC layer (#359)."""
+
+    def test_tool_result_preserves_unicode(self, monkeypatch):
+        """Tool results with non-ASCII text should serialize without error."""
+        from mempalace import mcp_server
+
+        # Stub a tool that returns Chinese text
+        monkeypatch.setitem(
+            mcp_server.TOOLS,
+            "echo_unicode",
+            {
+                "handler": lambda text="": {"echo": text},
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                },
+            },
+        )
+
+        resp = mcp_server.handle_request(
+            {
+                "method": "tools/call",
+                "id": 99,
+                "params": {"name": "echo_unicode", "arguments": {"text": "你好世界"}},
+            }
+        )
+        assert "error" not in resp
+        payload = resp["result"]["content"][0]["text"]
+        # With ensure_ascii=False, Chinese chars appear verbatim
+        assert "你好世界" in payload
+        # Round-trip through json.dumps must not raise
+        json.dumps(resp, ensure_ascii=False)
+
+    def test_main_loop_writes_unicode(self, monkeypatch, tmp_path):
+        """The main loop stdout writer should handle non-ASCII responses."""
+        from mempalace import mcp_server
+
+        response = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": "日本語テスト"}]},
+        }
+        # Verify json.dumps with ensure_ascii=False doesn't raise
+        encoded = json.dumps(response, ensure_ascii=False)
+        assert "日本語テスト" in encoded


### PR DESCRIPTION
Fixes #359

`json.dumps` in the MCP server didn't set `ensure_ascii=False`, so non-ASCII text (Chinese, Japanese, etc.) would either get escaped to `\uXXXX` or crash outright when lone surrogate characters showed up from certain MCP client encoding paths.

**Before:**
```python
json.dumps(result, indent=2)          # line 907 — tool result
json.dumps(response)                  # line 937 — stdout writer
```
Chinese text → `UnicodeEncodeError` or garbled `\uXXXX` output.

**After:**
```python
json.dumps(result, indent=2, ensure_ascii=False)
json.dumps(response, ensure_ascii=False)
```
Chinese text → preserved as-is in the JSON output.

Added two tests in `test_mcp_server.py`:
- `test_tool_result_preserves_unicode` — end-to-end through `handle_request` with Chinese text
- `test_main_loop_writes_unicode` — verifies the serialization doesn't crash

All 35 tests pass.