### PR TITLE
fix(status): paginate metadata reads so palaces over 10k drawers report correctly

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 from .config import MempalaceConfig, sanitize_name, sanitize_content
 from .version import __version__
+from .palace import iter_all_metadatas
 from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
 import chromadb
@@ -144,8 +145,7 @@ def tool_status():
     wings = {}
     rooms = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
+        for m in iter_all_metadatas(col):
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
             wings[w] = wings.get(w, 0) + 1
@@ -201,8 +201,7 @@ def tool_list_wings():
         return _no_palace()
     wings = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
+        for m in iter_all_metadatas(col):
             w = m.get("wing", "unknown")
             wings[w] = wings.get(w, 0) + 1
     except Exception:
@@ -216,11 +215,8 @@ def tool_list_rooms(wing: str = None):
         return _no_palace()
     rooms = {}
     try:
-        kwargs = {"include": ["metadatas"], "limit": 10000}
-        if wing:
-            kwargs["where"] = {"wing": wing}
-        all_meta = col.get(**kwargs)["metadatas"]
-        for m in all_meta:
+        where = {"wing": wing} if wing else None
+        for m in iter_all_metadatas(col, where=where):
             r = m.get("room", "unknown")
             rooms[r] = rooms.get(r, 0) + 1
     except Exception:
@@ -234,8 +230,7 @@ def tool_get_taxonomy():
         return _no_palace()
     taxonomy = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
+        for m in iter_all_metadatas(col):
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
             if w not in taxonomy:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -614,6 +614,8 @@ def mine(
 
 def status(palace_path: str):
     """Show what's been filed in the palace."""
+    from .palace import iter_all_metadatas
+
     try:
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")
@@ -622,16 +624,14 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
-
+    # Authoritative total from ChromaDB; walk metadatas in pages for the breakdown
+    total = col.count()
     wing_rooms = defaultdict(lambda: defaultdict(int))
-    for m in metas:
+    for m in iter_all_metadatas(col):
         wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
 
     print(f"\n{'=' * 55}")
-    print(f"  MemPalace Status — {len(metas)} drawers")
+    print(f"  MemPalace Status — {total} drawers")
     print(f"{'=' * 55}\n")
     for wing, rooms in sorted(wing_rooms.items()):
         print(f"  WING: {wing}")

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -48,6 +48,27 @@ def get_collection(palace_path: str, collection_name: str = "mempalace_drawers")
         return client.create_collection(collection_name)
 
 
+def iter_all_metadatas(collection, where=None, page_size: int = 10000):
+    """Yield every metadata entry in the collection, paginating past the page cap.
+
+    ChromaDB's ``collection.get()`` enforces a per-call limit, so a single fetch
+    silently truncates large palaces. This walks the collection in pages so
+    callers see every drawer — with or without a ``where`` filter.
+    """
+    offset = 0
+    while True:
+        kwargs = {"include": ["metadatas"], "limit": page_size, "offset": offset}
+        if where is not None:
+            kwargs["where"] = where
+        page = collection.get(**kwargs)
+        metas = page.get("metadatas") or []
+        if not metas:
+            break
+        for m in metas:
+            yield m
+        offset += len(metas)
+
+
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:
     """Check if a file has already been filed in the palace.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -222,6 +222,45 @@ class TestReadTools:
         result = tool_status()
         assert "error" in result
 
+    def test_status_above_10k_drawers(self, monkeypatch, config, palace_path, kg):
+        """Regression test: palaces over 10k drawers were silently truncated.
+
+        tool_status previously called col.get(limit=10000, ...) and reported
+        len(metadatas) as the total, so any palace bigger than 10k reported
+        exactly 10000. This test seeds 10,500 drawers across two wings and
+        confirms the full count and per-wing breakdown come back correct.
+        """
+        _patch_mcp_server(monkeypatch, config, kg)
+        client, col = _get_collection(palace_path, create=True)
+
+        total = 10500
+        wing_a_count = 6000
+        wing_b_count = total - wing_a_count
+
+        ids = [f"id_{i}" for i in range(total)]
+        docs = [f"doc body {i}" for i in range(total)]
+        metas = []
+        for i in range(total):
+            wing = "wing_a" if i < wing_a_count else "wing_b"
+            room = "room_1" if i % 2 == 0 else "room_2"
+            metas.append({"wing": wing, "room": room})
+
+        # Chroma has its own per-call add limit, so batch the seed data.
+        batch_size = 2000
+        for start in range(0, total, batch_size):
+            end = min(start + batch_size, total)
+            col.add(ids=ids[start:end], documents=docs[start:end], metadatas=metas[start:end])
+        del client
+
+        from mempalace.mcp_server import tool_status
+
+        result = tool_status()
+        assert result["total_drawers"] == total
+        assert result["wings"]["wing_a"] == wing_a_count
+        assert result["wings"]["wing_b"] == wing_b_count
+        # Per-room breakdown should also reflect the full dataset, not just 10k.
+        assert result["rooms"]["room_1"] + result["rooms"]["room_2"] == total
+
 
 # ── Search Tool ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Fixes a silent truncation bug where palaces with more than 10,000 drawers report `10000` as their total drawer count. Found this on a real palace with 39,334 drawers — both `mempalace status` (CLI) and the `mempalace_status` MCP tool returned `10000` instead of the actual total.

Both code paths called `col.get(limit=10000, ...)` and treated `len(metadatas)` as the total. The four affected MCP read tools (`mempalace_status`, `mempalace_list_wings`, `mempalace_list_rooms`, `mempalace_get_taxonomy`) and the CLI `status()` function all had the same pattern.

## Fix

- New shared helper `iter_all_metadatas(collection, where=None, page_size=10000)` in `palace.py` walks the collection in pages until an empty page is returned. Uses a clean `while True / break on empty` pattern that handles both unfiltered and `where`-filtered queries without needing `col.count()` up front.
- `mempalace status` (`miner.py`) uses `col.count()` for the authoritative total and `iter_all_metadatas()` for the per-wing / per-room breakdown.
- All four affected MCP read tools (`mcp_server.py`) import and use the shared helper — one implementation, four callers.
- The diary read path keeps its 10k limit since per-agent diary collections are small and the call is already filtered by wing+room.

## Replaces

This replaces the older #364. That branch was based on an older `main` and accumulated stale diffs; this PR is on a clean branch off current `main` and also incorporates the [Octocode review feedback](https://github.com/milla-jovovich/mempalace/pull/364#issuecomment-4216364410) from that PR:

- **Cleaner iterator** — `while True / break on empty` instead of `while offset < total`, so filtered queries no longer overshoot
- **Shared helper** — moved from `mcp_server.py` into `palace.py` so `miner.py` and `mcp_server.py` both use it, instead of duplicating the pagination inline
- **Regression test** — new `test_status_above_10k_drawers` seeds 10,500 drawers across two wings and two rooms and asserts `total_drawers`, `wings`, and `rooms` all reflect the full dataset

## How to test

```bash
python -m pytest tests/test_mcp_server.py::TestReadTools -v
```

All 8 tests pass, including the new regression test. The existing `test_status_with_data` / `test_list_wings` / etc. continue to pass unchanged.

## Manual verification

On a palace with 39,334 drawers:

```
$ mempalace status
=======================================================
  MemPalace Status — 39334 drawers
=======================================================

  WING: claude_sessions
    ROOM: technical            29058 drawers
    ROOM: architecture          5136 drawers
    ROOM: problems              1733 drawers
    ROOM: planning               531 drawers
    ROOM: general                485 drawers
    ROOM: decisions               54 drawers

  WING: projects
    ROOM: general               1501 drawers
    ROOM: agent_exploration      709 drawers
    ...
```

Previously this reported `10000` total with a truncated per-room breakdown.

## Checklist

- [x] Tests pass (`python -m pytest tests/test_mcp_server.py::TestReadTools -v`)
- [x] Ruff lint + format clean (`ruff check .` / `ruff format --check .`)
- [x] No hardcoded paths
- [x] New regression test for the >10k case
- [x] Addresses Octocode review feedback from #364