### PR TITLE
fix: remove duplicate cache variable declarations in mcp_server.py

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -100,10 +100,6 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         logger.error(f"WAL write failed: {e}")
 
 
-_client_cache = None
-_collection_cache = None
-
-
 def _get_client():
     """Return a singleton ChromaDB PersistentClient."""
     global _client_cache


### PR DESCRIPTION
## Summary
- Lines 103-104 of `mempalace/mcp_server.py` contained redundant re-declarations of `_client_cache = None` and `_collection_cache = None`, which are already defined as module-level globals at lines 66-67.
- This is likely a merge or copy-paste artifact. Removed the duplicates.

## Test plan
- [ ] Verify existing tests pass (no behavioral change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)