### PR TITLE
chore(deps): pin chromadb to >=1.0,<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "chromadb>=0.5.0,<0.7",
+    "chromadb>=1.0,<2",
     "pyyaml>=6.0,<7",
 ]
 


### PR DESCRIPTION
## What does this PR do?

Fixes installs for users whose palaces were created with chromadb 1.x (see #445). The current constraint `chromadb>=0.5.0,<0.7` forces installs onto the 0.5/0.6 line, which uses an older on-disk format. Palaces built on chromadb 1.x can't be opened by 0.6 — `get_collection` fails with `KeyError: '_type'` when reading collection config JSON, and the CLI surfaces it as a misleading "No palace found" message.

Pin to the 1.x line so:

- editable installs keep working with palaces built on 1.x
- new installs land on the same major as the current chromadb release (1.5.x)
- we have a single supported major instead of straddling two on-disk formats

## Known break and migration note

**This change does break users with existing chromadb 0.5/0.6 palaces.** chromadb 1.x does not auto-migrate the 0.6 on-disk format — the [chromadb 1.0 migration guide](https://docs.trychroma.com/docs/migration/) covers a dedicated process. For mempalace specifically, the simplest recovery is to back up `~/.mempalace/palace/` and re-mine the source files into a fresh 1.x palace.

A proper in-tool migration command (`mempalace migrate-chroma` or similar) is a separate concern and belongs in a follow-up PR. This PR is intentionally scoped to the dependency pin.

## API compatibility audit

All chromadb APIs used by mempalace are part of the stable core interface and work identically on 0.5 → 1.x:

| API                                   | Callers                                                        |
| ------------------------------------- | -------------------------------------------------------------- |
| `chromadb.PersistentClient(path=...)` | `palace.py`, `mcp_server.py`, `layers.py`, `searcher.py`, `cli.py` |
| `client.get_collection(name)`         | `palace.py`, `mcp_server.py`, `layers.py`, `searcher.py`, `cli.py` |
| `client.create_collection(name)`      | `palace.py`                                                    |
| `client.get_or_create_collection(name)` | `mcp_server.py`                                              |
| `collection.get(where=..., limit=...)` | `palace.py`, `miner.py`, `mcp_server.py`                     |
| `collection.count()`                  | `mcp_server.py`, `cli.py`, `layers.py`                         |
| `collection.query(...)`               | `searcher.py`, `layers.py`                                     |
| `collection.add(...)`                 | `miner.py`, `convo_miner.py`                                   |
| `collection.delete(...)`              | `mcp_server.py`                                                |

No code changes needed.

## How to test

1. Install the branch in a fresh venv: `pip install -e .`
2. Confirm chromadb 1.x resolves: `python -c "import chromadb; print(chromadb.__version__)"` → `1.5.x`
3. Run the test suite: `python -m pytest tests/ -v` (passes locally against chromadb 1.5.7)
4. If you have an existing 1.x palace, verify `mempalace status` opens it without a `KeyError: '_type'`.

## Replaces

This replaces #365, which accumulated stale diffs from being rebased off an older main. This PR is a single clean commit off current `main`.

## Related

- Fixes #445 (1.x palace can't be opened under current pin)

## Checklist
- [x] Single-line dependency change, no new dependencies
- [x] All chromadb API calls audited for 1.x compatibility
- [x] Conventional commit title
- [x] Known migration impact documented
- [ ] Tests pass in CI (ran locally — need maintainer CI run)