### PR TITLE
fix: correct agent-facing instructions in SKILL.md and init/mine docs

### DIFF
--- a/.claude-plugin/skills/mempalace/SKILL.md
+++ b/.claude-plugin/skills/mempalace/SKILL.md
@@ -13,7 +13,7 @@ A searchable memory palace for AI — mine projects and conversations, then sear
 Ensure `mempalace` is installed:
 
 ```bash
-mempalace --version
+mempalace status
 ```
 
 If not installed:

--- a/mempalace/instructions/init.md
+++ b/mempalace/instructions/init.md
@@ -41,7 +41,9 @@ before continuing.
 
 ## Step 5: Initialize the palace
 
-Run `mempalace init <dir>` where `<dir>` is the directory from Step 4.
+Run `mempalace init --yes <dir>` where `<dir>` is the directory from Step 4.
+The `--yes` flag skips interactive prompts, which is required when running
+from an agent context (no TTY).
 
 If this fails, report the error and stop.
 

--- a/mempalace/instructions/mine.md
+++ b/mempalace/instructions/mine.md
@@ -2,6 +2,10 @@
 
 When the user invokes this skill, follow these steps:
 
+**Prerequisite:** The palace must already be initialized. If `mempalace status`
+fails or reports no palace, run `mempalace init --yes <dir>` first (see
+/mempalace:init).
+
 ## 1. Ask what to mine
 
 Ask the user what they want to mine and where the source data is located.


### PR DESCRIPTION
## Summary

Fixes #534 — three issues in agent-facing documentation that cause failures when agents follow the instructions:

- **SKILL.md:** Changed `mempalace --version` to `mempalace status` — the CLI has no `--version` flag, so the prerequisite check always failed
- **init.md:** Changed `mempalace init <dir>` to `mempalace init --yes <dir>` — without `--yes`, agents hit `EOFError` because there is no TTY for interactive prompts
- **mine.md:** Added a prerequisite note that `mempalace init` must be run before mining, so agents don't attempt to mine into an uninitialized palace

## Test plan

- [x] Verify `mempalace status` works as an install check (returns non-zero if not installed)
- [x] Verify `mempalace init --yes <dir>` completes non-interactively
- [x] Confirm mine instructions now reference the init prerequisite