### PR TITLE
fix: add compress_query() for symmetric AAAK retrieval

### DIFF
--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -244,8 +244,8 @@ def build_palace_and_retrieve(entry, granularity="session", n_results=50):
 def build_palace_and_retrieve_aaak(entry, granularity="session", n_results=50):
     """
     AAAK mode: compress each session/turn with AAAK dialect before ingesting.
-    Query still uses raw question text — tests whether compressed representations
-    retain enough semantic signal for retrieval.
+    Query is also compressed with compress_query() for symmetric retrieval —
+    both query and documents share the same AAAK representational space.
     """
     from mempalace.dialect import Dialect
 
@@ -295,8 +295,8 @@ def build_palace_and_retrieve_aaak(entry, granularity="session", n_results=50):
         ],
     )
 
-    # Query with raw question (not compressed)
-    query = entry["question"]
+    # Query with compressed question for symmetric AAAK retrieval
+    query = dialect.compress_query(entry["question"])
     results = collection.query(
         query_texts=[query],
         n_results=min(n_results, len(corpus)),

--- a/mempalace/dialect.py
+++ b/mempalace/dialect.py
@@ -607,6 +607,31 @@ class Dialect:
 
         return "\n".join(lines)
 
+    def compress_query(self, text: str) -> str:
+        """
+        Encode a question into lightweight AAAK format for symmetric retrieval.
+
+        Extracts entity codes and topic keywords only — no emotions, flags, or
+        key sentences (questions don't have those). Keeps query and stored
+        documents in the same representational space for ChromaDB, avoiding the
+        vocabulary mismatch that occurs when raw natural language is compared
+        against AAAK-compressed documents.
+
+        Falls back to raw text if the question is too sparse to compress
+        meaningfully (avoids producing useless 0:???|misc output that would
+        be worse than the original question for retrieval).
+        """
+        entities = self._detect_entities_in_text(text)
+        entity_str = "+".join(entities[:3]) if entities else "???"
+        topics = self._extract_topics(text)
+
+        # Fallback: if we can't extract anything meaningful, raw text retrieves better
+        if not topics and entity_str == "???":
+            return text
+
+        topic_str = "_".join(topics[:3]) if topics else "misc"
+        return f"0:{entity_str}|{topic_str}"
+
     # === ZETTEL-BASED ENCODING (original format, kept for compatibility) ===
 
     def extract_key_quote(self, zettel: dict) -> str:

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -145,6 +145,40 @@ class TestZettelEncoding:
         assert "002" in result
 
 
+class TestCompressQuery:
+    def test_compress_query_keyword_rich(self):
+        """Keyword-rich question produces output containing topic words."""
+        d = Dialect()
+        result = d.compress_query("Where do we do yoga in the morning?")
+        assert "yoga" in result
+
+    def test_compress_query_with_known_entity(self):
+        """Known entity name is encoded as its AAAK code in the query output."""
+        d = Dialect(entities={"Alice": "ALC"})
+        result = d.compress_query("What did Alice say about the project?")
+        assert "ALC" in result
+
+    def test_compress_query_sparse_falls_back_to_raw(self):
+        """Sparse question with no extractable content returns the original string."""
+        d = Dialect()
+        question = "Why?"
+        result = d.compress_query(question)
+        assert result == question
+
+    def test_compress_query_aaak_format_for_rich_input(self):
+        """Keyword-rich question produces AAAK pipe-separated format."""
+        d = Dialect()
+        result = d.compress_query("What programming language should I use for my machine learning project?")
+        assert "|" in result
+
+    def test_compress_query_no_quoted_fragment(self):
+        """compress_query never includes a quoted key sentence — queries are not documents."""
+        import re
+        d = Dialect()
+        result = d.compress_query("Where did we go for dinner last Tuesday?")
+        assert not re.search(r'"[^"]+"', result)
+
+
 class TestDecode:
     def test_decode_roundtrip(self):
         d = Dialect()


### PR DESCRIPTION
## Problem

AAAK benchmark mode scores 84.2% vs 96.6% in raw mode. The root cause is a query-document representation mismatch — a known information retrieval problem called vocabulary mismatch in dense retrieval.

Documents are stored in compressed AAAK format (e.g. `0:ALI+BOB|yoga_morning|"went this morning"|joy`), but queries use raw natural language. ChromaDB embeds both for similarity search — raw English and AAAK pipe-delimited symbols land in different semantic spaces, causing retrieval misses.

## Fix

Adds `compress_query()` to the `Dialect` class. Extracts entity codes and topic keywords from a question using the existing `_detect_entities_in_text()` and `_extract_topics()` methods — without applying document summarization logic (no emotions, no flags, no quoted fragment).

Falls back to raw text when extraction yields no meaningful output, ensuring no regression on sparse or vague questions.

## Changes

- `mempalace/dialect.py` — new `compress_query()` method on `Dialect`
- `benchmarks/longmemeval_bench.py` line 299 — query now uses `dialect.compress_query()` instead of raw text
- `tests/test_dialect.py` — 5 new tests covering keyword extraction, entity matching, sparse fallback, format correctness, and absence of quoted fragment

## Testing

All 5 new tests pass. All existing tests unaffected.