### PR TITLE
feat: add `mempalace prune` to detect and remove stale drawers

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -157,6 +157,63 @@ def cmd_status(args):
     status(palace_path=palace_path)
 
 
+def cmd_prune(args):
+    """Detect and remove stale drawers from the palace."""
+    from .pruner import prune
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+
+    if not os.path.isdir(palace_path):
+        print(f"\n  No palace found at {palace_path}")
+        return
+
+    print(f"\n{'=' * 55}")
+    print("  MemPalace Prune — Stale Drawer Cleanup")
+    print(f"{'=' * 55}")
+    print(f"  Palace:   {palace_path}")
+    print(f"  Strategy: {args.strategy}")
+    if args.wing:
+        print(f"  Wing:     {args.wing}")
+    if args.dry_run:
+        print(f"  Mode:     DRY RUN (no deletions)")
+    print(f"{'-' * 55}\n")
+
+    result = prune(
+        palace_path=palace_path,
+        strategy=args.strategy,
+        wing=args.wing,
+        dry_run=args.dry_run,
+    )
+
+    if "error" in result:
+        print(f"  Error: {result['error']}")
+        return
+
+    print(f"  Total drawers:  {result['total_drawers']}")
+    print(f"  Stale found:    {result['stale_found']}")
+
+    if result["by_reason"]:
+        print(f"\n  By reason:")
+        for reason, count in result["by_reason"].items():
+            print(f"    {reason}: {count}")
+
+    if result.get("stale_drawers"):
+        print(f"\n  Stale drawers (showing up to 50):")
+        for entry in result["stale_drawers"]:
+            src = os.path.basename(entry.get("source_file", "?"))
+            reason = entry.get("reason", "?")
+            wing = entry.get("wing", "?")
+            print(f"    [{wing}] {src} — {reason}")
+
+    if not args.dry_run and result["deleted"] > 0:
+        print(f"\n  Deleted: {result['deleted']} stale drawers")
+
+    if args.dry_run and result["stale_found"] > 0:
+        print(f"\n  Run without --dry-run to delete these drawers.")
+
+    print(f"\n{'=' * 55}\n")
+
+
 def cmd_repair(args):
     """Rebuild palace vector index from SQLite metadata."""
     import chromadb
@@ -518,6 +575,22 @@ def main():
     for instr_name in ["init", "search", "mine", "help", "status"]:
         instructions_sub.add_parser(instr_name, help=f"Output {instr_name} instructions")
 
+    # prune
+    p_prune = sub.add_parser(
+        "prune",
+        help="Detect and remove stale drawers (deleted/modified source files)",
+    )
+    p_prune.add_argument(
+        "--strategy",
+        choices=["existence", "mtime", "orphans", "all"],
+        default="all",
+        help="Detection strategy: 'existence' (deleted files), 'mtime' (modified files), 'orphans' (leftover chunks), 'all' (default)",
+    )
+    p_prune.add_argument("--wing", default=None, help="Limit to one wing")
+    p_prune.add_argument(
+        "--dry-run", action="store_true", help="Preview stale drawers without deleting"
+    )
+
     # repair
     sub.add_parser(
         "repair",
@@ -564,6 +637,7 @@ def main():
         "mcp": cmd_mcp,
         "compress": cmd_compress,
         "wake-up": cmd_wakeup,
+        "prune": cmd_prune,
         "repair": cmd_repair,
         "status": cmd_status,
     }

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -381,6 +381,20 @@ def tool_add_drawer(
         return {"success": False, "error": str(e)}
 
 
+def tool_prune(strategy: str = "all", wing: str = None, dry_run: bool = True):
+    """Detect and optionally remove stale drawers."""
+    from .pruner import prune
+
+    result = prune(
+        palace_path=_config.palace_path,
+        strategy=strategy,
+        wing=wing,
+        dry_run=dry_run,
+        wal_log=_wal_log,
+    )
+    return result
+
+
 def tool_delete_drawer(drawer_id: str):
     """Delete a single drawer by ID."""
     col = _get_collection()
@@ -782,6 +796,27 @@ TOOLS = {
             "required": ["wing", "room", "content"],
         },
         "handler": tool_add_drawer,
+    },
+    "mempalace_prune": {
+        "description": "Detect and remove stale drawers. Strategies: 'existence' (source file deleted), 'mtime' (source file modified since mining), 'orphans' (leftover chunks after file shrank), 'all' (default). Use dry_run=true to preview before deleting.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "strategy": {
+                    "type": "string",
+                    "description": "Detection strategy: existence, mtime, orphans, or all (default: all)",
+                },
+                "wing": {
+                    "type": "string",
+                    "description": "Limit to one wing (optional)",
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "Preview only, no deletions (default: true)",
+                },
+            },
+        },
+        "handler": tool_prune,
     },
     "mempalace_delete_drawer": {
         "description": "Delete a drawer by ID. Irreversible.",

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -415,10 +415,17 @@ def process_file(
 ) -> tuple:
     """Read, chunk, route, and file one file. Returns (drawer_count, room_name)."""
 
-    # Skip if already filed
+    # Skip if already filed; clean old drawers if file was modified
     source_file = str(filepath)
-    if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
-        return 0, None
+    if not dry_run:
+        if file_already_mined(collection, source_file, check_mtime=True):
+            return 0, None
+        else:
+            # File is new or modified — remove old drawers before re-mining
+            # to prevent orphaned chunks when file content shrinks.
+            from .pruner import prune_file
+
+            prune_file(collection, source_file)
 
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")

--- a/mempalace/pruner.py
+++ b/mempalace/pruner.py
@@ -1,0 +1,276 @@
+"""
+pruner.py — Detect and remove stale drawers from the palace.
+
+Stale drawers arise when:
+  1. Source files are deleted but their drawers remain (strategy: existence)
+  2. Source files are modified but old chunks linger (strategy: mtime)
+  3. Orphaned chunks remain after a file shrinks (strategy: orphans)
+
+Usage:
+  from mempalace.pruner import prune
+  result = prune(palace_path, strategy="existence", dry_run=True)
+"""
+
+import os
+import hashlib
+from collections import defaultdict
+from datetime import datetime
+
+from .palace import get_collection
+
+
+# ── Batch helpers ────────────────────────────────────────────────────────────
+
+_BATCH = 5000
+
+
+def _iter_all_drawers(collection, wing=None):
+    """Yield all (id, metadata) tuples from the collection, in batches."""
+    offset = 0
+    while True:
+        kwargs = {"include": ["metadatas"], "limit": _BATCH, "offset": offset}
+        if wing:
+            kwargs["where"] = {"wing": wing}
+        try:
+            batch = collection.get(**kwargs)
+        except Exception:
+            break
+        ids = batch.get("ids", [])
+        metas = batch.get("metadatas", [])
+        if not ids:
+            break
+        for drawer_id, meta in zip(ids, metas):
+            yield drawer_id, meta
+        if len(ids) < _BATCH:
+            break
+        offset += len(ids)
+
+
+def _batch_delete(collection, ids, wal_log=None):
+    """Delete drawer IDs in ChromaDB-safe batches."""
+    deleted = 0
+    for i in range(0, len(ids), _BATCH):
+        batch = ids[i : i + _BATCH]
+        if wal_log:
+            wal_log("prune_batch", {"count": len(batch), "ids": batch[:10]})
+        collection.delete(ids=batch)
+        deleted += len(batch)
+    return deleted
+
+
+# ── Strategies ───────────────────────────────────────────────────────────────
+
+
+def _find_stale_existence(collection, wing=None):
+    """Find drawers whose source_file no longer exists on disk."""
+    stale = []
+    checked_paths = {}
+
+    for drawer_id, meta in _iter_all_drawers(collection, wing):
+        source = meta.get("source_file", "")
+        if not source:
+            continue
+
+        if source not in checked_paths:
+            checked_paths[source] = os.path.exists(source)
+
+        if not checked_paths[source]:
+            stale.append({
+                "id": drawer_id,
+                "source_file": source,
+                "wing": meta.get("wing", "?"),
+                "room": meta.get("room", "?"),
+                "reason": "file_deleted",
+            })
+
+    return stale
+
+
+def _find_stale_mtime(collection, wing=None):
+    """Find drawers whose source_file has been modified since mining."""
+    stale = []
+    checked_files = {}
+
+    for drawer_id, meta in _iter_all_drawers(collection, wing):
+        source = meta.get("source_file", "")
+        stored_mtime = meta.get("source_mtime")
+        if not source or stored_mtime is None:
+            continue
+
+        if source not in checked_files:
+            try:
+                checked_files[source] = os.path.getmtime(source)
+            except OSError:
+                checked_files[source] = None
+
+        current_mtime = checked_files[source]
+        if current_mtime is None:
+            # File deleted — caught by existence strategy
+            continue
+
+        if float(stored_mtime) != current_mtime:
+            stale.append({
+                "id": drawer_id,
+                "source_file": source,
+                "wing": meta.get("wing", "?"),
+                "room": meta.get("room", "?"),
+                "stored_mtime": stored_mtime,
+                "current_mtime": current_mtime,
+                "reason": "file_modified",
+            })
+
+    return stale
+
+
+def _find_stale_orphans(collection, wing=None):
+    """Find orphaned chunks: file exists and has been re-mined, but old
+    chunks with higher chunk_index than current chunking remain.
+
+    For each source_file, compute how many chunks the current content
+    would produce, then flag drawers with chunk_index >= that count.
+    """
+    from .miner import chunk_text, MIN_CHUNK_SIZE
+
+    # Group drawers by source_file
+    file_drawers = defaultdict(list)
+    for drawer_id, meta in _iter_all_drawers(collection, wing):
+        source = meta.get("source_file", "")
+        if not source:
+            continue
+        chunk_index = meta.get("chunk_index", 0)
+        file_drawers[source].append((drawer_id, chunk_index, meta))
+
+    stale = []
+    for source, drawers in file_drawers.items():
+        if not os.path.exists(source):
+            continue  # Handled by existence strategy
+
+        try:
+            content = open(source, encoding="utf-8", errors="replace").read().strip()
+        except OSError:
+            continue
+
+        if len(content) < MIN_CHUNK_SIZE:
+            expected_chunks = 0
+        else:
+            expected_chunks = len(chunk_text(content, source))
+
+        for drawer_id, chunk_index, meta in drawers:
+            if chunk_index >= expected_chunks:
+                stale.append({
+                    "id": drawer_id,
+                    "source_file": source,
+                    "wing": meta.get("wing", "?"),
+                    "room": meta.get("room", "?"),
+                    "chunk_index": chunk_index,
+                    "expected_chunks": expected_chunks,
+                    "reason": "orphaned_chunk",
+                })
+
+    return stale
+
+
+# ── Main entry point ─────────────────────────────────────────────────────────
+
+STRATEGIES = {
+    "existence": _find_stale_existence,
+    "mtime": _find_stale_mtime,
+    "orphans": _find_stale_orphans,
+    "all": None,  # runs all strategies
+}
+
+
+def prune(
+    palace_path: str,
+    strategy: str = "all",
+    wing: str = None,
+    dry_run: bool = True,
+    wal_log=None,
+):
+    """Detect and optionally remove stale drawers.
+
+    Args:
+        palace_path: Path to the palace directory.
+        strategy: Detection strategy — 'existence', 'mtime', 'orphans', or 'all'.
+        wing: Limit scan to a specific wing (optional).
+        dry_run: If True, only report — don't delete.
+        wal_log: Optional WAL logging function(operation, params).
+
+    Returns:
+        dict with results: stale drawers found, deleted count, etc.
+    """
+    if strategy not in STRATEGIES:
+        return {"error": f"Unknown strategy: {strategy}. Choose: {', '.join(STRATEGIES)}"}
+
+    collection = get_collection(palace_path)
+    total_before = collection.count()
+
+    # Collect stale drawers
+    all_stale = []
+
+    if strategy == "all":
+        for name, fn in STRATEGIES.items():
+            if fn is not None:
+                all_stale.extend(fn(collection, wing))
+    else:
+        all_stale = STRATEGIES[strategy](collection, wing)
+
+    # Deduplicate by drawer ID
+    seen = set()
+    unique_stale = []
+    for entry in all_stale:
+        if entry["id"] not in seen:
+            seen.add(entry["id"])
+            unique_stale.append(entry)
+
+    # Group by reason for summary
+    by_reason = defaultdict(int)
+    by_file = defaultdict(int)
+    for entry in unique_stale:
+        by_reason[entry["reason"]] += 1
+        by_file[entry.get("source_file", "?")] += 1
+
+    result = {
+        "total_drawers": total_before,
+        "stale_found": len(unique_stale),
+        "by_reason": dict(by_reason),
+        "stale_files": len(by_file),
+        "dry_run": dry_run,
+        "strategy": strategy,
+        "wing": wing,
+        "deleted": 0,
+    }
+
+    if dry_run:
+        # Include details for review
+        result["stale_drawers"] = unique_stale[:50]  # Cap preview at 50
+        if len(unique_stale) > 50:
+            result["truncated"] = True
+    else:
+        # Actually delete
+        ids_to_delete = [e["id"] for e in unique_stale]
+        if ids_to_delete:
+            result["deleted"] = _batch_delete(collection, ids_to_delete, wal_log)
+
+    return result
+
+
+def prune_file(collection, source_file: str):
+    """Delete all drawers for a specific source file.
+
+    Used by the miner before re-mining a modified file to prevent
+    orphaned chunks. Returns the number of drawers deleted.
+    """
+    try:
+        results = collection.get(
+            where={"source_file": source_file},
+            include=["metadatas"],
+            limit=10000,
+        )
+        ids = results.get("ids", [])
+        if not ids:
+            return 0
+        collection.delete(ids=ids)
+        return len(ids)
+    except Exception:
+        return 0


### PR DESCRIPTION
## Summary

Stale drawers accumulate when source files are deleted or modified after mining. This causes outdated content to surface in `mempalace_search` results, which can inject contradictory information into agent context — a memory correctness risk, not just a maintenance inconvenience.

This PR adds:

- **`mempalace/pruner.py`** — core prune logic with three detection strategies:
  - `existence`: finds drawers whose source file no longer exists on disk
  - `mtime`: finds drawers whose source file has been modified since mining
  - `orphans`: finds leftover chunks when a file shrinks after re-mining
- **CLI command**: `mempalace prune --strategy <all|existence|mtime|orphans> --wing <w> --dry-run`
- **MCP tool**: `mempalace_prune` — callable from Claude Code / Cursor
- **Clean-before-remine**: patches `miner.py` to delete all old drawers for a source file before re-mining, preventing orphaned chunks from accumulating in the first place

## Addresses

- #224 — Stale drawer retrieval can inject contradictory memory into live agent context
- #420 — Mempalace as hoarder cleanup
- #331 — time-decay scoring (this PR provides the cleanup foundation)

## Usage

```bash
# Preview stale drawers without deleting
mempalace prune --dry-run

# Delete drawers from deleted source files only
mempalace prune --strategy existence

# Full cleanup: deleted files + modified files + orphaned chunks
mempalace prune --strategy all

# Scope to one wing
mempalace prune --wing my_project --dry-run
```

Via MCP:
```
mempalace_prune(strategy="all", dry_run=true)
mempalace_prune(strategy="existence", dry_run=false)
```

## Test plan

- [x] Verified `existence` strategy detects drawers with missing source files
- [x] Verified `mtime` strategy detects drawers with outdated modification times
- [x] Verified `--wing` filter scopes detection correctly
- [x] Verified `--dry-run` reports without deleting
- [x] Verified actual deletion removes only stale drawers, keeps fresh ones
- [x] Verified CLI output formatting
- [x] Clean-before-remine prevents orphaned chunks on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)