### PR TITLE
feat: add cli stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ mempalace compress --wing myapp                   # AAAK compress
 
 # Status
 mempalace status                                  # palace overview
+mempalace stats                                   # show wings, halls, rooms, memories
 
 # MCP
 mempalace mcp                                     # show MCP setup command

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -17,8 +17,8 @@ Commands:
     mempalace mcp                         Show MCP setup command
     mempalace wake-up                     Show L0 + L1 wake-up context
     mempalace wake-up --wing my_app       Wake-up for a specific project
-    mempalace status                      Show what's been filed
-    mempalace stats                       Show counts for wings, halls, rooms, memories
+    mempalace status                      Show palace structure and what's been filed
+    mempalace stats                       Show numeric counts for wings, halls, rooms, memories
 
 Examples:
     mempalace init ~/projects/my_app
@@ -595,10 +595,10 @@ def main():
     )
 
     # status
-    sub.add_parser("status", help="Show what's been filed")
+    sub.add_parser("status", help="Show palace structure and what's been filed")
 
     # stats
-    sub.add_parser("stats", help="Show counts for wings, halls, rooms, memories")
+    sub.add_parser("stats", help="Show numeric counts for wings, halls, rooms, memories")
 
     args = parser.parse_args()
 

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -18,6 +18,7 @@ Commands:
     mempalace wake-up                     Show L0 + L1 wake-up context
     mempalace wake-up --wing my_app       Wake-up for a specific project
     mempalace status                      Show what's been filed
+    mempalace stats                       Show counts for wings, halls, rooms, memories
 
 Examples:
     mempalace init ~/projects/my_app
@@ -155,6 +156,69 @@ def cmd_status(args):
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     status(palace_path=palace_path)
+
+
+def _palace_stats(col):
+    """Collect unique wing/hall/room counts and total memories from a collection."""
+    total = col.count()
+    wings = set()
+    halls = set()
+    rooms = set()
+    offset = 0
+    batch_size = 1000
+
+    while offset < total:
+        batch = col.get(limit=batch_size, offset=offset, include=["metadatas"])
+        metadatas = batch.get("metadatas", []) or []
+        for meta in metadatas:
+            if not meta:
+                continue
+
+            wing = meta.get("wing")
+            hall = meta.get("hall")
+            room = meta.get("room")
+
+            if wing:
+                wings.add(wing)
+            if hall:
+                halls.add(hall)
+            if room:
+                rooms.add(room)
+
+        ids = batch.get("ids", []) or []
+        if not ids:
+            break
+        offset += len(ids)
+
+    return {
+        "wings": len(wings),
+        "halls": len(halls),
+        "rooms": len(rooms),
+        "memories": total,
+    }
+
+
+def cmd_stats(args):
+    """Show palace statistics: wings, halls, rooms, memories."""
+    import chromadb
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+
+    try:
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+    except Exception:
+        print(f"\n  No palace found at {palace_path}")
+        print("  Run: mempalace init <dir> then mempalace mine <dir>")
+        sys.exit(1)
+
+    stats = _palace_stats(col)
+    print("\nMemPalace stats")
+    print("=" * 40)
+    print(f"Wings: {stats['wings']:,}")
+    print(f"Halls: {stats['halls']:,}")
+    print(f"Rooms: {stats['rooms']:,}")
+    print(f"Memories: {stats['memories']:,}")
 
 
 def cmd_repair(args):
@@ -515,7 +579,7 @@ def main():
         help="Output skill instructions to stdout",
     )
     instructions_sub = p_instructions.add_subparsers(dest="instructions_name")
-    for instr_name in ["init", "search", "mine", "help", "status"]:
+    for instr_name in ["init", "search", "mine", "help", "status", "stats"]:
         instructions_sub.add_parser(instr_name, help=f"Output {instr_name} instructions")
 
     # repair
@@ -532,6 +596,9 @@ def main():
 
     # status
     sub.add_parser("status", help="Show what's been filed")
+
+    # stats
+    sub.add_parser("stats", help="Show counts for wings, halls, rooms, memories")
 
     args = parser.parse_args()
 
@@ -566,6 +633,7 @@ def main():
         "wake-up": cmd_wakeup,
         "repair": cmd_repair,
         "status": cmd_status,
+        "stats": cmd_stats,
     }
     dispatch[args.command](args)
 

--- a/mempalace/instructions/help.md
+++ b/mempalace/instructions/help.md
@@ -12,6 +12,7 @@ AI memory system. Store everything, find anything. Local, free, no API key.
 | /mempalace:search    | Search your memories           |
 | /mempalace:mine      | Mine projects and conversations|
 | /mempalace:status    | Palace overview and stats      |
+| /mempalace:stats     | Compact palace counts          |
 | /mempalace:help      | This help message              |
 
 ---
@@ -59,6 +60,7 @@ AI memory system. Store everything, find anything. Local, free, no API key.
     mempalace wake-up                     Load palace into context
     mempalace compress                    Compress palace storage
     mempalace status                      Show palace status
+    mempalace stats                       Show wing, hall, room, and memory counts
     mempalace repair                      Rebuild vector index
     mempalace mcp                         Show MCP setup command
     mempalace hook run                    Run hook logic (for harness integration)

--- a/mempalace/instructions/stats.md
+++ b/mempalace/instructions/stats.md
@@ -1,0 +1,27 @@
+# MemPalace Stats
+
+Show a compact summary of the current palace:
+
+- total wings
+- total halls
+- total rooms
+- total memories
+
+Run:
+
+```bash
+mempalace stats
+```
+
+Optional custom palace path:
+
+```bash
+mempalace --palace /path/to/palace stats
+```
+
+If no palace exists yet, initialize and mine one first:
+
+```bash
+mempalace init <dir>
+mempalace mine <dir>
+```

--- a/mempalace/instructions_cli.py
+++ b/mempalace/instructions_cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 INSTRUCTIONS_DIR = Path(__file__).parent / "instructions"
 
-AVAILABLE = ["init", "search", "mine", "help", "status"]
+AVAILABLE = ["help", "init", "mine", "search", "stats", "status"]
 
 
 def run_instructions(name: str):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mempalace.cli import (
+    cmd_stats,
     cmd_compress,
     cmd_hook,
     cmd_init,
@@ -45,6 +46,54 @@ def test_cmd_status_custom_palace(mock_config_cls):
 
         expected = os.path.expanduser("~/my_palace")
         mock_miner.status.assert_called_once_with(palace_path=expected)
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_stats_handles_missing_palace(mock_config_cls, capsys):
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = argparse.Namespace(palace=None)
+    mock_chromadb = MagicMock()
+    mock_chromadb.PersistentClient.return_value.get_collection.side_effect = Exception("missing")
+
+    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_stats(args)
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "No palace found" in out
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_stats_prints_summary(mock_config_cls, capsys):
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = argparse.Namespace(palace=None)
+    mock_col = MagicMock()
+    mock_col.count.return_value = 4
+    mock_col.get.side_effect = [
+        {
+            "ids": ["1", "2", "3", "4"],
+            "metadatas": [
+                {"wing": "alpha", "hall": "facts", "room": "auth"},
+                {"wing": "alpha", "hall": "events", "room": "billing"},
+                {"wing": "beta", "room": "auth"},
+                {"wing": "beta", "hall": "facts", "room": "deploy"},
+            ],
+        }
+    ]
+    mock_client = MagicMock()
+    mock_client.get_collection.return_value = mock_col
+    mock_chromadb = MagicMock()
+    mock_chromadb.PersistentClient.return_value = mock_client
+
+    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+        cmd_stats(args)
+
+    out = capsys.readouterr().out
+    assert "Wings: 2" in out
+    assert "Halls: 2" in out
+    assert "Rooms: 3" in out
+    assert "Memories: 4" in out
 
 
 # ── cmd_search ─────────────────────────────────────────────────────────
@@ -277,6 +326,15 @@ def test_main_status_dispatches():
     with (
         patch("sys.argv", ["mempalace", "status"]),
         patch("mempalace.cli.cmd_status") as mock_cmd,
+    ):
+        main()
+        mock_cmd.assert_called_once()
+
+
+def test_main_stats_dispatches():
+    with (
+        patch("sys.argv", ["mempalace", "stats"]),
+        patch("mempalace.cli.cmd_stats") as mock_cmd,
     ):
         main()
         mock_cmd.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,6 +100,36 @@ def test_cmd_stats_prints_summary(mock_config_cls, capsys):
 
 
 @patch("mempalace.cli.MempalaceConfig")
+def test_cmd_stats_reports_zero_when_halls_metadata_is_missing(mock_config_cls, capsys):
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = argparse.Namespace(palace=None)
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_col.get.side_effect = [
+        {
+            "ids": ["1", "2"],
+            "metadatas": [
+                {"wing": "alpha", "room": "auth"},
+                {"wing": "beta", "room": "billing"},
+            ],
+        }
+    ]
+    mock_client = MagicMock()
+    mock_client.get_collection.return_value = mock_col
+    mock_chromadb = MagicMock()
+    mock_chromadb.PersistentClient.return_value = mock_client
+
+    with patch.dict("sys.modules", {"chromadb": mock_chromadb}):
+        cmd_stats(args)
+
+    out = capsys.readouterr().out
+    assert "Wings: 2" in out
+    assert "Halls: 0" in out
+    assert "Rooms: 2" in out
+    assert "Memories: 2" in out
+
+
+@patch("mempalace.cli.MempalaceConfig")
 def test_cmd_search_calls_search(mock_config_cls):
     mock_config_cls.return_value.palace_path = "/fake/palace"
     args = argparse.Namespace(


### PR DESCRIPTION
## What does this PR do?

Adds a new CLI command:

```bash
mempalace stats
```

This command provides a quick overview of the current palace contents by showing counts for:

* Wings
* Halls
* Rooms
* Memories

It helps users quickly understand what has been indexed without needing to inspect storage manually.

---

## How to test

```bash
mempalace --help
mempalace --palace .\tmp\missing_palace stats
mempalace init .\demo
mempalace mine .\demo
mempalace stats
```

Expected:

* missing palace → helpful error message
* after mining → non-zero counts (Memories, Rooms, etc.)

---

## Checklist

* [x] Added CLI parser entry for `stats`
* [x] Added command dispatch for `stats`
* [x] Added implementation in `mempalace/cli.py`
* [x] Added tests for missing palace, summary output, and dispatch
* [x] Updated docs and instructions

---

## Validation

* [x] `ruff check .` passes
* [x] New stats-related tests pass
* [ ] Full offline test suite passes

The failing tests appear unrelated to this change and are caused by existing Chroma/embedding download paths that require network access.
Errors occur in `searcher`, `miner`, and `mcp_server` tests and result in `httpx.ConnectError (WinError 10013)` in offline environments.

The `stats` command:

* does not use embeddings
* does not perform network calls
* only reads metadata from the local Chroma collection

---

## Notes

This is a small, self-contained CLI feature intended as a safe and minimal contribution.
