### PR TITLE
feat: auto-populate knowledge graph from palace drawers

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -264,6 +264,58 @@ def cmd_mcp(args):
         print(f"  {base_server_cmd} --palace /path/to/palace")
 
 
+def cmd_extract_kg(args):
+    """Auto-populate the knowledge graph from palace drawers."""
+    from .kg_extractor import extract_kg
+    from .knowledge_graph import KnowledgeGraph
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    kg_path = os.path.join(palace_path, "knowledge_graph.sqlite3")
+    kg = KnowledgeGraph(db_path=kg_path)
+
+    mode = "DRY RUN" if args.dry_run else "EXTRACT"
+    print(f"\n{'=' * 55}")
+    print(f"  Knowledge Graph Auto-Extract ({mode})")
+    print(f"  Palace: {palace_path}")
+    if args.wing:
+        print(f"  Wing filter: {args.wing}")
+    if args.room:
+        print(f"  Room filter: {args.room}")
+    print(f"{'=' * 55}\n")
+
+    result = extract_kg(
+        palace_path=palace_path,
+        kg=kg,
+        wing=args.wing,
+        room=args.room,
+        dry_run=args.dry_run,
+    )
+
+    print(f"  Drawers scanned:  {result.drawers_scanned}")
+    print(f"  Entities found:   {result.entities_found}")
+    print(f"  Patterns matched: {result.patterns_matched}")
+    print(f"  Triples added:    {result.triples_added}")
+    print(f"  Triples skipped:  {result.triples_skipped} (already in KG)")
+
+    if result.errors:
+        print(f"\n  Errors ({len(result.errors)}):")
+        for err in result.errors[:5]:
+            print(f"    - {err}")
+
+    if result.details:
+        print("\n  Sample extractions:")
+        for t in result.details[:10]:
+            print(f"    {t['subject']} → {t['predicate']} → {t['object']}")
+            if t.get("source"):
+                print(f"      from: {t['source']}")
+
+    if not args.dry_run:
+        stats = kg.stats()
+        print(f"\n  KG totals: {stats['entities']} entities, {stats['triples']} triples")
+
+    print(f"\n{'=' * 55}\n")
+
+
 def cmd_compress(args):
     """Compress drawers in a wing using AAAK Dialect."""
     import chromadb
@@ -530,6 +582,18 @@ def main():
         help="Show MCP setup command for connecting MemPalace to your AI client",
     )
 
+    # extract-kg
+    p_extract = sub.add_parser(
+        "extract-kg",
+        help="Auto-populate knowledge graph from palace drawers",
+    )
+    p_extract.add_argument("--wing", default=None, help="Filter by wing")
+    p_extract.add_argument("--room", default=None, help="Filter by room")
+    p_extract.add_argument(
+        "--dry-run", action="store_true",
+        help="Show what would be extracted without writing to KG",
+    )
+
     # status
     sub.add_parser("status", help="Show what's been filed")
 
@@ -563,6 +627,7 @@ def main():
         "search": cmd_search,
         "mcp": cmd_mcp,
         "compress": cmd_compress,
+        "extract-kg": cmd_extract_kg,
         "wake-up": cmd_wakeup,
         "repair": cmd_repair,
         "status": cmd_status,

--- a/mempalace/kg_extractor.py
+++ b/mempalace/kg_extractor.py
@@ -241,6 +241,8 @@ def extract_from_text(text: str, source_file: str = "") -> List[dict]:
                     "predicate": "works_at",
                     "object": org,
                     "source": source_file,
+                    "subject_type": "person",
+                    "object_type": "company",
                 })
 
     # Roles — only if the extracted role contains a role-like word
@@ -254,6 +256,8 @@ def extract_from_text(text: str, source_file: str = "") -> List[dict]:
                     "predicate": "has_role",
                     "object": role,
                     "source": source_file,
+                    "subject_type": "person",
+                    "object_type": "role",
                 })
 
     # Family relationships
@@ -304,6 +308,8 @@ def extract_from_text(text: str, source_file: str = "") -> List[dict]:
                     "predicate": "uses",
                     "object": tool,
                     "source": source_file,
+                    "subject_type": "team",
+                    "object_type": "tool",
                 })
 
     # Creation
@@ -317,6 +323,7 @@ def extract_from_text(text: str, source_file: str = "") -> List[dict]:
                     "predicate": "created",
                     "object": thing,
                     "source": source_file,
+                    "subject_type": "person",
                 })
 
     # Interests
@@ -330,13 +337,20 @@ def extract_from_text(text: str, source_file: str = "") -> List[dict]:
                     "predicate": "loves",
                     "object": interest,
                     "source": source_file,
+                    "subject_type": "person",
                 })
 
     return triples
 
 
 def _dedupe_triples(triples: List[dict]) -> List[dict]:
-    """Remove duplicate triples (same subject+predicate+object)."""
+    """Remove duplicate triples (same subject+predicate+object).
+
+    TODO: Add fuzzy dedup for entity aliases (e.g. "PostgreSQL" vs "Postgres").
+    Suggested approach: hard dedup at cosine >= 0.86, soft dedup at >= 0.55
+    flagged for review. Requires embedding similarity — separate PR.
+    (Credit: @web3guru888 for the tiered threshold idea)
+    """
     seen = set()
     unique = []
     for t in triples:
@@ -436,6 +450,9 @@ def extract_kg(
     result.entities_found = len(entities)
 
     # Write to KG
+    # Count triples once before the batch, not per-triple (avoids 2N SQLite queries)
+    triples_before = kg.stats()["triples"] if not dry_run else 0
+
     for t in all_triples:
         if dry_run:
             result.triples_added += 1
@@ -447,26 +464,33 @@ def extract_kg(
             })
         else:
             try:
-                stats_before = kg.stats()["triples"]
+                # Add entities with inferred types based on pattern
+                sub_type = t.get("subject_type", "unknown")
+                obj_type = t.get("object_type", "unknown")
+                if sub_type != "unknown":
+                    kg.add_entity(t["subject"], entity_type=sub_type)
+                if obj_type != "unknown":
+                    kg.add_entity(t["object"], entity_type=obj_type)
+
                 triple_id = kg.add_triple(
                     t["subject"],
                     t["predicate"],
                     t["object"],
                     source_file=t["source"],
                 )
-                stats_after = kg.stats()["triples"]
-                if stats_after > stats_before:
-                    result.triples_added += 1
-                    result.details.append({
-                        "subject": t["subject"],
-                        "predicate": t["predicate"],
-                        "object": t["object"],
-                        "source": t["source"],
-                        "triple_id": triple_id,
-                    })
-                else:
-                    result.triples_skipped += 1
+                result.details.append({
+                    "subject": t["subject"],
+                    "predicate": t["predicate"],
+                    "object": t["object"],
+                    "source": t["source"],
+                    "triple_id": triple_id,
+                })
             except Exception as e:
                 result.errors.append(f"Error adding triple {t}: {e}")
+
+    if not dry_run:
+        triples_after = kg.stats()["triples"]
+        result.triples_added = triples_after - triples_before
+        result.triples_skipped = len(all_triples) - result.triples_added - len(result.errors)
 
     return result

--- a/mempalace/kg_extractor.py
+++ b/mempalace/kg_extractor.py
@@ -450,8 +450,19 @@ def extract_kg(
     result.entities_found = len(entities)
 
     # Write to KG
-    # Count triples once before the batch, not per-triple (avoids 2N SQLite queries)
-    triples_before = kg.stats()["triples"] if not dry_run else 0
+    # Pre-fetch existing triple keys once so we can detect duplicates without
+    # relying on stats() comparisons (which can be unreliable under concurrent
+    # writes per @web3guru888's review on PR #434).
+    existing_keys = set()
+    if not dry_run:
+        try:
+            conn = kg._conn()
+            for row in conn.execute(
+                "SELECT subject, predicate, object FROM triples WHERE valid_to IS NULL"
+            ).fetchall():
+                existing_keys.add((row["subject"], row["predicate"], row["object"]))
+        except Exception as e:
+            result.errors.append(f"Error pre-fetching existing triples: {e}")
 
     for t in all_triples:
         if dry_run:
@@ -472,25 +483,33 @@ def extract_kg(
                 if obj_type != "unknown":
                     kg.add_entity(t["object"], entity_type=obj_type)
 
+                # Compute the normalized key the same way KG does
+                sub_key = t["subject"].lower().replace(" ", "_").replace("'", "")
+                obj_key = t["object"].lower().replace(" ", "_").replace("'", "")
+                pred_key = t["predicate"].lower().replace(" ", "_")
+                triple_key = (sub_key, pred_key, obj_key)
+                is_new = triple_key not in existing_keys
+
                 triple_id = kg.add_triple(
                     t["subject"],
                     t["predicate"],
                     t["object"],
                     source_file=t["source"],
                 )
-                result.details.append({
-                    "subject": t["subject"],
-                    "predicate": t["predicate"],
-                    "object": t["object"],
-                    "source": t["source"],
-                    "triple_id": triple_id,
-                })
+
+                if is_new:
+                    result.triples_added += 1
+                    existing_keys.add(triple_key)
+                    result.details.append({
+                        "subject": t["subject"],
+                        "predicate": t["predicate"],
+                        "object": t["object"],
+                        "source": t["source"],
+                        "triple_id": triple_id,
+                    })
+                else:
+                    result.triples_skipped += 1
             except Exception as e:
                 result.errors.append(f"Error adding triple {t}: {e}")
-
-    if not dry_run:
-        triples_after = kg.stats()["triples"]
-        result.triples_added = triples_after - triples_before
-        result.triples_skipped = len(all_triples) - result.triples_added - len(result.errors)
 
     return result

--- a/mempalace/kg_extractor.py
+++ b/mempalace/kg_extractor.py
@@ -1,0 +1,472 @@
+"""
+kg_extractor.py — Auto-populate the Knowledge Graph from palace drawers.
+=========================================================================
+
+Reads verbatim drawer content from ChromaDB and extracts entity
+relationships using rule-based pattern matching. Populates the KG
+automatically so users don't have to manually call kg_add for every fact.
+
+Zero API calls. Zero new dependencies. Pure regex + KG writes.
+
+Extraction pipeline:
+  1. Read drawers from ChromaDB (all or filtered by wing/room)
+  2. Extract entity names (capitalized words appearing 2+ times)
+  3. Match relationship patterns against drawer text
+  4. Deduplicate against existing KG triples (idempotent)
+  5. Write new triples with source_file provenance
+
+Supported relationship patterns:
+  - Works at / employed by:  "Alice works at Acme Corp"
+  - Role / position:         "Bob is the lead engineer"
+  - Parent / child:          "Alice's daughter Riley" or "Riley is Alice's daughter"
+  - Partnership:             "Alice and Bob are married"
+  - Uses / works with:       "We use PostgreSQL for the database"
+  - Decided / chose:         "We decided to switch to GraphQL"
+  - Created / built:         "Alice created the auth module"
+  - Loves / enjoys:          "Max loves chess"
+
+Usage:
+    from mempalace.kg_extractor import extract_kg
+
+    stats = extract_kg(palace_path="/path/to/palace")
+    # => {"drawers_scanned": 150, "triples_added": 42, "entities_found": 12, ...}
+
+CLI:
+    mempalace extract-kg
+    mempalace extract-kg --wing my_project
+    mempalace extract-kg --dry-run
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import chromadb
+
+from mempalace.knowledge_graph import KnowledgeGraph
+
+logger = logging.getLogger("mempalace")
+
+
+# ── Relationship patterns ────────────────────────────────────────────
+# Each pattern returns (subject, predicate, object) tuples.
+
+_NAME = r"([A-Z][a-z]+(?:\s[A-Z][a-z]+)?)"
+_NAME_LOWER = r"([A-Za-z][a-z]+(?:\s[A-Za-z][a-z]+)?)"
+
+# "X works at Y" / "X is employed by Y" / "X joined Y"
+_EMPLOYMENT_PATTERNS = [
+    re.compile(
+        rf"\b{_NAME}\s+(?:works?|worked)\s+(?:at|for)\s+{_NAME}", re.IGNORECASE
+    ),
+    re.compile(
+        rf"\b{_NAME}\s+(?:is|was)\s+employed\s+(?:at|by)\s+{_NAME}", re.IGNORECASE
+    ),
+    re.compile(
+        rf"\b{_NAME}\s+joined\s+{_NAME}", re.IGNORECASE
+    ),
+]
+
+# "X is a/the Y" (role extraction)
+_ROLE_PATTERNS = [
+    re.compile(
+        rf"\b{_NAME}\s+is\s+(?:a|the|an|our)\s+([\w\s]{{2,30}}?)(?:\s+(?:at|of|for|in|on)\b|[.,;]|$)",
+        re.IGNORECASE,
+    ),
+]
+
+# Role words that confirm it's actually a role
+_ROLE_WORDS = {
+    "engineer", "developer", "designer", "manager", "lead", "director",
+    "architect", "scientist", "analyst", "admin", "founder", "ceo", "cto",
+    "intern", "consultant", "specialist", "coordinator", "owner", "chief",
+    "head", "senior", "junior", "principal", "staff", "vp",
+}
+
+# "X's daughter/son/partner Y" or "Y is X's daughter/son"
+# NOTE: These do NOT use IGNORECASE because _NAME relies on case to find proper nouns.
+_REL_WORDS = r"(?:daughter|son|child|mother|father|parent|wife|husband|partner|brother|sister|sibling|dog|cat|pet)"
+_FAMILY_PATTERNS = [
+    # "Alice's daughter Riley"
+    re.compile(
+        rf"\b([A-Z][a-z]+)'s\s+{_REL_WORDS}\s+([A-Z][a-z]+)",
+    ),
+    # "Riley is Alice's daughter"
+    re.compile(
+        rf"\b([A-Z][a-z]+)\s+is\s+([A-Z][a-z]+)'s\s+{_REL_WORDS}",
+    ),
+]
+
+# "We use X for Y" / "switched to X" / "decided to use X"
+_TOOL_PATTERNS = [
+    re.compile(
+        r"\b(?:we|they|team)\s+(?:use|uses|used|using)\s+([A-Z][\w.+-]+)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:switched|migrated|moved)\s+to\s+([A-Z][\w.+-]+)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:decided|chose|choosing)\s+(?:to\s+use\s+)?([A-Z][\w.+-]+)",
+        re.IGNORECASE,
+    ),
+]
+
+# "X created/built/designed Y"
+_CREATION_PATTERNS = [
+    re.compile(
+        rf"\b{_NAME}\s+(?:created|built|designed|wrote|implemented|developed|shipped)\s+(?:the\s+)?(.+?)(?:[.,;]|$)",
+        re.IGNORECASE,
+    ),
+]
+
+# "X loves/enjoys Y"
+_INTEREST_PATTERNS = [
+    re.compile(
+        rf"\b{_NAME}\s+(?:loves?|enjoys?|likes?|is\s+(?:into|passionate\s+about))\s+(.+?)(?:[.,;]|$)",
+        re.IGNORECASE,
+    ),
+]
+
+# Map family relationship words to KG predicates
+_FAMILY_PREDICATES = {
+    "daughter": ("parent_of", False),   # Alice parent_of Riley
+    "son": ("parent_of", False),
+    "child": ("parent_of", False),
+    "mother": ("parent_of", True),      # Riley parent_of Alice → reversed
+    "father": ("parent_of", True),
+    "parent": ("parent_of", True),
+    "wife": ("married_to", False),
+    "husband": ("married_to", False),
+    "partner": ("married_to", False),
+    "brother": ("sibling_of", False),
+    "sister": ("sibling_of", False),
+    "sibling": ("sibling_of", False),
+    "dog": ("is_pet_of", True),
+    "cat": ("is_pet_of", True),
+    "pet": ("is_pet_of", True),
+}
+
+# Common words that should NOT be treated as entity names
+_SKIP_NAMES = {
+    "the", "this", "that", "here", "there", "been", "just", "also",
+    "very", "much", "many", "some", "most", "each", "every", "both",
+    "even", "still", "already", "always", "never", "often", "only",
+    "well", "really", "actually", "basically", "certainly", "probably",
+    "definitely", "currently", "recently", "finally", "however", "instead",
+    "because", "since", "while", "before", "after", "above", "below",
+    "now", "then", "when", "where", "why", "how", "what", "which",
+    "who", "all", "new", "old", "big", "next", "last", "first",
+    "second", "third", "good", "bad", "best", "same", "different",
+    "important", "possible", "available", "specific", "general",
+    "true", "false", "null", "none", "yes",
+}
+
+
+# ── Extraction result ────────────────────────────────────────────────
+
+
+@dataclass
+class ExtractionResult:
+    """Result of KG extraction from palace drawers."""
+
+    drawers_scanned: int = 0
+    entities_found: int = 0
+    triples_added: int = 0
+    triples_skipped: int = 0  # already existed
+    patterns_matched: int = 0
+    errors: List[str] = field(default_factory=list)
+    details: List[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Serialize for MCP/CLI output."""
+        return {
+            "drawers_scanned": self.drawers_scanned,
+            "entities_found": self.entities_found,
+            "triples_added": self.triples_added,
+            "triples_skipped": self.triples_skipped,
+            "patterns_matched": self.patterns_matched,
+            "errors": self.errors[:10],  # cap error list
+            "sample_triples": self.details[:20],  # cap detail list
+        }
+
+
+# ── Core extraction ──────────────────────────────────────────────────
+
+
+def _is_valid_name(name: str) -> bool:
+    """Check if a string looks like a real entity name."""
+    if not name or len(name) < 2:
+        return False
+    if name.lower() in _SKIP_NAMES:
+        return False
+    # Must start with uppercase
+    if not name[0].isupper():
+        return False
+    return True
+
+
+def _clean_object(text: str, max_len: int = 60) -> str:
+    """Clean and truncate an extracted object string."""
+    text = text.strip().rstrip(".,;:!?")
+    # Remove leading articles
+    text = re.sub(r"^(?:the|a|an)\s+", "", text, flags=re.IGNORECASE)
+    if len(text) > max_len:
+        text = text[:max_len].rsplit(" ", 1)[0]
+    return text.strip()
+
+
+def _has_role_word(text: str) -> bool:
+    """Check if a text contains a word that signals a role/position."""
+    words = set(text.lower().split())
+    return bool(words & _ROLE_WORDS)
+
+
+def extract_from_text(text: str, source_file: str = "") -> List[dict]:
+    """Extract relationship triples from a single text block.
+
+    Returns a list of dicts: {"subject": ..., "predicate": ..., "object": ..., "source": ...}
+    """
+    triples = []
+
+    # Employment
+    for pattern in _EMPLOYMENT_PATTERNS:
+        for match in pattern.finditer(text):
+            person, org = match.group(1), match.group(2)
+            if _is_valid_name(person) and _is_valid_name(org):
+                triples.append({
+                    "subject": person,
+                    "predicate": "works_at",
+                    "object": org,
+                    "source": source_file,
+                })
+
+    # Roles — only if the extracted role contains a role-like word
+    for pattern in _ROLE_PATTERNS:
+        for match in pattern.finditer(text):
+            person = match.group(1)
+            role = _clean_object(match.group(2))
+            if _is_valid_name(person) and role and _has_role_word(role):
+                triples.append({
+                    "subject": person,
+                    "predicate": "has_role",
+                    "object": role,
+                    "source": source_file,
+                })
+
+    # Family relationships
+    # Extract the relationship word separately since it's non-capturing in the regex
+    _rel_word_re = re.compile(
+        r"'s\s+(daughter|son|child|mother|father|parent|wife|husband|partner|brother|sister|sibling|dog|cat|pet)\b",
+        re.IGNORECASE,
+    )
+    for i, pattern in enumerate(_FAMILY_PATTERNS):
+        for match in pattern.finditer(text):
+            person_1, person_2 = match.group(1), match.group(2)
+            # Extract the relationship word from the matched span
+            span_text = match.group(0)
+            rel_match = _rel_word_re.search(span_text)
+            if not rel_match:
+                continue
+            rel_word = rel_match.group(1).lower()
+
+            if rel_word not in _FAMILY_PREDICATES:
+                continue
+            if not (_is_valid_name(person_1) and _is_valid_name(person_2)):
+                continue
+
+            predicate, reverse = _FAMILY_PREDICATES[rel_word]
+
+            if i == 0:
+                # Pattern 1: "Alice's daughter Riley" → person_1=Alice, person_2=Riley
+                subject, obj = (person_2, person_1) if reverse else (person_1, person_2)
+            else:
+                # Pattern 2: "Riley is Alice's daughter" → person_1=Riley, person_2=Alice
+                # Alice is the parent, Riley is the child
+                subject, obj = (person_1, person_2) if reverse else (person_2, person_1)
+
+            triples.append({
+                "subject": subject,
+                "predicate": predicate,
+                "object": obj,
+                "source": source_file,
+            })
+
+    # Tool/technology usage
+    for pattern in _TOOL_PATTERNS:
+        for match in pattern.finditer(text):
+            tool = match.group(1)
+            if _is_valid_name(tool) and len(tool) >= 2:
+                triples.append({
+                    "subject": "team",
+                    "predicate": "uses",
+                    "object": tool,
+                    "source": source_file,
+                })
+
+    # Creation
+    for pattern in _CREATION_PATTERNS:
+        for match in pattern.finditer(text):
+            person = match.group(1)
+            thing = _clean_object(match.group(2))
+            if _is_valid_name(person) and thing and len(thing) >= 3:
+                triples.append({
+                    "subject": person,
+                    "predicate": "created",
+                    "object": thing,
+                    "source": source_file,
+                })
+
+    # Interests
+    for pattern in _INTEREST_PATTERNS:
+        for match in pattern.finditer(text):
+            person = match.group(1)
+            interest = _clean_object(match.group(2))
+            if _is_valid_name(person) and interest and len(interest) >= 2:
+                triples.append({
+                    "subject": person,
+                    "predicate": "loves",
+                    "object": interest,
+                    "source": source_file,
+                })
+
+    return triples
+
+
+def _dedupe_triples(triples: List[dict]) -> List[dict]:
+    """Remove duplicate triples (same subject+predicate+object)."""
+    seen = set()
+    unique = []
+    for t in triples:
+        key = (t["subject"].lower(), t["predicate"], t["object"].lower())
+        if key not in seen:
+            seen.add(key)
+            unique.append(t)
+    return unique
+
+
+# ── Main extraction function ─────────────────────────────────────────
+
+
+def extract_kg(
+    palace_path: str,
+    kg: Optional[KnowledgeGraph] = None,
+    wing: Optional[str] = None,
+    room: Optional[str] = None,
+    dry_run: bool = False,
+) -> ExtractionResult:
+    """Extract relationships from palace drawers and populate the knowledge graph.
+
+    Args:
+        palace_path: Path to the palace ChromaDB directory.
+        kg: KnowledgeGraph instance (creates default if None).
+        wing: Filter drawers by wing (optional).
+        room: Filter drawers by room (optional).
+        dry_run: If True, extract but don't write to KG.
+
+    Returns:
+        ExtractionResult with stats and sample triples.
+    """
+    result = ExtractionResult()
+
+    # Connect to palace
+    try:
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+    except Exception as e:
+        result.errors.append(f"No palace found at {palace_path}: {e}")
+        return result
+
+    if kg is None:
+        kg = KnowledgeGraph()
+
+    # Build where filter
+    where = None
+    if wing and room:
+        where = {"$and": [{"wing": wing}, {"room": room}]}
+    elif wing:
+        where = {"wing": wing}
+    elif room:
+        where = {"room": room}
+
+    # Read drawers in batches
+    all_triples = []
+    batch_size = 500
+    offset = 0
+
+    while True:
+        try:
+            kwargs = {
+                "include": ["documents", "metadatas"],
+                "limit": batch_size,
+                "offset": offset,
+            }
+            if where:
+                kwargs["where"] = where
+            batch = col.get(**kwargs)
+        except Exception as e:
+            if not all_triples and offset == 0:
+                result.errors.append(f"Error reading drawers: {e}")
+            break
+
+        docs = batch.get("documents", [])
+        metas = batch.get("metadatas", [])
+        if not docs:
+            break
+
+        for doc, meta in zip(docs, metas):
+            result.drawers_scanned += 1
+            source = meta.get("source_file", "")
+            triples = extract_from_text(doc, source_file=source)
+            all_triples.extend(triples)
+
+        offset += len(docs)
+
+    # Deduplicate
+    all_triples = _dedupe_triples(all_triples)
+    result.patterns_matched = len(all_triples)
+
+    # Track unique entities
+    entities = set()
+    for t in all_triples:
+        entities.add(t["subject"].lower())
+        entities.add(t["object"].lower())
+    result.entities_found = len(entities)
+
+    # Write to KG
+    for t in all_triples:
+        if dry_run:
+            result.triples_added += 1
+            result.details.append({
+                "subject": t["subject"],
+                "predicate": t["predicate"],
+                "object": t["object"],
+                "source": t["source"],
+            })
+        else:
+            try:
+                stats_before = kg.stats()["triples"]
+                triple_id = kg.add_triple(
+                    t["subject"],
+                    t["predicate"],
+                    t["object"],
+                    source_file=t["source"],
+                )
+                stats_after = kg.stats()["triples"]
+                if stats_after > stats_before:
+                    result.triples_added += 1
+                    result.details.append({
+                        "subject": t["subject"],
+                        "predicate": t["predicate"],
+                        "object": t["object"],
+                        "source": t["source"],
+                        "triple_id": triple_id,
+                    })
+                else:
+                    result.triples_skipped += 1
+            except Exception as e:
+                result.errors.append(f"Error adding triple {t}: {e}")
+
+    return result

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -471,6 +471,21 @@ def tool_kg_stats():
     return _kg.stats()
 
 
+def tool_kg_extract(wing: str = None, room: str = None, dry_run: bool = False):
+    """Auto-populate the knowledge graph from palace drawers."""
+    from mempalace.kg_extractor import extract_kg
+
+    palace_path = _config.palace_path
+    result = extract_kg(
+        palace_path=palace_path,
+        kg=_kg,
+        wing=wing,
+        room=room,
+        dry_run=dry_run,
+    )
+    return result.to_dict()
+
+
 # ==================== AGENT DIARY ====================
 
 
@@ -698,6 +713,27 @@ TOOLS = {
         "description": "Knowledge graph overview: entities, triples, current vs expired facts, relationship types.",
         "input_schema": {"type": "object", "properties": {}},
         "handler": tool_kg_stats,
+    },
+    "mempalace_kg_extract": {
+        "description": "Auto-populate the knowledge graph by extracting relationships from palace drawers. Scans verbatim text for people, roles, employment, family, tools, and decisions. Idempotent — won't duplicate existing triples.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "wing": {
+                    "type": "string",
+                    "description": "Filter by wing (optional — omit to scan all drawers)",
+                },
+                "room": {
+                    "type": "string",
+                    "description": "Filter by room (optional)",
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true, show what would be extracted without writing (default: false)",
+                },
+            },
+        },
+        "handler": tool_kg_extract,
     },
     "mempalace_traverse": {
         "description": "Walk the palace graph from a room. Shows connected ideas across wings — the tunnels. Like following a thread through the palace: start at 'chromadb-setup' in wing_code, discover it connects to wing_myproject (planning) and wing_user (feelings about it).",

--- a/tests/test_kg_extractor.py
+++ b/tests/test_kg_extractor.py
@@ -1,0 +1,241 @@
+"""
+test_kg_extractor.py — Tests for auto-KG extraction from palace drawers.
+
+Covers: pattern extraction from text, full pipeline with ChromaDB,
+dry-run mode, wing/room filtering, deduplication, and edge cases.
+"""
+
+import os
+
+from mempalace.kg_extractor import extract_from_text, extract_kg, ExtractionResult
+
+
+# ── Pattern extraction from text ─────────────────────────────────────
+
+
+class TestEmploymentExtraction:
+    def test_works_at(self):
+        triples = extract_from_text("Alice works at Acme Corp on the backend team.")
+        assert any(
+            t["subject"] == "Alice" and t["predicate"] == "works_at" and "Acme" in t["object"]
+            for t in triples
+        )
+
+    def test_joined(self):
+        triples = extract_from_text("Bob joined Google recently.")
+        assert any(
+            t["subject"] == "Bob" and t["predicate"] == "works_at" and "Google" in t["object"]
+            for t in triples
+        )
+
+    def test_employed_by(self):
+        triples = extract_from_text("Carol is employed by Microsoft.")
+        assert any(
+            t["subject"] == "Carol" and t["predicate"] == "works_at"
+            for t in triples
+        )
+
+
+class TestRoleExtraction:
+    def test_role_with_keyword(self):
+        triples = extract_from_text("Alice is the lead engineer at Acme.")
+        assert any(
+            t["subject"] == "Alice" and t["predicate"] == "has_role" and "engineer" in t["object"]
+            for t in triples
+        )
+
+    def test_ignores_non_role(self):
+        """'Alice is a good friend' should NOT extract a role."""
+        triples = extract_from_text("Alice is a good friend to everyone.")
+        role_triples = [t for t in triples if t["predicate"] == "has_role"]
+        assert len(role_triples) == 0
+
+    def test_senior_developer(self):
+        triples = extract_from_text("Bob is a senior developer for the platform team.")
+        assert any(
+            t["subject"] == "Bob" and t["predicate"] == "has_role"
+            for t in triples
+        )
+
+
+class TestFamilyExtraction:
+    def test_possessive_pattern(self):
+        """'Alice's daughter Riley' → Alice parent_of Riley."""
+        triples = extract_from_text("I spoke with Alice's daughter Riley today.")
+        assert any(
+            t["subject"] == "Alice" and t["predicate"] == "parent_of" and t["object"] == "Riley"
+            for t in triples
+        )
+
+    def test_is_possessive_pattern(self):
+        """'Riley is Alice's daughter' → Alice parent_of Riley."""
+        triples = extract_from_text("Riley is Alice's daughter and she loves chess.")
+        assert any(
+            t["subject"] == "Alice" and t["predicate"] == "parent_of" and t["object"] == "Riley"
+            for t in triples
+        )
+
+    def test_marriage(self):
+        triples = extract_from_text("Dan is Carol's husband and works remotely.")
+        assert any(
+            t["predicate"] == "married_to"
+            for t in triples
+        )
+
+    def test_pet(self):
+        triples = extract_from_text("Alice's dog Buddy is very playful.")
+        assert any(
+            t["predicate"] == "is_pet_of"
+            for t in triples
+        )
+
+
+class TestToolExtraction:
+    def test_we_use(self):
+        triples = extract_from_text("We use PostgreSQL for the main database.")
+        assert any(
+            t["predicate"] == "uses" and t["object"] == "PostgreSQL"
+            for t in triples
+        )
+
+    def test_switched_to(self):
+        triples = extract_from_text("We switched to GraphQL for the API layer.")
+        assert any(
+            t["predicate"] == "uses" and t["object"] == "GraphQL"
+            for t in triples
+        )
+
+    def test_decided_to_use(self):
+        triples = extract_from_text("The team decided to use Redis for caching.")
+        assert any(
+            t["predicate"] == "uses" and t["object"] == "Redis"
+            for t in triples
+        )
+
+
+class TestCreationExtraction:
+    def test_created(self):
+        triples = extract_from_text("Alice created the authentication module.")
+        assert any(
+            t["subject"] == "Alice" and t["predicate"] == "created"
+            and "authentication" in t["object"]
+            for t in triples
+        )
+
+    def test_built(self):
+        triples = extract_from_text("Bob built the deployment pipeline last month.")
+        assert any(
+            t["subject"] == "Bob" and t["predicate"] == "created"
+            for t in triples
+        )
+
+
+class TestInterestExtraction:
+    def test_loves(self):
+        triples = extract_from_text("Max loves chess and plays every weekend.")
+        assert any(
+            t["subject"] == "Max" and t["predicate"] == "loves"
+            for t in triples
+        )
+
+    def test_enjoys(self):
+        triples = extract_from_text("Riley enjoys swimming at the local pool.")
+        assert any(
+            t["subject"] == "Riley" and t["predicate"] == "loves"
+            for t in triples
+        )
+
+
+# ── Edge cases ───────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_empty_text(self):
+        triples = extract_from_text("")
+        assert triples == []
+
+    def test_no_entities(self):
+        triples = extract_from_text("the quick brown fox jumps over the lazy dog")
+        assert triples == []
+
+    def test_skip_common_words(self):
+        """Common words like 'The' should not be extracted as entity names."""
+        triples = extract_from_text("The system is very important for everyone.")
+        assert all(t["subject"] != "The" for t in triples)
+
+    def test_multiple_patterns_same_text(self):
+        """Text with multiple patterns should extract all."""
+        text = (
+            "Alice works at Acme Corp. She is the lead engineer. "
+            "Alice's daughter Riley loves swimming. We use PostgreSQL."
+        )
+        triples = extract_from_text(text)
+        predicates = {t["predicate"] for t in triples}
+        assert "works_at" in predicates
+        assert "has_role" in predicates
+        assert "parent_of" in predicates
+        assert "uses" in predicates
+
+    def test_source_file_preserved(self):
+        triples = extract_from_text("Alice works at Acme.", source_file="notes.md")
+        assert triples[0]["source"] == "notes.md"
+
+
+# ── Full pipeline with ChromaDB ──────────────────────────────────────
+
+
+class TestFullPipeline:
+    def test_extract_from_seeded_palace(self, palace_path, seeded_collection, kg):
+        """Extract KG from the seeded test palace."""
+        result = extract_kg(palace_path=palace_path, kg=kg)
+        assert isinstance(result, ExtractionResult)
+        assert result.drawers_scanned == 4  # seeded_collection has 4 drawers
+        assert result.errors == []
+
+    def test_dry_run_does_not_write(self, palace_path, seeded_collection, kg):
+        """Dry run should not add triples to the KG."""
+        before = kg.stats()
+        result = extract_kg(palace_path=palace_path, kg=kg, dry_run=True)
+        after = kg.stats()
+        assert before["triples"] == after["triples"]
+        # But should still report what it found
+        assert result.drawers_scanned == 4
+
+    def test_wing_filter(self, palace_path, seeded_collection, kg):
+        """Filtering by wing should only scan matching drawers."""
+        result = extract_kg(palace_path=palace_path, kg=kg, wing="notes")
+        assert result.drawers_scanned == 1  # only "notes" wing has 1 drawer
+
+    def test_room_filter(self, palace_path, seeded_collection, kg):
+        """Filtering by room should only scan matching drawers."""
+        result = extract_kg(palace_path=palace_path, kg=kg, room="backend")
+        assert result.drawers_scanned == 2  # 2 drawers in "backend" room
+
+    def test_idempotent(self, palace_path, seeded_collection, kg):
+        """Running extraction twice should not duplicate triples."""
+        result1 = extract_kg(palace_path=palace_path, kg=kg)
+        result2 = extract_kg(palace_path=palace_path, kg=kg)
+        assert result2.triples_skipped >= result1.triples_added or result2.triples_added == 0
+
+    def test_no_palace_returns_error(self, tmp_dir, kg):
+        """Missing palace should return error in result."""
+        result = extract_kg(palace_path=os.path.join(tmp_dir, "missing"), kg=kg)
+        assert len(result.errors) > 0
+        assert result.drawers_scanned == 0
+
+
+class TestExtractionResultSerialization:
+    def test_to_dict(self):
+        result = ExtractionResult(
+            drawers_scanned=10,
+            entities_found=5,
+            triples_added=3,
+            triples_skipped=1,
+            patterns_matched=4,
+        )
+        d = result.to_dict()
+        assert d["drawers_scanned"] == 10
+        assert d["entities_found"] == 5
+        assert d["triples_added"] == 3
+        assert isinstance(d["sample_triples"], list)
+        assert isinstance(d["errors"], list)

--- a/tests/test_kg_extractor.py
+++ b/tests/test_kg_extractor.py
@@ -180,6 +180,22 @@ class TestEdgeCases:
         triples = extract_from_text("Alice works at Acme.", source_file="notes.md")
         assert triples[0]["source"] == "notes.md"
 
+    def test_long_unpunctuated_line(self):
+        """Creation pattern on a long line without punctuation should truncate cleanly."""
+        long_obj = "the " + "very " * 20 + "important authentication module"
+        text = f"Alice created {long_obj}"
+        triples = extract_from_text(text)
+        created = [t for t in triples if t["predicate"] == "created"]
+        if created:
+            assert len(created[0]["object"]) <= 60
+
+    def test_entity_types_inferred(self):
+        """Employment triples should have subject_type and object_type."""
+        triples = extract_from_text("Alice works at Acme Corp.")
+        emp = [t for t in triples if t["predicate"] == "works_at"]
+        assert emp[0]["subject_type"] == "person"
+        assert emp[0]["object_type"] == "company"
+
 
 # ── Full pipeline with ChromaDB ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The Knowledge Graph is powerful but empty for most users — it requires manual `kg_add` calls for every fact. This PR bridges that gap by **automatically extracting relationships from existing palace drawers** into the KG.

### New module: `mempalace/kg_extractor.py`

Reads verbatim drawer content and extracts 8 relationship types using rule-based pattern matching:

| Pattern | Example | KG Triple |
|---------|---------|-----------|
| Employment | "Alice works at Acme Corp" | Alice → works_at → Acme Corp |
| Role | "Bob is the lead engineer" | Bob → has_role → lead engineer |
| Family | "Alice's daughter Riley" | Alice → parent_of → Riley |
| Marriage | "Dan is Carol's husband" | Dan → married_to → Carol |
| Tool usage | "We use PostgreSQL" | team → uses → PostgreSQL |
| Decisions | "We switched to GraphQL" | team → uses → GraphQL |
| Creation | "Alice created the auth module" | Alice → created → auth module |
| Interests | "Max loves chess" | Max → loves → chess |

### Integration points

- **CLI**: `mempalace extract-kg [--wing X] [--room Y] [--dry-run]`
- **MCP tool**: `mempalace_kg_extract` — AI agents can trigger extraction
- **Idempotent**: existing triples are detected and skipped (safe to re-run)
- **Source provenance**: each triple records which drawer file it came from
- **Batched reads**: handles large palaces without OOM (500 drawers/batch)

### Why this matters

This connects the two storage systems: **drawers** (verbatim text in ChromaDB) and the **knowledge graph** (structured facts in SQLite). Before this PR, users had thousands of memories but an empty KG. After: one command populates it.

```bash
mempalace mine ~/projects/myapp        # stores verbatim memories
mempalace extract-kg                    # auto-populates the KG
mempalace extract-kg --dry-run          # preview what would be extracted
```

## Test plan

- [x] `pytest tests/test_kg_extractor.py -v` — 29 tests pass
- [x] `pytest tests/ -v` — full suite 563 passed, 0 failed
- [x] `ruff check` — no lint errors
- [x] No new dependencies
- [x] No API keys or network access needed
- [x] Dry-run mode tested (no KG writes)
- [x] Idempotency tested (running twice doesn't duplicate)
- [x] Wing/room filtering tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)