### PR TITLE
fix: resolve 10 bugs found in code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ mempalace/
 ## Requirements
 
 - Python 3.9+
-- `chromadb>=0.4.0`
+- `chromadb>=0.5.0`
 - `pyyaml>=6.0`
 
 No API key. No internet after install. Everything local.

--- a/mempalace/__main__.py
+++ b/mempalace/__main__.py
@@ -2,4 +2,5 @@
 
 from .cli import main
 
-main()
+if __name__ == "__main__":
+    main()

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -452,7 +452,7 @@ def main():
 
     # compress
     p_compress = sub.add_parser(
-        "compress", help="Compress drawers using AAAK Dialect (~30x reduction)"
+        "compress", help="Compress drawers using AAAK Dialect"
     )
     p_compress.add_argument("--wing", default=None, help="Wing to compress (default: all wings)")
     p_compress.add_argument(

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -57,6 +57,7 @@ class KnowledgeGraph:
         conn = self._conn()
         conn.executescript("""
             PRAGMA journal_mode=WAL;
+            PRAGMA foreign_keys=ON;
 
             CREATE TABLE IF NOT EXISTS entities (
                 id TEXT PRIMARY KEY,
@@ -92,6 +93,7 @@ class KnowledgeGraph:
         if self._connection is None:
             self._connection = sqlite3.connect(self.db_path, timeout=10, check_same_thread=False)
             self._connection.execute("PRAGMA journal_mode=WAL")
+            self._connection.execute("PRAGMA foreign_keys=ON")
             self._connection.row_factory = sqlite3.Row
         return self._connection
 
@@ -291,7 +293,7 @@ class KnowledgeGraph:
                 JOIN entities s ON t.subject = s.id
                 JOIN entities o ON t.object = o.id
                 WHERE (t.subject = ? OR t.object = ?)
-                ORDER BY t.valid_from ASC NULLS LAST
+                ORDER BY CASE WHEN t.valid_from IS NULL THEN 1 ELSE 0 END, t.valid_from ASC
                 LIMIT 100
             """,
                 (eid, eid),
@@ -302,7 +304,7 @@ class KnowledgeGraph:
                 FROM triples t
                 JOIN entities s ON t.subject = s.id
                 JOIN entities o ON t.object = o.id
-                ORDER BY t.valid_from ASC NULLS LAST
+                ORDER BY CASE WHEN t.valid_from IS NULL THEN 1 ELSE 0 END, t.valid_from ASC
                 LIMIT 100
             """).fetchall()
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -100,10 +100,6 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         logger.error(f"WAL write failed: {e}")
 
 
-_client_cache = None
-_collection_cache = None
-
-
 def _get_client():
     """Return a singleton ChromaDB PersistentClient."""
     global _client_cache
@@ -448,6 +444,12 @@ def tool_kg_add(
 
 def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = None):
     """Mark a fact as no longer true (set end date)."""
+    try:
+        subject = sanitize_name(subject, "subject")
+        predicate = sanitize_name(predicate, "predicate")
+        object = sanitize_name(object, "object")
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
     _wal_log(
         "kg_invalidate",
         {"subject": subject, "predicate": predicate, "object": object, "ended": ended},
@@ -545,6 +547,10 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
     Read an agent's recent diary entries. Returns the last N entries
     in chronological order — the agent's personal journal.
     """
+    try:
+        agent_name = sanitize_name(agent_name, "agent_name")
+    except ValueError as e:
+        return {"error": str(e)}
     wing = f"wing_{agent_name.lower().replace(' ', '_')}"
     col = _get_collection()
     if not col:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -375,28 +375,25 @@ def add_drawer(
 ):
     """Add one drawer to the palace."""
     drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(chunk_index)).encode()).hexdigest()[:24]}"
+    metadata = {
+        "wing": wing,
+        "room": room,
+        "source_file": source_file,
+        "chunk_index": chunk_index,
+        "added_by": agent,
+        "filed_at": datetime.now().isoformat(),
+    }
+    # Store file mtime so we can detect modifications later.
     try:
-        metadata = {
-            "wing": wing,
-            "room": room,
-            "source_file": source_file,
-            "chunk_index": chunk_index,
-            "added_by": agent,
-            "filed_at": datetime.now().isoformat(),
-        }
-        # Store file mtime so we can detect modifications later.
-        try:
-            metadata["source_mtime"] = os.path.getmtime(source_file)
-        except OSError:
-            pass
-        collection.upsert(
-            documents=[content],
-            ids=[drawer_id],
-            metadatas=[metadata],
-        )
-        return True
-    except Exception:
-        raise
+        metadata["source_mtime"] = os.path.getmtime(source_file)
+    except OSError:
+        pass
+    collection.upsert(
+        documents=[content],
+        ids=[drawer_id],
+        metadatas=[metadata],
+    )
+    return True
 
 
 # =============================================================================

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -65,7 +65,7 @@ def file_already_mined(collection, source_file: str, check_mtime: bool = False) 
             if stored_mtime is None:
                 return False
             current_mtime = os.path.getmtime(source_file)
-            return float(stored_mtime) == current_mtime
+            return abs(float(stored_mtime) - current_mtime) < 0.001
         return True
     except Exception:
         return False

--- a/mempalace/spellcheck.py
+++ b/mempalace/spellcheck.py
@@ -119,7 +119,7 @@ def _load_known_names() -> set:
 
         reg = EntityRegistry.load()
         names = set()
-        for entity in reg._data.get("entities", {}).values():
+        for entity in reg._data.get("people", {}).values():
             names.add(entity.get("canonical", "").lower())
             for alias in entity.get("aliases", []):
                 names.add(alias.lower())

--- a/tests/test_spellcheck_extra.py
+++ b/tests/test_spellcheck_extra.py
@@ -12,7 +12,7 @@ class TestLoadKnownNames:
     def test_returns_names_from_registry(self):
         mock_reg = MagicMock()
         mock_reg._data = {
-            "entities": {
+            "people": {
                 "e1": {"canonical": "Alice", "aliases": ["ali"]},
                 "e2": {"canonical": "Bob", "aliases": []},
             }


### PR DESCRIPTION
## Summary

Code review identified and fixes 10 bugs across the codebase:

- **SQLite `NULLS LAST` not supported** — `knowledge_graph.py` `timeline()` used PostgreSQL-only syntax that crashes on SQLite. Replaced with `CASE WHEN IS NULL` ordering.
- **`__main__.py` unconditional `main()` call** — `main()` fired on import, not just on `python -m mempalace`. Guarded with `if __name__ == "__main__"`.
- **Spellcheck loads from wrong registry key** — `_load_known_names()` used `"entities"` but `EntityRegistry` stores data under `"people"`. Known entity names were never loaded, so names like "Riley" and "Max" were not protected from spell correction.
- **Missing input sanitization in `tool_kg_invalidate` and `tool_diary_read`** — `tool_kg_add` sanitized inputs but `tool_kg_invalidate` did not; `tool_diary_write` sanitized but `tool_diary_read` did not. Added `sanitize_name()` to both.
- **Brittle exact-float mtime comparison** — `file_already_mined()` compared mtimes with `==` which fails on filesystem precision differences. Changed to tolerance-based comparison (`abs(a - b) < 0.001`).
- **Duplicate cache variable declarations** — `_client_cache` and `_collection_cache` were declared twice in `mcp_server.py` (likely merge artifact).
- **Redundant no-op `except Exception: raise`** — In `miner.py` `add_drawer()`, catches and re-raises all exceptions, doing nothing. Removed.
- **Misleading CLI help text** — `compress` subcommand claimed "~30x reduction" which the README itself retracted.
- **SQLite foreign keys not enforced** — Schema defined `FOREIGN KEY` constraints but never ran `PRAGMA foreign_keys=ON`. Added to both `_init_db()` and `_conn()`.
- **ChromaDB version mismatch** — README said `>=0.4.0` but `pyproject.toml` requires `>=0.5.0,<0.7`.

## Test plan

- [x] All 534 existing tests pass
- [x] Updated `test_spellcheck_extra.py` to use correct registry key `"people"`
- [ ] Manual verification of `timeline()` with NULL `valid_from` values
- [ ] Manual verification of `file_already_mined` with files having sub-second mtime differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)