### PR TITLE
fix: Update skipped filenames and directories for pnpm compatibility

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -66,6 +66,9 @@ SKIP_FILENAMES = {
     ".gitignore",
     "package-lock.json",
     "pnpm-lock.yaml",
+    ".pnpm-debug.log",
+    "pnpm-debug.log",
+    "pnpm-workspace.yaml",
     "yarn.lock",
 }
 

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -41,6 +41,7 @@ SKIP_DIRS = {
     ".eggs",
     "htmlcov",
     "target",
+    ".pnpm-store",
 }
 
 _DEFAULT_BACKEND = ChromaBackend()


### PR DESCRIPTION
## What does this PR do?

This pull request adds ignoring of directories and files generated by the pnpm package manager during `pnpm install`, to prevent memory pollution with unnecessary data from auxiliary files.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
