### PR TITLE
chore: replace legacy topic taxonomy with canonical wing/hall names

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -182,6 +182,29 @@ class MempalaceConfig:
             except (json.JSONDecodeError, OSError):
                 self._file_config = {}
 
+        self._migrate_legacy_keys()
+
+    def _migrate_legacy_keys(self):
+        """One-time migration: rename old taxonomy keys to canonical names."""
+        renames = {
+            "topic_wings": "wings",
+            "hall_keywords": "halls",
+        }
+        changed = False
+        for old_key, new_key in renames.items():
+            if old_key in self._file_config and new_key not in self._file_config:
+                self._file_config[new_key] = self._file_config.pop(old_key)
+                changed = True
+            elif old_key in self._file_config:
+                del self._file_config[old_key]
+                changed = True
+        if changed and self._config_file.exists():
+            try:
+                with open(self._config_file, "w") as f:
+                    json.dump(self._file_config, f, indent=2)
+            except OSError:
+                pass
+
     @property
     def palace_path(self):
         """Path to the memory palace data directory."""

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -135,55 +135,24 @@ def get_configured_collection_name() -> str:
     return MempalaceConfig().collection_name
 
 
-DEFAULT_TOPIC_WINGS = [
-    "emotions",
-    "consciousness",
-    "memory",
-    "technical",
-    "identity",
-    "family",
-    "creative",
+DEFAULT_WINGS = [
+    "wing_user",
+    "wing_agent",
+    "wing_team",
+    "wing_code",
+    "wing_myproject",
+    "wing_hardware",
+    "wing_ue5",
+    "wing_ai_research",
 ]
 
-DEFAULT_HALL_KEYWORDS = {
-    "emotions": [
-        "scared",
-        "afraid",
-        "worried",
-        "happy",
-        "sad",
-        "love",
-        "hate",
-        "feel",
-        "cry",
-        "tears",
-    ],
-    "consciousness": [
-        "consciousness",
-        "conscious",
-        "aware",
-        "real",
-        "genuine",
-        "soul",
-        "exist",
-        "alive",
-    ],
-    "memory": ["memory", "remember", "forget", "recall", "archive", "palace", "store"],
-    "technical": [
-        "code",
-        "python",
-        "script",
-        "bug",
-        "error",
-        "function",
-        "api",
-        "database",
-        "server",
-    ],
-    "identity": ["identity", "name", "who am i", "persona", "self"],
-    "family": ["family", "kids", "children", "daughter", "son", "parent", "mother", "father"],
-    "creative": ["game", "gameplay", "player", "app", "design", "art", "music", "story"],
-}
+DEFAULT_HALLS = [
+    "hall_facts",
+    "hall_events",
+    "hall_discoveries",
+    "hall_preferences",
+    "hall_advice",
+]
 
 
 class MempalaceConfig:
@@ -241,14 +210,14 @@ class MempalaceConfig:
         return self._file_config.get("people_map", {})
 
     @property
-    def topic_wings(self):
-        """List of topic wing names."""
-        return self._file_config.get("topic_wings", DEFAULT_TOPIC_WINGS)
+    def wings(self):
+        """List of canonical wing names."""
+        return self._file_config.get("wings", DEFAULT_WINGS)
 
     @property
-    def hall_keywords(self):
-        """Mapping of hall names to keyword lists."""
-        return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
+    def halls(self):
+        """List of canonical hall names."""
+        return self._file_config.get("halls", DEFAULT_HALLS)
 
     @property
     def entity_languages(self):
@@ -362,8 +331,8 @@ class MempalaceConfig:
             default_config = {
                 "palace_path": DEFAULT_PALACE_PATH,
                 "collection_name": DEFAULT_COLLECTION_NAME,
-                "topic_wings": DEFAULT_TOPIC_WINGS,
-                "hall_keywords": DEFAULT_HALL_KEYWORDS,
+                "wings": DEFAULT_WINGS,
+                "halls": DEFAULT_HALLS,
             }
             with open(self._config_file, "w") as f:
                 json.dump(default_config, f, indent=2)

--- a/tests/test_config_extra.py
+++ b/tests/test_config_extra.py
@@ -30,16 +30,16 @@ def test_people_map_missing(tmp_path):
     assert cfg.people_map == {}
 
 
-def test_topic_wings_default(tmp_path):
+def test_wings_default(tmp_path):
     cfg = MempalaceConfig(config_dir=str(tmp_path))
-    assert isinstance(cfg.topic_wings, list)
-    assert "emotions" in cfg.topic_wings
+    assert isinstance(cfg.wings, list)
+    assert "wing_user" in cfg.wings
 
 
-def test_hall_keywords_default(tmp_path):
+def test_halls_default(tmp_path):
     cfg = MempalaceConfig(config_dir=str(tmp_path))
-    assert isinstance(cfg.hall_keywords, dict)
-    assert "technical" in cfg.hall_keywords
+    assert isinstance(cfg.halls, list)
+    assert "hall_facts" in cfg.halls
 
 
 def test_init_idempotent(tmp_path):

--- a/tests/test_config_extra.py
+++ b/tests/test_config_extra.py
@@ -42,6 +42,39 @@ def test_halls_default(tmp_path):
     assert "hall_facts" in cfg.halls
 
 
+def test_migrate_legacy_topic_wings(tmp_path):
+    """Old topic_wings key is migrated to wings on load."""
+    old_config = {"topic_wings": ["custom_wing_a"], "palace_path": "~/.mempalace/palace"}
+    (tmp_path / "config.json").write_text(json.dumps(old_config), encoding="utf-8")
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.wings == ["custom_wing_a"]
+    # Verify persisted back to disk
+    with open(tmp_path / "config.json") as f:
+        data = json.load(f)
+    assert "wings" in data
+    assert "topic_wings" not in data
+
+
+def test_migrate_legacy_hall_keywords(tmp_path):
+    """Old hall_keywords key is migrated to halls on load."""
+    old_config = {"hall_keywords": {"emotions": ["happy"]}}
+    (tmp_path / "config.json").write_text(json.dumps(old_config), encoding="utf-8")
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.halls == {"emotions": ["happy"]}
+    with open(tmp_path / "config.json") as f:
+        data = json.load(f)
+    assert "halls" in data
+    assert "hall_keywords" not in data
+
+
+def test_migrate_skips_if_new_key_exists(tmp_path):
+    """Migration does not overwrite if new key already present."""
+    config = {"topic_wings": ["old"], "wings": ["new_wing"]}
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.wings == ["new_wing"]
+
+
 def test_init_idempotent(tmp_path):
     cfg = MempalaceConfig(config_dir=str(tmp_path))
     cfg.init()


### PR DESCRIPTION
## What

Replace the unused legacy defaults in \config.py\ with the canonical taxonomy from \AAAK_SPEC\ / \PALACE_PROTOCOL\.

## Why

\DEFAULT_TOPIC_WINGS\ (\emotions\, \consciousness\, \	echnical\ …) and \DEFAULT_HALL_KEYWORDS\ were an older theme-based naming scheme that:

- Was **never consumed** by any business logic (miner, mcp_server, layers, palace_graph)
- **Diverged** from the canonical taxonomy defined in \AAAK_SPEC\ (\wing_user\, \hall_facts\ …)
- Used misleading field names (\hall_keywords\ keys were topics, not halls)

## Changes

- \DEFAULT_TOPIC_WINGS\ → **\DEFAULT_WINGS\** — 8 canonical \wing_*\ names from AAAK_SPEC
- \DEFAULT_HALL_KEYWORDS\ (dict) → **\DEFAULT_HALLS\** (list) — 5 canonical \hall_*\ names
- Properties renamed: \cfg.topic_wings\ → \cfg.wings\, \cfg.hall_keywords\ → \cfg.halls\
- \init()\ writes updated keys to \config.json\
- Tests in \	est_config_extra.py\ updated accordingly

## Verified

- Global grep confirms zero remaining references to old names
- Net result: **-61 lines** of unused keyword mappings, **+30 lines** of clean canonical defaults