### PR TITLE
fix: security hardening, performance, and input validation

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -18,11 +18,12 @@ Tools (write):
 """
 
 import argparse
-import os
-import sys
+import hashlib
 import json
 import logging
-import hashlib
+import os
+import sys
+import time as _time
 from datetime import datetime
 from pathlib import Path
 
@@ -100,16 +101,40 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         logger.error(f"WAL write failed: {e}")
 
 
-_client_cache = None
-_collection_cache = None
-
-
 def _get_client():
     """Return a singleton ChromaDB PersistentClient."""
     global _client_cache
     if _client_cache is None:
         _client_cache = chromadb.PersistentClient(path=_config.palace_path)
     return _client_cache
+
+
+# ── Metadata cache (avoids repeated full-collection scans) ──────────────
+_META_CACHE = None  # list of metadata dicts
+_META_CACHE_TIME = 0.0
+_META_CACHE_TTL = 2.0  # seconds — short enough to stay fresh, long enough
+                        # to coalesce multiple read-tool calls in one batch
+
+
+def _get_all_metadata(col):
+    """Return all metadata from the collection, using a short-lived cache."""
+    global _META_CACHE, _META_CACHE_TIME
+    now = _time.monotonic()
+    if _META_CACHE is not None and (now - _META_CACHE_TIME) < _META_CACHE_TTL:
+        return _META_CACHE
+    try:
+        _META_CACHE = col.get(include=["metadatas"], limit=10000)["metadatas"]
+    except Exception as e:
+        logger.error("Failed to retrieve metadata: %s", e)
+        _META_CACHE = []
+    _META_CACHE_TIME = now
+    return _META_CACHE
+
+
+def _invalidate_meta_cache():
+    """Clear metadata cache after writes."""
+    global _META_CACHE
+    _META_CACHE = None
 
 
 def _get_collection(create=False):
@@ -122,7 +147,8 @@ def _get_collection(create=False):
         elif _collection_cache is None:
             _collection_cache = client.get_collection(_config.collection_name)
         return _collection_cache
-    except Exception:
+    except Exception as e:
+        logger.error("Failed to get ChromaDB collection: %s", e)
         return None
 
 
@@ -143,15 +169,12 @@ def tool_status():
     count = col.count()
     wings = {}
     rooms = {}
-    try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
-            w = m.get("wing", "unknown")
-            r = m.get("room", "unknown")
-            wings[w] = wings.get(w, 0) + 1
-            rooms[r] = rooms.get(r, 0) + 1
-    except Exception:
-        pass
+    all_meta = _get_all_metadata(col)
+    for m in all_meta:
+        w = m.get("wing", "unknown")
+        r = m.get("room", "unknown")
+        wings[w] = wings.get(w, 0) + 1
+        rooms[r] = rooms.get(r, 0) + 1
     return {
         "total_drawers": count,
         "wings": wings,
@@ -200,13 +223,10 @@ def tool_list_wings():
     if not col:
         return _no_palace()
     wings = {}
-    try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
-            w = m.get("wing", "unknown")
-            wings[w] = wings.get(w, 0) + 1
-    except Exception:
-        pass
+    all_meta = _get_all_metadata(col)
+    for m in all_meta:
+        w = m.get("wing", "unknown")
+        wings[w] = wings.get(w, 0) + 1
     return {"wings": wings}
 
 
@@ -215,16 +235,12 @@ def tool_list_rooms(wing: str = None):
     if not col:
         return _no_palace()
     rooms = {}
-    try:
-        kwargs = {"include": ["metadatas"], "limit": 10000}
-        if wing:
-            kwargs["where"] = {"wing": wing}
-        all_meta = col.get(**kwargs)["metadatas"]
-        for m in all_meta:
-            r = m.get("room", "unknown")
-            rooms[r] = rooms.get(r, 0) + 1
-    except Exception:
-        pass
+    all_meta = _get_all_metadata(col)
+    for m in all_meta:
+        if wing and m.get("wing") != wing:
+            continue
+        r = m.get("room", "unknown")
+        rooms[r] = rooms.get(r, 0) + 1
     return {"wing": wing or "all", "rooms": rooms}
 
 
@@ -233,26 +249,25 @@ def tool_get_taxonomy():
     if not col:
         return _no_palace()
     taxonomy = {}
-    try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
-        for m in all_meta:
-            w = m.get("wing", "unknown")
-            r = m.get("room", "unknown")
-            if w not in taxonomy:
-                taxonomy[w] = {}
-            taxonomy[w][r] = taxonomy[w].get(r, 0) + 1
-    except Exception:
-        pass
+    all_meta = _get_all_metadata(col)
+    for m in all_meta:
+        w = m.get("wing", "unknown")
+        r = m.get("room", "unknown")
+        if w not in taxonomy:
+            taxonomy[w] = {}
+        taxonomy[w][r] = taxonomy[w].get(r, 0) + 1
     return {"taxonomy": taxonomy}
 
 
 def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+    col = _get_collection()
     return search_memories(
         query,
         palace_path=_config.palace_path,
         wing=wing,
         room=room,
         n_results=limit,
+        collection=col,
     )
 
 
@@ -288,7 +303,8 @@ def tool_check_duplicate(content: str, threshold: float = 0.9):
             "matches": duplicates,
         }
     except Exception as e:
-        return {"error": str(e)}
+        logger.error("Duplicate check failed: %s", e)
+        return {"error": "Duplicate check failed"}
 
 
 def tool_get_aaak_spec():
@@ -338,7 +354,7 @@ def tool_add_drawer(
     if not col:
         return _no_palace()
 
-    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content[:100]).encode()).hexdigest()[:24]}"
+    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content).encode()).hexdigest()[:24]}"
 
     _wal_log(
         "add_drawer",
@@ -348,7 +364,7 @@ def tool_add_drawer(
             "room": room,
             "added_by": added_by,
             "content_length": len(content),
-            "content_preview": content[:200],
+            "content_hash": hashlib.sha256(content.encode()).hexdigest(),
         },
     )
 
@@ -375,10 +391,12 @@ def tool_add_drawer(
                 }
             ],
         )
+        _invalidate_meta_cache()
         logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
         return {"success": True, "drawer_id": drawer_id, "wing": wing, "room": room}
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        logger.error("Failed to file drawer %s: %s", drawer_id, e)
+        return {"success": False, "error": "Failed to file drawer"}
 
 
 def tool_delete_drawer(drawer_id: str):
@@ -398,25 +416,66 @@ def tool_delete_drawer(drawer_id: str):
         {
             "drawer_id": drawer_id,
             "deleted_meta": deleted_meta,
-            "content_preview": deleted_content[:200],
+            "content_hash": hashlib.sha256(deleted_content.encode()).hexdigest(),
         },
     )
 
     try:
         col.delete(ids=[drawer_id])
+        _invalidate_meta_cache()
         logger.info(f"Deleted drawer: {drawer_id}")
         return {"success": True, "drawer_id": drawer_id}
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        logger.error("Failed to delete drawer %s: %s", drawer_id, e)
+        return {"success": False, "error": "Failed to delete drawer"}
 
 
 # ==================== KNOWLEDGE GRAPH ====================
 
 
+_VALID_DIRECTIONS = {"outgoing", "incoming", "both"}
+
+
+def _validate_date(value: str, field_name: str = "date") -> str:
+    """Validate a YYYY-MM-DD date string. Returns the value if valid."""
+    if value is None:
+        return None
+    from datetime import datetime as _dt
+
+    try:
+        _dt.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        raise ValueError(f"{field_name} must be in YYYY-MM-DD format, got: {value}")
+    return value
+
+
 def tool_kg_query(entity: str, as_of: str = None, direction: str = "both"):
     """Query the knowledge graph for an entity's relationships."""
+    try:
+        entity = sanitize_name(entity, "entity")
+        as_of = _validate_date(as_of, "as_of")
+    except ValueError as e:
+        return {"entity": entity, "error": str(e), "facts": [], "count": 0}
+    if direction not in _VALID_DIRECTIONS:
+        return {
+            "entity": entity,
+            "error": f"direction must be one of {sorted(_VALID_DIRECTIONS)}, got: {direction}",
+            "facts": [],
+            "count": 0,
+        }
     results = _kg.query_entity(entity, as_of=as_of, direction=direction)
     return {"entity": entity, "as_of": as_of, "facts": results, "count": len(results)}
+
+
+def tool_kg_query_relationship(predicate: str, as_of: str = None):
+    """Query the knowledge graph by relationship type. Returns all triples with this predicate."""
+    try:
+        predicate = sanitize_name(predicate, "predicate")
+        as_of = _validate_date(as_of, "as_of")
+    except ValueError as e:
+        return {"predicate": predicate, "error": str(e), "facts": [], "count": 0}
+    results = _kg.query_relationship(predicate, as_of=as_of)
+    return {"predicate": predicate, "as_of": as_of, "facts": results, "count": len(results)}
 
 
 def tool_kg_add(
@@ -427,6 +486,7 @@ def tool_kg_add(
         subject = sanitize_name(subject, "subject")
         predicate = sanitize_name(predicate, "predicate")
         object = sanitize_name(object, "object")
+        valid_from = _validate_date(valid_from, "valid_from")
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
@@ -448,6 +508,13 @@ def tool_kg_add(
 
 def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = None):
     """Mark a fact as no longer true (set end date)."""
+    try:
+        subject = sanitize_name(subject, "subject")
+        predicate = sanitize_name(predicate, "predicate")
+        object = sanitize_name(object, "object")
+        ended = _validate_date(ended, "ended")
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
     _wal_log(
         "kg_invalidate",
         {"subject": subject, "predicate": predicate, "object": object, "ended": ended},
@@ -462,6 +529,11 @@ def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = N
 
 def tool_kg_timeline(entity: str = None):
     """Get chronological timeline of facts, optionally for one entity."""
+    if entity:
+        try:
+            entity = sanitize_name(entity, "entity")
+        except ValueError as e:
+            return {"entity": entity, "error": str(e), "timeline": [], "count": 0}
     results = _kg.timeline(entity)
     return {"entity": entity or "all", "timeline": results, "count": len(results)}
 
@@ -503,7 +575,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
             "agent_name": agent_name,
             "topic": topic,
             "entry_id": entry_id,
-            "entry_preview": entry[:200],
+            "entry_hash": hashlib.sha256(entry[:200].encode()).hexdigest(),
         },
     )
 
@@ -528,6 +600,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
                 }
             ],
         )
+        _invalidate_meta_cache()
         logger.info(f"Diary entry: {entry_id} → {wing}/diary/{topic}")
         return {
             "success": True,
@@ -537,7 +610,8 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
             "timestamp": now.isoformat(),
         }
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        logger.error("Failed to write diary entry: %s", e)
+        return {"success": False, "error": "Failed to write diary entry"}
 
 
 def tool_diary_read(agent_name: str, last_n: int = 10):
@@ -582,7 +656,8 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
             "showing": len(entries),
         }
     except Exception as e:
-        return {"error": str(e)}
+        logger.error("Failed to read diary for %s: %s", agent_name, e)
+        return {"error": "Failed to read diary entries"}
 
 
 # ==================== MCP PROTOCOL ====================
@@ -639,6 +714,24 @@ TOOLS = {
             "required": ["entity"],
         },
         "handler": tool_kg_query,
+    },
+    "mempalace_kg_query_relationship": {
+        "description": "Query the knowledge graph by relationship type. Returns all triples with this predicate. E.g. 'loves' → all entities that love something. Filter by date with as_of.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "predicate": {
+                    "type": "string",
+                    "description": "Relationship type to query (e.g. 'loves', 'works_on', 'child_of')",
+                },
+                "as_of": {
+                    "type": "string",
+                    "description": "Date filter — only facts valid at this date (YYYY-MM-DD, optional)",
+                },
+            },
+            "required": ["predicate"],
+        },
+        "handler": tool_kg_query_relationship,
     },
     "mempalace_kg_add": {
         "description": "Add a fact to the knowledge graph. Subject → predicate → object with optional time window. E.g. ('Max', 'started_school', 'Year 7', valid_from='2026-09-01').",
@@ -921,21 +1014,58 @@ def handle_request(request):
     }
 
 
+_use_framing = None  # auto-detect: None=unknown, True=Content-Length, False=newline-delimited
+
+
+def _read_message():
+    """Read a JSON-RPC message, auto-detecting transport format on first message."""
+    global _use_framing
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            return None  # EOF
+        line = line.strip()
+        if not line:
+            continue
+        if line.lower().startswith("content-length:"):
+            _use_framing = True
+            content_length = int(line.split(":", 1)[1].strip())
+            # Skip remaining headers until blank line
+            while True:
+                h = sys.stdin.readline()
+                if not h or h.strip() == "":
+                    break
+            body = sys.stdin.read(content_length)
+            if not body:
+                return None
+            return json.loads(body)
+        else:
+            if _use_framing is None:
+                _use_framing = False
+            return json.loads(line)
+
+
+def _write_message(response):
+    """Write a JSON-RPC message matching the detected transport format."""
+    body = json.dumps(response)
+    if _use_framing:
+        sys.stdout.write(f"Content-Length: {len(body)}\r\n\r\n")
+    sys.stdout.write(body)
+    if not _use_framing:
+        sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
 def main():
     logger.info("MemPalace MCP Server starting...")
     while True:
         try:
-            line = sys.stdin.readline()
-            if not line:
+            request = _read_message()
+            if request is None:
                 break
-            line = line.strip()
-            if not line:
-                continue
-            request = json.loads(line)
             response = handle_request(request)
             if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
-                sys.stdout.flush()
+                _write_message(response)
         except KeyboardInterrupt:
             break
         except Exception as e:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -91,15 +91,26 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: str,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    collection=None,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
     Used by the MCP server and other callers that need data.
+
+    If *collection* is provided, it is used directly instead of
+    opening a new PersistentClient (avoids redundant connections).
     """
     try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        if collection is not None:
+            col = collection
+        else:
+            client = chromadb.PersistentClient(path=palace_path)
+            col = client.get_collection("mempalace_drawers")
     except Exception as e:
         logger.error("No palace found at %s: %s", palace_path, e)
         return {
@@ -127,7 +138,8 @@ def search_memories(
 
         results = col.query(**kwargs)
     except Exception as e:
-        return {"error": f"Search error: {e}"}
+        logger.error("Search error: %s", e)
+        return {"error": "Search failed"}
 
     docs = results["documents"][0]
     metas = results["metadatas"][0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ def _reset_mcp_cache():
 
             mcp_server._client_cache = None
             mcp_server._collection_cache = None
+            mcp_server._META_CACHE = None
         except (ImportError, AttributeError):
             pass
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -403,3 +403,260 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+
+# ── Input Validation Tests ─────────────────────────────────────────────
+
+
+class TestInputValidation:
+    """Tests for input sanitization and validation across tools."""
+
+    def test_kg_query_rejects_path_traversal(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query
+
+        result = tool_kg_query(entity="../../etc/passwd")
+        assert "error" in result
+        assert result["count"] == 0
+
+    def test_kg_query_rejects_empty_entity(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query
+
+        result = tool_kg_query(entity="")
+        assert "error" in result
+        assert result["count"] == 0
+
+    def test_kg_query_rejects_invalid_direction(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query
+
+        result = tool_kg_query(entity="Max", direction="sideways")
+        assert "error" in result
+        assert "direction" in result["error"]
+
+    def test_kg_query_rejects_invalid_date(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query
+
+        result = tool_kg_query(entity="Max", as_of="not-a-date")
+        assert "error" in result
+        assert "YYYY-MM-DD" in result["error"]
+
+    def test_kg_query_accepts_valid_date(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query
+
+        result = tool_kg_query(entity="Max", as_of="2026-01-15")
+        assert "error" not in result
+        assert result["count"] >= 0
+
+    def test_kg_invalidate_sanitizes_inputs(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_invalidate
+
+        result = tool_kg_invalidate(
+            subject="../../evil", predicate="does", object="chess"
+        )
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_kg_invalidate_validates_ended_date(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_invalidate
+
+        result = tool_kg_invalidate(
+            subject="Max", predicate="does", object="chess", ended="bad-date"
+        )
+        assert result["success"] is False
+        assert "YYYY-MM-DD" in result["error"]
+
+    def test_kg_add_validates_date(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_kg_add
+
+        result = tool_kg_add(
+            subject="Alice", predicate="likes", object="tea", valid_from="nope"
+        )
+        assert result["success"] is False
+        assert "YYYY-MM-DD" in result["error"]
+
+    def test_kg_timeline_validates_entity(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_timeline
+
+        result = tool_kg_timeline(entity="../../etc")
+        assert "error" in result
+        assert result["count"] == 0
+
+    def test_add_drawer_rejects_null_bytes(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(wing="test", room="test", content="hello\x00world")
+        assert result["success"] is False
+
+
+# ── Drawer ID Uniqueness Tests ─────────────────────────────────────────
+
+
+class TestDrawerIdUniqueness:
+    """Verify that drawers with different content get different IDs."""
+
+    def test_different_content_same_prefix_gets_different_id(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        prefix = "A" * 200
+        r1 = tool_add_drawer(wing="w", room="r", content=prefix + " ENDING ONE")
+        r2 = tool_add_drawer(wing="w", room="r", content=prefix + " ENDING TWO")
+        assert r1["success"] is True
+        assert r2["success"] is True
+        assert r1["drawer_id"] != r2["drawer_id"]
+
+
+# ── Error Message Sanitization Tests ───────────────────────────────────
+
+
+class TestErrorSanitization:
+    """Verify that internal errors don't leak system information."""
+
+    def test_search_error_does_not_leak_path(self):
+        from mempalace.searcher import search_memories
+
+        # Trigger an error by pointing to a nonexistent palace
+        result = search_memories("test", "/nonexistent/path/palace")
+        assert "error" in result
+        # Should NOT contain the raw path in the error
+        assert "/nonexistent" not in result.get("error", "")
+
+    def test_add_drawer_error_is_generic(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_add_drawer
+
+        # Force _get_collection to return a broken mock
+        from unittest.mock import MagicMock
+
+        mock_col = MagicMock()
+        mock_col.get.return_value = {"ids": []}
+        mock_col.upsert.side_effect = RuntimeError("internal db corruption at /secret/path")
+        monkeypatch.setattr("mempalace.mcp_server._get_collection", lambda create=False: mock_col)
+
+        result = tool_add_drawer(wing="w", room="r", content="test content here")
+        assert result["success"] is False
+        assert "/secret/path" not in result["error"]
+        assert result["error"] == "Failed to file drawer"
+
+
+# ── WAL Content Hashing Tests ──────────────────────────────────────────
+
+
+class TestWALSecurity:
+    """Verify that WAL entries use content hashes instead of plaintext previews."""
+
+    def test_wal_uses_hash_not_preview(self, monkeypatch, config, palace_path, kg, tmp_dir):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+
+        import os
+        from pathlib import Path
+
+        wal_dir = Path(os.path.join(tmp_dir, "wal"))
+        wal_dir.mkdir(parents=True, exist_ok=True)
+        wal_file = wal_dir / "write_log.jsonl"
+        monkeypatch.setattr("mempalace.mcp_server._WAL_FILE", wal_file)
+        monkeypatch.setattr("mempalace.mcp_server._WAL_DIR", wal_dir)
+
+        from mempalace.mcp_server import tool_add_drawer
+
+        secret_content = "My SSN is 123-45-6789 and my password is hunter2"
+        tool_add_drawer(wing="secrets", room="test", content=secret_content)
+
+        wal_text = wal_file.read_text()
+        assert "123-45-6789" not in wal_text
+        assert "hunter2" not in wal_text
+        assert "content_hash" in wal_text
+        assert "content_preview" not in wal_text
+
+
+# ── KG Query Relationship Tool Tests ───────────────────────────────────
+
+
+class TestKGQueryRelationship:
+    """Tests for the new mempalace_kg_query_relationship tool."""
+
+    def test_query_relationship_basic(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query_relationship
+
+        result = tool_kg_query_relationship(predicate="does")
+        assert result["count"] >= 2  # Max does swimming and chess
+        assert all("predicate" in f for f in result["facts"])
+
+    def test_query_relationship_with_date_filter(
+        self, monkeypatch, config, palace_path, seeded_kg
+    ):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query_relationship
+
+        result = tool_kg_query_relationship(predicate="works_at", as_of="2025-06-01")
+        # Alice works_at NewCo from 2025-01-01 — should appear
+        assert result["count"] >= 1
+        assert any(f["subject"] == "Alice" for f in result["facts"])
+
+    def test_query_relationship_validates_predicate(
+        self, monkeypatch, config, palace_path, seeded_kg
+    ):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query_relationship
+
+        result = tool_kg_query_relationship(predicate="../../etc")
+        assert "error" in result
+        assert result["count"] == 0
+
+    def test_query_relationship_validates_date(
+        self, monkeypatch, config, palace_path, seeded_kg
+    ):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_query_relationship
+
+        result = tool_kg_query_relationship(predicate="does", as_of="invalid")
+        assert "error" in result
+
+    def test_query_relationship_registered_in_tools(self):
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request({"method": "tools/list", "id": 1, "params": {}})
+        names = {t["name"] for t in resp["result"]["tools"]}
+        assert "mempalace_kg_query_relationship" in names
+
+
+# ── Metadata Cache Tests ───────────────────────────────────────────────
+
+
+class TestMetadataCache:
+    """Verify metadata caching behavior."""
+
+    def test_cache_invalidated_on_write(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_status, tool_add_drawer
+
+        # First call caches metadata
+        result1 = tool_status()
+        assert result1["total_drawers"] == 4
+
+        # Add a drawer — should invalidate cache
+        tool_add_drawer(wing="new", room="room", content="New content for cache test")
+
+        result2 = tool_status()
+        assert result2["total_drawers"] == 5
+        assert "new" in result2["wings"]

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -62,7 +62,7 @@ class TestSearchMemories:
         with patch("mempalace.searcher.chromadb.PersistentClient", return_value=mock_client):
             result = search_memories("test", "/fake/path")
         assert "error" in result
-        assert "query failed" in result["error"]
+        assert result["error"] == "Search failed"
 
     def test_search_memories_filters_in_result(self, palace_path, seeded_collection):
         result = search_memories("test", palace_path, wing="project", room="backend")


### PR DESCRIPTION
## Summary

Comprehensive audit of the MCP server surface area, addressing security, performance, and functional issues:

- **Security (5 fixes):** Sanitize all KG tool inputs via `sanitize_name()`, validate date/direction params, replace WAL plaintext content previews with SHA-256 hashes, sanitize error messages returned to MCP clients to prevent leaking system paths and DB internals
- **Performance (2 fixes):** Add 2-second TTL metadata cache so `status`/`wings`/`rooms`/`taxonomy` share one collection scan instead of four independent 10K fetches; pass cached ChromaDB collection to `search_memories()` instead of creating a new `PersistentClient` per call
- **Functional (4 fixes):** Fix drawer ID hash collision (hash full content instead of `content[:100]`), remove duplicate cache variable initialization, replace all silent `except: pass` with `logger.error()`, expose `query_relationship()` as `mempalace_kg_query_relationship` MCP tool

### Files changed

| File | Changes |
|------|---------|
| `mempalace/mcp_server.py` | Input validation, metadata cache, WAL hashing, error sanitization, new tool |
| `mempalace/searcher.py` | Accept optional `collection` param, sanitize error message |
| `tests/conftest.py` | Clear metadata cache between tests |
| `tests/test_mcp_server.py` | +16 new tests (input validation, error sanitization, WAL, cache, new tool) |
| `tests/test_searcher.py` | Update error message assertion to match sanitized output |

### Breaking changes

- WAL log entries now use `content_hash` instead of `content_preview` — tools that parse the WAL for content previews will need updating
- `search_memories()` has a new optional `collection` parameter (backwards compatible)
- Error messages returned to MCP clients are now generic (no longer contain raw exception text)

## Test plan

- [x] All 554 tests pass (up from 534 — 16 new tests added)
- [x] Ruff lint clean
- [x] Verified path traversal, null bytes, invalid dates, and invalid direction all rejected
- [x] Verified drawer ID uniqueness with same-prefix different-suffix content
- [x] Verified WAL no longer contains plaintext content
- [x] Verified error messages don't leak system paths
- [x] Verified metadata cache invalidates on writes
- [x] Verified `mempalace_kg_query_relationship` tool registered and functional