### PR TITLE
feat: make embedding model configurable for non-English search

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -60,6 +60,7 @@ def sanitize_content(value: str, max_length: int = 100_000) -> str:
 
 DEFAULT_PALACE_PATH = os.path.expanduser("~/.mempalace/palace")
 DEFAULT_COLLECTION_NAME = "mempalace_drawers"
+DEFAULT_EMBEDDING_MODEL = None  # None = use ChromaDB built-in (all-MiniLM-L6-v2)
 
 DEFAULT_TOPIC_WINGS = [
     "emotions",
@@ -151,6 +152,21 @@ class MempalaceConfig:
     def collection_name(self):
         """ChromaDB collection name."""
         return self._file_config.get("collection_name", DEFAULT_COLLECTION_NAME)
+
+    @property
+    def embedding_model(self):
+        """SentenceTransformer model name for embeddings.
+
+        Set to a multilingual model (e.g. "paraphrase-multilingual-MiniLM-L12-v2")
+        to improve search quality for non-English content.
+        None means use ChromaDB's built-in default (all-MiniLM-L6-v2, English-only).
+
+        Can also be set via the MEMPALACE_EMBEDDING_MODEL environment variable.
+        """
+        env_val = os.environ.get("MEMPALACE_EMBEDDING_MODEL")
+        if env_val:
+            return env_val or None
+        return self._file_config.get("embedding_model", DEFAULT_EMBEDDING_MODEL)
 
     @property
     def people_map(self):

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -6,6 +6,7 @@ Consolidates ChromaDB access patterns used by both miners and the MCP server.
 
 import os
 import chromadb
+from mempalace.config import MempalaceConfig
 
 SKIP_DIRS = {
     ".git",
@@ -34,6 +35,34 @@ SKIP_DIRS = {
 }
 
 
+def _get_embedding_function():
+    """Return a ChromaDB embedding function based on config, or None for the default.
+
+    When ``embedding_model`` is set in ``~/.mempalace/config.json`` (or via the
+    ``MEMPALACE_EMBEDDING_MODEL`` env var), a ``SentenceTransformerEmbeddingFunction``
+    is returned so that any HuggingFace sentence-transformers model can be used.
+    This is useful for non-English content — for example::
+
+        # ~/.mempalace/config.json
+        {"embedding_model": "paraphrase-multilingual-MiniLM-L12-v2"}
+
+    Returns ``None`` to fall back to ChromaDB's built-in ONNX model
+    (``all-MiniLM-L6-v2``), which is the default behaviour and requires no
+    extra dependencies.
+    """
+    model_name = MempalaceConfig().embedding_model
+    if not model_name:
+        return None
+    try:
+        from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
+        return SentenceTransformerEmbeddingFunction(model_name=model_name)
+    except ImportError:
+        raise ImportError(
+            f"embedding_model is set to '{model_name}' but the 'sentence-transformers' "
+            "package is not installed. Run: pip install sentence-transformers"
+        )
+
+
 def get_collection(palace_path: str, collection_name: str = "mempalace_drawers"):
     """Get or create the palace ChromaDB collection."""
     os.makedirs(palace_path, exist_ok=True)
@@ -42,10 +71,12 @@ def get_collection(palace_path: str, collection_name: str = "mempalace_drawers")
     except (OSError, NotImplementedError):
         pass
     client = chromadb.PersistentClient(path=palace_path)
+    ef = _get_embedding_function()
+    kwargs = {"embedding_function": ef} if ef is not None else {}
     try:
-        return client.get_collection(collection_name)
+        return client.get_collection(collection_name, **kwargs)
     except Exception:
-        return client.create_collection(collection_name)
+        return client.create_collection(collection_name, **kwargs)
 
 
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:


### PR DESCRIPTION
## Problem

The default ChromaDB embedding model (`all-MiniLM-L6-v2`) is English-only. Users writing in Chinese, Japanese, Korean, or other non-Latin languages get poor search results — match scores go negative and retrieved memories are irrelevant.

## Solution

Add an `embedding_model` config option that lets users opt into any HuggingFace sentence-transformers model without patching installed files.

**Configuration (priority order):**
1. Env var: `MEMPALACE_EMBEDDING_MODEL=paraphrase-multilingual-MiniLM-L12-v2`
2. Config file: `~/.mempalace/config.json` → `{"embedding_model": "paraphrase-multilingual-MiniLM-L12-v2"}`
3. Default: `null` → uses ChromaDB built-in (unchanged behaviour)

**Example for Chinese/Japanese/Korean users:**
```json
{
  "embedding_model": "paraphrase-multilingual-MiniLM-L12-v2"
}
```

## Changes

- `config.py`: added `DEFAULT_EMBEDDING_MODEL = None` and `embedding_model` property with env var support (`MEMPALACE_EMBEDDING_MODEL`)
- `palace.py`: added `_get_embedding_function()` helper that reads config and lazily imports `sentence-transformers` only when needed

## Backward compatibility

- Default is `null` → behaviour identical to before
- `sentence-transformers` is **not** a new required dependency — only needed when `embedding_model` is set
- Existing palaces continue to work without any migration

## Motivation

Discovered this while setting up MemPalace for daily use in Chinese. Had to patch the installed package directly — this PR makes it a proper first-class config option.