### PR TITLE
feat: add backup, export, and import commands

### DIFF
--- a/mempalace/backup.py
+++ b/mempalace/backup.py
@@ -57,6 +57,7 @@ def backup_palace(palace_path: str, zip_mode: bool = False, max_backups: int = 5
         pattern = "palace-backup-*.zip" if zip_mode else "palace-backup-*"
         existing = sorted(parent.glob(pattern))
         if not zip_mode:
+            # Filter to directories only — prevents matching zip files without extension
             existing = [p for p in existing if p.is_dir()]
         if len(existing) > max_backups:
             to_remove = existing[: len(existing) - max_backups]
@@ -89,7 +90,7 @@ def export_palace(palace_path: str, output_dir: str):
     print(f"  Exporting {total} drawers from {palace_path}")
 
     # Fetch all drawers in batches
-    batch_size = 5000
+    batch_size = 500
     all_docs = []
     all_metas = []
     all_ids = []
@@ -128,6 +129,7 @@ def export_palace(palace_path: str, output_dir: str):
         print(f"  {wing}/{room}.jsonl — {len(drawers)} drawers")
 
     print(f"\n  Exported to {output_dir}")
+    print(f"  Note: embeddings are not included. Import will re-embed using the configured model.")
     print(f"  {total_files} files, {len(all_ids)} drawers total")
 
 
@@ -180,7 +182,7 @@ def import_palace(palace_path: str, input_dir: str):
         skipped = len(drawers) - len(new_drawers)
 
         if new_drawers:
-            batch_size = 5000
+            batch_size = 500
             for i in range(0, len(new_drawers), batch_size):
                 batch = new_drawers[i : i + batch_size]
                 col.add(

--- a/mempalace/backup.py
+++ b/mempalace/backup.py
@@ -1,0 +1,196 @@
+"""
+MemPalace backup, export, and import utilities.
+
+backup  — copy or zip the palace directory (binary, fast restore)
+export  — dump drawers to JSONL files organized by wing/room (git-friendly)
+import  — load JSONL drawers into the palace (merge, deduplicate by ID)
+"""
+
+import json
+import os
+import shutil
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+import chromadb
+
+
+def backup_palace(palace_path: str, zip_mode: bool = False, max_backups: int = 5):
+    """Create a timestamped backup of the palace directory.
+
+    Args:
+        palace_path: Path to the palace directory.
+        zip_mode: If True, create a zip archive instead of a directory copy.
+        max_backups: Maximum number of backups to retain (0 = unlimited).
+    """
+    palace = Path(palace_path)
+    if not palace.exists():
+        print(f"  No palace found at {palace_path}")
+        return None
+
+    parent = palace.parent
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_name = f"palace-backup-{timestamp}"
+
+    if zip_mode:
+        backup_path = parent / f"{backup_name}.zip"
+        print(f"  Creating zip backup: {backup_path}")
+        with zipfile.ZipFile(backup_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, dirs, files in os.walk(palace):
+                for f in files:
+                    file_path = Path(root) / f
+                    arcname = file_path.relative_to(palace)
+                    zf.write(file_path, arcname)
+        size_mb = backup_path.stat().st_size / (1024 * 1024)
+        print(f"  Backup size: {size_mb:.1f} MB")
+    else:
+        backup_path = parent / backup_name
+        print(f"  Creating backup: {backup_path}")
+        shutil.copytree(palace, backup_path)
+        total = sum(f.stat().st_size for f in backup_path.rglob("*") if f.is_file())
+        size_mb = total / (1024 * 1024)
+        print(f"  Backup size: {size_mb:.1f} MB")
+
+    # Prune old backups
+    if max_backups > 0:
+        pattern = "palace-backup-*.zip" if zip_mode else "palace-backup-*"
+        existing = sorted(parent.glob(pattern))
+        if not zip_mode:
+            existing = [p for p in existing if p.is_dir()]
+        if len(existing) > max_backups:
+            to_remove = existing[: len(existing) - max_backups]
+            for old in to_remove:
+                print(f"  Pruning old backup: {old.name}")
+                if old.is_dir():
+                    shutil.rmtree(old)
+                else:
+                    old.unlink()
+
+    print(f"  Done.")
+    return backup_path
+
+
+def export_palace(palace_path: str, output_dir: str):
+    """Export all drawers to JSONL files organized by wing/room.
+
+    Args:
+        palace_path: Path to the palace directory.
+        output_dir: Directory to write JSONL files to.
+    """
+    try:
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+    except Exception:
+        print(f"  No palace found at {palace_path}")
+        return
+
+    total = col.count()
+    print(f"  Exporting {total} drawers from {palace_path}")
+
+    # Fetch all drawers in batches
+    batch_size = 5000
+    all_docs = []
+    all_metas = []
+    all_ids = []
+
+    offset = 0
+    while offset < total:
+        results = col.get(
+            limit=batch_size, offset=offset, include=["documents", "metadatas"]
+        )
+        all_docs.extend(results["documents"])
+        all_metas.extend(results["metadatas"])
+        all_ids.extend(results["ids"])
+        offset += batch_size
+
+    # Group by wing/room
+    groups = {}
+    for doc, meta, did in zip(all_docs, all_metas, all_ids):
+        wing = meta.get("wing", "unknown")
+        room = meta.get("room", "general")
+        key = (wing, room)
+        if key not in groups:
+            groups[key] = []
+        groups[key].append({"id": did, "document": doc, "metadata": meta})
+
+    # Write JSONL files
+    out = Path(output_dir)
+    total_files = 0
+    for (wing, room), drawers in sorted(groups.items()):
+        wing_dir = out / wing
+        wing_dir.mkdir(parents=True, exist_ok=True)
+        filepath = wing_dir / f"{room}.jsonl"
+        with open(filepath, "w", encoding="utf-8") as f:
+            for drawer in drawers:
+                f.write(json.dumps(drawer, ensure_ascii=False) + "\n")
+        total_files += 1
+        print(f"  {wing}/{room}.jsonl — {len(drawers)} drawers")
+
+    print(f"\n  Exported to {output_dir}")
+    print(f"  {total_files} files, {len(all_ids)} drawers total")
+
+
+def import_palace(palace_path: str, input_dir: str):
+    """Import JSONL drawers into the palace, deduplicating by ID.
+
+    Args:
+        palace_path: Path to the palace directory.
+        input_dir: Directory containing wing/room.jsonl files.
+    """
+    os.makedirs(palace_path, exist_ok=True)
+    client = chromadb.PersistentClient(path=palace_path)
+    try:
+        col = client.get_collection("mempalace_drawers")
+    except Exception:
+        col = client.create_collection("mempalace_drawers")
+
+    inp = Path(input_dir)
+    if not inp.exists():
+        print(f"  Import directory not found: {input_dir}")
+        return
+
+    total_added = 0
+    total_skipped = 0
+
+    for jsonl_file in sorted(inp.rglob("*.jsonl")):
+        wing = jsonl_file.parent.name
+        room = jsonl_file.stem
+
+        drawers = []
+        with open(jsonl_file, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    drawers.append(json.loads(line))
+
+        if not drawers:
+            continue
+
+        # Check which IDs already exist
+        ids = [d["id"] for d in drawers]
+        existing = set()
+        try:
+            result = col.get(ids=ids, include=[])
+            existing = set(result["ids"])
+        except Exception:
+            pass
+
+        new_drawers = [d for d in drawers if d["id"] not in existing]
+        skipped = len(drawers) - len(new_drawers)
+
+        if new_drawers:
+            batch_size = 5000
+            for i in range(0, len(new_drawers), batch_size):
+                batch = new_drawers[i : i + batch_size]
+                col.add(
+                    ids=[d["id"] for d in batch],
+                    documents=[d["document"] for d in batch],
+                    metadatas=[d["metadata"] for d in batch],
+                )
+
+        total_added += len(new_drawers)
+        total_skipped += skipped
+        print(f"  {wing}/{room}.jsonl — +{len(new_drawers)} new, {skipped} skipped")
+
+    print(f"\n  Import complete: {total_added} added, {total_skipped} already existed")

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -17,6 +17,10 @@ Commands:
     mempalace mcp                         Show MCP setup command
     mempalace wake-up                     Show L0 + L1 wake-up context
     mempalace wake-up --wing my_app       Wake-up for a specific project
+    mempalace backup                      Backup the palace
+    mempalace backup --zip                Backup as zip archive
+    mempalace export                      Export to JSONL (git-friendly)
+    mempalace import <dir>                Import JSONL into palace
     mempalace status                      Show what's been filed
 
 Examples:
@@ -67,6 +71,10 @@ def cmd_init(args):
 
 def cmd_mine(args):
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+
+    if getattr(args, "backup", False):
+        from .backup import backup_palace
+        backup_palace(palace_path=palace_path, zip_mode=False, max_backups=5)
     include_ignored = []
     for raw in args.include_ignored or []:
         include_ignored.extend(part.strip() for part in raw.split(",") if part.strip())
@@ -264,6 +272,39 @@ def cmd_mcp(args):
         print(f"  {base_server_cmd} --palace /path/to/palace")
 
 
+
+def cmd_backup(args):
+    """Create a timestamped backup of the palace."""
+    from .backup import backup_palace
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    print()
+    backup_palace(
+        palace_path=palace_path,
+        zip_mode=args.zip,
+        max_backups=args.max_backups,
+    )
+
+
+def cmd_export(args):
+    """Export palace drawers to JSONL files organized by wing/room."""
+    from .backup import export_palace
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    output_dir = args.output or os.path.join(os.path.dirname(palace_path), "export")
+    print()
+    export_palace(palace_path=palace_path, output_dir=output_dir)
+
+
+def cmd_import(args):
+    """Import JSONL drawers into the palace (merge, deduplicate)."""
+    from .backup import import_palace
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    print()
+    import_palace(palace_path=palace_path, input_dir=args.input)
+
+
 def cmd_compress(args):
     """Compress drawers in a wing using AAAK Dialect."""
     import chromadb
@@ -437,6 +478,9 @@ def main():
         "--dry-run", action="store_true", help="Show what would be filed without filing"
     )
     p_mine.add_argument(
+        "--backup", action="store_true", help="Create a backup before mining"
+    )
+    p_mine.add_argument(
         "--extract",
         choices=["exchange", "general"],
         default="exchange",
@@ -530,6 +574,19 @@ def main():
         help="Show MCP setup command for connecting MemPalace to your AI client",
     )
 
+    # backup
+    p_backup = sub.add_parser("backup", help="Create a timestamped backup of the palace")
+    p_backup.add_argument("--zip", action="store_true", help="Create a zip archive instead of directory copy")
+    p_backup.add_argument("--max-backups", type=int, default=5, help="Max backups to retain (default: 5, 0=unlimited)")
+
+    # export
+    p_export = sub.add_parser("export", help="Export drawers to JSONL files (git-friendly)")
+    p_export.add_argument("--output", default=None, help="Output directory (default: ~/.mempalace/export/)")
+
+    # import
+    p_import = sub.add_parser("import", help="Import JSONL drawers into the palace (merge, deduplicate)")
+    p_import.add_argument("input", help="Directory containing wing/room.jsonl files")
+
     # status
     sub.add_parser("status", help="Show what's been filed")
 
@@ -565,6 +622,9 @@ def main():
         "compress": cmd_compress,
         "wake-up": cmd_wakeup,
         "repair": cmd_repair,
+        "backup": cmd_backup,
+        "export": cmd_export,
+        "import": cmd_import,
         "status": cmd_status,
     }
     dispatch[args.command](args)


### PR DESCRIPTION
## Summary

- Add `mempalace backup` — timestamped palace backup (directory copy or zip archive) with auto-pruning
- Add `mempalace export` — dump all drawers to JSONL files organized by wing/room (git-friendly)
- Add `mempalace import <dir>` — merge JSONL drawers into palace with deduplication by ID
- Add `mempalace mine --backup` — opt-in auto-backup before mining operations

## Motivation

The palace stores irreplaceable conversation context (design decisions, debugging insights, requirement discussions). Currently there is no built-in way to back up, export, or sync this data across machines.

This PR enables a **private git repo workflow** for cross-device sync:

```bash
# Machine A: after coding session
mempalace export
cd ~/.mempalace/export && git add . && git commit -m "session" && git push

# Machine B: before coding session
cd ~/.mempalace/export && git pull
mempalace import ~/.mempalace/export/
```

Benefits: backup (git history), sync (push/pull), version history (git log), recovery (git checkout), free (GitHub private repo, ~15 MB for 6 months of daily use).

## Usage

```bash
# Backup (binary copy for fast restore)
mempalace backup                    # directory copy
mempalace backup --zip              # zip archive (~30-60 MB for 10k embeddings)
mempalace backup --max-backups 3    # auto-prune old backups

# Export (JSONL for git sync)
mempalace export                    # → ~/.mempalace/export/
mempalace export --output /path     # custom output directory

# Import (merge from JSONL)
mempalace import ~/.mempalace/export/   # adds new drawers, skips duplicates

# Auto-backup before mining
mempalace mine ~/chats --mode convos --backup
```

## Export format

```
export/
├── rebuild/
│   ├── architecture.jsonl
│   ├── technical.jsonl
│   └── planning.jsonl
└── trello/
    └── general.jsonl
```

Each JSONL line contains `id`, `document`, and `metadata`. Import deduplicates by ID, making it safe to import the same export multiple times.

## Changes

| File | Change |
|------|--------|
| `mempalace/backup.py` | New module: `backup_palace()`, `export_palace()`, `import_palace()` |
| `mempalace/cli.py` | Add `backup`, `export`, `import` subcommands + `mine --backup` flag |

## Related

- Closes #448
- Related #452 (cross-device sync)
- Related #444 (palace corruption — backup is the safety net)