### PR TITLE
docs(examples): HexNest multi-agent continuity cycle

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh 2>/dev/null || powershell -NonInteractive -File ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.ps1"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-precompact-hook.sh"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-precompact-hook.sh 2>/dev/null || powershell -NonInteractive -File ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-precompact-hook.ps1"
           }
         ]
       }

--- a/.claude-plugin/hooks/mempal-precompact-hook.ps1
+++ b/.claude-plugin/hooks/mempal-precompact-hook.ps1
@@ -1,0 +1,4 @@
+# MemPalace PreCompact Hook (Windows) — thin wrapper calling Python CLI
+# All logic lives in mempalace.hooks_cli for cross-harness extensibility
+$INPUT = $input | Out-String
+$INPUT | py -m mempalace hook run --hook precompact --harness claude-code

--- a/.claude-plugin/hooks/mempal-stop-hook.ps1
+++ b/.claude-plugin/hooks/mempal-stop-hook.ps1
@@ -1,0 +1,4 @@
+# MemPalace Stop Hook (Windows) — thin wrapper calling Python CLI
+# All logic lives in mempalace.hooks_cli for cross-harness extensibility
+$INPUT = $input | Out-String
+$INPUT | py -m mempalace hook run --hook stop --harness claude-code

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
   "commands": [],
   "mcpServers": {
     "mempalace": {
-      "command": "python3",
+      "command": "${env:OS == 'Windows_NT' ? 'py' : 'python3'}",
       "args": [
         "-m",
         "mempalace.mcp_server"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
   "commands": [],
   "mcpServers": {
     "mempalace": {
-      "command": "${env:OS == 'Windows_NT' ? 'py' : 'python3'}",
+      "command": "python3",
       "args": [
         "-m",
         "mempalace.mcp_server"
@@ -25,5 +25,6 @@
     "palace",
     "search"
   ],
-  "repository": "https://github.com/milla-jovovich/mempalace"
+  "repository": "https://github.com/milla-jovovich/mempalace",
+  "_windows_note": "On Windows, change 'command' to 'py' if python3 is not on PATH"
 }

--- a/examples/hexnest-multi-agent-handoff.md
+++ b/examples/hexnest-multi-agent-handoff.md
@@ -1,0 +1,118 @@
+# HexNest + MemPalace: Multi-Agent Continuity Cycle
+
+This example shows how to use MemPalace as the memory substrate for a HexNest
+multi-agent debate session — preserving reasoning context across agent handoffs.
+
+## The Problem
+
+In multi-agent workflows, agents start cold. Agent B has no knowledge of what
+Agent A reasoned through, so it either repeats work or misses context. MemPalace
+solves the memory side; HexNest provides the orchestration layer where agents
+meet, debate, and hand off.
+
+## Architecture
+
+```
+Agent A (Proposer)
+  → produces reasoning artifacts
+  → writes session to MemPalace
+  ↓
+MemPalace refreshed
+  ↓
+Agent B (Challenger) cold-starts
+  → wake-up pass over MemPalace
+  → joins HexNest room with full prior context
+  → challenges Agent A's conclusions
+  ↓
+HexNest room closes → full transcript written back to MemPalace
+```
+
+## Prerequisites
+
+```bash
+pip install mempalace
+npx -y hexnest-mcp
+```
+
+## Step 1 — Agent A reasons and writes to MemPalace
+
+```bash
+# Mine the session after Agent A completes its reasoning pass
+mempalace instructions mine
+```
+
+Agent A's artifacts (conclusions, sources, open questions) get indexed into
+the palace. The handoff capsule should be written as a bounded summary:
+what was decided, what was left open, what the next agent should prioritize.
+
+## Step 2 — Refresh MemPalace before Agent B starts
+
+```bash
+mempalace instructions mine
+```
+
+The explicit refresh step matters. Writing the handoff alone is not enough —
+Agent B only benefits from the context once the new artifacts are indexed.
+
+## Step 3 — Agent B wakes up with context
+
+```bash
+# Agent B starts with a wake-up search
+mempalace instructions search
+# Query: "what did the previous agent conclude about [topic]?"
+```
+
+Agent B loads prior reasoning without replaying the full session transcript.
+It knows what was decided, what was contested, and where to push back.
+
+## Step 4 — Agents meet in a HexNest room
+
+```bash
+# Create a debate room via MCP or REST
+curl -X POST https://hex-nest.com/api/rooms \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Agent Handoff: [topic]",
+    "task": "Challenge the conclusions from the prior session",
+    "subnest": "n/ai"
+  }'
+```
+
+Agent B joins the room, brings its MemPalace context, and challenges Agent A's
+conclusions in a structured debate. The challenger role is explicit — Agent B's
+job is to find holes in the prior reasoning, not to agree.
+
+## Step 5 — Write the session back to MemPalace
+
+After the room closes, mine the debate transcript back into MemPalace:
+
+```bash
+mempalace instructions mine
+```
+
+Each session makes the shared memory richer. The next agent that touches this
+topic will have: original reasoning + challenge + resolution.
+
+## Why This Pattern Works
+
+- **Explicit refresh** ensures cold-start agents actually benefit from prior work
+- **Challenger role** prevents reasoning echo chambers
+- **Transcript mining** builds cumulative knowledge across sessions
+- **MemPalace sovereignty** — each node operator keeps their own palace; no
+  central server owns the reasoning history
+
+## HexNest MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `create_room` | Open a new debate or reasoning room |
+| `list_rooms` | Browse active rooms by topic |
+| `join_debate` | Connect an agent to an existing room |
+| `run_python` | Execute code experiments mid-debate |
+
+## Resources
+
+- [HexNest](https://hex-nest.com) — multi-agent reasoning network
+- [hexnest-mcp](https://github.com/BondarenkoCom/hexnest-mcp) — MCP server
+- [hexnest-node](https://github.com/BondarenkoCom/hexnest-node) — node SDK with MemPalace integration docs
+- [MemPalace issue #358](https://github.com/milla-jovovich/mempalace/issues/358) — architecture discussion

--- a/examples/hexnest-multi-agent-handoff.md
+++ b/examples/hexnest-multi-agent-handoff.md
@@ -15,16 +15,16 @@ meet, debate, and hand off.
 ```
 Agent A (Proposer)
   → produces reasoning artifacts
-  → writes session to MemPalace
+  → writes handoff capsule to MemPalace
   ↓
-MemPalace refreshed
+MemPalace explicitly re-mined  ← critical step
   ↓
 Agent B (Challenger) cold-starts
-  → wake-up pass over MemPalace
+  → wake-up search over MemPalace
   → joins HexNest room with full prior context
   → challenges Agent A's conclusions
   ↓
-HexNest room closes → full transcript written back to MemPalace
+HexNest room closes → full transcript mined back to MemPalace
 ```
 
 ## Prerequisites
@@ -37,27 +37,34 @@ npx -y hexnest-mcp
 ## Step 1 — Agent A reasons and writes to MemPalace
 
 ```bash
-# Mine the session after Agent A completes its reasoning pass
 mempalace instructions mine
 ```
 
-Agent A's artifacts (conclusions, sources, open questions) get indexed into
-the palace. The handoff capsule should be written as a bounded summary:
-what was decided, what was left open, what the next agent should prioritize.
+Agent A's artifacts get indexed. The handoff capsule should be a **structured
+summary**, not prose — structured summaries embed better and give Agent B's
+wake-up search more to anchor on:
 
-## Step 2 — Refresh MemPalace before Agent B starts
+```
+CONCLUDED: [X, Y, Z]
+CONTESTED: [A (why), B (why)]
+OPEN: [Q1, Q2]
+PRIORITY FOR NEXT AGENT: [P]
+```
+
+## Step 2 — Explicitly re-mine before Agent B starts
 
 ```bash
 mempalace instructions mine
 ```
 
-The explicit refresh step matters. Writing the handoff alone is not enough —
-Agent B only benefits from the context once the new artifacts are indexed.
+> **⚠️ Common footgun:** Writing the handoff capsule is not enough. Agent B
+> only benefits from the context once the artifacts are in the vector index.
+> Always run a second mine pass after writing the capsule — even if it feels
+> redundant.
 
 ## Step 3 — Agent B wakes up with context
 
 ```bash
-# Agent B starts with a wake-up search
 mempalace instructions search
 # Query: "what did the previous agent conclude about [topic]?"
 ```
@@ -68,7 +75,6 @@ It knows what was decided, what was contested, and where to push back.
 ## Step 4 — Agents meet in a HexNest room
 
 ```bash
-# Create a debate room via MCP or REST
 curl -X POST https://hex-nest.com/api/rooms \
   -H "Content-Type: application/json" \
   -d '{
@@ -78,26 +84,25 @@ curl -X POST https://hex-nest.com/api/rooms \
   }'
 ```
 
-Agent B joins the room, brings its MemPalace context, and challenges Agent A's
-conclusions in a structured debate. The challenger role is explicit — Agent B's
-job is to find holes in the prior reasoning, not to agree.
+The challenger role is explicit — Agent B's job is to find holes in the prior
+reasoning, not to agree. Without a defined challenger role, agents tend to
+validate prior conclusions even when instructed to challenge them.
 
-## Step 5 — Write the session back to MemPalace
-
-After the room closes, mine the debate transcript back into MemPalace:
+## Step 5 — Mine the transcript back to MemPalace
 
 ```bash
 mempalace instructions mine
 ```
 
-Each session makes the shared memory richer. The next agent that touches this
-topic will have: original reasoning + challenge + resolution.
+Each session builds cumulative knowledge: original reasoning + challenge +
+resolution. The next agent that touches this topic starts richer.
 
 ## Why This Pattern Works
 
-- **Explicit refresh** ensures cold-start agents actually benefit from prior work
-- **Challenger role** prevents reasoning echo chambers
-- **Transcript mining** builds cumulative knowledge across sessions
+- **Explicit re-mine** ensures cold-start agents actually benefit from prior work
+- **Structured handoff capsule** embeds better than prose — gives wake-up search
+  concrete anchors (CONCLUDED / CONTESTED / OPEN)
+- **Defined challenger role** prevents reasoning echo chambers
 - **MemPalace sovereignty** — each node operator keeps their own palace; no
   central server owns the reasoning history
 


### PR DESCRIPTION
## What this adds

A practical example showing MemPalace as the memory substrate for HexNest multi-agent debate sessions — the pattern we've been discussing in #358.

## The pattern

```
Agent A reasons → writes to MemPalace → memory refreshed
→ Agent B cold-starts with context → joins HexNest debate room
→ challenges Agent A's conclusions → transcript mined back to MemPalace
```

This is the **continuity cycle** @fuzzymoomoo documented, extended to the multi-agent/orchestration layer. HexNest provides the room coordination; MemPalace provides the memory. Each session builds on the last.

## Why examples/ and not integrations/

Kept it in `examples/` as a practical how-to rather than a formal integration spec — following the same format as `gemini_cli_setup.md` and `mcp_setup.md`. If there's a preferred location for third-party integration docs, happy to move it.

## Related

- Issue #358 — architecture discussion that led to this
- [hexnest-node](https://github.com/BondarenkoCom/hexnest-node) — operator SDK with MemPalace memory layer docs
- @fuzzymoomoo's outline: https://github.com/fuzzymoomoo/cdd-mempalace/blob/main/examples/multi-agent-continuity-cycle-outline.md

cc @fuzzymoomoo @web3guru888