### PR TITLE
fix(bench): include assistant turns in document construction (#242)

### DIFF
--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -186,22 +186,21 @@ def build_palace_and_retrieve(entry, granularity="session", n_results=50):
 
     for sess_idx, (session, sess_id, date) in enumerate(zip(sessions, session_ids, dates)):
         if granularity == "session":
-            # One document per session: join all user content
-            user_turns = [t["content"] for t in session if t["role"] == "user"]
-            if user_turns:
-                doc = "\n".join(user_turns)
+            # One document per session: join all turns (user + assistant) — #242
+            all_turns = [t["content"] for t in session]
+            if all_turns:
+                doc = "\n".join(all_turns)
                 corpus.append(doc)
                 corpus_ids.append(sess_id)
                 corpus_timestamps.append(date)
         else:
-            # One document per user turn
+            # One document per turn (user + assistant) — #242
             turn_num = 0
             for turn in session:
-                if turn["role"] == "user":
-                    corpus.append(turn["content"])
-                    corpus_ids.append(f"{sess_id}_turn_{turn_num}")
-                    corpus_timestamps.append(date)
-                    turn_num += 1
+                corpus.append(turn["content"])
+                corpus_ids.append(f"{sess_id}_turn_{turn_num}")
+                corpus_timestamps.append(date)
+                turn_num += 1
 
     if not corpus:
         return [], corpus, corpus_ids, corpus_timestamps
@@ -262,24 +261,25 @@ def build_palace_and_retrieve_aaak(entry, granularity="session", n_results=50):
 
     for sess_idx, (session, sess_id, date) in enumerate(zip(sessions, session_ids, dates)):
         if granularity == "session":
-            user_turns = [t["content"] for t in session if t["role"] == "user"]
-            if user_turns:
-                doc = "\n".join(user_turns)
+            # Join all turns (user + assistant) — #242
+            all_turns = [t["content"] for t in session]
+            if all_turns:
+                doc = "\n".join(all_turns)
                 compressed = dialect.compress(doc, metadata={"date": date})
                 corpus.append(doc)
                 corpus_compressed.append(compressed)
                 corpus_ids.append(sess_id)
                 corpus_timestamps.append(date)
         else:
+            # One document per turn (user + assistant) — #242
             turn_num = 0
             for turn in session:
-                if turn["role"] == "user":
-                    compressed = dialect.compress(turn["content"])
-                    corpus.append(turn["content"])
-                    corpus_compressed.append(compressed)
-                    corpus_ids.append(f"{sess_id}_turn_{turn_num}")
-                    corpus_timestamps.append(date)
-                    turn_num += 1
+                compressed = dialect.compress(turn["content"])
+                corpus.append(turn["content"])
+                corpus_compressed.append(compressed)
+                corpus_ids.append(f"{sess_id}_turn_{turn_num}")
+                corpus_timestamps.append(date)
+                turn_num += 1
 
     if not corpus:
         return [], corpus, corpus_ids, corpus_timestamps
@@ -413,24 +413,25 @@ def build_palace_and_retrieve_rooms(entry, granularity="session", n_results=50):
 
     for sess_idx, (session, sess_id, date) in enumerate(zip(sessions, session_ids, dates)):
         if granularity == "session":
-            user_turns = [t["content"] for t in session if t["role"] == "user"]
-            if user_turns:
-                doc = "\n".join(user_turns)
+            # Join all turns (user + assistant) — #242
+            all_turns = [t["content"] for t in session]
+            if all_turns:
+                doc = "\n".join(all_turns)
                 room = detect_room_for_text(doc)
                 corpus.append(doc)
                 corpus_ids.append(sess_id)
                 corpus_timestamps.append(date)
                 corpus_rooms.append(room)
         else:
+            # One document per turn (user + assistant) — #242
             turn_num = 0
             for turn in session:
-                if turn["role"] == "user":
-                    room = detect_room_for_text(turn["content"])
-                    corpus.append(turn["content"])
-                    corpus_ids.append(f"{sess_id}_turn_{turn_num}")
-                    corpus_timestamps.append(date)
-                    corpus_rooms.append(room)
-                    turn_num += 1
+                room = detect_room_for_text(turn["content"])
+                corpus.append(turn["content"])
+                corpus_ids.append(f"{sess_id}_turn_{turn_num}")
+                corpus_timestamps.append(date)
+                corpus_rooms.append(room)
+                turn_num += 1
 
     if not corpus:
         return [], corpus, corpus_ids, corpus_timestamps
@@ -571,20 +572,21 @@ def build_palace_and_retrieve_hybrid(
 
     for sess_idx, (session, sess_id, date) in enumerate(zip(sessions, session_ids, dates)):
         if granularity == "session":
-            user_turns = [t["content"] for t in session if t["role"] == "user"]
-            if user_turns:
-                doc = "\n".join(user_turns)
+            # Join all turns (user + assistant) — #242
+            all_turns = [t["content"] for t in session]
+            if all_turns:
+                doc = "\n".join(all_turns)
                 corpus.append(doc)
                 corpus_ids.append(sess_id)
                 corpus_timestamps.append(date)
         else:
+            # One document per turn (user + assistant) — #242
             turn_num = 0
             for turn in session:
-                if turn["role"] == "user":
-                    corpus.append(turn["content"])
-                    corpus_ids.append(f"{sess_id}_turn_{turn_num}")
-                    corpus_timestamps.append(date)
-                    turn_num += 1
+                corpus.append(turn["content"])
+                corpus_ids.append(f"{sess_id}_turn_{turn_num}")
+                corpus_timestamps.append(date)
+                turn_num += 1
 
     if not corpus:
         return [], corpus, corpus_ids, corpus_timestamps
@@ -2621,11 +2623,12 @@ def build_palace_and_retrieve_diary(
     pref_wing_meta = []
 
     for session, sess_id, date in zip(sessions, session_ids, dates):
-        user_turns = [t["content"] for t in session if t["role"] == "user"]
-        if not user_turns:
+        # #242: index all turns (user + assistant), not just user turns
+        all_turns = [t["content"] for t in session]
+        if not all_turns:
             continue
 
-        user_doc = "\n".join(user_turns)
+        user_doc = "\n".join(all_turns)
         corpus_user.append(user_doc)
         corpus_ids.append(sess_id)
         corpus_timestamps.append(date)


### PR DESCRIPTION
## What this fixes

Closes #242.

The LongMemEval benchmark adapter was building one document per session from only user turns, dropping all assistant content. This systematically under-recalled questions whose answers lived in assistant responses, biasing every benchmark number the project has published.

dial481's #29 audit and gizmax's #39 reproduction both flagged this as a likely cause of measurement skew. This patch addresses it.

## What changed

9 document-construction sites in `benchmarks/longmemeval_bench.py` now include both user AND assistant turns when building per-session or per-turn corpus documents. The fixes mirror the existing `build_palace_and_retrieve_full` reference at line 638, whose docstring already noted *"Indexing only user turns misses half the signal."*

| Function | Lines fixed |
|---|---|
| `build_palace_and_retrieve` | 190, 200 |
| `build_palace_and_retrieve_aaak` | 265, 276 |
| `build_palace_and_retrieve_rooms` | 416, 427 |
| (additional bench mode) | 574, 583 |
| `build_palace_and_retrieve_diary` | 2624 |

## What was deliberately NOT changed

8 sites that legitimately need to distinguish user vs assistant were left alone:

- Lines 869, 1198, 1657, 2392 — single-turn scoring paths
- Lines 1830/1831 and 2186/2187 — paired user-text vs assistant-text comparisons (separate handling is correct)

These all have `role == "user"` filters that serve a different purpose than corpus construction.

## Net diff

`+44 / -41` in a single file. No imports added, no signatures changed, no behavior outside `benchmarks/longmemeval_bench.py`.

## Test plan

- [x] `python3 -m py_compile benchmarks/longmemeval_bench.py` — passes
- [x] All 6 remaining `role == "user"` filter sites verified as intentional (per-turn scoring or paired user/assistant comparisons)
- [ ] Re-run LongMemEval against current main vs this branch to measure the actual recall delta — recommended as a follow-up before merging so we can publish the honest number alongside the fix

## Why this matters

Per Sage's earlier triage of issue #242: *"Every benchmark number the project has published is biased in a specific direction. Fix first, re-run, ship honest numbers."* This is the fix; the re-run is the next step.

Thank you from Milla and Lu✨