### PR TITLE
fix: harden palace.py mtime check and expand test coverage

### DIFF
--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -4,8 +4,12 @@ palace.py — Shared palace operations.
 Consolidates ChromaDB access patterns used by both miners and the MCP server.
 """
 
+import logging
 import os
+
 import chromadb
+
+logger = logging.getLogger("mempalace")
 
 SKIP_DIRS = {
     ".git",
@@ -45,6 +49,7 @@ def get_collection(palace_path: str, collection_name: str = "mempalace_drawers")
     try:
         return client.get_collection(collection_name)
     except Exception:
+        logger.debug("Collection %r not found, creating it", collection_name)
         return client.create_collection(collection_name)
 
 
@@ -65,7 +70,7 @@ def file_already_mined(collection, source_file: str, check_mtime: bool = False) 
             if stored_mtime is None:
                 return False
             current_mtime = os.path.getmtime(source_file)
-            return float(stored_mtime) == current_mtime
+            return abs(float(stored_mtime) - current_mtime) < 0.01
         return True
     except Exception:
         return False

--- a/tests/test_palace.py
+++ b/tests/test_palace.py
@@ -1,0 +1,105 @@
+"""
+test_palace.py -- Direct unit tests for palace.py.
+
+Covers get_collection, file_already_mined (including mtime tolerance),
+and SKIP_DIRS constants.
+"""
+
+import os
+
+from mempalace.palace import SKIP_DIRS, file_already_mined, get_collection
+
+
+class TestGetCollection:
+    def test_creates_collection_if_missing(self, palace_path):
+        col = get_collection(palace_path, "test_col")
+        assert col is not None
+        assert col.name == "test_col"
+
+    def test_returns_existing_collection(self, palace_path):
+        col1 = get_collection(palace_path, "test_col")
+        col1.add(ids=["d1"], documents=["hello"], metadatas=[{"wing": "w"}])
+        col2 = get_collection(palace_path, "test_col")
+        assert col2.count() == 1
+
+    def test_creates_palace_directory(self, tmp_dir):
+        new_path = os.path.join(tmp_dir, "new_palace")
+        col = get_collection(new_path)
+        assert col is not None
+        assert os.path.isdir(new_path)
+
+
+class TestFileAlreadyMined:
+    def test_false_for_new_file(self, collection):
+        assert file_already_mined(collection, "never_seen.py") is False
+
+    def test_true_for_known_file(self, collection):
+        collection.add(
+            ids=["d1"],
+            documents=["content"],
+            metadatas=[{"source_file": "known.py", "wing": "w", "room": "r"}],
+        )
+        assert file_already_mined(collection, "known.py") is True
+
+    def test_mtime_exact_match(self, collection, tmp_dir):
+        src = os.path.join(tmp_dir, "file.txt")
+        with open(src, "w") as f:
+            f.write("data")
+        mtime = os.path.getmtime(src)
+        collection.add(
+            ids=["d1"],
+            documents=["content"],
+            metadatas=[{"source_file": src, "source_mtime": mtime, "wing": "w", "room": "r"}],
+        )
+        assert file_already_mined(collection, src, check_mtime=True) is True
+
+    def test_mtime_tolerance(self, collection, tmp_dir):
+        """A tiny float rounding difference should still count as mined."""
+        src = os.path.join(tmp_dir, "file.txt")
+        with open(src, "w") as f:
+            f.write("data")
+        mtime = os.path.getmtime(src)
+        # Simulate a tiny rounding error from serialization
+        stored = mtime + 1e-7
+        collection.add(
+            ids=["d1"],
+            documents=["content"],
+            metadatas=[{"source_file": src, "source_mtime": stored, "wing": "w", "room": "r"}],
+        )
+        assert file_already_mined(collection, src, check_mtime=True) is True
+
+    def test_mtime_detects_modification(self, collection, tmp_dir):
+        """If the file was modified after mining, it should return False."""
+        src = os.path.join(tmp_dir, "file.txt")
+        with open(src, "w") as f:
+            f.write("original")
+        old_mtime = os.path.getmtime(src)
+        collection.add(
+            ids=["d1"],
+            documents=["content"],
+            metadatas=[{"source_file": src, "source_mtime": old_mtime, "wing": "w", "room": "r"}],
+        )
+        # Modify the file so mtime changes
+        os.utime(src, (old_mtime + 10, old_mtime + 10))
+        assert file_already_mined(collection, src, check_mtime=True) is False
+
+    def test_mtime_missing_metadata(self, collection, tmp_dir):
+        """If source_mtime was never stored, treat as not mined."""
+        src = os.path.join(tmp_dir, "file.txt")
+        with open(src, "w") as f:
+            f.write("data")
+        collection.add(
+            ids=["d1"],
+            documents=["content"],
+            metadatas=[{"source_file": src, "wing": "w", "room": "r"}],
+        )
+        assert file_already_mined(collection, src, check_mtime=True) is False
+
+
+class TestSkipDirs:
+    def test_contains_expected_entries(self):
+        for d in (".git", "node_modules", "__pycache__", ".venv", ".mempalace"):
+            assert d in SKIP_DIRS
+
+    def test_is_a_set(self):
+        assert isinstance(SKIP_DIRS, set)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -123,3 +123,29 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         # Should have output with at least one result block
         assert "[1]" in captured.out
+
+
+# ── Edge-case tests ──────────────────────────────────────────────────
+
+
+class TestSearchEdgeCases:
+    def test_search_nonexistent_wing(self, palace_path, seeded_collection):
+        """Filtering by a wing with no entries returns empty results."""
+        result = search_memories("code", palace_path, wing="nonexistent_wing_xyz")
+        assert result["results"] == []
+
+    def test_search_nonexistent_room(self, palace_path, seeded_collection):
+        """Filtering by a room with no entries returns empty results."""
+        result = search_memories("code", palace_path, room="nonexistent_room_xyz")
+        assert result["results"] == []
+
+    def test_search_special_characters(self, palace_path, seeded_collection):
+        """Queries with special characters should not crash."""
+        for query in ['"quoted"', "pipe|char", "back\\slash", "uni\u00e9code"]:
+            result = search_memories(query, palace_path)
+            assert "results" in result
+
+    def test_search_memories_nonexistent_wing_and_room(self, palace_path, seeded_collection):
+        """Combined nonexistent wing+room returns empty results."""
+        result = search_memories("anything", palace_path, wing="nope", room="nada")
+        assert result["results"] == []


### PR DESCRIPTION
## Summary

- **Fix float equality bug** in `file_already_mined()` — replace exact `==` comparison with tolerance check (`< 0.01s`) to prevent false negatives caused by float serialization rounding through ChromaDB metadata
- **Add debug logging** to `get_collection()` fallback path so silent collection creation is traceable
- **New `test_palace.py`** with 11 direct unit tests covering `get_collection`, `file_already_mined` (mtime tolerance, modification detection, missing metadata), and `SKIP_DIRS`
- **New searcher edge-case tests** for nonexistent wing/room filters and special character queries

## Test plan

- [x] `pytest tests/test_palace.py -v` — all 11 new tests pass
- [x] `pytest tests/test_searcher.py -v` — all 17 tests pass (13 existing + 4 new)
- [x] `pytest tests/ -v` — full suite 549 passed, 0 failed
- [x] `ruff check` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)