### PR TITLE
fix: use filed_at as tiebreaker in Layer1 sort so recent memories surface first

### DIFF
--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -136,8 +136,8 @@ class Layer1:
                     break
             scored.append((importance, meta, doc))
 
-        # Sort by importance descending, take top N
-        scored.sort(key=lambda x: x[0], reverse=True)
+        # Sort by importance descending, then by most-recent filing
+        scored.sort(key=lambda x: (x[0], x[1].get("filed_at", "")), reverse=True)
         top = scored[: self.MAX_DRAWERS]
 
         # Group by room for readability

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -136,7 +136,9 @@ class Layer1:
                     break
             scored.append((importance, meta, doc))
 
-        # Sort by importance descending, then by most-recent filing
+        # Sort by importance descending, then by most-recent filing.
+        # Drawers without filed_at (e.g. migrated from older palaces) get ""
+        # which sorts after all real ISO-8601 timestamps — intentionally last.
         scored.sort(key=lambda x: (x[0], x[1].get("filed_at", "")), reverse=True)
         top = scored[: self.MAX_DRAWERS]
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -185,6 +185,29 @@ def test_layer1_respects_max_chars():
     assert "more in L3 search" in result
 
 
+def test_layer1_recent_filing_tiebreaker():
+    """When importance is equal, most recently filed drawers come first."""
+    docs = ["old memory", "new memory"]
+    metas = [
+        {"room": "r", "source_file": "old.txt", "filed_at": "2025-01-01T00:00:00"},
+        {"room": "r", "source_file": "new.txt", "filed_at": "2026-03-15T12:00:00"},
+    ]
+    mock_client = _mock_chromadb_for_layer(docs, metas)
+
+    with (
+        patch("mempalace.layers.MempalaceConfig") as mock_cfg,
+        patch("mempalace.layers.chromadb.PersistentClient", return_value=mock_client),
+    ):
+        mock_cfg.return_value.palace_path = "/fake"
+        layer = Layer1(palace_path="/fake")
+        result = layer.generate()
+
+    # "new memory" should appear before "old memory" in the output
+    new_pos = result.index("new memory")
+    old_pos = result.index("old memory")
+    assert new_pos < old_pos, "Most recent drawer should appear first in L1"
+
+
 def test_layer1_importance_from_various_keys():
     """Layer1 tries importance, emotional_weight, weight keys."""
     docs = ["mem1", "mem2", "mem3"]


### PR DESCRIPTION
## Problem

The `Layer1` class docstring says *'highest-weight / most-recent drawers'* and the scoring comment says *'prefer high importance, recent filing'*, but the sort key only used importance:

```python
scored.sort(key=lambda x: x[0], reverse=True)
```

Since `miner.py` and `convo_miner.py` never write an importance field to drawer metadata, every drawer defaults to importance=3. The sort is effectively a no-op, and L1 returns whichever drawers ChromaDB happens to return first (insertion/ID order) rather than the most recent ones.

## Fix

Add `filed_at` (already written by both miners) as a secondary sort key:

```python
scored.sort(key=lambda x: (x[0], x[1].get('filed_at', '')), reverse=True)
```

When importance scores are equal (the common case), the most recently filed drawers now surface first in L1 wake-up context.

## Changes

- **`mempalace/layers.py`** (1 line): add `filed_at` as secondary sort key
- **`tests/test_layers.py`** (1 new test): regression test verifying recent-first ordering

## Test results

42/42 passed (41 existing + 1 new).
