### PR TITLE
[codex] docs add safe hook wrapper guidance

### DIFF
--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -38,3 +38,45 @@ User → MCP Server → searcher → results
 ```
 
 The palace (ChromaDB) stores verbatim content. The knowledge graph (SQLite) stores structured relationships. The MCP server exposes both to any AI tool.
+
+## Safe Hook Wrappers
+
+If you wire `mempalace mine` into editor, agent, or CI hooks, protect the wrapper against overlapping runs. Frequent save or stop events can otherwise launch multiple concurrent miners for the same path. The data will usually remain correct, but CPU and wall-clock cost can spike.
+
+Recommended protections:
+
+1. Acquire a global or per-target lock before the hook backgrounds any worker process.
+2. Add stale-lock expiry so crashed runs do not block future mining forever.
+3. Add a kill switch such as `MEMPALACE_AUTOSAVE=0` or `~/.mempalace/disable_autosave`.
+4. If you mine many different projects, prefer per-target locks keyed by the path.
+
+Minimal pattern:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "${MEMPALACE_AUTOSAVE:-1}" = "0" ] && exit 0
+[ -f "${HOME}/.mempalace/disable_autosave" ] && exit 0
+
+TARGET="$1"
+LOCK_AGE=300
+LOCK_KEY="$(printf '%s' "$TARGET" | sha256sum | cut -c1-8)"
+LOCKDIR="${HOME}/.mempalace/mine-${LOCK_KEY}.lock"
+
+if [ -d "$LOCKDIR" ]; then
+  AGE="$(($(date +%s) - $(stat -c %Y "$LOCKDIR" 2>/dev/null || echo 0)))"
+  if [ "$AGE" -gt "$LOCK_AGE" ]; then
+    rm -rf "$LOCKDIR"
+  fi
+fi
+
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+  exit 0
+fi
+
+trap 'rm -rf "$LOCKDIR"' EXIT
+mempalace mine "$TARGET"
+```
+
+Important: take the lock in the foreground hook process. If the script forks into the background before locking, multiple overlapping hook invocations can still start duplicate miners.


### PR DESCRIPTION
## Summary
- add a short README section with safe hook wrapper guidance for `mempalace mine`
- document global or per-target locking, stale-lock expiry, and kill switches
- call out the important nuance that the lock must be acquired before the hook backgrounds any worker process

## Why
Issue #504 describes a common operational failure mode when MemPalace is wired into autosave, stop, or multi-agent hooks: several overlapping `mempalace mine` runs can scan the same path at once. The results may still be correct, but CPU and wall-clock cost spike badly.

This PR adds the missing usage guidance directly to the main README so users hit the safe pattern before they hit the failure mode.

Closes #504.
