### PR TITLE
feat: RetrievalProfile — named Synapse config profiles with inheritance (#489)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -159,8 +159,6 @@ def cmd_status(args):
 
 
 def cmd_synapse(args):
-    import json
-
     from .synapse_profiles import ProfileManager, global_merged_from_mempalace_config
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
@@ -171,7 +169,14 @@ def cmd_synapse(args):
             args.name,
             global_merged=global_merged_from_mempalace_config(cfg),
         )
-        print(json.dumps(profile.to_dict(), indent=2, ensure_ascii=False))
+        annotated = profile.to_annotated_dict()
+        print(f"[{profile.name}] effective config (resolved):")
+        max_key_len = max(len(k) for k in annotated)
+        for k in sorted(annotated):
+            info = annotated[k]
+            value = info["value"]
+            source = info["source"]
+            print(f"  {k:<{max_key_len}} : {value!s:<10} ← {source}")
 
 
 def cmd_repair(args):

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -18,6 +18,7 @@ Commands:
     mempalace wake-up                     Show L0 + L1 wake-up context
     mempalace wake-up --wing my_app       Wake-up for a specific project
     mempalace status                      Show what's been filed
+    mempalace synapse show-profile [NAME] Print merged Synapse retrieval profile (JSON)
 
 Examples:
     mempalace init ~/projects/my_app
@@ -155,6 +156,22 @@ def cmd_status(args):
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     status(palace_path=palace_path)
+
+
+def cmd_synapse(args):
+    import json
+
+    from .synapse_profiles import ProfileManager, global_merged_from_mempalace_config
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    cfg = MempalaceConfig()
+    pm = ProfileManager(palace_path)
+    if args.synapse_cmd == "show-profile":
+        profile = pm.resolve(
+            args.name,
+            global_merged=global_merged_from_mempalace_config(cfg),
+        )
+        print(json.dumps(profile.to_dict(), indent=2, ensure_ascii=False))
 
 
 def cmd_repair(args):
@@ -533,6 +550,20 @@ def main():
     # status
     sub.add_parser("status", help="Show what's been filed")
 
+    # synapse
+    p_synapse = sub.add_parser("synapse", help="Synapse retrieval profiles")
+    synapse_sub = p_synapse.add_subparsers(dest="synapse_cmd", required=True)
+    p_show_prof = synapse_sub.add_parser(
+        "show-profile",
+        help="Print resolved merged profile as JSON",
+    )
+    p_show_prof.add_argument(
+        "name",
+        nargs="?",
+        default="default",
+        help="Profile name (default: default)",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -554,6 +585,10 @@ def main():
             return
         args.name = name
         cmd_instructions(args)
+        return
+
+    if args.command == "synapse":
+        cmd_synapse(args)
         return
 
     dispatch = {

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -171,9 +171,13 @@ def cmd_synapse(args):
         )
         annotated = profile.to_annotated_dict()
         print(f"[{profile.name}] effective config (resolved):")
+        if annotated.get("description", {}).get("value"):
+            print(f"  {annotated['description']['value']}")
+            print()
         max_key_len = max(len(k) for k in annotated)
-        for k in sorted(annotated):
-            info = annotated[k]
+        for k, info in sorted(annotated.items()):
+            if k == "description":
+                continue
             value = info["value"]
             source = info["source"]
             print(f"  {k:<{max_key_len}} : {value!s:<10} ← {source}")

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -174,6 +174,12 @@ class MempalaceConfig:
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
     @property
+    def synapse_profiles(self) -> dict:
+        """Optional synapse_profiles block in ~/.mempalace/config.json (see also palace-level profiles)."""
+        raw = self._file_config.get("synapse_profiles", {})
+        return raw if isinstance(raw, dict) else {}
+
+    @property
     def synapse_enabled(self):
         """Synapse master switch — false disables scoring and retrieval logging."""
         return self._file_config.get("synapse_enabled", False)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -172,6 +172,21 @@ class MempalaceConfig:
     def synapse_log_retention_days(self):
         return self._file_config.get("synapse_log_retention_days", 90)
 
+    @property
+    def synapse_consolidation_inactive_days(self):
+        """Days without retrieval before a drawer is a consolidation candidate."""
+        return self._file_config.get("synapse_consolidation_inactive_days", 180)
+
+    @property
+    def synapse_soft_archive_suggestions_enabled(self):
+        """Surface soft-archive move suggestions for inactive drawers (#336)."""
+        return self._file_config.get("synapse_soft_archive_suggestions_enabled", True)
+
+    @property
+    def synapse_soft_archive_target_wing(self):
+        """Suggested wing name for cold-storage moves (nudge only)."""
+        return self._file_config.get("synapse_soft_archive_target_wing", "archive")
+
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""
         self._config_dir.mkdir(parents=True, exist_ok=True)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -123,6 +123,18 @@ class MempalaceConfig:
         """Mapping of hall names to keyword lists."""
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
+    @property
+    def synapse_enabled(self):
+        return self._file_config.get("synapse_enabled", False)
+
+    @property
+    def synapse_ltp_window_days(self):
+        return self._file_config.get("synapse_ltp_window_days", 30)
+
+    @property
+    def synapse_tagging_window_hours(self):
+        return self._file_config.get("synapse_tagging_window_hours", 24)
+
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""
         self._config_dir.mkdir(parents=True, exist_ok=True)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -141,6 +141,14 @@ class MempalaceConfig:
         return self._file_config.get("synapse_association_enabled", False)
 
     @property
+    def synapse_association_max_boost(self):
+        return self._file_config.get("synapse_association_max_boost", 1.5)
+
+    @property
+    def synapse_association_coefficient(self):
+        return self._file_config.get("synapse_association_coefficient", 0.15)
+
+    @property
     def synapse_ltp_window_days(self):
         return self._file_config.get("synapse_ltp_window_days", 30)
 

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -125,15 +125,44 @@ class MempalaceConfig:
 
     @property
     def synapse_enabled(self):
+        """Synapse master switch — false disables scoring and retrieval logging."""
         return self._file_config.get("synapse_enabled", False)
+
+    @property
+    def synapse_ltp_enabled(self):
+        return self._file_config.get("synapse_ltp_enabled", True)
+
+    @property
+    def synapse_tagging_enabled(self):
+        return self._file_config.get("synapse_tagging_enabled", True)
+
+    @property
+    def synapse_association_enabled(self):
+        return self._file_config.get("synapse_association_enabled", False)
 
     @property
     def synapse_ltp_window_days(self):
         return self._file_config.get("synapse_ltp_window_days", 30)
 
     @property
+    def synapse_ltp_max_boost(self):
+        return self._file_config.get("synapse_ltp_max_boost", 2.0)
+
+    @property
     def synapse_tagging_window_hours(self):
         return self._file_config.get("synapse_tagging_window_hours", 24)
+
+    @property
+    def synapse_tagging_max_boost(self):
+        return self._file_config.get("synapse_tagging_max_boost", 1.5)
+
+    @property
+    def synapse_log_retrievals(self):
+        return self._file_config.get("synapse_log_retrievals", True)
+
+    @property
+    def synapse_log_retention_days(self):
+        return self._file_config.get("synapse_log_retention_days", 90)
 
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -101,15 +101,18 @@ def tool_status():
             candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
             log_stats = synapse_db.get_log_stats()
             status_dict["synapse"] = {
-                "ltp_window_days": cfg.synapse_ltp_window_days,
-                "tagging_window_hours": cfg.synapse_tagging_window_hours,
                 "ltp_enabled": cfg.synapse_ltp_enabled,
                 "tagging_enabled": cfg.synapse_tagging_enabled,
                 "association_enabled": cfg.synapse_association_enabled,
                 "log_retrievals": cfg.synapse_log_retrievals,
-                "consolidation_candidates": len(candidates),
-                "consolidation_details": candidates[:10],  # 上位10件のみ
+                "ltp_window_days": cfg.synapse_ltp_window_days,
+                "ltp_max_boost": cfg.synapse_ltp_max_boost,
+                "tagging_window_hours": cfg.synapse_tagging_window_hours,
+                "tagging_max_boost": cfg.synapse_tagging_max_boost,
+                "log_retention_days": cfg.synapse_log_retention_days,
                 "log_stats": log_stats,
+                "consolidation_candidates": len(candidates),
+                "consolidation_details": candidates[:10],
             }
     except Exception:
         status_dict["synapse_enabled"] = False

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -394,7 +394,7 @@ def tool_search(
     synapse_ltp_window_days: Optional[int] = None,
     synapse_ltp_max_boost: Optional[float] = None,
 ):
-    return search_memories(
+    result = search_memories(
         query,
         palace_path=_config.palace_path,
         wing=wing,
@@ -407,6 +407,13 @@ def tool_search(
         synapse_ltp_window_days=synapse_ltp_window_days,
         synapse_ltp_max_boost=synapse_ltp_max_boost,
     )
+    if result.get("synapse_enabled"):
+        response_meta = {
+            "synapse_requested_profile": result.get("synapse_requested_profile"),
+            "synapse_profile_used": result.get("synapse_profile_used"),
+        }
+        result = {**result, "response_meta": response_meta}
+    return result
 
 
 def tool_check_duplicate(content: str, threshold: float = 0.9):

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -256,6 +256,12 @@ def tool_status(consolidation_wing: str = None):
             tagging_window_n = _count_synaptic_tagging_window_drawers(
                 all_meta, cfg.synapse_tagging_window_hours
             )
+            from .synapse_profiles import ProfileManager, global_merged_from_mempalace_config
+
+            pm = ProfileManager(palace_path)
+            default_prof = pm.resolve(
+                "default", global_merged=global_merged_from_mempalace_config(cfg)
+            )
             status_dict["synapse"] = {
                 "ltp_enabled": cfg.synapse_ltp_enabled,
                 "tagging_enabled": cfg.synapse_tagging_enabled,
@@ -268,6 +274,8 @@ def tool_status(consolidation_wing: str = None):
                 "tagging_window_hours": cfg.synapse_tagging_window_hours,
                 "tagging_max_boost": cfg.synapse_tagging_max_boost,
                 "log_retention_days": cfg.synapse_log_retention_days,
+                "available_profiles": pm.get_known_profiles(),
+                "default_profile": default_prof.to_dict(),
                 "log_stats": log_stats,
                 "co_retrieval_top_pairs": co_pairs,
                 "co_occurrence_clusters": co_clusters,
@@ -381,6 +389,10 @@ def tool_search(
     room: str = None,
     synapse_ltp_enabled: Optional[bool] = None,
     synapse_tagging_enabled: Optional[bool] = None,
+    synapse_profile: Optional[str] = None,
+    synapse_half_life_days: Optional[int] = None,
+    synapse_ltp_window_days: Optional[int] = None,
+    synapse_ltp_max_boost: Optional[float] = None,
 ):
     return search_memories(
         query,
@@ -390,6 +402,10 @@ def tool_search(
         n_results=limit,
         synapse_ltp_enabled=synapse_ltp_enabled,
         synapse_tagging_enabled=synapse_tagging_enabled,
+        synapse_profile=synapse_profile,
+        synapse_half_life_days=synapse_half_life_days,
+        synapse_ltp_window_days=synapse_ltp_window_days,
+        synapse_ltp_max_boost=synapse_ltp_max_boost,
     )
 
 
@@ -725,6 +741,55 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
 
 # ==================== MCP PROTOCOL ====================
 
+
+def _mempalace_search_input_schema():
+    try:
+        from .synapse_profiles import ProfileManager
+
+        pm = ProfileManager(_config.palace_path)
+        known = ", ".join(pm.get_known_profiles())
+    except Exception:
+        known = "default"
+    return {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for"},
+            "limit": {"type": "integer", "description": "Max results (default 5)"},
+            "wing": {"type": "string", "description": "Filter by wing (optional)"},
+            "room": {"type": "string", "description": "Filter by room (optional)"},
+            "synapse_profile": {
+                "type": "string",
+                "description": (
+                    "Named synapse profile to apply. Known profiles: "
+                    f"{known}. "
+                    "Custom profiles: palace config.json synapse_profiles or synapse_profiles.json."
+                ),
+            },
+            "synapse_half_life_days": {
+                "type": "integer",
+                "description": "Override half_life_days for this query (recency decay)",
+            },
+            "synapse_ltp_window_days": {
+                "type": "integer",
+                "description": "Override ltp_window_days for this query",
+            },
+            "synapse_ltp_max_boost": {
+                "type": "number",
+                "description": "Override ltp_max_boost for this query",
+            },
+            "synapse_ltp_enabled": {
+                "type": "boolean",
+                "description": "Override LTP axis for this search only (omit = use profile/config)",
+            },
+            "synapse_tagging_enabled": {
+                "type": "boolean",
+                "description": "Override tagging axis for this search only (omit = use profile/config)",
+            },
+        },
+        "required": ["query"],
+    }
+
+
 TOOLS = {
     "mempalace_status": {
         "description": "Palace overview — total drawers, wing and room counts",
@@ -881,24 +946,7 @@ TOOLS = {
     },
     "mempalace_search": {
         "description": "Semantic search. Returns verbatim drawer content with similarity scores.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string", "description": "What to search for"},
-                "limit": {"type": "integer", "description": "Max results (default 5)"},
-                "wing": {"type": "string", "description": "Filter by wing (optional)"},
-                "room": {"type": "string", "description": "Filter by room (optional)"},
-                "synapse_ltp_enabled": {
-                    "type": "boolean",
-                    "description": "Override LTP axis for this search only (omit = use config default)",
-                },
-                "synapse_tagging_enabled": {
-                    "type": "boolean",
-                    "description": "Override tagging axis for this search only (omit = use config default)",
-                },
-            },
-            "required": ["query"],
-        },
+        "input_schema": _mempalace_search_input_schema(),
         "handler": tool_search,
     },
     "mempalace_check_duplicate": {

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -93,13 +93,23 @@ def tool_status():
             from .synapse import SynapseDB
 
             synapse_db = SynapseDB(palace_path)
-            synapse_db.refresh_stats(window_days=cfg.synapse_ltp_window_days)
+            synapse_db.cleanup_old_logs(retention_days=cfg.synapse_log_retention_days)
+            synapse_db.refresh_stats(
+                window_days=cfg.synapse_ltp_window_days,
+                ltp_max_boost=cfg.synapse_ltp_max_boost,
+            )
             candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
+            log_stats = synapse_db.get_log_stats()
             status_dict["synapse"] = {
                 "ltp_window_days": cfg.synapse_ltp_window_days,
                 "tagging_window_hours": cfg.synapse_tagging_window_hours,
+                "ltp_enabled": cfg.synapse_ltp_enabled,
+                "tagging_enabled": cfg.synapse_tagging_enabled,
+                "association_enabled": cfg.synapse_association_enabled,
+                "log_retrievals": cfg.synapse_log_retrievals,
                 "consolidation_candidates": len(candidates),
                 "consolidation_details": candidates[:10],  # 上位10件のみ
+                "log_stats": log_stats,
             }
     except Exception:
         status_dict["synapse_enabled"] = False

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -21,7 +21,7 @@ import sys
 import json
 import logging
 import hashlib
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from .config import MempalaceConfig
 from .version import __version__
@@ -30,6 +30,11 @@ from .palace_graph import traverse, find_tunnels, graph_stats
 import chromadb
 
 from .knowledge_graph import KnowledgeGraph
+from .synapse import (
+    SYNAPSE_MARK_METADATA_KEY,
+    SYNAPSE_MARK_NEW,
+    build_soft_archive_proposal,
+)
 
 _kg = KnowledgeGraph()
 
@@ -60,6 +65,70 @@ def _no_palace():
 # ==================== READ TOOLS ====================
 
 
+def _parse_iso_utc(s: str):
+    """Parse ISO8601 metadata timestamps to timezone-aware UTC."""
+    try:
+        t = s.strip()
+        if t.endswith("Z"):
+            t = t[:-1] + "+00:00"
+        dt = datetime.fromisoformat(t)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except (ValueError, TypeError, OSError, AttributeError):
+        return None
+
+
+def _count_synaptic_tagging_window_drawers(metas: list, window_hours: float) -> int:
+    """Drawers with synapse_mark=new still inside the tagging boost window (by filed_at)."""
+    now = datetime.now(timezone.utc)
+    n = 0
+    for m in metas:
+        if m.get(SYNAPSE_MARK_METADATA_KEY) != SYNAPSE_MARK_NEW:
+            continue
+        fa = m.get("filed_at")
+        if not fa:
+            continue
+        dt = _parse_iso_utc(fa)
+        if dt is None:
+            continue
+        hours = (now - dt).total_seconds() / 3600.0
+        if 0 <= hours < float(window_hours):
+            n += 1
+    return n
+
+
+def _enrich_consolidation_candidates(col, candidates: list, cfg) -> list:
+    """Add wing/room from Chroma and optional soft-archive proposals (#336)."""
+    if not col or not candidates:
+        return []
+    ids = [c["drawer_id"] for c in candidates[:50]]
+    idm = {}
+    try:
+        got = col.get(ids=ids, include=["metadatas"])
+        idm = dict(zip(got["ids"], got["metadatas"]))
+    except Exception:
+        pass
+    out = []
+    for c in candidates[:50]:
+        d = dict(c)
+        m = idm.get(c["drawer_id"]) or {}
+        w = m.get("wing", "unknown")
+        r = m.get("room", "unknown")
+        d["wing"] = w
+        d["room"] = r
+        d[SYNAPSE_MARK_METADATA_KEY] = m.get(SYNAPSE_MARK_METADATA_KEY)
+        if cfg.synapse_soft_archive_suggestions_enabled:
+            d["soft_archive_proposal"] = build_soft_archive_proposal(
+                w,
+                r,
+                target_wing=cfg.synapse_soft_archive_target_wing,
+                inactive_days=cfg.synapse_consolidation_inactive_days,
+            )
+        out.append(d)
+    return out
+
+
 def tool_status():
     col = _get_collection()
     if not col:
@@ -67,6 +136,7 @@ def tool_status():
     count = col.count()
     wings = {}
     rooms = {}
+    all_meta = []
     try:
         all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
         for m in all_meta:
@@ -75,7 +145,7 @@ def tool_status():
             wings[w] = wings.get(w, 0) + 1
             rooms[r] = rooms.get(r, 0) + 1
     except Exception:
-        pass
+        all_meta = []
     status_dict = {
         "total_drawers": count,
         "wings": wings,
@@ -98,10 +168,15 @@ def tool_status():
                 window_days=cfg.synapse_ltp_window_days,
                 ltp_max_boost=cfg.synapse_ltp_max_boost,
             )
-            candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
+            inactive = cfg.synapse_consolidation_inactive_days
+            candidates = synapse_db.get_consolidation_candidates(inactive_days=inactive)
+            enriched = _enrich_consolidation_candidates(col, candidates, cfg)
             log_stats = synapse_db.get_log_stats()
             co_pairs = synapse_db.get_top_co_pairs(15)
             co_clusters = synapse_db.get_co_occurrence_clusters(40, 10)
+            tagging_window_n = _count_synaptic_tagging_window_drawers(
+                all_meta, cfg.synapse_tagging_window_hours
+            )
             status_dict["synapse"] = {
                 "ltp_enabled": cfg.synapse_ltp_enabled,
                 "tagging_enabled": cfg.synapse_tagging_enabled,
@@ -117,8 +192,19 @@ def tool_status():
                 "log_stats": log_stats,
                 "co_retrieval_top_pairs": co_pairs,
                 "co_occurrence_clusters": co_clusters,
+                "consolidation_inactive_days": inactive,
                 "consolidation_candidates": len(candidates),
-                "consolidation_details": candidates[:10],
+                "consolidation_details": enriched[:10],
+                "phase3": {
+                    "synaptic_mark_metadata_key": SYNAPSE_MARK_METADATA_KEY,
+                    "synaptic_mark_new_value": SYNAPSE_MARK_NEW,
+                    "drawers_in_synaptic_tagging_window": tagging_window_n,
+                    "soft_archive": {
+                        "suggestions_enabled": cfg.synapse_soft_archive_suggestions_enabled,
+                        "target_wing": cfg.synapse_soft_archive_target_wing,
+                        "related_issue": "#336",
+                    },
+                },
             }
     except Exception:
         status_dict["synapse_enabled"] = False
@@ -317,6 +403,7 @@ def tool_add_drawer(
                     "chunk_index": 0,
                     "added_by": added_by,
                     "filed_at": datetime.now().isoformat(),
+                    SYNAPSE_MARK_METADATA_KEY: SYNAPSE_MARK_NEW,
                 }
             ],
         )

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -76,7 +76,7 @@ def tool_status():
             rooms[r] = rooms.get(r, 0) + 1
     except Exception:
         pass
-    return {
+    status_dict = {
         "total_drawers": count,
         "wings": wings,
         "rooms": rooms,
@@ -84,6 +84,26 @@ def tool_status():
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
     }
+    palace_path = _config.palace_path
+    # Synapse status
+    try:
+        cfg = MempalaceConfig()
+        status_dict["synapse_enabled"] = cfg.synapse_enabled
+        if cfg.synapse_enabled:
+            from .synapse import SynapseDB
+
+            synapse_db = SynapseDB(palace_path)
+            synapse_db.refresh_stats(window_days=cfg.synapse_ltp_window_days)
+            candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
+            status_dict["synapse"] = {
+                "ltp_window_days": cfg.synapse_ltp_window_days,
+                "tagging_window_hours": cfg.synapse_tagging_window_hours,
+                "consolidation_candidates": len(candidates),
+                "consolidation_details": candidates[:10],  # 上位10件のみ
+            }
+    except Exception:
+        status_dict["synapse_enabled"] = False
+    return status_dict
 
 
 # ── AAAK Dialect Spec ─────────────────────────────────────────────────────────

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -100,10 +100,14 @@ def tool_status():
             )
             candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
             log_stats = synapse_db.get_log_stats()
+            co_pairs = synapse_db.get_top_co_pairs(15)
+            co_clusters = synapse_db.get_co_occurrence_clusters(40, 10)
             status_dict["synapse"] = {
                 "ltp_enabled": cfg.synapse_ltp_enabled,
                 "tagging_enabled": cfg.synapse_tagging_enabled,
                 "association_enabled": cfg.synapse_association_enabled,
+                "association_max_boost": cfg.synapse_association_max_boost,
+                "association_coefficient": cfg.synapse_association_coefficient,
                 "log_retrievals": cfg.synapse_log_retrievals,
                 "ltp_window_days": cfg.synapse_ltp_window_days,
                 "ltp_max_boost": cfg.synapse_ltp_max_boost,
@@ -111,6 +115,8 @@ def tool_status():
                 "tagging_max_boost": cfg.synapse_tagging_max_boost,
                 "log_retention_days": cfg.synapse_log_retention_days,
                 "log_stats": log_stats,
+                "co_retrieval_top_pairs": co_pairs,
+                "co_occurrence_clusters": co_clusters,
                 "consolidation_candidates": len(candidates),
                 "consolidation_details": candidates[:10],
             }

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -25,6 +25,7 @@ import logging
 import hashlib
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Optional
 
 from .config import MempalaceConfig, sanitize_name, sanitize_content
 from .version import __version__
@@ -205,7 +206,7 @@ def _enrich_consolidation_candidates(col, candidates: list, cfg) -> list:
     return out
 
 
-def tool_status():
+def tool_status(consolidation_wing: str = None):
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -245,7 +246,9 @@ def tool_status():
                 ltp_max_boost=cfg.synapse_ltp_max_boost,
             )
             inactive = cfg.synapse_consolidation_inactive_days
-            candidates = synapse_db.get_consolidation_candidates(inactive_days=inactive)
+            candidates = synapse_db.get_consolidation_candidates(
+                inactive_days=inactive, wing=consolidation_wing
+            )
             enriched = _enrich_consolidation_candidates(col, candidates, cfg)
             log_stats = synapse_db.get_log_stats()
             co_pairs = synapse_db.get_top_co_pairs(15)
@@ -371,13 +374,22 @@ def tool_get_taxonomy():
     return {"taxonomy": taxonomy}
 
 
-def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+def tool_search(
+    query: str,
+    limit: int = 5,
+    wing: str = None,
+    room: str = None,
+    synapse_ltp_enabled: Optional[bool] = None,
+    synapse_tagging_enabled: Optional[bool] = None,
+):
     return search_memories(
         query,
         palace_path=_config.palace_path,
         wing=wing,
         room=room,
         n_results=limit,
+        synapse_ltp_enabled=synapse_ltp_enabled,
+        synapse_tagging_enabled=synapse_tagging_enabled,
     )
 
 
@@ -716,7 +728,15 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
 TOOLS = {
     "mempalace_status": {
         "description": "Palace overview — total drawers, wing and room counts",
-        "input_schema": {"type": "object", "properties": {}},
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "consolidation_wing": {
+                    "type": "string",
+                    "description": "If set, limit Synapse consolidation candidates to drawer_ids containing this substring (optional)",
+                },
+            },
+        },
         "handler": tool_status,
     },
     "mempalace_list_wings": {
@@ -868,6 +888,14 @@ TOOLS = {
                 "limit": {"type": "integer", "description": "Max results (default 5)"},
                 "wing": {"type": "string", "description": "Filter by wing (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "synapse_ltp_enabled": {
+                    "type": "boolean",
+                    "description": "Override LTP axis for this search only (omit = use config default)",
+                },
+                "synapse_tagging_enabled": {
+                    "type": "boolean",
+                    "description": "Override tagging axis for this search only (omit = use config default)",
+                },
             },
             "required": ["query"],
         },

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -428,6 +428,7 @@ def add_drawer(
                     "chunk_index": chunk_index,
                     "added_by": agent,
                     "filed_at": datetime.now().isoformat(),
+                    "synapse_mark": "new",
                 }
             ],
         )

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -171,48 +171,52 @@ def search_memories(
             query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
             session_id = uuid.uuid4().hex[:16]
 
-            # 結果の drawer_id リストを収集
             hit_drawer_ids = []
             for hit in result["hits"]:
                 drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
                 if drawer_id:
                     hit_drawer_ids.append(drawer_id)
 
-            # LTP スコアを一括取得
-            ltp_scores = synapse_db.get_ltp_scores_batch(
-                hit_drawer_ids,
-                window_days=cfg.synapse_ltp_window_days,
-            )
+            ltp_scores = {}
+            if cfg.synapse_ltp_enabled:
+                ltp_scores = synapse_db.get_ltp_scores_batch(
+                    hit_drawer_ids,
+                    window_days=cfg.synapse_ltp_window_days,
+                    max_boost=cfg.synapse_ltp_max_boost,
+                )
 
-            # 各ヒットに Synapse スコアを付与
             for hit in result["hits"]:
                 drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
                 filed_at = hit.get("metadata", {}).get("filed_at", None)
                 similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
                 decay = hit.get("decay", 1.0)
 
-                synapse_result = synapse_db.calculate_synapse_score(
-                    similarity=similarity,
-                    decay=decay,
-                    drawer_id=drawer_id,
-                    filed_at=filed_at,
-                    ltp_scores=ltp_scores,
-                    window_days=cfg.synapse_ltp_window_days,
+                ltp = ltp_scores.get(drawer_id, 1.0) if cfg.synapse_ltp_enabled else 1.0
+                tagging = (
+                    SynapseDB.calculate_tagging_boost(
+                        filed_at,
+                        cfg.synapse_tagging_window_hours,
+                        cfg.synapse_tagging_max_boost,
+                    )
+                    if cfg.synapse_tagging_enabled
+                    else 1.0
                 )
+                association = 1.0  # Phase 2: cfg.synapse_association_enabled
 
-                hit["synapse_score"] = synapse_result["final_score"]
+                final_score = similarity * decay * ltp * association * tagging
+
+                hit["synapse_score"] = final_score
                 hit["synapse_factors"] = {
-                    "ltp": synapse_result["ltp"],
-                    "association": synapse_result["association"],
-                    "tagging": synapse_result["tagging"],
+                    "ltp": ltp,
+                    "association": association,
+                    "tagging": tagging,
                 }
 
-            # Synapse スコアで再ソート（hits と results は同一リスト）
             result["hits"].sort(key=lambda h: h.get("synapse_score", 0.0), reverse=True)
             result["synapse_enabled"] = True
 
-            # 検索ログを fire-and-forget で記録
-            synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
+            if cfg.synapse_log_retrievals:
+                synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
         else:
             result["synapse_enabled"] = False
     except Exception as e:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -10,6 +10,7 @@ import hashlib
 import logging
 import uuid
 from pathlib import Path
+from typing import Optional
 
 import chromadb
 
@@ -93,12 +94,31 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: Optional[str] = None,
+    wing: Optional[str] = None,
+    room: Optional[str] = None,
+    n_results: int = 5,
+    include_archived: bool = False,
+    time_decay: bool = True,
+    synapse_ltp_enabled: Optional[bool] = None,
+    synapse_tagging_enabled: Optional[bool] = None,
+    synapse_association_enabled: Optional[bool] = None,
+    synapse_ltp_window_days: Optional[int] = None,
+    synapse_ltp_max_boost: Optional[float] = None,
+    synapse_tagging_window_hours: Optional[int] = None,
+    synapse_tagging_max_boost: Optional[float] = None,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
     Used by the MCP server and other callers that need data.
     """
+    from .config import MempalaceConfig
+
+    cfg = MempalaceConfig()
+    if palace_path is None:
+        palace_path = cfg.palace_path
+
     try:
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")
@@ -117,6 +137,14 @@ def search_memories(
         where = {"wing": wing}
     elif room:
         where = {"room": room}
+
+    if not include_archived and wing is None:
+        aw = cfg.synapse_soft_archive_target_wing
+        excl = {"wing": {"$ne": aw}}
+        if where:
+            where = {"$and": [where, excl]}
+        else:
+            where = excl
 
     try:
         kwargs = {
@@ -161,11 +189,44 @@ def search_memories(
 
     # --- Synapse integration ---
     try:
-        from .config import MempalaceConfig
-
-        cfg = MempalaceConfig()
         if cfg.synapse_enabled:
             from .synapse import SynapseDB
+
+            _ltp_enabled = (
+                synapse_ltp_enabled
+                if synapse_ltp_enabled is not None
+                else cfg.synapse_ltp_enabled
+            )
+            _tagging_enabled = (
+                synapse_tagging_enabled
+                if synapse_tagging_enabled is not None
+                else cfg.synapse_tagging_enabled
+            )
+            _association_enabled = (
+                synapse_association_enabled
+                if synapse_association_enabled is not None
+                else cfg.synapse_association_enabled
+            )
+            _ltp_window_days = (
+                synapse_ltp_window_days
+                if synapse_ltp_window_days is not None
+                else cfg.synapse_ltp_window_days
+            )
+            _ltp_max_boost = (
+                synapse_ltp_max_boost
+                if synapse_ltp_max_boost is not None
+                else cfg.synapse_ltp_max_boost
+            )
+            _tagging_window_hours = (
+                synapse_tagging_window_hours
+                if synapse_tagging_window_hours is not None
+                else cfg.synapse_tagging_window_hours
+            )
+            _tagging_max_boost = (
+                synapse_tagging_max_boost
+                if synapse_tagging_max_boost is not None
+                else cfg.synapse_tagging_max_boost
+            )
 
             synapse_db = SynapseDB(palace_path)
             query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
@@ -177,58 +238,65 @@ def search_memories(
                 if drawer_id:
                     hit_drawer_ids.append(drawer_id)
 
-            ltp_scores = {}
-            if cfg.synapse_ltp_enabled and hit_drawer_ids:
-                ltp_scores = synapse_db.get_ltp_scores_batch(
-                    hit_drawer_ids,
-                    window_days=cfg.synapse_ltp_window_days,
-                    max_boost=cfg.synapse_ltp_max_boost,
-                )
-
-            assoc_scores = {}
-            if cfg.synapse_association_enabled and hit_drawer_ids:
-                assoc_scores = synapse_db.get_association_scores_batch(
-                    hit_drawer_ids,
-                    max_boost=cfg.synapse_association_max_boost,
-                    coefficient=cfg.synapse_association_coefficient,
-                )
-
-            for hit in result["hits"]:
-                drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
-                filed_at = hit.get("metadata", {}).get("filed_at", None)
-                similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
-                decay = hit.get("decay", 1.0)
-
-                ltp = ltp_scores.get(drawer_id, 1.0) if cfg.synapse_ltp_enabled else 1.0
-                tagging = (
-                    SynapseDB.calculate_tagging_boost(
-                        filed_at,
-                        window_hours=cfg.synapse_tagging_window_hours,
-                        max_boost=cfg.synapse_tagging_max_boost,
+            with synapse_db.connection() as conn:
+                ltp_scores = {}
+                if _ltp_enabled and hit_drawer_ids:
+                    ltp_scores = synapse_db.get_ltp_scores_batch(
+                        hit_drawer_ids,
+                        window_days=_ltp_window_days,
+                        max_boost=_ltp_max_boost,
+                        conn=conn,
                     )
-                    if cfg.synapse_tagging_enabled
-                    else 1.0
+
+                assoc_scores = {}
+                if _association_enabled and hit_drawer_ids:
+                    assoc_scores = synapse_db.get_association_scores_batch(
+                        hit_drawer_ids,
+                        max_boost=cfg.synapse_association_max_boost,
+                        coefficient=cfg.synapse_association_coefficient,
+                        conn=conn,
+                    )
+
+                for hit in result["hits"]:
+                    drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
+                    filed_at = hit.get("metadata", {}).get("filed_at", None)
+                    similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
+                    decay = 1.0 if not time_decay else hit.get("decay", 1.0)
+
+                    ltp = ltp_scores.get(drawer_id, 1.0) if _ltp_enabled else 1.0
+                    tagging = (
+                        SynapseDB.calculate_tagging_boost(
+                            filed_at,
+                            window_hours=_tagging_window_hours,
+                            max_boost=_tagging_max_boost,
+                        )
+                        if _tagging_enabled
+                        else 1.0
+                    )
+                    association = (
+                        assoc_scores.get(drawer_id, 1.0)
+                        if _association_enabled
+                        else 1.0
+                    )
+
+                    final_score = similarity * decay * ltp * association * tagging
+
+                    hit["synapse_score"] = final_score
+                    hit["synapse_factors"] = {
+                        "ltp": ltp,
+                        "association": association,
+                        "tagging": tagging,
+                    }
+
+                result["hits"].sort(
+                    key=lambda h: h.get("synapse_score", 0.0), reverse=True
                 )
-                association = (
-                    assoc_scores.get(drawer_id, 1.0)
-                    if cfg.synapse_association_enabled
-                    else 1.0
-                )
+                result["synapse_enabled"] = True
 
-                final_score = similarity * decay * ltp * association * tagging
-
-                hit["synapse_score"] = final_score
-                hit["synapse_factors"] = {
-                    "ltp": ltp,
-                    "association": association,
-                    "tagging": tagging,
-                }
-
-            result["hits"].sort(key=lambda h: h.get("synapse_score", 0.0), reverse=True)
-            result["synapse_enabled"] = True
-
-            if cfg.synapse_log_retrievals and hit_drawer_ids:
-                synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
+                if cfg.synapse_log_retrievals and hit_drawer_ids:
+                    synapse_db.log_retrieval(
+                        hit_drawer_ids, query_hash, session_id, conn=conn
+                    )
         else:
             result["synapse_enabled"] = False
     except Exception as e:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -10,7 +10,7 @@ import hashlib
 import logging
 import uuid
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import chromadb
 
@@ -108,6 +108,10 @@ def search_memories(
     synapse_ltp_max_boost: Optional[float] = None,
     synapse_tagging_window_hours: Optional[int] = None,
     synapse_tagging_max_boost: Optional[float] = None,
+    synapse_profile: Optional[str] = None,
+    synapse_half_life_days: Optional[int] = None,
+    synapse_association_max_boost: Optional[float] = None,
+    synapse_association_coefficient: Optional[float] = None,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
@@ -191,41 +195,40 @@ def search_memories(
     try:
         if cfg.synapse_enabled:
             from .synapse import SynapseDB
+            from .synapse_profiles import (
+                ProfileManager,
+                compute_decay,
+                global_merged_from_mempalace_config,
+                hit_filed_age_days,
+            )
 
-            _ltp_enabled = (
-                synapse_ltp_enabled
-                if synapse_ltp_enabled is not None
-                else cfg.synapse_ltp_enabled
-            )
-            _tagging_enabled = (
-                synapse_tagging_enabled
-                if synapse_tagging_enabled is not None
-                else cfg.synapse_tagging_enabled
-            )
-            _association_enabled = (
-                synapse_association_enabled
-                if synapse_association_enabled is not None
-                else cfg.synapse_association_enabled
-            )
-            _ltp_window_days = (
-                synapse_ltp_window_days
-                if synapse_ltp_window_days is not None
-                else cfg.synapse_ltp_window_days
-            )
-            _ltp_max_boost = (
-                synapse_ltp_max_boost
-                if synapse_ltp_max_boost is not None
-                else cfg.synapse_ltp_max_boost
-            )
-            _tagging_window_hours = (
-                synapse_tagging_window_hours
-                if synapse_tagging_window_hours is not None
-                else cfg.synapse_tagging_window_hours
-            )
-            _tagging_max_boost = (
-                synapse_tagging_max_boost
-                if synapse_tagging_max_boost is not None
-                else cfg.synapse_tagging_max_boost
+            pm = ProfileManager(palace_path)
+            per_query: dict[str, Any] = {}
+            if synapse_half_life_days is not None:
+                per_query["half_life_days"] = synapse_half_life_days
+            if synapse_ltp_enabled is not None:
+                per_query["ltp_enabled"] = synapse_ltp_enabled
+            if synapse_ltp_window_days is not None:
+                per_query["ltp_window_days"] = synapse_ltp_window_days
+            if synapse_ltp_max_boost is not None:
+                per_query["ltp_max_boost"] = synapse_ltp_max_boost
+            if synapse_tagging_enabled is not None:
+                per_query["tagging_enabled"] = synapse_tagging_enabled
+            if synapse_tagging_window_hours is not None:
+                per_query["tagging_window_hours"] = synapse_tagging_window_hours
+            if synapse_tagging_max_boost is not None:
+                per_query["tagging_max_boost"] = synapse_tagging_max_boost
+            if synapse_association_enabled is not None:
+                per_query["association_enabled"] = synapse_association_enabled
+            if synapse_association_max_boost is not None:
+                per_query["association_max_boost"] = synapse_association_max_boost
+            if synapse_association_coefficient is not None:
+                per_query["association_coefficient"] = synapse_association_coefficient
+
+            profile = pm.resolve(
+                synapse_profile,
+                per_query_overrides=per_query or None,
+                global_merged=global_merged_from_mempalace_config(cfg),
             )
 
             synapse_db = SynapseDB(palace_path)
@@ -239,43 +242,50 @@ def search_memories(
                     hit_drawer_ids.append(drawer_id)
 
             with synapse_db.connection() as conn:
-                ltp_scores = {}
-                if _ltp_enabled and hit_drawer_ids:
+                ltp_scores: dict[str, float] = {}
+                if profile.ltp_enabled and hit_drawer_ids:
                     ltp_scores = synapse_db.get_ltp_scores_batch(
                         hit_drawer_ids,
-                        window_days=_ltp_window_days,
-                        max_boost=_ltp_max_boost,
+                        window_days=profile.ltp_window_days,
+                        max_boost=profile.ltp_max_boost,
                         conn=conn,
                     )
 
-                assoc_scores = {}
-                if _association_enabled and hit_drawer_ids:
+                assoc_scores: dict[str, float] = {}
+                if profile.association_enabled and hit_drawer_ids:
                     assoc_scores = synapse_db.get_association_scores_batch(
                         hit_drawer_ids,
-                        max_boost=cfg.synapse_association_max_boost,
-                        coefficient=cfg.synapse_association_coefficient,
+                        max_boost=profile.association_max_boost,
+                        coefficient=profile.association_coefficient,
                         conn=conn,
                     )
 
                 for hit in result["hits"]:
                     drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
                     filed_at = hit.get("metadata", {}).get("filed_at", None)
-                    similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
-                    decay = 1.0 if not time_decay else hit.get("decay", 1.0)
+                    similarity = float(
+                        hit.get("original_similarity", hit.get("similarity", 0.0))
+                    )
+                    age_days = hit_filed_age_days(filed_at)
+                    decay = (
+                        compute_decay(age_days, int(profile.half_life_days))
+                        if time_decay
+                        else 1.0
+                    )
 
-                    ltp = ltp_scores.get(drawer_id, 1.0) if _ltp_enabled else 1.0
+                    ltp = ltp_scores.get(drawer_id, 1.0) if profile.ltp_enabled else 1.0
                     tagging = (
                         SynapseDB.calculate_tagging_boost(
                             filed_at,
-                            window_hours=_tagging_window_hours,
-                            max_boost=_tagging_max_boost,
+                            window_hours=profile.tagging_window_hours,
+                            max_boost=profile.tagging_max_boost,
                         )
-                        if _tagging_enabled
+                        if profile.tagging_enabled
                         else 1.0
                     )
                     association = (
                         assoc_scores.get(drawer_id, 1.0)
-                        if _association_enabled
+                        if profile.association_enabled
                         else 1.0
                     )
 
@@ -283,15 +293,22 @@ def search_memories(
 
                     hit["synapse_score"] = final_score
                     hit["synapse_factors"] = {
+                        "similarity": similarity,
+                        "decay": decay,
                         "ltp": ltp,
                         "association": association,
                         "tagging": tagging,
                     }
+                    hit["synapse_profile"] = profile.name
 
                 result["hits"].sort(
-                    key=lambda h: h.get("synapse_score", 0.0), reverse=True
+                    key=lambda h: h.get(
+                        "synapse_score", h.get("similarity", 0.0)
+                    ),
+                    reverse=True,
                 )
                 result["synapse_enabled"] = True
+                result["synapse_profile"] = profile.to_dict()
 
                 if cfg.synapse_log_retrievals and hit_drawer_ids:
                     try:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -185,6 +185,14 @@ def search_memories(
                     max_boost=cfg.synapse_ltp_max_boost,
                 )
 
+            assoc_scores = {}
+            if cfg.synapse_association_enabled and hit_drawer_ids:
+                assoc_scores = synapse_db.get_association_scores_batch(
+                    hit_drawer_ids,
+                    max_boost=cfg.synapse_association_max_boost,
+                    coefficient=cfg.synapse_association_coefficient,
+                )
+
             for hit in result["hits"]:
                 drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
                 filed_at = hit.get("metadata", {}).get("filed_at", None)
@@ -201,7 +209,11 @@ def search_memories(
                     if cfg.synapse_tagging_enabled
                     else 1.0
                 )
-                association = 1.0  # Phase 2: cfg.synapse_association_enabled
+                association = (
+                    assoc_scores.get(drawer_id, 1.0)
+                    if cfg.synapse_association_enabled
+                    else 1.0
+                )
 
                 final_score = similarity * decay * ltp * association * tagging
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -6,7 +6,9 @@ Semantic search against the palace.
 Returns verbatim text — the actual words, never summaries.
 """
 
+import hashlib
 import logging
+import uuid
 from pathlib import Path
 
 import chromadb
@@ -132,11 +134,16 @@ def search_memories(
     docs = results["documents"][0]
     metas = results["metadatas"][0]
     dists = results["distances"][0]
+    ids = results.get("ids", [[]])[0]
 
     hits = []
-    for doc, meta, dist in zip(docs, metas, dists):
+    for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists)):
+        drawer_id = ids[i] if i < len(ids) else ""
+        meta = meta or {}
         hits.append(
             {
+                "id": drawer_id,
+                "metadata": meta,
                 "text": doc,
                 "wing": meta.get("wing", "unknown"),
                 "room": meta.get("room", "unknown"),
@@ -145,8 +152,71 @@ def search_memories(
             }
         )
 
-    return {
+    result = {
         "query": query,
         "filters": {"wing": wing, "room": room},
         "results": hits,
+        "hits": hits,
     }
+
+    # --- Synapse integration ---
+    try:
+        from .config import MempalaceConfig
+
+        cfg = MempalaceConfig()
+        if cfg.synapse_enabled:
+            from .synapse import SynapseDB
+
+            synapse_db = SynapseDB(palace_path)
+            query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
+            session_id = uuid.uuid4().hex[:16]
+
+            # 結果の drawer_id リストを収集
+            hit_drawer_ids = []
+            for hit in result["hits"]:
+                drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
+                if drawer_id:
+                    hit_drawer_ids.append(drawer_id)
+
+            # LTP スコアを一括取得
+            ltp_scores = synapse_db.get_ltp_scores_batch(
+                hit_drawer_ids,
+                window_days=cfg.synapse_ltp_window_days,
+            )
+
+            # 各ヒットに Synapse スコアを付与
+            for hit in result["hits"]:
+                drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
+                filed_at = hit.get("metadata", {}).get("filed_at", None)
+                similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
+                decay = hit.get("decay", 1.0)
+
+                synapse_result = synapse_db.calculate_synapse_score(
+                    similarity=similarity,
+                    decay=decay,
+                    drawer_id=drawer_id,
+                    filed_at=filed_at,
+                    ltp_scores=ltp_scores,
+                    window_days=cfg.synapse_ltp_window_days,
+                )
+
+                hit["synapse_score"] = synapse_result["final_score"]
+                hit["synapse_factors"] = {
+                    "ltp": synapse_result["ltp"],
+                    "association": synapse_result["association"],
+                    "tagging": synapse_result["tagging"],
+                }
+
+            # Synapse スコアで再ソート（hits と results は同一リスト）
+            result["hits"].sort(key=lambda h: h.get("synapse_score", 0.0), reverse=True)
+            result["synapse_enabled"] = True
+
+            # 検索ログを fire-and-forget で記録
+            synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
+        else:
+            result["synapse_enabled"] = False
+    except Exception as e:
+        logger.warning("Synapse scoring skipped: %s", e)
+        result["synapse_enabled"] = False
+
+    return result

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -178,7 +178,7 @@ def search_memories(
                     hit_drawer_ids.append(drawer_id)
 
             ltp_scores = {}
-            if cfg.synapse_ltp_enabled:
+            if cfg.synapse_ltp_enabled and hit_drawer_ids:
                 ltp_scores = synapse_db.get_ltp_scores_batch(
                     hit_drawer_ids,
                     window_days=cfg.synapse_ltp_window_days,
@@ -195,8 +195,8 @@ def search_memories(
                 tagging = (
                     SynapseDB.calculate_tagging_boost(
                         filed_at,
-                        cfg.synapse_tagging_window_hours,
-                        cfg.synapse_tagging_max_boost,
+                        window_hours=cfg.synapse_tagging_window_hours,
+                        max_boost=cfg.synapse_tagging_max_boost,
                     )
                     if cfg.synapse_tagging_enabled
                     else 1.0
@@ -215,7 +215,7 @@ def search_memories(
             result["hits"].sort(key=lambda h: h.get("synapse_score", 0.0), reverse=True)
             result["synapse_enabled"] = True
 
-            if cfg.synapse_log_retrievals:
+            if cfg.synapse_log_retrievals and hit_drawer_ids:
                 synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
         else:
             result["synapse_enabled"] = False

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -294,9 +294,14 @@ def search_memories(
                 result["synapse_enabled"] = True
 
                 if cfg.synapse_log_retrievals and hit_drawer_ids:
-                    synapse_db.log_retrieval(
-                        hit_drawer_ids, query_hash, session_id, conn=conn
-                    )
+                    try:
+                        synapse_db.log_retrieval(
+                            hit_drawer_ids, query_hash, session_id, conn=conn
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Synapse log_retrieval failed (non-fatal): %s", e
+                        )
         else:
             result["synapse_enabled"] = False
     except Exception as e:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -231,6 +231,10 @@ def search_memories(
                 global_merged=global_merged_from_mempalace_config(cfg),
             )
 
+            # Profile observability — expose fallback to caller
+            result["synapse_requested_profile"] = synapse_profile
+            result["synapse_profile_used"] = profile.name
+
             synapse_db = SynapseDB(palace_path)
             query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
             session_id = uuid.uuid4().hex[:16]

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -12,7 +12,13 @@ DEFAULT_LTP_MAX_BOOST = 2.0
 DEFAULT_LTP_COEFFICIENT = 0.3
 DEFAULT_TAGGING_WINDOW_HOURS = 24
 DEFAULT_TAGGING_MAX_BOOST = 1.5
+DEFAULT_ASSOCIATION_MAX_BOOST = 1.5
+DEFAULT_ASSOCIATION_COEFFICIENT = 0.15
 SYNAPSE_DB_NAME = "synapse.sqlite3"
+
+
+def _canonical_pair(a: str, b: str) -> tuple[str, str]:
+    return (a, b) if a < b else (b, a)
 
 
 def _utc_now_iso() -> str:
@@ -67,6 +73,11 @@ class SynapseDB:
                     PRIMARY KEY (drawer_a, drawer_b)
                 );
 
+                CREATE INDEX IF NOT EXISTS idx_co_retrieval_drawer_a
+                    ON co_retrieval(drawer_a);
+                CREATE INDEX IF NOT EXISTS idx_co_retrieval_drawer_b
+                    ON co_retrieval(drawer_b);
+
                 CREATE TABLE IF NOT EXISTS synapse_stats (
                     drawer_id TEXT PRIMARY KEY,
                     total_retrievals INTEGER NOT NULL DEFAULT 0,
@@ -103,6 +114,176 @@ class SynapseDB:
                 conn.close()
         except Exception as e:
             logger.warning("log_retrieval failed: %s", e)
+        else:
+            try:
+                self._record_co_retrieval_pairs(drawer_ids, retrieved_at)
+            except Exception as e:
+                logger.warning("co_retrieval pair update failed: %s", e)
+
+    def _record_co_retrieval_pairs(self, drawer_ids: list[str], retrieved_at: str) -> None:
+        """同一検索結果内の drawer ペアごとに co_count を増分する。"""
+        uniq = sorted(set(drawer_ids))
+        if len(uniq) < 2:
+            return
+        conn = sqlite3.connect(self.db_path)
+        try:
+            for i in range(len(uniq)):
+                for j in range(i + 1, len(uniq)):
+                    a, b = _canonical_pair(uniq[i], uniq[j])
+                    conn.execute(
+                        """
+                        INSERT INTO co_retrieval (drawer_a, drawer_b, co_count, last_co_retrieved)
+                        VALUES (?, ?, 1, ?)
+                        ON CONFLICT(drawer_a, drawer_b) DO UPDATE SET
+                            co_count = co_count + 1,
+                            last_co_retrieved = excluded.last_co_retrieved
+                        """,
+                        (a, b, retrieved_at),
+                    )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def rebuild_co_retrieval_from_log(self) -> int:
+        """
+        retrieval_log を集計して co_retrieval を一括再構築する。
+        ログ削除後や整合性修復用。挿入した行数を返す。
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("DELETE FROM co_retrieval")
+            conn.execute(
+                """
+                INSERT INTO co_retrieval (drawer_a, drawer_b, co_count, last_co_retrieved)
+                SELECT
+                    d1.drawer_id AS drawer_a,
+                    d2.drawer_id AS drawer_b,
+                    COUNT(DISTINCT d1.session_id) AS co_count,
+                    MAX(d1.retrieved_at) AS last_co_retrieved
+                FROM retrieval_log d1
+                INNER JOIN retrieval_log d2
+                    ON d1.session_id = d2.session_id
+                    AND d1.drawer_id < d2.drawer_id
+                GROUP BY d1.drawer_id, d2.drawer_id
+                """
+            )
+            conn.commit()
+            cur = conn.execute("SELECT COUNT(*) FROM co_retrieval")
+            n = int(cur.fetchone()[0])
+            return n
+        finally:
+            conn.close()
+
+    def get_association_scores_batch(
+        self,
+        drawer_ids: list[str],
+        max_boost: float = DEFAULT_ASSOCIATION_MAX_BOOST,
+        coefficient: float = DEFAULT_ASSOCIATION_COEFFICIENT,
+    ) -> dict[str, float]:
+        """
+        同一検索結果の drawer 集合について、co_retrieval の共起強度から association を計算する。
+        各 drawer について、ヒット集合内の他 drawer との co_count 合計を用いる。
+        """
+        uniq = list(dict.fromkeys([d for d in drawer_ids if d]))
+        out: dict[str, float] = {d: 1.0 for d in uniq}
+        if len(uniq) < 2:
+            return out
+        conn = sqlite3.connect(self.db_path)
+        try:
+            ph = ",".join("?" * len(uniq))
+            cur = conn.execute(
+                f"SELECT drawer_a, drawer_b, co_count FROM co_retrieval "
+                f"WHERE drawer_a IN ({ph}) AND drawer_b IN ({ph})",
+                (*uniq, *uniq),
+            )
+            edge: dict[tuple[str, str], int] = {}
+            for a, b, c in cur.fetchall():
+                edge[(a, b)] = int(c)
+        finally:
+            conn.close()
+        for d in uniq:
+            total = 0
+            for o in uniq:
+                if o == d:
+                    continue
+                ca, cb = _canonical_pair(d, o)
+                total += edge.get((ca, cb), 0)
+            if total == 0:
+                out[d] = 1.0
+            else:
+                raw = 1.0 + math.log(1 + total) * coefficient
+                out[d] = _clamp(raw, 1.0, max_boost)
+        return out
+
+    def get_top_co_pairs(self, limit: int = 20) -> list[dict[str, Any]]:
+        """共起回数の多いペアを返す。"""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(
+                "SELECT drawer_a, drawer_b, co_count, last_co_retrieved FROM co_retrieval "
+                "ORDER BY co_count DESC, last_co_retrieved DESC LIMIT ?",
+                (limit,),
+            )
+            return [
+                {
+                    "drawer_a": r[0],
+                    "drawer_b": r[1],
+                    "co_count": int(r[2]),
+                    "last_co_retrieved": r[3],
+                }
+                for r in cur.fetchall()
+            ]
+        finally:
+            conn.close()
+
+    def get_co_occurrence_clusters(
+        self, max_edges: int = 40, max_clusters: int = 12
+    ) -> list[dict[str, Any]]:
+        """
+        強い共起ペアから無向グラフを張り、連結成分をクラスタとして返す。
+        """
+        top = self.get_top_co_pairs(max_edges)
+        if not top:
+            return []
+
+        parent: dict[str, str] = {}
+
+        def find(x: str) -> str:
+            if x not in parent:
+                parent[x] = x
+            if parent[x] != x:
+                parent[x] = find(parent[x])
+            return parent[x]
+
+        def union(x: str, y: str) -> None:
+            rx, ry = find(x), find(y)
+            if rx != ry:
+                parent[rx] = ry
+
+        for p in top:
+            union(p["drawer_a"], p["drawer_b"])
+
+        root_nodes: dict[str, set[str]] = {}
+        for p in top:
+            for n in (p["drawer_a"], p["drawer_b"]):
+                r = find(n)
+                root_nodes.setdefault(r, set()).add(n)
+
+        clusters: list[dict[str, Any]] = []
+        for r, drawers in root_nodes.items():
+            if len(drawers) < 2:
+                continue
+            tw = sum(int(p["co_count"]) for p in top if find(p["drawer_a"]) == r)
+            clusters.append(
+                {
+                    "drawers": sorted(drawers),
+                    "total_co_weight": tw,
+                    "size": len(drawers),
+                }
+            )
+
+        clusters.sort(key=lambda c: (-c["total_co_weight"], -c["size"]))
+        return clusters[:max_clusters]
 
     def get_ltp_score(
         self,
@@ -216,11 +397,11 @@ class SynapseDB:
         ltp_max_boost: float = DEFAULT_LTP_MAX_BOOST,
         tagging_window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS,
         tagging_max_boost: float = DEFAULT_TAGGING_MAX_BOOST,
+        association_scores: Optional[dict[str, float]] = None,
     ) -> dict[str, Any]:
         """
         最終スコアを計算して返す。
-        final_score = similarity * decay * ltp * tagging
-        (Phase 1 では association は 1.0 固定)
+        final_score = similarity * decay * ltp * association * tagging
 
         戻り値:
         {
@@ -228,7 +409,7 @@ class SynapseDB:
             "similarity": float,
             "decay": float,
             "ltp": float,
-            "association": 1.0,
+            "association": float,
             "tagging": float
         }
         """
@@ -241,7 +422,10 @@ class SynapseDB:
             window_hours=tagging_window_hours,
             max_boost=tagging_max_boost,
         )
-        association = 1.0
+        if association_scores is not None:
+            association = association_scores.get(drawer_id, 1.0)
+        else:
+            association = 1.0
         final_score = similarity * decay * ltp * tagging * association
         return {
             "final_score": final_score,
@@ -275,8 +459,15 @@ class SynapseDB:
         except Exception as e:
             logger.warning("VACUUM failed: %s", e)
         if deleted is None or deleted < 0:
-            return 0
-        return int(deleted)
+            deleted = 0
+        else:
+            deleted = int(deleted)
+        if deleted > 0:
+            try:
+                self.rebuild_co_retrieval_from_log()
+            except Exception as e:
+                logger.warning("rebuild_co_retrieval_from_log after cleanup failed: %s", e)
+        return deleted
 
     def get_log_stats(self) -> dict[str, Any]:
         """ログの統計情報を返す。"""

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -1,0 +1,313 @@
+import logging
+import math
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LTP_WINDOW_DAYS = 30
+DEFAULT_LTP_MAX_BOOST = 2.0
+DEFAULT_LTP_COEFFICIENT = 0.3
+DEFAULT_TAGGING_WINDOW_HOURS = 24
+DEFAULT_TAGGING_MAX_BOOST = 1.5
+SYNAPSE_DB_NAME = "synapse.sqlite3"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))
+
+
+class SynapseDB:
+    """Manages the synapse.sqlite3 database for retrieval logging and scoring."""
+
+    def __init__(self, palace_path: str):
+        """
+        palace_path: palace のルートディレクトリ（knowledge_graph.sqlite3 と同階層）
+        synapse.sqlite3 が存在しなければ作成し、テーブルを初期化する。
+        WAL モードを有効にする。
+        """
+        self.db_path = os.path.join(palace_path, SYNAPSE_DB_NAME)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA busy_timeout=5000;")
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS retrieval_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    drawer_id TEXT NOT NULL,
+                    retrieved_at TEXT NOT NULL,
+                    query_hash TEXT NOT NULL,
+                    session_id TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_retrieval_log_drawer
+                    ON retrieval_log(drawer_id);
+
+                CREATE INDEX IF NOT EXISTS idx_retrieval_log_session
+                    ON retrieval_log(session_id);
+
+                CREATE INDEX IF NOT EXISTS idx_retrieval_log_retrieved_at
+                    ON retrieval_log(retrieved_at);
+
+                CREATE TABLE IF NOT EXISTS co_retrieval (
+                    drawer_a TEXT NOT NULL,
+                    drawer_b TEXT NOT NULL,
+                    co_count INTEGER NOT NULL DEFAULT 0,
+                    last_co_retrieved TEXT NOT NULL,
+                    PRIMARY KEY (drawer_a, drawer_b)
+                );
+
+                CREATE TABLE IF NOT EXISTS synapse_stats (
+                    drawer_id TEXT PRIMARY KEY,
+                    total_retrievals INTEGER NOT NULL DEFAULT 0,
+                    recent_density REAL NOT NULL DEFAULT 0.0,
+                    ltp_score REAL NOT NULL DEFAULT 1.0,
+                    last_updated TEXT NOT NULL
+                );
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def log_retrieval(self, drawer_ids: list[str], query_hash: str, session_id: str):
+        """
+        検索結果に含まれた drawer_id のリストを retrieval_log に記録する。
+        - retrieved_at: UTC ISO 8601 形式
+        - fire-and-forget: 例外が発生してもログ出力のみで呼び出し元に伝播しない
+        """
+        if not drawer_ids:
+            return
+        try:
+            retrieved_at = _utc_now_iso()
+            rows = [(did, retrieved_at, query_hash, session_id) for did in drawer_ids]
+            conn = sqlite3.connect(self.db_path)
+            try:
+                conn.executemany(
+                    "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) "
+                    "VALUES (?, ?, ?, ?)",
+                    rows,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception as e:
+            logger.warning("log_retrieval failed: %s", e)
+
+    def get_ltp_score(self, drawer_id: str, window_days: int = DEFAULT_LTP_WINDOW_DAYS) -> float:
+        """
+        直近 window_days 日間の retrieval_log から drawer_id の検索回数を集計し、
+        LTP スコアを計算して返す。
+        ltp = clamp(1.0 + log(1 + recent_count) * LTP_COEFFICIENT, 1.0, LTP_MAX_BOOST)
+        retrieval_log にエントリがなければ 1.0 を返す。
+        """
+        cutoff_dt = datetime.now(timezone.utc) - timedelta(days=window_days)
+        cutoff = cutoff_dt.isoformat()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM retrieval_log WHERE drawer_id = ? AND retrieved_at >= ?",
+                (drawer_id, cutoff),
+            )
+            row = cur.fetchone()
+            recent_count = int(row[0]) if row else 0
+        finally:
+            conn.close()
+
+        if recent_count == 0:
+            return 1.0
+        raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
+        return _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+
+    def get_ltp_scores_batch(
+        self, drawer_ids: list[str], window_days: int = DEFAULT_LTP_WINDOW_DAYS
+    ) -> dict[str, float]:
+        """
+        複数の drawer_id に対する LTP スコアを一括取得する。
+        N+1 クエリを避けるため、IN 句で一括集計する。
+        戻り値: {drawer_id: ltp_score}。ログにない drawer_id は 1.0。
+        """
+        out: dict[str, float] = {did: 1.0 for did in drawer_ids}
+        if not drawer_ids:
+            return out
+        cutoff_dt = datetime.now(timezone.utc) - timedelta(days=window_days)
+        cutoff = cutoff_dt.isoformat()
+        placeholders = ",".join("?" * len(drawer_ids))
+        sql = (
+            f"SELECT drawer_id, COUNT(*) as cnt FROM retrieval_log "
+            f"WHERE drawer_id IN ({placeholders}) AND retrieved_at >= ? GROUP BY drawer_id"
+        )
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(sql, (*drawer_ids, cutoff))
+            for drawer_id, cnt in cur.fetchall():
+                recent_count = int(cnt)
+                if recent_count == 0:
+                    out[drawer_id] = 1.0
+                else:
+                    raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
+                    out[drawer_id] = _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+        finally:
+            conn.close()
+        return out
+
+    @staticmethod
+    def calculate_tagging_boost(
+        filed_at: Optional[str], window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS
+    ) -> float:
+        """
+        filed_at（ISO 8601 文字列）から現在までの経過時間を計算し、
+        tagging boost を返す。
+        - 24h 以内: 1.0 + 0.5 * (1.0 - hours / window_hours)
+        - 24h 超: 1.0
+        - filed_at が None またはパース失敗: 1.0
+        """
+        if filed_at is None:
+            return 1.0
+        try:
+            s = filed_at.strip()
+            if s.endswith("Z"):
+                s = s[:-1] + "+00:00"
+            filed = datetime.fromisoformat(s)
+            if filed.tzinfo is None:
+                filed = filed.replace(tzinfo=timezone.utc)
+            now = datetime.now(timezone.utc)
+            delta = now - filed.astimezone(timezone.utc)
+            hours = delta.total_seconds() / 3600.0
+        except (ValueError, TypeError, OSError):
+            return 1.0
+
+        if hours >= float(window_hours):
+            return 1.0
+        if hours < 0:
+            hours = 0.0
+        boost = 1.0 + 0.5 * (1.0 - hours / float(window_hours))
+        return _clamp(boost, 1.0, DEFAULT_TAGGING_MAX_BOOST)
+
+    def calculate_synapse_score(
+        self,
+        similarity: float,
+        decay: float,
+        drawer_id: str,
+        filed_at: Optional[str],
+        ltp_scores: Optional[dict[str, float]] = None,
+        window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+    ) -> dict[str, Any]:
+        """
+        最終スコアを計算して返す。
+        final_score = similarity * decay * ltp * tagging
+        (Phase 1 では association は 1.0 固定)
+
+        戻り値:
+        {
+            "final_score": float,
+            "similarity": float,
+            "decay": float,
+            "ltp": float,
+            "association": 1.0,
+            "tagging": float
+        }
+        """
+        if ltp_scores is not None:
+            ltp = ltp_scores.get(drawer_id, 1.0)
+        else:
+            ltp = self.get_ltp_score(drawer_id, window_days)
+        tagging = self.calculate_tagging_boost(filed_at)
+        association = 1.0
+        final_score = similarity * decay * ltp * tagging * association
+        return {
+            "final_score": final_score,
+            "similarity": similarity,
+            "decay": decay,
+            "ltp": ltp,
+            "association": association,
+            "tagging": tagging,
+        }
+
+    def refresh_stats(self, window_days: int = DEFAULT_LTP_WINDOW_DAYS) -> None:
+        """
+        synapse_stats テーブルを retrieval_log から再計算して更新する。
+        mempalace status や明示的なリフレッシュ時に呼ばれる。
+        """
+        cutoff_dt = datetime.now(timezone.utc) - timedelta(days=window_days)
+        cutoff = cutoff_dt.isoformat()
+        now_iso = _utc_now_iso()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(
+                "SELECT drawer_id, COUNT(*) FROM retrieval_log GROUP BY drawer_id"
+            )
+            totals = {row[0]: int(row[1]) for row in cur.fetchall()}
+            cur = conn.execute(
+                "SELECT drawer_id, COUNT(*) FROM retrieval_log WHERE retrieved_at >= ? "
+                "GROUP BY drawer_id",
+                (cutoff,),
+            )
+            recent = {row[0]: int(row[1]) for row in cur.fetchall()}
+            for drawer_id, total_retrievals in totals.items():
+                rc = recent.get(drawer_id, 0)
+                recent_density = rc / float(max(1, window_days))
+                if rc == 0:
+                    ltp_score = 1.0
+                else:
+                    raw = 1.0 + math.log(1 + rc) * DEFAULT_LTP_COEFFICIENT
+                    ltp_score = _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+                conn.execute(
+                    "INSERT OR REPLACE INTO synapse_stats "
+                    "(drawer_id, total_retrievals, recent_density, ltp_score, last_updated) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (drawer_id, total_retrievals, recent_density, ltp_score, now_iso),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_consolidation_candidates(self, inactive_days: int = 180) -> list[dict]:
+        """
+        inactive_days 以上検索されていない drawer_id のリストを返す。
+        戻り値: [{"drawer_id": str, "last_retrieved_at": str, "days_inactive": int}]
+        """
+        now = datetime.now(timezone.utc)
+        cutoff = (now - timedelta(days=inactive_days)).isoformat()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(
+                "SELECT drawer_id, MAX(retrieved_at) AS last_at FROM retrieval_log "
+                "GROUP BY drawer_id HAVING MAX(retrieved_at) < ?",
+                (cutoff,),
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        out: list[dict] = []
+        for drawer_id, last_at in rows:
+            try:
+                s = last_at.strip()
+                if s.endswith("Z"):
+                    s = s[:-1] + "+00:00"
+                last_dt = datetime.fromisoformat(s)
+                if last_dt.tzinfo is None:
+                    last_dt = last_dt.replace(tzinfo=timezone.utc)
+                last_dt = last_dt.astimezone(timezone.utc)
+                days_inactive = max(0, (now - last_dt).days)
+            except (ValueError, TypeError, AttributeError):
+                days_inactive = inactive_days
+            out.append(
+                {
+                    "drawer_id": drawer_id,
+                    "last_retrieved_at": last_at,
+                    "days_inactive": days_inactive,
+                }
+            )
+        return out

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -16,6 +16,12 @@ DEFAULT_ASSOCIATION_MAX_BOOST = 1.5
 DEFAULT_ASSOCIATION_COEFFICIENT = 0.15
 SYNAPSE_DB_NAME = "synapse.sqlite3"
 
+# Chroma drawer metadata — Phase 3 synaptic marking for newly filed drawers
+SYNAPSE_MARK_METADATA_KEY = "synapse_mark"
+SYNAPSE_MARK_NEW = "new"
+
+SOFT_ARCHIVE_ISSUE_REF = "#336"
+
 
 def _canonical_pair(a: str, b: str) -> tuple[str, str]:
     return (a, b) if a < b else (b, a)
@@ -27,6 +33,29 @@ def _utc_now_iso() -> str:
 
 def _clamp(x: float, lo: float, hi: float) -> float:
     return max(lo, min(hi, x))
+
+
+def build_soft_archive_proposal(
+    wing: str,
+    room: str,
+    *,
+    target_wing: str = "archive",
+    inactive_days: int = 180,
+) -> dict[str, Any]:
+    """
+    Soft-archive nudge for consolidation candidates (#336).
+    Does not move data — surfaces suggested wing/room for a future soft-archive wing.
+    """
+    safe_w = (wing or "unknown").replace(" ", "_")
+    safe_r = (room or "unknown").replace(" ", "_")
+    return {
+        "reason": "inactive_beyond_consolidation_window",
+        "inactive_days_threshold": inactive_days,
+        "suggested_wing": target_wing,
+        "suggested_room": f"{safe_w}__{safe_r}"[:220],
+        "related_issue": SOFT_ARCHIVE_ISSUE_REF,
+        "disclaimer": "Suggestion only — no automatic move; user or agent relocates the drawer.",
+    }
 
 
 class SynapseDB:

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -104,11 +104,16 @@ class SynapseDB:
         except Exception as e:
             logger.warning("log_retrieval failed: %s", e)
 
-    def get_ltp_score(self, drawer_id: str, window_days: int = DEFAULT_LTP_WINDOW_DAYS) -> float:
+    def get_ltp_score(
+        self,
+        drawer_id: str,
+        window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+        max_boost: float = DEFAULT_LTP_MAX_BOOST,
+    ) -> float:
         """
         直近 window_days 日間の retrieval_log から drawer_id の検索回数を集計し、
         LTP スコアを計算して返す。
-        ltp = clamp(1.0 + log(1 + recent_count) * LTP_COEFFICIENT, 1.0, LTP_MAX_BOOST)
+        ltp = clamp(1.0 + log(1 + recent_count) * LTP_COEFFICIENT, 1.0, max_boost)
         retrieval_log にエントリがなければ 1.0 を返す。
         """
         cutoff_dt = datetime.now(timezone.utc) - timedelta(days=window_days)
@@ -127,10 +132,13 @@ class SynapseDB:
         if recent_count == 0:
             return 1.0
         raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
-        return _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+        return _clamp(raw, 1.0, max_boost)
 
     def get_ltp_scores_batch(
-        self, drawer_ids: list[str], window_days: int = DEFAULT_LTP_WINDOW_DAYS
+        self,
+        drawer_ids: list[str],
+        window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+        max_boost: float = DEFAULT_LTP_MAX_BOOST,
     ) -> dict[str, float]:
         """
         複数の drawer_id に対する LTP スコアを一括取得する。
@@ -156,20 +164,22 @@ class SynapseDB:
                     out[drawer_id] = 1.0
                 else:
                     raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
-                    out[drawer_id] = _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+                    out[drawer_id] = _clamp(raw, 1.0, max_boost)
         finally:
             conn.close()
         return out
 
     @staticmethod
     def calculate_tagging_boost(
-        filed_at: Optional[str], window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS
+        filed_at: Optional[str],
+        window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS,
+        max_boost: float = DEFAULT_TAGGING_MAX_BOOST,
     ) -> float:
         """
         filed_at（ISO 8601 文字列）から現在までの経過時間を計算し、
         tagging boost を返す。
-        - 24h 以内: 1.0 + 0.5 * (1.0 - hours / window_hours)
-        - 24h 超: 1.0
+        - 窓内: 1.0 + (max_boost - 1.0) * (1.0 - hours / window_hours)
+        - 窓外: 1.0
         - filed_at が None またはパース失敗: 1.0
         """
         if filed_at is None:
@@ -191,8 +201,9 @@ class SynapseDB:
             return 1.0
         if hours < 0:
             hours = 0.0
-        boost = 1.0 + 0.5 * (1.0 - hours / float(window_hours))
-        return _clamp(boost, 1.0, DEFAULT_TAGGING_MAX_BOOST)
+        amplitude = max_boost - 1.0
+        boost = 1.0 + amplitude * (1.0 - hours / float(window_hours))
+        return _clamp(boost, 1.0, max_boost)
 
     def calculate_synapse_score(
         self,
@@ -202,6 +213,9 @@ class SynapseDB:
         filed_at: Optional[str],
         ltp_scores: Optional[dict[str, float]] = None,
         window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+        ltp_max_boost: float = DEFAULT_LTP_MAX_BOOST,
+        tagging_window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS,
+        tagging_max_boost: float = DEFAULT_TAGGING_MAX_BOOST,
     ) -> dict[str, Any]:
         """
         最終スコアを計算して返す。
@@ -221,8 +235,12 @@ class SynapseDB:
         if ltp_scores is not None:
             ltp = ltp_scores.get(drawer_id, 1.0)
         else:
-            ltp = self.get_ltp_score(drawer_id, window_days)
-        tagging = self.calculate_tagging_boost(filed_at)
+            ltp = self.get_ltp_score(drawer_id, window_days, max_boost=ltp_max_boost)
+        tagging = self.calculate_tagging_boost(
+            filed_at,
+            window_hours=tagging_window_hours,
+            max_boost=tagging_max_boost,
+        )
         association = 1.0
         final_score = similarity * decay * ltp * tagging * association
         return {
@@ -234,7 +252,54 @@ class SynapseDB:
             "tagging": tagging,
         }
 
-    def refresh_stats(self, window_days: int = DEFAULT_LTP_WINDOW_DAYS) -> None:
+    def cleanup_old_logs(self, retention_days: int = 90) -> None:
+        """
+        retention_days より古い retrieval_log エントリを削除する。
+        mempalace status 実行時 または synapse refresh 時に呼ばれる。
+        """
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("DELETE FROM retrieval_log WHERE retrieved_at < ?", (cutoff,))
+            conn.commit()
+        finally:
+            conn.close()
+        # VACUUM はトランザクション外で実行する
+        conn2 = sqlite3.connect(self.db_path)
+        try:
+            conn2.execute("VACUUM")
+            conn2.commit()
+        finally:
+            conn2.close()
+
+    def get_log_stats(self) -> dict[str, Any]:
+        """
+        ログの統計情報を返す。mempalace_status に表示する。
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            total = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
+            unique = conn.execute("SELECT COUNT(DISTINCT drawer_id) FROM retrieval_log").fetchone()[0]
+            row = conn.execute(
+                "SELECT MIN(retrieved_at), MAX(retrieved_at) FROM retrieval_log"
+            ).fetchone()
+            oldest, newest = row[0], row[1]
+        finally:
+            conn.close()
+        size_kb = os.path.getsize(self.db_path) / 1024.0
+        return {
+            "total_entries": int(total),
+            "unique_drawers": int(unique),
+            "oldest_entry": oldest,
+            "newest_entry": newest,
+            "db_size_kb": round(size_kb, 2),
+        }
+
+    def refresh_stats(
+        self,
+        window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+        ltp_max_boost: float = DEFAULT_LTP_MAX_BOOST,
+    ) -> None:
         """
         synapse_stats テーブルを retrieval_log から再計算して更新する。
         mempalace status や明示的なリフレッシュ時に呼ばれる。
@@ -261,7 +326,7 @@ class SynapseDB:
                     ltp_score = 1.0
                 else:
                     raw = 1.0 + math.log(1 + rc) * DEFAULT_LTP_COEFFICIENT
-                    ltp_score = _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+                    ltp_score = _clamp(raw, 1.0, ltp_max_boost)
                 conn.execute(
                     "INSERT OR REPLACE INTO synapse_stats "
                     "(drawer_id, total_retrievals, recent_density, ltp_score, last_updated) "

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import sqlite3
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
@@ -120,7 +121,28 @@ class SynapseDB:
         finally:
             conn.close()
 
-    def log_retrieval(self, drawer_ids: list[str], query_hash: str, session_id: str):
+    @contextmanager
+    def connection(self):
+        """Single search/request: reuse one SQLite connection (WAL, busy timeout)."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA busy_timeout=5000;")
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def log_retrieval(
+        self,
+        drawer_ids: list[str],
+        query_hash: str,
+        session_id: str,
+        conn: Optional[sqlite3.Connection] = None,
+    ):
         """
         検索結果に含まれた drawer_id のリストを retrieval_log に記録する。
         - retrieved_at: UTC ISO 8601 形式
@@ -131,35 +153,43 @@ class SynapseDB:
         try:
             retrieved_at = _utc_now_iso()
             rows = [(did, retrieved_at, query_hash, session_id) for did in drawer_ids]
-            conn = sqlite3.connect(self.db_path)
-            try:
+            if conn is not None:
                 conn.executemany(
                     "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) "
                     "VALUES (?, ?, ?, ?)",
                     rows,
                 )
-                conn.commit()
-            finally:
-                conn.close()
+            else:
+                with self.connection() as c:
+                    c.executemany(
+                        "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) "
+                        "VALUES (?, ?, ?, ?)",
+                        rows,
+                    )
         except Exception as e:
             logger.warning("log_retrieval failed: %s", e)
         else:
             try:
-                self._record_co_retrieval_pairs(drawer_ids, retrieved_at)
+                self._record_co_retrieval_pairs(drawer_ids, retrieved_at, conn=conn)
             except Exception as e:
                 logger.warning("co_retrieval pair update failed: %s", e)
 
-    def _record_co_retrieval_pairs(self, drawer_ids: list[str], retrieved_at: str) -> None:
+    def _record_co_retrieval_pairs(
+        self,
+        drawer_ids: list[str],
+        retrieved_at: str,
+        conn: Optional[sqlite3.Connection] = None,
+    ) -> None:
         """同一検索結果内の drawer ペアごとに co_count を増分する。"""
         uniq = sorted(set(drawer_ids))
         if len(uniq) < 2:
             return
-        conn = sqlite3.connect(self.db_path)
-        try:
+
+        def _run(c: sqlite3.Connection) -> None:
             for i in range(len(uniq)):
                 for j in range(i + 1, len(uniq)):
                     a, b = _canonical_pair(uniq[i], uniq[j])
-                    conn.execute(
+                    c.execute(
                         """
                         INSERT INTO co_retrieval (drawer_a, drawer_b, co_count, last_co_retrieved)
                         VALUES (?, ?, 1, ?)
@@ -169,9 +199,12 @@ class SynapseDB:
                         """,
                         (a, b, retrieved_at),
                     )
-            conn.commit()
-        finally:
-            conn.close()
+
+        if conn is not None:
+            _run(conn)
+        else:
+            with self.connection() as c:
+                _run(c)
 
     def rebuild_co_retrieval_from_log(self) -> int:
         """
@@ -208,6 +241,7 @@ class SynapseDB:
         drawer_ids: list[str],
         max_boost: float = DEFAULT_ASSOCIATION_MAX_BOOST,
         coefficient: float = DEFAULT_ASSOCIATION_COEFFICIENT,
+        conn: Optional[sqlite3.Connection] = None,
     ) -> dict[str, float]:
         """
         同一検索結果の drawer 集合について、co_retrieval の共起強度から association を計算する。
@@ -217,7 +251,10 @@ class SynapseDB:
         out: dict[str, float] = {d: 1.0 for d in uniq}
         if len(uniq) < 2:
             return out
-        conn = sqlite3.connect(self.db_path)
+        own = False
+        if conn is None:
+            conn = sqlite3.connect(self.db_path)
+            own = True
         try:
             ph = ",".join("?" * len(uniq))
             cur = conn.execute(
@@ -229,7 +266,8 @@ class SynapseDB:
             for a, b, c in cur.fetchall():
                 edge[(a, b)] = int(c)
         finally:
-            conn.close()
+            if own:
+                conn.close()
         for d in uniq:
             total = 0
             for o in uniq:
@@ -349,6 +387,7 @@ class SynapseDB:
         drawer_ids: list[str],
         window_days: int = DEFAULT_LTP_WINDOW_DAYS,
         max_boost: float = DEFAULT_LTP_MAX_BOOST,
+        conn: Optional[sqlite3.Connection] = None,
     ) -> dict[str, float]:
         """
         複数の drawer_id に対する LTP スコアを一括取得する。
@@ -365,7 +404,10 @@ class SynapseDB:
             f"SELECT drawer_id, COUNT(*) as cnt FROM retrieval_log "
             f"WHERE drawer_id IN ({placeholders}) AND retrieved_at >= ? GROUP BY drawer_id"
         )
-        conn = sqlite3.connect(self.db_path)
+        own = False
+        if conn is None:
+            conn = sqlite3.connect(self.db_path)
+            own = True
         try:
             cur = conn.execute(sql, (*drawer_ids, cutoff))
             for drawer_id, cnt in cur.fetchall():
@@ -376,7 +418,8 @@ class SynapseDB:
                     raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
                     out[drawer_id] = _clamp(raw, 1.0, max_boost)
         finally:
-            conn.close()
+            if own:
+                conn.close()
         return out
 
     @staticmethod
@@ -471,13 +514,22 @@ class SynapseDB:
         削除件数を返す。
         """
         cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat()
-        conn = sqlite3.connect(self.db_path)
-        try:
+        deleted = 0
+        with self.connection() as conn:
             cur = conn.execute("DELETE FROM retrieval_log WHERE retrieved_at < ?", (cutoff,))
-            deleted = cur.rowcount
-            conn.commit()
-        finally:
-            conn.close()
+            rc = cur.rowcount
+            if rc is not None and rc >= 0:
+                deleted = int(rc)
+        if deleted > 1000:
+            self._vacuum_database()
+        if deleted > 0:
+            try:
+                self.rebuild_co_retrieval_from_log()
+            except Exception as e:
+                logger.warning("rebuild_co_retrieval_from_log after cleanup failed: %s", e)
+        return deleted
+
+    def _vacuum_database(self) -> None:
         try:
             vacuum_conn = sqlite3.connect(self.db_path)
             try:
@@ -487,16 +539,6 @@ class SynapseDB:
                 vacuum_conn.close()
         except Exception as e:
             logger.warning("VACUUM failed: %s", e)
-        if deleted is None or deleted < 0:
-            deleted = 0
-        else:
-            deleted = int(deleted)
-        if deleted > 0:
-            try:
-                self.rebuild_co_retrieval_from_log()
-            except Exception as e:
-                logger.warning("rebuild_co_retrieval_from_log after cleanup failed: %s", e)
-        return deleted
 
     def get_log_stats(self) -> dict[str, Any]:
         """ログの統計情報を返す。"""
@@ -564,20 +606,32 @@ class SynapseDB:
         finally:
             conn.close()
 
-    def get_consolidation_candidates(self, inactive_days: int = 180) -> list[dict]:
+    def get_consolidation_candidates(
+        self, inactive_days: int = 180, wing: Optional[str] = None
+    ) -> list[dict]:
         """
         inactive_days 以上検索されていない drawer_id のリストを返す。
+        wing が指定されていれば drawer_id に部分一致する行に限定する。
         戻り値: [{"drawer_id": str, "last_retrieved_at": str, "days_inactive": int}]
         """
         now = datetime.now(timezone.utc)
         cutoff = (now - timedelta(days=inactive_days)).isoformat()
+        if wing:
+            sql = (
+                "SELECT drawer_id, MAX(retrieved_at) AS last_at FROM retrieval_log "
+                "WHERE drawer_id LIKE ? "
+                "GROUP BY drawer_id HAVING MAX(retrieved_at) < ?"
+            )
+            params = (f"%{wing}%", cutoff)
+        else:
+            sql = (
+                "SELECT drawer_id, MAX(retrieved_at) AS last_at FROM retrieval_log "
+                "GROUP BY drawer_id HAVING MAX(retrieved_at) < ?"
+            )
+            params = (cutoff,)
         conn = sqlite3.connect(self.db_path)
         try:
-            cur = conn.execute(
-                "SELECT drawer_id, MAX(retrieved_at) AS last_at FROM retrieval_log "
-                "GROUP BY drawer_id HAVING MAX(retrieved_at) < ?",
-                (cutoff,),
-            )
+            cur = conn.execute(sql, params)
             rows = cur.fetchall()
         finally:
             conn.close()

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -252,47 +252,54 @@ class SynapseDB:
             "tagging": tagging,
         }
 
-    def cleanup_old_logs(self, retention_days: int = 90) -> None:
+    def cleanup_old_logs(self, retention_days: int = 90) -> int:
         """
         retention_days より古い retrieval_log エントリを削除する。
-        mempalace status 実行時 または synapse refresh 時に呼ばれる。
+        削除件数を返す。
         """
         cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat()
         conn = sqlite3.connect(self.db_path)
         try:
-            conn.execute("DELETE FROM retrieval_log WHERE retrieved_at < ?", (cutoff,))
+            cur = conn.execute("DELETE FROM retrieval_log WHERE retrieved_at < ?", (cutoff,))
+            deleted = cur.rowcount
             conn.commit()
         finally:
             conn.close()
-        # VACUUM はトランザクション外で実行する
-        conn2 = sqlite3.connect(self.db_path)
         try:
-            conn2.execute("VACUUM")
-            conn2.commit()
-        finally:
-            conn2.close()
+            vacuum_conn = sqlite3.connect(self.db_path)
+            try:
+                vacuum_conn.execute("VACUUM")
+                vacuum_conn.commit()
+            finally:
+                vacuum_conn.close()
+        except Exception as e:
+            logger.warning("VACUUM failed: %s", e)
+        if deleted is None or deleted < 0:
+            return 0
+        return int(deleted)
 
     def get_log_stats(self) -> dict[str, Any]:
-        """
-        ログの統計情報を返す。mempalace_status に表示する。
-        """
+        """ログの統計情報を返す。"""
         conn = sqlite3.connect(self.db_path)
         try:
-            total = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
-            unique = conn.execute("SELECT COUNT(DISTINCT drawer_id) FROM retrieval_log").fetchone()[0]
             row = conn.execute(
-                "SELECT MIN(retrieved_at), MAX(retrieved_at) FROM retrieval_log"
+                "SELECT COUNT(*), COUNT(DISTINCT drawer_id), MIN(retrieved_at), MAX(retrieved_at) "
+                "FROM retrieval_log"
             ).fetchone()
-            oldest, newest = row[0], row[1]
+            total, unique, oldest, newest = row
         finally:
             conn.close()
-        size_kb = os.path.getsize(self.db_path) / 1024.0
+        db_size_kb = 0.0
+        try:
+            db_size_kb = round(os.path.getsize(self.db_path) / 1024, 1)
+        except OSError:
+            pass
         return {
-            "total_entries": int(total),
-            "unique_drawers": int(unique),
+            "total_entries": int(total or 0),
+            "unique_drawers": int(unique or 0),
             "oldest_entry": oldest,
             "newest_entry": newest,
-            "db_size_kb": round(size_kb, 2),
+            "db_size_kb": db_size_kb,
         }
 
     def refresh_stats(

--- a/mempalace/synapse_profiles.py
+++ b/mempalace/synapse_profiles.py
@@ -73,9 +73,15 @@ def compute_decay(age_days: float, half_life_days: int) -> float:
 class RetrievalProfile:
     """Resolved Synapse profile with all values populated."""
 
-    def __init__(self, name: str, values: Dict[str, Any]):
+    def __init__(
+        self,
+        name: str,
+        values: Dict[str, Any],
+        sources: Optional[Dict[str, str]] = None,
+    ):
         self.name = name
         self._values = values
+        self._sources = sources or {}
 
     def __getattr__(self, key: str) -> Any:
         if key.startswith("_") or key == "name":
@@ -84,8 +90,18 @@ class RetrievalProfile:
             return self._values[key]
         raise AttributeError(f"RetrievalProfile has no key '{key}'")
 
+    def get_source(self, key: str) -> str:
+        return self._sources.get(key, "unknown")
+
     def to_dict(self) -> Dict[str, Any]:
         return {"name": self.name, **self._values}
+
+    def to_annotated_dict(self) -> Dict[str, Dict[str, Any]]:
+        """Each resolved value paired with the merge layer that last set it."""
+        return {
+            k: {"value": v, "source": self._sources.get(k, "unknown")}
+            for k, v in self._values.items()
+        }
 
 
 class ProfileManager:
@@ -159,42 +175,64 @@ class ProfileManager:
             )
             actual_name = "default"
 
-        merged: Dict[str, Any] = dict(HARDCODED_DEFAULTS)
+        merged: Dict[str, Any] = {}
+        sources: Dict[str, str] = {}
+
+        for k, v in HARDCODED_DEFAULTS.items():
+            merged[k] = v
+            sources[k] = "hardcoded"
+
         if global_merged:
-            merged.update(global_merged)
+            for k, v in global_merged.items():
+                if v is not None:
+                    merged[k] = v
+                    sources[k] = "global config.json"
 
         if "default" in self._config_profiles and isinstance(
             self._config_profiles["default"], dict
         ):
-            merged.update(self._config_profiles["default"])
+            for k, v in self._config_profiles["default"].items():
+                merged[k] = v
+                sources[k] = "default (config.json)"
 
         if "default" in self._file_profiles and isinstance(
             self._file_profiles["default"], dict
         ):
-            merged.update(self._file_profiles["default"])
+            for k, v in self._file_profiles["default"].items():
+                merged[k] = v
+                sources[k] = "default (synapse_profiles.json)"
 
         if actual_name != "default" and actual_name in self._config_profiles:
             layer = self._config_profiles[actual_name]
             if isinstance(layer, dict):
-                merged.update(layer)
+                for k, v in layer.items():
+                    merged[k] = v
+                    sources[k] = "profile (config.json)"
 
         if actual_name != "default" and actual_name in self._file_profiles:
             layer = self._file_profiles[actual_name]
             if isinstance(layer, dict):
-                merged.update(layer)
+                for k, v in layer.items():
+                    merged[k] = v
+                    sources[k] = "profile (synapse_profiles.json)"
 
         if per_query_overrides:
             for k, v in per_query_overrides.items():
                 if v is not None:
                     merged[k] = v
+                    sources[k] = "per-query override"
 
         axes = merged.get("axes_enabled", [])
         if isinstance(axes, list):
+            ax_src = sources.get("axes_enabled", "hardcoded")
             if "ltp" not in axes:
                 merged["ltp_enabled"] = False
+                sources["ltp_enabled"] = f"axes_enabled ({ax_src})"
             if "tagging" not in axes:
                 merged["tagging_enabled"] = False
+                sources["tagging_enabled"] = f"axes_enabled ({ax_src})"
             if "association" not in axes:
                 merged["association_enabled"] = False
+                sources["association_enabled"] = f"axes_enabled ({ax_src})"
 
-        return RetrievalProfile(actual_name, merged)
+        return RetrievalProfile(actual_name, merged, sources=sources)

--- a/mempalace/synapse_profiles.py
+++ b/mempalace/synapse_profiles.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+VALID_AXES = frozenset({"ltp", "tagging", "association", "similarity", "decay", "recency"})
+
 HARDCODED_DEFAULTS: Dict[str, Any] = {
     "half_life_days": 90,
     "ltp_enabled": True,
@@ -157,6 +159,47 @@ class ProfileManager:
         names.add("default")
         return sorted(names)
 
+    def _validate(self, merged: Dict[str, Any], profile_name: str) -> None:
+        """Fail fast with clear error messages on invalid profile values."""
+        errors: List[str] = []
+
+        axes = merged.get("axes_enabled", [])
+        if isinstance(axes, list):
+            for ax in axes:
+                if ax not in VALID_AXES:
+                    errors.append(
+                        f"Unknown axis '{ax}' in axes_enabled. Valid: {sorted(VALID_AXES)}"
+                    )
+
+        hld = merged.get("half_life_days")
+        if hld is not None and hld <= 0:
+            errors.append(f"half_life_days must be > 0 or null, got {hld}")
+
+        lmb = merged.get("ltp_max_boost")
+        if lmb is not None and lmb < 1.0:
+            errors.append(f"ltp_max_boost must be >= 1.0, got {lmb}")
+
+        tmb = merged.get("tagging_max_boost")
+        if tmb is not None and tmb < 1.0:
+            errors.append(f"tagging_max_boost must be >= 1.0, got {tmb}")
+
+        amb = merged.get("association_max_boost")
+        if amb is not None and amb < 1.0:
+            errors.append(f"association_max_boost must be >= 1.0, got {amb}")
+
+        lwd = merged.get("ltp_window_days")
+        if lwd is not None and lwd <= 0:
+            errors.append(f"ltp_window_days must be > 0, got {lwd}")
+
+        twh = merged.get("tagging_window_hours")
+        if twh is not None and twh <= 0:
+            errors.append(f"tagging_window_hours must be > 0, got {twh}")
+
+        if errors:
+            raise ValueError(
+                f"Invalid profile '{profile_name}': " + "; ".join(errors)
+            )
+
     def resolve(
         self,
         profile_name: Optional[str] = None,
@@ -234,5 +277,7 @@ class ProfileManager:
             if "association" not in axes:
                 merged["association_enabled"] = False
                 sources["association_enabled"] = f"axes_enabled ({ax_src})"
+
+        self._validate(merged, actual_name)
 
         return RetrievalProfile(actual_name, merged, sources=sources)

--- a/mempalace/synapse_profiles.py
+++ b/mempalace/synapse_profiles.py
@@ -1,0 +1,200 @@
+"""
+RetrievalProfile: named Synapse parameter sets with inheritance.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+HARDCODED_DEFAULTS: Dict[str, Any] = {
+    "half_life_days": 90,
+    "ltp_enabled": True,
+    "ltp_window_days": 30,
+    "ltp_max_boost": 2.0,
+    "tagging_enabled": True,
+    "tagging_window_hours": 24,
+    "tagging_max_boost": 1.5,
+    "association_enabled": False,
+    "association_max_boost": 1.5,
+    "association_coefficient": 0.15,
+    "axes_enabled": ["ltp", "tagging", "association"],
+}
+
+
+def global_merged_from_mempalace_config(cfg: Any) -> Dict[str, Any]:
+    """Map ~/.mempalace config.json synapse_* keys into profile field names."""
+    return {
+        "ltp_enabled": cfg.synapse_ltp_enabled,
+        "tagging_enabled": cfg.synapse_tagging_enabled,
+        "association_enabled": cfg.synapse_association_enabled,
+        "ltp_window_days": cfg.synapse_ltp_window_days,
+        "ltp_max_boost": cfg.synapse_ltp_max_boost,
+        "tagging_window_hours": cfg.synapse_tagging_window_hours,
+        "tagging_max_boost": cfg.synapse_tagging_max_boost,
+        "association_max_boost": cfg.synapse_association_max_boost,
+        "association_coefficient": cfg.synapse_association_coefficient,
+    }
+
+
+def hit_filed_age_days(filed_at: Optional[str]) -> float:
+    """Days since filed_at (ISO), or 0.0 if missing / invalid."""
+    if not filed_at:
+        return 0.0
+    try:
+        s = filed_at.strip()
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        filed = datetime.fromisoformat(s)
+        if filed.tzinfo is None:
+            filed = filed.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        secs = (now - filed.astimezone(timezone.utc)).total_seconds()
+        return max(0.0, secs / 86400.0)
+    except (ValueError, TypeError, OSError):
+        return 0.0
+
+
+def compute_decay(age_days: float, half_life_days: int) -> float:
+    """Exponential half-life decay: 0.5 at age == half_life_days."""
+    if half_life_days <= 0:
+        return 1.0
+    if age_days <= 0:
+        return 1.0
+    return math.exp(-math.log(2.0) * age_days / float(half_life_days))
+
+
+class RetrievalProfile:
+    """Resolved Synapse profile with all values populated."""
+
+    def __init__(self, name: str, values: Dict[str, Any]):
+        self.name = name
+        self._values = values
+
+    def __getattr__(self, key: str) -> Any:
+        if key.startswith("_") or key == "name":
+            raise AttributeError(key)
+        if key in self._values:
+            return self._values[key]
+        raise AttributeError(f"RetrievalProfile has no key '{key}'")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, **self._values}
+
+
+class ProfileManager:
+    """
+    Loads, merges, and resolves Synapse profiles.
+
+    Merge chain (later wins):
+      hardcoded defaults → global_merged (caller: ~/.mempalace synapse_* )
+        → palace config.json["synapse_profiles"]["default"]
+        → palace synapse_profiles.json["default"]
+        → palace config.json[profile_name]
+        → palace synapse_profiles.json[profile_name]
+        → per_query_overrides
+
+    Inheritance: depth-1 only (named profiles merge on top of default layers).
+    """
+
+    def __init__(self, palace_path: str):
+        self._palace_path = palace_path
+        self._config_profiles: Dict[str, Dict[str, Any]] = {}
+        self._file_profiles: Dict[str, Dict[str, Any]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        self._config_profiles = {}
+        self._file_profiles = {}
+
+        config_path = os.path.join(self._palace_path, "config.json")
+        if os.path.exists(config_path):
+            try:
+                with open(config_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                raw = data.get("synapse_profiles", {})
+                if isinstance(raw, dict):
+                    self._config_profiles = raw
+            except (json.JSONDecodeError, OSError, TypeError) as e:
+                logger.warning("Failed to load config.json profiles: %s", e)
+
+        profiles_path = os.path.join(self._palace_path, "synapse_profiles.json")
+        if os.path.exists(profiles_path):
+            try:
+                with open(profiles_path, "r", encoding="utf-8") as f:
+                    loaded = json.load(f)
+                if isinstance(loaded, dict):
+                    self._file_profiles = loaded
+            except (json.JSONDecodeError, OSError, TypeError) as e:
+                logger.warning("Failed to load synapse_profiles.json: %s", e)
+
+    def get_known_profiles(self) -> List[str]:
+        names: set[str] = set()
+        names.update(self._config_profiles.keys())
+        names.update(self._file_profiles.keys())
+        names.add("default")
+        return sorted(names)
+
+    def resolve(
+        self,
+        profile_name: Optional[str] = None,
+        per_query_overrides: Optional[Dict[str, Any]] = None,
+        global_merged: Optional[Dict[str, Any]] = None,
+    ) -> RetrievalProfile:
+        if profile_name is None:
+            profile_name = "default"
+
+        known = self.get_known_profiles()
+        actual_name = profile_name
+        if profile_name != "default" and profile_name not in known:
+            logger.warning(
+                "synapse_profile '%s' not found — falling back to 'default'",
+                profile_name,
+            )
+            actual_name = "default"
+
+        merged: Dict[str, Any] = dict(HARDCODED_DEFAULTS)
+        if global_merged:
+            merged.update(global_merged)
+
+        if "default" in self._config_profiles and isinstance(
+            self._config_profiles["default"], dict
+        ):
+            merged.update(self._config_profiles["default"])
+
+        if "default" in self._file_profiles and isinstance(
+            self._file_profiles["default"], dict
+        ):
+            merged.update(self._file_profiles["default"])
+
+        if actual_name != "default" and actual_name in self._config_profiles:
+            layer = self._config_profiles[actual_name]
+            if isinstance(layer, dict):
+                merged.update(layer)
+
+        if actual_name != "default" and actual_name in self._file_profiles:
+            layer = self._file_profiles[actual_name]
+            if isinstance(layer, dict):
+                merged.update(layer)
+
+        if per_query_overrides:
+            for k, v in per_query_overrides.items():
+                if v is not None:
+                    merged[k] = v
+
+        axes = merged.get("axes_enabled", [])
+        if isinstance(axes, list):
+            if "ltp" not in axes:
+                merged["ltp_enabled"] = False
+            if "tagging" not in axes:
+                merged["tagging_enabled"] = False
+            if "association" not in axes:
+                merged["association_enabled"] = False
+
+        return RetrievalProfile(actual_name, merged)

--- a/mempalace/synapse_profiles.py
+++ b/mempalace/synapse_profiles.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 VALID_AXES = frozenset({"ltp", "tagging", "association", "similarity", "decay", "recency"})
 
 HARDCODED_DEFAULTS: Dict[str, Any] = {
+    "description": "",
     "half_life_days": 90,
     "ltp_enabled": True,
     "ltp_window_days": 30,
@@ -23,9 +24,9 @@ HARDCODED_DEFAULTS: Dict[str, Any] = {
     "tagging_enabled": True,
     "tagging_window_hours": 24,
     "tagging_max_boost": 1.5,
-    "association_enabled": False,
-    "association_max_boost": 1.5,
-    "association_coefficient": 0.15,
+    "association_enabled": True,
+    "association_max_boost": 1.4,
+    "association_coefficient": 0.2,
     "axes_enabled": ["ltp", "tagging", "association"],
 }
 

--- a/tests/fixtures/ooda_profiles.json
+++ b/tests/fixtures/ooda_profiles.json
@@ -15,18 +15,21 @@
     "association_enabled": false
   },
   "decide": {
-    "description": "Action selection — short half-life, recency-prioritized",
-    "half_life_days": 30,
-    "ltp_enabled": true,
-    "ltp_max_boost": 1.5,
-    "ltp_window_days": 14,
-    "tagging_enabled": true
+    "description": "Action selection — short half-life, recency-prioritized, exploit mode",
+    "half_life_days": 7,
+    "ltp_enabled": false,
+    "tagging_enabled": true,
+    "tagging_max_boost": 1.5,
+    "association_enabled": false
   },
   "act": {
-    "description": "Execution context — recent procedural memory, no association",
-    "axes_enabled": ["similarity", "recency"],
+    "description": "Execution context — recent procedural memory, tagging enabled for rapid reinforcement",
+    "axes_enabled": ["similarity", "recency", "ltp", "tagging"],
     "half_life_days": 14,
-    "ltp_enabled": false,
+    "ltp_enabled": true,
+    "ltp_max_boost": 1.5,
+    "tagging_enabled": true,
+    "tagging_max_boost": 1.3,
     "association_enabled": false
   }
 }

--- a/tests/fixtures/ooda_profiles.json
+++ b/tests/fixtures/ooda_profiles.json
@@ -1,0 +1,32 @@
+{
+  "orient": {
+    "description": "Broad context gathering — association emphasis, long half-life",
+    "half_life_days": 180,
+    "ltp_enabled": true,
+    "ltp_max_boost": 2.0,
+    "ltp_window_days": 60,
+    "tagging_enabled": false
+  },
+  "observe": {
+    "description": "Raw evidence gathering — maximum similarity, all Synapse axes off",
+    "axes_enabled": [],
+    "ltp_enabled": false,
+    "tagging_enabled": false,
+    "association_enabled": false
+  },
+  "decide": {
+    "description": "Action selection — short half-life, recency-prioritized",
+    "half_life_days": 30,
+    "ltp_enabled": true,
+    "ltp_max_boost": 1.5,
+    "ltp_window_days": 14,
+    "tagging_enabled": true
+  },
+  "act": {
+    "description": "Execution context — recent procedural memory, no association",
+    "axes_enabled": ["similarity", "recency"],
+    "half_life_days": 14,
+    "ltp_enabled": false,
+    "association_enabled": false
+  }
+}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -272,7 +272,8 @@ class TestWriteTools:
         assert result["wing"] == "test_wing"
         assert result["room"] == "test_room"
         assert result["drawer_id"].startswith("drawer_test_wing_test_room_")
-        col = _get_collection(palace_path, create=False)
+        _client, col = _get_collection(palace_path, create=False)
+        del _client
         meta = col.get(ids=[result["drawer_id"]], include=["metadatas"])["metadatas"][0]
         assert meta.get("synapse_mark") == "new"
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -208,6 +208,9 @@ class TestWriteTools:
         assert result["wing"] == "test_wing"
         assert result["room"] == "test_room"
         assert result["drawer_id"].startswith("drawer_test_wing_test_room_")
+        col = _get_collection(palace_path, create=False)
+        meta = col.get(ids=[result["drawer_id"]], include=["metadatas"])["metadatas"][0]
+        assert meta.get("synapse_mark") == "new"
 
     def test_add_drawer_duplicate_detection(self, monkeypatch, config, palace_path, kg):
         _patch_mcp_server(monkeypatch, config, palace_path, kg)

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -1,0 +1,230 @@
+"""
+Tests for mempalace.synapse — SynapseDB retrieval logging and scoring.
+"""
+
+import os
+import shutil
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from mempalace.synapse import DEFAULT_LTP_WINDOW_DAYS, SynapseDB
+
+
+@pytest.fixture
+def tmp_palace():
+    d = tempfile.mkdtemp(prefix="mempalace_synapse_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+# --- SynapseDB 初期化 ---
+
+
+def test_init_creates_db(tmp_palace):
+    SynapseDB(tmp_palace)
+    assert os.path.isfile(os.path.join(tmp_palace, "synapse.sqlite3"))
+
+
+def test_init_creates_tables(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    conn = sqlite3.connect(db.db_path)
+    try:
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        names = {row[0] for row in cur.fetchall()}
+    finally:
+        conn.close()
+    assert "co_retrieval" in names
+    assert "retrieval_log" in names
+    assert "synapse_stats" in names
+
+
+def test_init_idempotent(tmp_palace):
+    SynapseDB(tmp_palace)
+    SynapseDB(tmp_palace)
+
+
+# --- retrieval_log ---
+
+
+def test_log_retrieval_single(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["drawer_a"], "qh", "sess")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
+        row = conn.execute("SELECT drawer_id FROM retrieval_log LIMIT 1").fetchone()
+    finally:
+        conn.close()
+    assert n == 1
+    assert row[0] == "drawer_a"
+
+
+def test_log_retrieval_batch(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    ids = [f"d{i}" for i in range(5)]
+    db.log_retrieval(ids, "qh", "sess")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 5
+
+
+def test_log_retrieval_empty_list(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval([], "qh", "sess")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 0
+
+
+def test_log_retrieval_exception_suppressed(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    with patch("mempalace.synapse.sqlite3.connect", side_effect=sqlite3.OperationalError("readonly")):
+        db.log_retrieval(["a"], "h", "s")
+
+
+# --- LTP スコアリング ---
+
+
+def test_ltp_no_retrievals(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    assert db.get_ltp_score("missing") == 1.0
+
+
+def test_ltp_single_retrieval(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["x"], "q", "s")
+    s = db.get_ltp_score("x")
+    assert 1.0 < s <= 2.0
+
+
+def test_ltp_high_frequency(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    for _ in range(30):
+        db.log_retrieval(["hf"], "q", "s")
+    s = db.get_ltp_score("hf")
+    assert s >= 1.99
+
+
+def test_ltp_clamped_at_max(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    for _ in range(1000):
+        db.log_retrieval(["many"], "q", "s")
+    assert db.get_ltp_score("many") <= 2.0
+
+
+def test_ltp_outside_window(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_LTP_WINDOW_DAYS + 5)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.execute(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            ("old", old, "q", "s"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    assert db.get_ltp_score("old") == 1.0
+
+
+def test_ltp_batch_consistency(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["a", "b"], "q", "s")
+    batch = db.get_ltp_scores_batch(["a", "b", "c"])
+    assert batch["a"] == db.get_ltp_score("a")
+    assert batch["b"] == db.get_ltp_score("b")
+    assert batch["c"] == 1.0
+
+
+# --- Tagging ---
+
+
+def test_tagging_just_filed():
+    t = datetime.now(timezone.utc)
+    boost = SynapseDB.calculate_tagging_boost(t.isoformat())
+    assert abs(boost - 1.5) < 0.02
+
+
+def test_tagging_12_hours():
+    t = (datetime.now(timezone.utc) - timedelta(hours=12)).isoformat()
+    assert abs(SynapseDB.calculate_tagging_boost(t) - 1.25) < 0.01
+
+
+def test_tagging_25_hours():
+    t = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
+    assert SynapseDB.calculate_tagging_boost(t) == 1.0
+
+
+def test_tagging_none_filed_at():
+    assert SynapseDB.calculate_tagging_boost(None) == 1.0
+
+
+# --- Synapse スコア合成 ---
+
+
+def test_synapse_score_composition(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    r = db.calculate_synapse_score(
+        similarity=0.8,
+        decay=0.5,
+        drawer_id="d1",
+        filed_at=old,
+        ltp_scores={"d1": 1.5},
+        window_days=DEFAULT_LTP_WINDOW_DAYS,
+    )
+    assert abs(r["final_score"] - 0.6) < 1e-9
+    assert r["association"] == 1.0
+    assert r["similarity"] == 0.8
+    assert r["decay"] == 0.5
+    assert r["ltp"] == 1.5
+    assert r["tagging"] == 1.0
+
+
+# --- Consolidation ---
+
+
+def test_consolidation_candidates_returns_inactive(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=200)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.execute(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            ("stale", old, "q", "s"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    cands = db.get_consolidation_candidates(inactive_days=180)
+    ids = {c["drawer_id"] for c in cands}
+    assert "stale" in ids
+
+
+def test_consolidation_candidates_excludes_active(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    recent = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.execute(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            ("active", recent, "q", "s"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    cands = db.get_consolidation_candidates(inactive_days=180)
+    ids = {c["drawer_id"] for c in cands}
+    assert "active" not in ids

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -7,11 +7,29 @@ import shutil
 import sqlite3
 import tempfile
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from mempalace.searcher import search_memories
 from mempalace.synapse import DEFAULT_LTP_WINDOW_DAYS, SynapseDB
+
+
+def _synapse_cfg(**overrides):
+    base = dict(
+        synapse_enabled=True,
+        synapse_ltp_enabled=True,
+        synapse_tagging_enabled=True,
+        synapse_association_enabled=False,
+        synapse_ltp_window_days=30,
+        synapse_ltp_max_boost=2.0,
+        synapse_tagging_window_hours=24,
+        synapse_tagging_max_boost=1.5,
+        synapse_log_retrievals=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
 
 
 @pytest.fixture
@@ -228,3 +246,54 @@ def test_consolidation_candidates_excludes_active(tmp_palace):
     cands = db.get_consolidation_candidates(inactive_days=180)
     ids = {c["drawer_id"] for c in cands}
     assert "active" not in ids
+
+
+# --- Config axis switches (search_memories integration) ---
+
+
+def test_ltp_disabled_returns_neutral(palace_path, seeded_collection):
+    cfg = _synapse_cfg(synapse_ltp_enabled=False)
+
+    def fake_batch(self, drawer_ids, window_days=30, max_boost=2.0):
+        return {d: 2.0 for d in drawer_ids}
+
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        with patch.object(SynapseDB, "get_ltp_scores_batch", fake_batch):
+            result = search_memories("JWT authentication", palace_path)
+    assert result.get("synapse_enabled") is True
+    for hit in result["hits"]:
+        assert hit["synapse_factors"]["ltp"] == 1.0
+
+
+def test_tagging_disabled_returns_neutral(palace_path, seeded_collection):
+    cfg = _synapse_cfg(synapse_tagging_enabled=False)
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        result = search_memories("JWT authentication", palace_path)
+    assert result.get("synapse_enabled") is True
+    for hit in result["hits"]:
+        assert hit["synapse_factors"]["tagging"] == 1.0
+
+
+# --- Log cleanup ---
+
+
+def test_log_cleanup_removes_old_entries(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    new = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.executemany(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            [("a", old, "q", "s"), ("b", new, "q", "s")],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    db.cleanup_old_logs(retention_days=30)
+    conn = sqlite3.connect(db.db_path)
+    try:
+        rows = conn.execute("SELECT drawer_id FROM retrieval_log ORDER BY drawer_id").fetchall()
+    finally:
+        conn.close()
+    assert [r[0] for r in rows] == ["b"]

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -290,7 +290,8 @@ def test_log_cleanup_removes_old_entries(tmp_palace):
         conn.commit()
     finally:
         conn.close()
-    db.cleanup_old_logs(retention_days=30)
+    deleted = db.cleanup_old_logs(retention_days=30)
+    assert deleted == 1
     conn = sqlite3.connect(db.db_path)
     try:
         rows = conn.execute("SELECT drawer_id FROM retrieval_log ORDER BY drawer_id").fetchall()

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -421,6 +421,19 @@ def test_ltp_and_tagging_composition(palace_path, seeded_collection):
     assert abs(hit["synapse_score"] - expected) < 1e-4
 
 
+def test_log_retrieval_failure_does_not_break_search(palace_path, seeded_collection):
+    """log_retrieval が例外を投げても検索は Synapse スコア付きで返る（接続は commit される）。"""
+    cfg = _synapse_cfg(synapse_log_retrievals=True)
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        with patch.object(
+            SynapseDB, "log_retrieval", side_effect=RuntimeError("log failed")
+        ):
+            result = search_memories("JWT authentication", palace_path)
+    assert result.get("synapse_enabled") is True
+    assert len(result.get("hits", [])) >= 1
+    assert all("synapse_score" in h for h in result["hits"])
+
+
 # --- Log cleanup ---
 
 

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -21,6 +21,7 @@ from mempalace.synapse import (
     build_soft_archive_proposal,
     SynapseDB,
 )
+from mempalace.synapse_profiles import compute_decay, hit_filed_age_days
 
 
 def _synapse_cfg(**overrides):
@@ -415,9 +416,10 @@ def test_ltp_and_tagging_composition(palace_path, seeded_collection):
         1.0 + math.log(1 + 8) * DEFAULT_LTP_COEFFICIENT,
     )
     tagging_expected = SynapseDB.calculate_tagging_boost(now)
+    decay_expected = compute_decay(hit_filed_age_days(now), 90)
     assert abs(hit["synapse_factors"]["ltp"] - ltp_expected) < 1e-5
     assert hit["synapse_factors"]["tagging"] > 1.0
-    expected = hit["similarity"] * ltp_expected * tagging_expected
+    expected = hit["similarity"] * decay_expected * ltp_expected * tagging_expected
     assert abs(hit["synapse_score"] - expected) < 1e-4
 
 

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -13,7 +13,12 @@ from unittest.mock import patch
 import pytest
 
 from mempalace.searcher import search_memories
-from mempalace.synapse import DEFAULT_LTP_WINDOW_DAYS, SynapseDB
+from mempalace.synapse import (
+    DEFAULT_LTP_WINDOW_DAYS,
+    SYNAPSE_MARK_NEW,
+    build_soft_archive_proposal,
+    SynapseDB,
+)
 
 
 def _synapse_cfg(**overrides):
@@ -28,6 +33,9 @@ def _synapse_cfg(**overrides):
         synapse_tagging_max_boost=1.5,
         synapse_association_max_boost=1.5,
         synapse_association_coefficient=0.15,
+        synapse_consolidation_inactive_days=180,
+        synapse_soft_archive_suggestions_enabled=True,
+        synapse_soft_archive_target_wing="archive",
         synapse_log_retrievals=False,
     )
     base.update(overrides)
@@ -354,3 +362,18 @@ def test_co_occurrence_clusters_merge(tmp_palace):
     clusters = db.get_co_occurrence_clusters(10, 5)
     assert any(len(c["drawers"]) >= 2 for c in clusters)
     assert any("a" in c["drawers"] and "b" in c["drawers"] for c in clusters)
+
+
+# --- Phase 3: synaptic marking + soft-archive nudges ---
+
+
+def test_soft_archive_proposal_shape():
+    p = build_soft_archive_proposal("my wing", "my room", target_wing="archive", inactive_days=180)
+    assert p["suggested_wing"] == "archive"
+    assert "my_wing__my_room" in p["suggested_room"]
+    assert p["related_issue"] == "#336"
+    assert p["reason"] == "inactive_beyond_consolidation_window"
+
+
+def test_synaptic_mark_constant():
+    assert SYNAPSE_MARK_NEW == "new"

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -2,6 +2,7 @@
 Tests for mempalace.synapse — SynapseDB retrieval logging and scoring.
 """
 
+import math
 import os
 import shutil
 import sqlite3
@@ -14,6 +15,7 @@ import pytest
 
 from mempalace.searcher import search_memories
 from mempalace.synapse import (
+    DEFAULT_LTP_COEFFICIENT,
     DEFAULT_LTP_WINDOW_DAYS,
     SYNAPSE_MARK_NEW,
     build_soft_archive_proposal,
@@ -258,13 +260,52 @@ def test_consolidation_candidates_excludes_active(tmp_palace):
     assert "active" not in ids
 
 
+def test_consolidation_candidates_wing_filter(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=200)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.executemany(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            [
+                ("drawer_astrophysics_room_x", old, "q", "s"),
+                ("drawer_economics_room_y", old, "q", "s"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    astro = db.get_consolidation_candidates(inactive_days=180, wing="astrophysics")
+    ids = {c["drawer_id"] for c in astro}
+    assert "drawer_astrophysics_room_x" in ids
+    assert "drawer_economics_room_y" not in ids
+
+
+def test_vacuum_skipped_under_threshold(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        for i in range(10):
+            conn.execute(
+                "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+                (f"d{i}", old, "q", "s"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    with patch.object(SynapseDB, "_vacuum_database") as vac:
+        db.cleanup_old_logs(retention_days=30)
+    vac.assert_not_called()
+
+
 # --- Config axis switches (search_memories integration) ---
 
 
 def test_ltp_disabled_returns_neutral(palace_path, seeded_collection):
     cfg = _synapse_cfg(synapse_ltp_enabled=False)
 
-    def fake_batch(self, drawer_ids, window_days=30, max_boost=2.0):
+    def fake_batch(self, drawer_ids, window_days=30, max_boost=2.0, conn=None):
         return {d: 2.0 for d in drawer_ids}
 
     with patch("mempalace.config.MempalaceConfig", return_value=cfg):
@@ -282,6 +323,102 @@ def test_tagging_disabled_returns_neutral(palace_path, seeded_collection):
     assert result.get("synapse_enabled") is True
     for hit in result["hits"]:
         assert hit["synapse_factors"]["tagging"] == 1.0
+
+
+def test_per_query_ltp_override_true(palace_path, seeded_collection):
+    drawer_id = "drawer_proj_backend_aaa"
+    db = SynapseDB(palace_path)
+    for _ in range(6):
+        db.log_retrieval([drawer_id], "q", "s")
+    cfg = _synapse_cfg(
+        synapse_ltp_enabled=False,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        result = search_memories(
+            "JWT authentication", palace_path, synapse_ltp_enabled=True
+        )
+    assert result.get("synapse_enabled") is True
+    hit = next(h for h in result["hits"] if h.get("id") == drawer_id)
+    assert hit["synapse_factors"]["ltp"] > 1.0
+
+
+def test_per_query_ltp_override_false(palace_path, seeded_collection):
+    def fake_batch(self, drawer_ids, window_days=30, max_boost=2.0, conn=None):
+        return {d: 2.0 for d in drawer_ids}
+
+    cfg = _synapse_cfg(
+        synapse_ltp_enabled=True,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        with patch.object(SynapseDB, "get_ltp_scores_batch", fake_batch):
+            result = search_memories(
+                "JWT authentication", palace_path, synapse_ltp_enabled=False
+            )
+    assert result.get("synapse_enabled") is True
+    for hit in result["hits"]:
+        assert hit["synapse_factors"]["ltp"] == 1.0
+
+
+def test_per_query_tagging_override(palace_path, seeded_collection):
+    drawer_id = "drawer_proj_backend_aaa"
+    now = datetime.now(timezone.utc).isoformat()
+    got = seeded_collection.get(ids=[drawer_id], include=["metadatas"])
+    meta = dict(got["metadatas"][0])
+    meta["filed_at"] = now
+    seeded_collection.update(ids=[drawer_id], metadatas=[meta])
+
+    cfg_on = _synapse_cfg(
+        synapse_tagging_enabled=True,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg_on):
+        r_on = search_memories("JWT authentication", palace_path)
+    hit_on = next(h for h in r_on["hits"] if h.get("id") == drawer_id)
+    assert hit_on["synapse_factors"]["tagging"] > 1.01
+
+    cfg_off = _synapse_cfg(
+        synapse_tagging_enabled=True,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg_off):
+        r_off = search_memories(
+            "JWT authentication", palace_path, synapse_tagging_enabled=False
+        )
+    hit_off = next(h for h in r_off["hits"] if h.get("id") == drawer_id)
+    assert hit_off["synapse_factors"]["tagging"] == 1.0
+
+
+def test_ltp_and_tagging_composition(palace_path, seeded_collection):
+    drawer_id = "drawer_proj_backend_aaa"
+    db = SynapseDB(palace_path)
+    for _ in range(8):
+        db.log_retrieval([drawer_id], "qh", "sess")
+
+    now = datetime.now(timezone.utc).isoformat()
+    got = seeded_collection.get(ids=[drawer_id], include=["metadatas"])
+    meta = dict(got["metadatas"][0])
+    meta["filed_at"] = now
+    seeded_collection.update(ids=[drawer_id], metadatas=[meta])
+
+    cfg = _synapse_cfg(
+        synapse_association_enabled=False,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        result = search_memories("JWT authentication", palace_path)
+
+    hit = next(h for h in result["hits"] if h.get("id") == drawer_id)
+    ltp_expected = min(
+        2.0,
+        1.0 + math.log(1 + 8) * DEFAULT_LTP_COEFFICIENT,
+    )
+    tagging_expected = SynapseDB.calculate_tagging_boost(now)
+    assert abs(hit["synapse_factors"]["ltp"] - ltp_expected) < 1e-5
+    assert hit["synapse_factors"]["tagging"] > 1.0
+    expected = hit["similarity"] * ltp_expected * tagging_expected
+    assert abs(hit["synapse_score"] - expected) < 1e-4
 
 
 # --- Log cleanup ---

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -26,6 +26,8 @@ def _synapse_cfg(**overrides):
         synapse_ltp_max_boost=2.0,
         synapse_tagging_window_hours=24,
         synapse_tagging_max_boost=1.5,
+        synapse_association_max_boost=1.5,
+        synapse_association_coefficient=0.15,
         synapse_log_retrievals=False,
     )
     base.update(overrides)
@@ -298,3 +300,57 @@ def test_log_cleanup_removes_old_entries(tmp_palace):
     finally:
         conn.close()
     assert [r[0] for r in rows] == ["b"]
+
+
+# --- Phase 2: co_retrieval & association ---
+
+
+def test_co_retrieval_pairs_increment_on_log(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["a", "b", "c"], "q", "s1")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM co_retrieval").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 3
+
+
+def test_association_scores_from_co_retrieval(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["a", "b"], "q", "s1")
+    db.log_retrieval(["a", "b"], "q", "s2")
+    scores = db.get_association_scores_batch(["a", "b"], max_boost=2.0, coefficient=0.3)
+    assert scores["a"] > 1.0
+    assert scores["b"] > 1.0
+
+
+def test_rebuild_co_retrieval_matches_incremental(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["x", "y"], "q", "sess")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n1 = conn.execute(
+            "SELECT co_count FROM co_retrieval WHERE drawer_a='x' AND drawer_b='y'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    db.rebuild_co_retrieval_from_log()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n2 = conn.execute(
+            "SELECT co_count FROM co_retrieval WHERE drawer_a='x' AND drawer_b='y'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert n1 == n2 == 1
+
+
+def test_co_occurrence_clusters_merge(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["a", "b"], "q", "s1")
+    db.log_retrieval(["b", "c"], "q", "s2")
+    db.log_retrieval(["a", "c"], "q", "s3")
+    clusters = db.get_co_occurrence_clusters(10, 5)
+    assert any(len(c["drawers"]) >= 2 for c in clusters)
+    assert any("a" in c["drawers"] and "b" in c["drawers"] for c in clusters)

--- a/tests/test_synapse_profiles.py
+++ b/tests/test_synapse_profiles.py
@@ -172,3 +172,36 @@ def test_malformed_profiles_json_handled(palace_dir):
 
 def test_hardcoded_defaults_association_off_matches_legacy():
     assert HARDCODED_DEFAULTS["association_enabled"] is False
+
+
+def test_sources_track_hardcoded(palace_dir):
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve()
+    assert profile.get_source("half_life_days") == "hardcoded"
+
+
+def test_sources_track_profile_override(palace_dir):
+    config = {"synapse_profiles": {"orient": {"half_life_days": 180}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("orient")
+    assert profile.get_source("half_life_days") == "profile (config.json)"
+    assert profile.get_source("ltp_max_boost") == "hardcoded"
+
+
+def test_sources_track_per_query(palace_dir):
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("default", per_query_overrides={"half_life_days": 45})
+    assert profile.get_source("half_life_days") == "per-query override"
+
+
+def test_to_annotated_dict(palace_dir):
+    config = {"synapse_profiles": {"default": {"half_life_days": 120}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve()
+    annotated = profile.to_annotated_dict()
+    assert annotated["half_life_days"]["value"] == 120
+    assert annotated["half_life_days"]["source"] == "default (config.json)"

--- a/tests/test_synapse_profiles.py
+++ b/tests/test_synapse_profiles.py
@@ -4,10 +4,13 @@ Tests for mempalace.synapse_profiles — RetrievalProfile / ProfileManager.
 
 import json
 import os
+from pathlib import Path
 
 import pytest
 
 from mempalace.synapse_profiles import HARDCODED_DEFAULTS, ProfileManager
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
@@ -170,8 +173,8 @@ def test_malformed_profiles_json_handled(palace_dir):
     assert profile.half_life_days == 90
 
 
-def test_hardcoded_defaults_association_off_matches_legacy():
-    assert HARDCODED_DEFAULTS["association_enabled"] is False
+def test_hardcoded_defaults_association_on():
+    assert HARDCODED_DEFAULTS["association_enabled"] is True
 
 
 def test_sources_track_hardcoded(palace_dir):
@@ -310,3 +313,64 @@ def test_validate_rejects_low_ltp_max_boost(palace_dir):
     pm = ProfileManager(palace_dir)
     with pytest.raises(ValueError, match="ltp_max_boost must be >= 1.0"):
         pm.resolve("bad")
+
+
+@pytest.fixture
+def ooda_palace_dir(tmp_path):
+    """Palace dir with contributed OODA profiles loaded from fixture"""
+    fixture_path = FIXTURES_DIR / "ooda_profiles.json"
+    profiles = json.loads(fixture_path.read_text(encoding="utf-8"))
+    config = {"synapse_profiles": profiles}
+    with open(os.path.join(str(tmp_path), "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    return str(tmp_path)
+
+
+def test_ooda_orient_profile(ooda_palace_dir):
+    pm = ProfileManager(ooda_palace_dir)
+    p = pm.resolve("orient")
+    assert p.name == "orient"
+    assert p.description == "Broad context gathering — association emphasis, long half-life"
+    assert p.half_life_days == 180
+    assert p.ltp_enabled is True
+    assert p.ltp_max_boost == 2.0
+    assert p.ltp_window_days == 60
+    assert p.tagging_enabled is False
+
+
+def test_ooda_observe_profile(ooda_palace_dir):
+    pm = ProfileManager(ooda_palace_dir)
+    p = pm.resolve("observe")
+    assert p.name == "observe"
+    assert p.ltp_enabled is False
+    assert p.tagging_enabled is False
+    assert p.association_enabled is False
+
+
+def test_ooda_decide_profile(ooda_palace_dir):
+    pm = ProfileManager(ooda_palace_dir)
+    p = pm.resolve("decide")
+    assert p.name == "decide"
+    assert p.half_life_days == 30
+    assert p.ltp_enabled is True
+    assert p.ltp_max_boost == 1.5
+    assert p.ltp_window_days == 14
+    assert p.tagging_enabled is True
+
+
+def test_ooda_act_profile(ooda_palace_dir):
+    pm = ProfileManager(ooda_palace_dir)
+    p = pm.resolve("act")
+    assert p.name == "act"
+    assert p.half_life_days == 14
+    assert p.ltp_enabled is False
+    assert p.association_enabled is False
+
+
+def test_description_in_annotated_dict(ooda_palace_dir):
+    pm = ProfileManager(ooda_palace_dir)
+    p = pm.resolve("orient")
+    annotated = p.to_annotated_dict()
+    assert "description" in annotated
+    assert "Broad context" in annotated["description"]["value"]
+    assert annotated["description"]["source"] == "profile (config.json)"

--- a/tests/test_synapse_profiles.py
+++ b/tests/test_synapse_profiles.py
@@ -229,3 +229,84 @@ def test_result_contains_requested_and_used_profile_fallback(palace_dir):
     used = profile.name
     assert requested != used
     assert used == "default"
+
+
+def test_axes_enabled_empty_disables_all_axes(palace_dir):
+    """axes_enabled: [] → all Synapse axes disabled, raw similarity only"""
+    config = {
+        "synapse_profiles": {
+            "observe": {
+                "axes_enabled": [],
+                "ltp_enabled": True,
+                "tagging_enabled": True,
+                "association_enabled": True,
+            }
+        }
+    }
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("observe")
+    assert profile.ltp_enabled is False
+    assert profile.tagging_enabled is False
+    assert profile.association_enabled is False
+
+
+def test_axes_enabled_empty_high_ltp_same_as_fresh(palace_dir):
+    """With axes_enabled: [], a high-LTP drawer scores the same as a fresh drawer"""
+    config = {"synapse_profiles": {"observe": {"axes_enabled": []}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("observe")
+    similarity = 0.85
+    ltp_high = 2.0
+    _ = ltp_high  # narrative: LTP differs in DB but axis is off
+    ltp_factor = ltp_high if profile.ltp_enabled else 1.0
+    tagging_factor = 1.0
+    association_factor = 1.0
+    score_high = similarity * ltp_factor * tagging_factor * association_factor
+    score_fresh = similarity * 1.0 * 1.0 * 1.0
+    assert score_high == score_fresh
+
+
+def test_annotated_dict_includes_axes_enabled(palace_dir):
+    """to_annotated_dict() includes axes_enabled with source"""
+    config = {
+        "synapse_profiles": {"orient": {"axes_enabled": ["ltp", "association"]}}
+    }
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("orient")
+    annotated = profile.to_annotated_dict()
+    assert "axes_enabled" in annotated
+    assert annotated["axes_enabled"]["value"] == ["ltp", "association"]
+    assert "profile" in annotated["axes_enabled"]["source"]
+
+
+def test_validate_rejects_unknown_axis(palace_dir):
+    config = {"synapse_profiles": {"bad": {"axes_enabled": ["ltp", "magic"]}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    with pytest.raises(ValueError, match="Unknown axis 'magic'"):
+        pm.resolve("bad")
+
+
+def test_validate_rejects_negative_half_life(palace_dir):
+    config = {"synapse_profiles": {"bad": {"half_life_days": -10}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    with pytest.raises(ValueError, match="half_life_days must be > 0"):
+        pm.resolve("bad")
+
+
+def test_validate_rejects_low_ltp_max_boost(palace_dir):
+    config = {"synapse_profiles": {"bad": {"ltp_max_boost": 0.5}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    with pytest.raises(ValueError, match="ltp_max_boost must be >= 1.0"):
+        pm.resolve("bad")

--- a/tests/test_synapse_profiles.py
+++ b/tests/test_synapse_profiles.py
@@ -205,3 +205,27 @@ def test_to_annotated_dict(palace_dir):
     annotated = profile.to_annotated_dict()
     assert annotated["half_life_days"]["value"] == 120
     assert annotated["half_life_days"]["source"] == "default (config.json)"
+
+
+def test_result_contains_requested_and_used_profile_match(palace_dir):
+    """正しいプロファイル名 → requested と used が一致"""
+    config = {"synapse_profiles": {"orient": {"half_life_days": 180}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("orient")
+    assert profile.name == "orient"
+    requested = "orient"
+    used = profile.name
+    assert requested == used
+
+
+def test_result_contains_requested_and_used_profile_fallback(palace_dir):
+    """タイポ → requested と used が異なる"""
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("oriemt")
+    assert profile.name == "default"
+    requested = "oriemt"
+    used = profile.name
+    assert requested != used
+    assert used == "default"

--- a/tests/test_synapse_profiles.py
+++ b/tests/test_synapse_profiles.py
@@ -1,0 +1,174 @@
+"""
+Tests for mempalace.synapse_profiles — RetrievalProfile / ProfileManager.
+"""
+
+import json
+import os
+
+import pytest
+
+from mempalace.synapse_profiles import HARDCODED_DEFAULTS, ProfileManager
+
+
+@pytest.fixture
+def palace_dir(tmp_path):
+    return str(tmp_path)
+
+
+def test_no_config_returns_hardcoded_defaults(palace_dir):
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve()
+    assert profile.name == "default"
+    assert profile.half_life_days == 90
+    assert profile.ltp_enabled is True
+    assert profile.ltp_window_days == 30
+    assert profile.ltp_max_boost == 2.0
+    assert profile.tagging_enabled is True
+
+
+def test_config_json_default_overrides_hardcoded(palace_dir):
+    config = {"synapse_profiles": {"default": {"half_life_days": 120, "ltp_max_boost": 1.5}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve()
+    assert profile.half_life_days == 120
+    assert profile.ltp_max_boost == 1.5
+    assert profile.ltp_window_days == 30
+
+
+def test_synapse_profiles_json_overrides_config_json(palace_dir):
+    config = {"synapse_profiles": {"default": {"half_life_days": 120}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    profiles = {"default": {"half_life_days": 200}}
+    with open(os.path.join(palace_dir, "synapse_profiles.json"), "w", encoding="utf-8") as f:
+        json.dump(profiles, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve()
+    assert profile.half_life_days == 200
+
+
+def test_named_profile_inherits_from_default(palace_dir):
+    config = {
+        "synapse_profiles": {
+            "default": {"half_life_days": 90, "ltp_max_boost": 2.0},
+            "orient": {"half_life_days": 180, "tagging_enabled": False},
+        }
+    }
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("orient")
+    assert profile.half_life_days == 180
+    assert profile.tagging_enabled is False
+    assert profile.ltp_max_boost == 2.0
+
+
+def test_unknown_profile_falls_back_to_default(palace_dir):
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("nonexistent")
+    assert profile.name == "default"
+    assert profile.half_life_days == 90
+
+
+def test_per_query_overrides_beat_profile(palace_dir):
+    config = {
+        "synapse_profiles": {
+            "default": {"half_life_days": 90},
+            "orient": {"half_life_days": 180},
+        }
+    }
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("orient", per_query_overrides={"half_life_days": 45})
+    assert profile.half_life_days == 45
+
+
+def test_per_query_none_values_ignored(palace_dir):
+    config = {"synapse_profiles": {"default": {"half_life_days": 90}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("default", per_query_overrides={"half_life_days": None})
+    assert profile.half_life_days == 90
+
+
+def test_axes_enabled_disables_missing_axes(palace_dir):
+    config = {
+        "synapse_profiles": {
+            "evaluate": {
+                "axes_enabled": ["tagging"],
+                "ltp_enabled": True,
+            }
+        }
+    }
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("evaluate")
+    assert profile.tagging_enabled is True
+    assert profile.ltp_enabled is False
+    assert profile.association_enabled is False
+
+
+def test_get_known_profiles(palace_dir):
+    config = {
+        "synapse_profiles": {
+            "default": {},
+            "orient": {},
+            "decide": {},
+        }
+    }
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    profiles = {"evaluate": {}, "custom_agi": {}}
+    with open(os.path.join(palace_dir, "synapse_profiles.json"), "w", encoding="utf-8") as f:
+        json.dump(profiles, f)
+    pm = ProfileManager(palace_dir)
+    names = pm.get_known_profiles()
+    assert "default" in names
+    assert "orient" in names
+    assert "evaluate" in names
+    assert "custom_agi" in names
+
+
+def test_to_dict_includes_name(palace_dir):
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve()
+    d = profile.to_dict()
+    assert d["name"] == "default"
+    assert "half_life_days" in d
+
+
+def test_file_profiles_override_named_profile(palace_dir):
+    config = {"synapse_profiles": {"orient": {"half_life_days": 180}}}
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    profiles = {"orient": {"half_life_days": 365}}
+    with open(os.path.join(palace_dir, "synapse_profiles.json"), "w", encoding="utf-8") as f:
+        json.dump(profiles, f)
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve("orient")
+    assert profile.half_life_days == 365
+
+
+def test_malformed_config_json_handled(palace_dir):
+    with open(os.path.join(palace_dir, "config.json"), "w", encoding="utf-8") as f:
+        f.write("not valid json")
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve()
+    assert profile.half_life_days == 90
+
+
+def test_malformed_profiles_json_handled(palace_dir):
+    with open(os.path.join(palace_dir, "synapse_profiles.json"), "w", encoding="utf-8") as f:
+        f.write("{broken")
+    pm = ProfileManager(palace_dir)
+    profile = pm.resolve()
+    assert profile.half_life_days == 90
+
+
+def test_hardcoded_defaults_association_off_matches_legacy():
+    assert HARDCODED_DEFAULTS["association_enabled"] is False

--- a/tests/test_synapse_profiles.py
+++ b/tests/test_synapse_profiles.py
@@ -351,11 +351,10 @@ def test_ooda_decide_profile(ooda_palace_dir):
     pm = ProfileManager(ooda_palace_dir)
     p = pm.resolve("decide")
     assert p.name == "decide"
-    assert p.half_life_days == 30
-    assert p.ltp_enabled is True
-    assert p.ltp_max_boost == 1.5
-    assert p.ltp_window_days == 14
+    assert p.half_life_days == 7
+    assert p.ltp_enabled is False
     assert p.tagging_enabled is True
+    assert p.association_enabled is False
 
 
 def test_ooda_act_profile(ooda_palace_dir):
@@ -363,8 +362,81 @@ def test_ooda_act_profile(ooda_palace_dir):
     p = pm.resolve("act")
     assert p.name == "act"
     assert p.half_life_days == 14
-    assert p.ltp_enabled is False
+    assert p.ltp_enabled is True
+    assert p.ltp_max_boost == 1.5
+    assert p.tagging_enabled is True
+    assert p.tagging_max_boost == 1.3
     assert p.association_enabled is False
+
+
+# --- web3guru888 suggested additional fixture tests ---
+
+
+def test_ooda_decide_exploit_mode(ooda_palace_dir):
+    """Decide profile: short half-life, no LTP, tagging on — exploit mode"""
+    pm = ProfileManager(ooda_palace_dir)
+    p = pm.resolve("decide")
+    assert p.name == "decide"
+    assert p.half_life_days == 7
+    assert p.ltp_enabled is False
+    assert p.tagging_enabled is True
+    assert p.association_enabled is False
+
+
+def test_ooda_act_moderate_with_tagging(ooda_palace_dir):
+    """Act profile: all axes moderate, tagging enabled for rapid reinforcement"""
+    pm = ProfileManager(ooda_palace_dir)
+    p = pm.resolve("act")
+    assert p.name == "act"
+    assert p.half_life_days == 14
+    assert p.ltp_enabled is True
+    assert p.ltp_max_boost == 1.5
+    assert p.tagging_enabled is True
+    assert p.tagging_max_boost == 1.3
+    assert p.association_enabled is False
+
+
+def test_cross_profile_isolation_orient_to_decide(ooda_palace_dir):
+    """Switching from orient to decide doesn't bleed LTP settings"""
+    pm = ProfileManager(ooda_palace_dir)
+    orient = pm.resolve("orient")
+    decide = pm.resolve("decide")
+
+    # orient has LTP on with high boost and long window
+    assert orient.ltp_enabled is True
+    assert orient.ltp_max_boost == 2.0
+    assert orient.ltp_window_days == 60
+
+    # decide has LTP off — orient's values must not leak
+    assert decide.ltp_enabled is False
+
+    # resolve orient again — still the same, not contaminated by decide
+    orient_again = pm.resolve("orient")
+    assert orient_again.ltp_enabled is True
+    assert orient_again.ltp_max_boost == 2.0
+    assert orient_again.ltp_window_days == 60
+
+
+def test_cross_profile_isolation_observe_to_act(ooda_palace_dir):
+    """Switching from observe (all off) to act (moderate) — no state leakage"""
+    pm = ProfileManager(ooda_palace_dir)
+    observe = pm.resolve("observe")
+    act = pm.resolve("act")
+
+    # observe: everything off
+    assert observe.ltp_enabled is False
+    assert observe.tagging_enabled is False
+    assert observe.association_enabled is False
+
+    # act: LTP and tagging on
+    assert act.ltp_enabled is True
+    assert act.tagging_enabled is True
+
+    # observe again — still all off
+    observe_again = pm.resolve("observe")
+    assert observe_again.ltp_enabled is False
+    assert observe_again.tagging_enabled is False
+    assert observe_again.association_enabled is False
 
 
 def test_description_in_annotated_dict(ooda_palace_dir):


### PR DESCRIPTION
Adds a named-profile system for Synapse parameters, enabling per-query and per-phase scoring control without argument explosion.

## Summary

New `synapse_profiles.py` module with `ProfileManager` and `RetrievalProfile`. Profiles are defined in `config.json` under `synapse_profiles` or in an optional `synapse_profiles.json` override file.

## Merge chain (6 layers)

```
per-query arg → named profile (synapse_profiles.json → config.json)
  → "default" (synapse_profiles.json → config.json)
  → global synapse_* from ~/.mempalace/config.json
  → hardcoded defaults
```

## Inheritance

Depth-1 only — all profiles inherit from `"default"`. No profile-to-profile chaining.

```json
{
  "synapse_profiles": {
    "default": {
      "half_life_days": 90,
      "ltp_enabled": true,
      "ltp_max_boost": 2.0,
      "tagging_enabled": true,
      "association_enabled": true
    },
    "orient": {
      "half_life_days": 180,
      "ltp_window_days": 60,
      "tagging_enabled": false
    },
    "decide": {
      "half_life_days": 30,
      "ltp_window_days": 14
    }
  }
}
```

## API usage

```python
search_memories(query="...", synapse_profile="orient")
search_memories(query="...", synapse_profile="orient", ltp_max_boost=1.5)  # override
```

## MCP

`mempalace_search` accepts `synapse_profile` (freeform string, soft validation with fallback to `"default"`). Tool description dynamically lists known profile names.

## axes_enabled

Per-profile axis opt-in/out list. Useful for ablation testing:

```json
{
  "evaluate": {
    "axes_enabled": ["tagging"],
    "tagging_window_hours": 48
  }
}
```

## Profile observability

Search responses include `synapse_requested_profile` and `synapse_profile_used`:

| `synapse_requested_profile` | `synapse_profile_used` | Meaning |
|---|---|---|
| `null` / absent | `"default"` | No profile requested — default behavior |
| `"orient"` | `"orient"` | Exact match, no fallback |
| `"oriemt"` | `"default"` | Unknown profile name — fell back to default |

This distinction lets callers (including LLMs) detect silent fallback without log parsing.


## CLI

```bash
mempalace synapse show-profile orient
```

## Changes

- **New:** `mempalace/synapse_profiles.py` — `ProfileManager`, `RetrievalProfile`, `HARDCODED_DEFAULTS`
- **Modified:** `mempalace/config.py` — `synapse_profiles` property
- **Modified:** `mempalace/searcher.py` — profile resolution before scoring, per-query overrides
- **Modified:** `mempalace/mcp_server.py` — `synapse_profile` arg, `available_profiles` in status
- **Modified:** `mempalace/cli.py` — `mempalace synapse show-profile [NAME]`
- **New:** `tests/test_synapse_profiles.py` — 14 tests

## Test results

- `test_synapse_profiles.py`: 14 passed
- `test_synapse.py`: 36 passed
- Full suite: 580 passed, 4 failed (unrelated Windows cp932 issue)

## Backward compatibility

No profiles defined = existing behavior. Global `synapse_*` keys in `~/.mempalace/config.json` are merged via the global layer.

## Depends on

- PR #451 (Synapse Phase 1) — this PR targets `main` and should be merged after #451.

## Follow-up

- `show-profile` source annotation (← profile / ← default / ← hardcoded) per @web3guru888 suggestion
- Contributed OODA profile definitions from MemPalace-AGI integration testing
