### PR TITLE
fix: close KnowledgeGraph SQLite connections in test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,9 @@ def seeded_collection(collection):
 def kg(tmp_dir):
     """An isolated KnowledgeGraph using a temp SQLite file."""
     db_path = os.path.join(tmp_dir, "test_kg.sqlite3")
-    return KnowledgeGraph(db_path=db_path)
+    graph = KnowledgeGraph(db_path=db_path)
+    yield graph
+    graph.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- The `kg` fixture in `tests/conftest.py` creates a `KnowledgeGraph` (which opens SQLite connections) but never calls `.close()`, leaking connections during the test session.
- Changed `return` to `yield` + `graph.close()` for proper teardown cleanup.

## Test plan
- [ ] Verify existing tests pass with the fixture change
- [ ] Confirm no SQLite "database is locked" warnings in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)