### PR TITLE
feat: palace export/import for backup and migration

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -264,6 +264,68 @@ def cmd_mcp(args):
         print(f"  {base_server_cmd} --palace /path/to/palace")
 
 
+def cmd_export(args):
+    """Export palace data to a portable JSON file."""
+    from .exporter import export_palace
+    from .knowledge_graph import KnowledgeGraph
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    output_file = args.output
+
+    kg_path = os.path.join(palace_path, "knowledge_graph.sqlite3")
+    kg = KnowledgeGraph(db_path=kg_path) if os.path.exists(kg_path) else None
+
+    print(f"\n{'=' * 55}")
+    print("  Palace Export")
+    print(f"  Palace: {palace_path}")
+    print(f"  Output: {output_file}")
+    print(f"{'=' * 55}\n")
+
+    result = export_palace(palace_path=palace_path, output_file=output_file, kg=kg)
+
+    print(f"  Drawers exported:     {result.drawers_exported}")
+    print(f"  KG entities exported: {result.kg_entities_exported}")
+    print(f"  KG triples exported:  {result.kg_triples_exported}")
+
+    if result.errors:
+        print(f"\n  Errors ({len(result.errors)}):")
+        for err in result.errors[:5]:
+            print(f"    - {err}")
+    else:
+        size = os.path.getsize(output_file)
+        print(f"\n  Saved: {output_file} ({size:,} bytes)")
+
+    print(f"\n{'=' * 55}\n")
+
+
+def cmd_import(args):
+    """Import palace data from a JSON export file."""
+    from .exporter import import_palace
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    input_file = args.input_file
+
+    print(f"\n{'=' * 55}")
+    print("  Palace Import")
+    print(f"  From:   {input_file}")
+    print(f"  Palace: {palace_path}")
+    print(f"{'=' * 55}\n")
+
+    result = import_palace(input_file=input_file, palace_path=palace_path)
+
+    print(f"  Drawers imported:     {result.drawers_imported}")
+    print(f"  Drawers skipped:      {result.drawers_skipped} (already existed)")
+    print(f"  KG entities imported: {result.kg_entities_imported}")
+    print(f"  KG triples imported:  {result.kg_triples_imported}")
+
+    if result.errors:
+        print(f"\n  Errors ({len(result.errors)}):")
+        for err in result.errors[:5]:
+            print(f"    - {err}")
+
+    print(f"\n{'=' * 55}\n")
+
+
 def cmd_compress(args):
     """Compress drawers in a wing using AAAK Dialect."""
     import chromadb
@@ -530,6 +592,14 @@ def main():
         help="Show MCP setup command for connecting MemPalace to your AI client",
     )
 
+    # export
+    p_export = sub.add_parser("export", help="Export palace to a portable JSON file")
+    p_export.add_argument("output", help="Output JSON file path")
+
+    # import
+    p_import = sub.add_parser("import", help="Import palace from a JSON export file")
+    p_import.add_argument("input_file", help="Input JSON file path")
+
     # status
     sub.add_parser("status", help="Show what's been filed")
 
@@ -563,6 +633,8 @@ def main():
         "search": cmd_search,
         "mcp": cmd_mcp,
         "compress": cmd_compress,
+        "export": cmd_export,
+        "import": cmd_import,
         "wake-up": cmd_wakeup,
         "repair": cmd_repair,
         "status": cmd_status,

--- a/mempalace/exporter.py
+++ b/mempalace/exporter.py
@@ -1,0 +1,375 @@
+"""
+exporter.py — Export and import palace data for backup and migration.
+=====================================================================
+
+Exports all palace data (drawers from ChromaDB + knowledge graph from
+SQLite) into a single portable JSON file. Imports from that file to
+restore or migrate a palace to a new machine.
+
+The export format is a self-describing JSON document:
+
+    {
+        "format": "mempalace_export",
+        "version": 1,
+        "exported_at": "2026-04-09T...",
+        "drawers": [...],
+        "kg_entities": [...],
+        "kg_triples": [...]
+    }
+
+Zero API calls. Zero new dependencies. Uses only json + existing modules.
+
+Usage:
+    from mempalace.exporter import export_palace, import_palace
+
+    export_palace(palace_path, output_file="palace_backup.json")
+    import_palace("palace_backup.json", palace_path)
+
+CLI:
+    mempalace export palace_backup.json
+    mempalace import palace_backup.json
+"""
+
+import json
+import logging
+import os
+from datetime import datetime
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import chromadb
+
+from mempalace.knowledge_graph import KnowledgeGraph
+
+logger = logging.getLogger("mempalace")
+
+EXPORT_FORMAT = "mempalace_export"
+EXPORT_VERSION = 1
+
+
+# ── Result types ─────────────────────────────────────────────────────
+
+
+@dataclass
+class ExportResult:
+    """Result of a palace export operation."""
+
+    success: bool = False
+    output_file: str = ""
+    drawers_exported: int = 0
+    kg_entities_exported: int = 0
+    kg_triples_exported: int = 0
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "success": self.success,
+            "output_file": self.output_file,
+            "drawers_exported": self.drawers_exported,
+            "kg_entities_exported": self.kg_entities_exported,
+            "kg_triples_exported": self.kg_triples_exported,
+            "errors": self.errors[:10],
+        }
+
+
+@dataclass
+class ImportResult:
+    """Result of a palace import operation."""
+
+    success: bool = False
+    drawers_imported: int = 0
+    drawers_skipped: int = 0
+    kg_entities_imported: int = 0
+    kg_triples_imported: int = 0
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "success": self.success,
+            "drawers_imported": self.drawers_imported,
+            "drawers_skipped": self.drawers_skipped,
+            "kg_entities_imported": self.kg_entities_imported,
+            "kg_triples_imported": self.kg_triples_imported,
+            "errors": self.errors[:10],
+        }
+
+
+# ── Export ───────────────────────────────────────────────────────────
+
+
+def _read_all_drawers(palace_path: str) -> List[dict]:
+    """Read all drawers from ChromaDB in batches."""
+    try:
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+    except Exception as e:
+        logger.warning("No palace collection found: %s", e)
+        return []
+
+    drawers = []
+    batch_size = 500
+    offset = 0
+
+    while True:
+        try:
+            batch = col.get(
+                include=["documents", "metadatas"],
+                limit=batch_size,
+                offset=offset,
+            )
+        except Exception:
+            break
+
+        ids = batch.get("ids", [])
+        docs = batch.get("documents", [])
+        metas = batch.get("metadatas", [])
+
+        if not ids:
+            break
+
+        for drawer_id, doc, meta in zip(ids, docs, metas):
+            drawers.append({
+                "id": drawer_id,
+                "document": doc,
+                "metadata": meta,
+            })
+
+        offset += len(ids)
+
+    return drawers
+
+
+def _read_all_kg(kg: KnowledgeGraph) -> tuple:
+    """Read all entities and triples from the knowledge graph."""
+    conn = kg._conn()
+
+    entities = []
+    for row in conn.execute("SELECT * FROM entities").fetchall():
+        entities.append({
+            "id": row["id"],
+            "name": row["name"],
+            "type": row["type"],
+            "properties": row["properties"],
+        })
+
+    triples = []
+    for row in conn.execute(
+        """SELECT t.*, s.name as sub_name, o.name as obj_name
+           FROM triples t
+           JOIN entities s ON t.subject = s.id
+           JOIN entities o ON t.object = o.id"""
+    ).fetchall():
+        triples.append({
+            "id": row["id"],
+            "subject": row["sub_name"],
+            "subject_id": row["subject"],
+            "predicate": row["predicate"],
+            "object": row["obj_name"],
+            "object_id": row["object"],
+            "valid_from": row["valid_from"],
+            "valid_to": row["valid_to"],
+            "confidence": row["confidence"],
+            "source_closet": row["source_closet"],
+            "source_file": row["source_file"],
+        })
+
+    return entities, triples
+
+
+def export_palace(
+    palace_path: str,
+    output_file: str,
+    kg: Optional[KnowledgeGraph] = None,
+) -> ExportResult:
+    """Export all palace data to a JSON file.
+
+    Args:
+        palace_path: Path to the palace ChromaDB directory.
+        output_file: Path for the output JSON file.
+        kg: KnowledgeGraph instance (creates from palace_path if None).
+
+    Returns:
+        ExportResult with export stats.
+    """
+    result = ExportResult(output_file=output_file)
+
+    # Read drawers
+    drawers = _read_all_drawers(palace_path)
+    result.drawers_exported = len(drawers)
+
+    # Read KG
+    if kg is None:
+        kg_path = os.path.join(palace_path, "knowledge_graph.sqlite3")
+        if os.path.exists(kg_path):
+            kg = KnowledgeGraph(db_path=kg_path)
+        else:
+            kg = None
+
+    entities, triples = [], []
+    if kg is not None:
+        try:
+            entities, triples = _read_all_kg(kg)
+            result.kg_entities_exported = len(entities)
+            result.kg_triples_exported = len(triples)
+        except Exception as e:
+            result.errors.append(f"KG read error: {e}")
+
+    # Build export document
+    export_data = {
+        "format": EXPORT_FORMAT,
+        "version": EXPORT_VERSION,
+        "exported_at": datetime.now().isoformat(),
+        "palace_path": palace_path,
+        "drawers": drawers,
+        "kg_entities": entities,
+        "kg_triples": triples,
+    }
+
+    # Write to file
+    try:
+        output_dir = os.path.dirname(output_file)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(export_data, f, indent=2, ensure_ascii=False)
+        result.success = True
+    except Exception as e:
+        result.errors.append(f"Write error: {e}")
+
+    return result
+
+
+# ── Import ───────────────────────────────────────────────────────────
+
+
+def import_palace(
+    input_file: str,
+    palace_path: str,
+    kg: Optional[KnowledgeGraph] = None,
+    skip_existing: bool = True,
+) -> ImportResult:
+    """Import palace data from a JSON export file.
+
+    Args:
+        input_file: Path to the JSON export file.
+        palace_path: Path to the target palace directory.
+        kg: KnowledgeGraph instance (creates from palace_path if None).
+        skip_existing: If True, skip drawers that already exist (by ID).
+
+    Returns:
+        ImportResult with import stats.
+    """
+    result = ImportResult()
+
+    # Read export file
+    try:
+        with open(input_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        result.errors.append(f"Read error: {e}")
+        return result
+
+    # Validate format
+    if data.get("format") != EXPORT_FORMAT:
+        result.errors.append(
+            f"Unknown format: {data.get('format')}. Expected: {EXPORT_FORMAT}"
+        )
+        return result
+
+    if data.get("version", 0) > EXPORT_VERSION:
+        result.errors.append(
+            f"Export version {data.get('version')} is newer than supported ({EXPORT_VERSION})"
+        )
+        return result
+
+    # Import drawers
+    drawers = data.get("drawers", [])
+    if drawers:
+        try:
+            os.makedirs(palace_path, exist_ok=True)
+            client = chromadb.PersistentClient(path=palace_path)
+            try:
+                col = client.get_collection("mempalace_drawers")
+            except Exception:
+                col = client.create_collection("mempalace_drawers")
+
+            # Get existing IDs to skip duplicates
+            existing_ids = set()
+            if skip_existing:
+                offset = 0
+                while True:
+                    try:
+                        batch = col.get(limit=500, offset=offset)
+                        batch_ids = batch.get("ids", [])
+                        if not batch_ids:
+                            break
+                        existing_ids.update(batch_ids)
+                        offset += len(batch_ids)
+                    except Exception:
+                        break
+
+            # Add drawers in batches
+            batch_ids, batch_docs, batch_metas = [], [], []
+            for drawer in drawers:
+                drawer_id = drawer["id"]
+                if skip_existing and drawer_id in existing_ids:
+                    result.drawers_skipped += 1
+                    continue
+
+                batch_ids.append(drawer_id)
+                batch_docs.append(drawer["document"])
+                batch_metas.append(drawer["metadata"])
+
+                if len(batch_ids) >= 100:
+                    col.add(ids=batch_ids, documents=batch_docs, metadatas=batch_metas)
+                    result.drawers_imported += len(batch_ids)
+                    batch_ids, batch_docs, batch_metas = [], [], []
+
+            if batch_ids:
+                col.add(ids=batch_ids, documents=batch_docs, metadatas=batch_metas)
+                result.drawers_imported += len(batch_ids)
+
+        except Exception as e:
+            result.errors.append(f"Drawer import error: {e}")
+
+    # Import KG
+    kg_entities = data.get("kg_entities", [])
+    kg_triples = data.get("kg_triples", [])
+
+    if kg_entities or kg_triples:
+        if kg is None:
+            kg_path = os.path.join(palace_path, "knowledge_graph.sqlite3")
+            kg = KnowledgeGraph(db_path=kg_path)
+
+        for entity in kg_entities:
+            try:
+                props = entity.get("properties", "{}")
+                if isinstance(props, str):
+                    props = json.loads(props)
+                kg.add_entity(
+                    entity["name"],
+                    entity_type=entity.get("type", "unknown"),
+                    properties=props,
+                )
+                result.kg_entities_imported += 1
+            except Exception as e:
+                result.errors.append(f"Entity import error ({entity.get('name')}): {e}")
+
+        for triple in kg_triples:
+            try:
+                kg.add_triple(
+                    triple["subject"],
+                    triple["predicate"],
+                    triple["object"],
+                    valid_from=triple.get("valid_from"),
+                    valid_to=triple.get("valid_to"),
+                    confidence=triple.get("confidence", 1.0),
+                    source_closet=triple.get("source_closet"),
+                    source_file=triple.get("source_file"),
+                )
+                result.kg_triples_imported += 1
+            except Exception as e:
+                result.errors.append(f"Triple import error: {e}")
+
+    result.success = len(result.errors) == 0
+    return result

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -471,6 +471,30 @@ def tool_kg_stats():
     return _kg.stats()
 
 
+def tool_export(output_file: str):
+    """Export palace data to a portable JSON file."""
+    from mempalace.exporter import export_palace
+
+    result = export_palace(
+        palace_path=_config.palace_path,
+        output_file=output_file,
+        kg=_kg,
+    )
+    return result.to_dict()
+
+
+def tool_import(input_file: str):
+    """Import palace data from a JSON export file."""
+    from mempalace.exporter import import_palace
+
+    result = import_palace(
+        input_file=input_file,
+        palace_path=_config.palace_path,
+        kg=_kg,
+    )
+    return result.to_dict()
+
+
 # ==================== AGENT DIARY ====================
 
 
@@ -698,6 +722,34 @@ TOOLS = {
         "description": "Knowledge graph overview: entities, triples, current vs expired facts, relationship types.",
         "input_schema": {"type": "object", "properties": {}},
         "handler": tool_kg_stats,
+    },
+    "mempalace_export": {
+        "description": "Export all palace data (drawers + knowledge graph) to a portable JSON file for backup or migration.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "output_file": {
+                    "type": "string",
+                    "description": "Path for the output JSON file (e.g. 'palace_backup.json')",
+                },
+            },
+            "required": ["output_file"],
+        },
+        "handler": tool_export,
+    },
+    "mempalace_import": {
+        "description": "Import palace data from a JSON export file. Skips existing drawers to avoid duplicates.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "input_file": {
+                    "type": "string",
+                    "description": "Path to the JSON export file to import",
+                },
+            },
+            "required": ["input_file"],
+        },
+        "handler": tool_import,
     },
     "mempalace_traverse": {
         "description": "Walk the palace graph from a room. Shows connected ideas across wings — the tunnels. Like following a thread through the palace: start at 'chromadb-setup' in wing_code, discover it connects to wing_myproject (planning) and wing_user (feelings about it).",

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,244 @@
+"""
+test_exporter.py — Tests for palace export/import functionality.
+
+Covers: full export, full import, round-trip fidelity, skip-existing
+deduplication, format validation, empty palace handling, and error paths.
+"""
+
+import json
+import os
+
+from mempalace.exporter import (
+    export_palace,
+    import_palace,
+    EXPORT_FORMAT,
+    EXPORT_VERSION,
+)
+
+
+class TestExport:
+    def test_export_drawers(self, palace_path, seeded_collection, tmp_dir):
+        output = os.path.join(tmp_dir, "export.json")
+        result = export_palace(palace_path=palace_path, output_file=output)
+
+        assert result.success
+        assert result.drawers_exported == 4
+        assert os.path.exists(output)
+
+        with open(output, "r") as f:
+            data = json.load(f)
+        assert data["format"] == EXPORT_FORMAT
+        assert data["version"] == EXPORT_VERSION
+        assert len(data["drawers"]) == 4
+
+    def test_export_with_kg(self, palace_path, seeded_collection, seeded_kg, tmp_dir):
+        output = os.path.join(tmp_dir, "export.json")
+        result = export_palace(palace_path=palace_path, output_file=output, kg=seeded_kg)
+
+        assert result.success
+        assert result.drawers_exported == 4
+        assert result.kg_entities_exported > 0
+        assert result.kg_triples_exported > 0
+
+        with open(output, "r") as f:
+            data = json.load(f)
+        assert len(data["kg_entities"]) > 0
+        assert len(data["kg_triples"]) > 0
+
+    def test_export_empty_palace(self, palace_path, collection, tmp_dir):
+        """Export of empty palace should succeed with zero counts."""
+        output = os.path.join(tmp_dir, "empty.json")
+        result = export_palace(palace_path=palace_path, output_file=output)
+
+        assert result.success
+        assert result.drawers_exported == 0
+
+    def test_export_no_palace(self, tmp_dir):
+        """Export from nonexistent palace should still create valid JSON."""
+        output = os.path.join(tmp_dir, "none.json")
+        missing = os.path.join(tmp_dir, "missing_palace")
+        result = export_palace(palace_path=missing, output_file=output)
+
+        assert result.drawers_exported == 0
+        # Should still write a valid (empty) export file
+        assert os.path.exists(output)
+
+    def test_export_drawer_fields(self, palace_path, seeded_collection, tmp_dir):
+        """Each exported drawer should have id, document, and metadata."""
+        output = os.path.join(tmp_dir, "export.json")
+        export_palace(palace_path=palace_path, output_file=output)
+
+        with open(output, "r") as f:
+            data = json.load(f)
+
+        for drawer in data["drawers"]:
+            assert "id" in drawer
+            assert "document" in drawer
+            assert "metadata" in drawer
+            assert isinstance(drawer["metadata"], dict)
+
+
+class TestImport:
+    def test_import_drawers(self, tmp_dir):
+        """Import drawers into a fresh palace."""
+        export_data = {
+            "format": EXPORT_FORMAT,
+            "version": EXPORT_VERSION,
+            "exported_at": "2026-04-09T00:00:00",
+            "drawers": [
+                {
+                    "id": "test_001",
+                    "document": "Alice works at Acme Corp on auth.",
+                    "metadata": {"wing": "project", "room": "backend", "source_file": "test.py"},
+                },
+                {
+                    "id": "test_002",
+                    "document": "Bob built the deployment pipeline.",
+                    "metadata": {"wing": "project", "room": "devops", "source_file": "deploy.py"},
+                },
+            ],
+            "kg_entities": [],
+            "kg_triples": [],
+        }
+        input_file = os.path.join(tmp_dir, "import.json")
+        with open(input_file, "w") as f:
+            json.dump(export_data, f)
+
+        palace = os.path.join(tmp_dir, "new_palace")
+        result = import_palace(input_file=input_file, palace_path=palace)
+
+        assert result.success
+        assert result.drawers_imported == 2
+
+    def test_import_skips_existing(self, palace_path, seeded_collection, tmp_dir):
+        """Import should skip drawers that already exist."""
+        # Export first
+        export_file = os.path.join(tmp_dir, "export.json")
+        export_palace(palace_path=palace_path, output_file=export_file)
+
+        # Import back into the same palace
+        result = import_palace(input_file=export_file, palace_path=palace_path)
+
+        assert result.drawers_skipped == 4
+        assert result.drawers_imported == 0
+
+    def test_import_kg(self, tmp_dir, kg):
+        """Import KG entities and triples."""
+        export_data = {
+            "format": EXPORT_FORMAT,
+            "version": EXPORT_VERSION,
+            "exported_at": "2026-04-09T00:00:00",
+            "drawers": [],
+            "kg_entities": [
+                {"id": "alice", "name": "Alice", "type": "person", "properties": "{}"},
+            ],
+            "kg_triples": [
+                {
+                    "subject": "Alice",
+                    "predicate": "works_at",
+                    "object": "Acme",
+                    "valid_from": "2020-01-01",
+                    "valid_to": None,
+                    "confidence": 1.0,
+                    "source_closet": None,
+                    "source_file": None,
+                },
+            ],
+        }
+        input_file = os.path.join(tmp_dir, "import.json")
+        with open(input_file, "w") as f:
+            json.dump(export_data, f)
+
+        palace = os.path.join(tmp_dir, "new_palace")
+        result = import_palace(input_file=input_file, palace_path=palace, kg=kg)
+
+        assert result.kg_entities_imported == 1
+        assert result.kg_triples_imported == 1
+
+        # Verify KG data
+        facts = kg.query_entity("Alice", direction="outgoing")
+        assert any(f["predicate"] == "works_at" for f in facts)
+
+    def test_import_invalid_format(self, tmp_dir):
+        """Import should reject files with wrong format."""
+        input_file = os.path.join(tmp_dir, "bad.json")
+        with open(input_file, "w") as f:
+            json.dump({"format": "not_mempalace", "drawers": []}, f)
+
+        palace = os.path.join(tmp_dir, "palace")
+        result = import_palace(input_file=input_file, palace_path=palace)
+
+        assert not result.success
+        assert any("Unknown format" in e for e in result.errors)
+
+    def test_import_missing_file(self, tmp_dir):
+        """Import should handle missing file gracefully."""
+        palace = os.path.join(tmp_dir, "palace")
+        result = import_palace(input_file="/nonexistent/file.json", palace_path=palace)
+
+        assert not result.success
+        assert len(result.errors) > 0
+
+
+class TestRoundTrip:
+    def test_full_roundtrip(self, palace_path, seeded_collection, seeded_kg, tmp_dir):
+        """Export → import into new palace → verify data matches."""
+        export_file = os.path.join(tmp_dir, "roundtrip.json")
+
+        # Export
+        export_result = export_palace(
+            palace_path=palace_path,
+            output_file=export_file,
+            kg=seeded_kg,
+        )
+        assert export_result.success
+
+        # Import into fresh palace
+        new_palace = os.path.join(tmp_dir, "new_palace")
+        from mempalace.knowledge_graph import KnowledgeGraph
+
+        new_kg = KnowledgeGraph(db_path=os.path.join(tmp_dir, "new_kg.sqlite3"))
+
+        import_result = import_palace(
+            input_file=export_file,
+            palace_path=new_palace,
+            kg=new_kg,
+        )
+        assert import_result.drawers_imported == export_result.drawers_exported
+        assert import_result.kg_entities_imported == export_result.kg_entities_exported
+
+        # Verify drawer content in new palace
+        import chromadb
+
+        client = chromadb.PersistentClient(path=new_palace)
+        col = client.get_collection("mempalace_drawers")
+        all_data = col.get(include=["documents", "metadatas"])
+        assert len(all_data["ids"]) == 4
+
+        # Verify KG content
+        facts = new_kg.query_entity("Alice", direction="both")
+        assert len(facts) > 0
+
+
+class TestResultSerialization:
+    def test_export_result_to_dict(self, palace_path, seeded_collection, tmp_dir):
+        output = os.path.join(tmp_dir, "export.json")
+        result = export_palace(palace_path=palace_path, output_file=output)
+        d = result.to_dict()
+
+        assert "success" in d
+        assert "drawers_exported" in d
+        assert "kg_entities_exported" in d
+        assert isinstance(d["errors"], list)
+
+    def test_import_result_to_dict(self, tmp_dir):
+        input_file = os.path.join(tmp_dir, "bad.json")
+        with open(input_file, "w") as f:
+            json.dump({"format": "wrong"}, f)
+
+        result = import_palace(input_file=input_file, palace_path=tmp_dir)
+        d = result.to_dict()
+
+        assert "success" in d
+        assert "drawers_imported" in d
+        assert "drawers_skipped" in d


### PR DESCRIPTION
## Summary

There's currently no way to back up, migrate, or share palace data. If ChromaDB or SQLite gets corrupted, everything is lost. This PR adds portable export/import.

- **`mempalace export backup.json`** — exports all drawers + KG entities + KG triples to a single JSON file
- **`mempalace import backup.json`** — restores into a new or existing palace with automatic deduplication
- **MCP tools**: `mempalace_export` and `mempalace_import` for AI agents

### Export format

Self-describing JSON with version field for forward compatibility:
```json
{
  "format": "mempalace_export",
  "version": 1,
  "exported_at": "2026-04-09T...",
  "drawers": [{"id": "...", "document": "...", "metadata": {...}}],
  "kg_entities": [...],
  "kg_triples": [...]
}
```

### Key behaviors

- **Idempotent import**: existing drawers are detected by ID and skipped
- **Batched I/O**: reads/writes in 500-item batches for large palaces
- **Format validation**: rejects unknown formats and future versions
- **Graceful errors**: missing files, empty palaces, and corrupted data handled cleanly

## Test plan

- [x] `pytest tests/test_exporter.py -v` — 13 tests pass
- [x] `pytest tests/ -v` — full suite 547 passed, 0 failed
- [x] `ruff check` — no lint errors
- [x] No new dependencies
- [x] Full round-trip test: export → import into new palace → verify data matches
- [x] Skip-existing deduplication tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)