### PR TITLE
fix: purge stale drawers before re-mine to avoid hnswlib update-path race

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -436,6 +436,16 @@ def process_file(
         print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
         return len(chunks), room
 
+    # Purge stale drawers for this file before re-inserting the fresh chunks.
+    # Converts modified-file re-mines from upsert-over-existing-IDs (which hits
+    # hnswlib's thread-unsafe updatePoint path and can segfault on macOS ARM
+    # with chromadb 0.6.3) into a clean delete+insert, bypassing the update
+    # path entirely.
+    try:
+        collection.delete(where={"source_file": source_file})
+    except Exception:
+        pass
+
     drawers_added = 0
     for chunk in chunks:
         added = add_drawer(


### PR DESCRIPTION
## Summary

Fixes the hnswlib `updatePoint` / `repairConnectionsForUpdate` race documented in #521. One-hunk patch in `mempalace/miner.py::process_file`: delete any drawers for a `source_file` before re-inserting the fresh chunks, so modified-file re-mines never enter the update path.

## Why only miner.py

`mcp_server.py::tool_add_drawer` uses a content-keyed drawer_id and has an existence pre-check at lines 355-361 that short-circuits before the upsert. Combined with single-item batches per MCP tool call, that path is structurally incapable of reaching `updatePoint` / `repairConnectionsForUpdate` under normal operation. No parallel fix needed.

## Test plan
- [ ] New regression test: mine a file, `os.utime()` the file, re-mine, assert no crash and new chunks replace old
- [x] `pytest tests/ -v` — full suite passes (534 passed, 106 deselected, 20.78s)
- [x] `ruff check mempalace/miner.py` — clean
- [x] `ruff format --check mempalace/miner.py` — clean
- [ ] Manual reproduction: mine a directory, `touch` a file, re-mine — no segfault after patch

## Not included

- No changes to `mcp_server.py` (analysis in the commit message).
- No changes to the on-disk index format or migration.
- No new dependencies.

Fixes #521
