### PR TITLE
feat: add semantic dedup to add_drawer (closes #464)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -58,7 +58,9 @@ if _args.palace:
 
 _config = MempalaceConfig()
 if _args.palace:
-    _kg = KnowledgeGraph(db_path=os.path.join(_config.palace_path, "knowledge_graph.sqlite3"))
+    _kg = KnowledgeGraph(
+        db_path=os.path.join(_config.palace_path, "knowledge_graph.sqlite3")
+    )
 else:
     _kg = KnowledgeGraph()
 
@@ -324,7 +326,13 @@ def tool_graph_stats():
 
 
 def tool_add_drawer(
-    wing: str, room: str, content: str, source_file: str = None, added_by: str = "mcp"
+    wing: str,
+    room: str,
+    content: str,
+    source_file: str = None,
+    added_by: str = "mcp",
+    dedup_threshold: float = 0.92,
+    force: bool = False,
 ):
     """File verbatim content into a wing/room. Checks for duplicates first."""
     try:
@@ -338,7 +346,9 @@ def tool_add_drawer(
     if not col:
         return _no_palace()
 
-    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content[:100]).encode()).hexdigest()[:24]}"
+    drawer_id = (
+        f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content[:100]).encode()).hexdigest()[:24]}"
+    )
 
     _wal_log(
         "add_drawer",
@@ -359,6 +369,35 @@ def tool_add_drawer(
             return {"success": True, "reason": "already_exists", "drawer_id": drawer_id}
     except Exception:
         pass
+
+    # Semantic dedup: reject near-duplicates unless force=True
+    if not force:
+        try:
+            if col.count() > 0:
+                results = col.query(
+                    query_texts=[content],
+                    n_results=1,
+                    include=["documents", "distances"],
+                )
+                if results["ids"] and results["ids"][0]:
+                    dist = results["distances"][0][0]
+                    similarity = round(1 - dist, 3)
+                    if similarity >= dedup_threshold:
+                        existing_id = results["ids"][0][0]
+                        existing_doc = results["documents"][0][0]
+                        return {
+                            "success": True,
+                            "reason": "semantic_duplicate",
+                            "existing_drawer_id": existing_id,
+                            "similarity": similarity,
+                            "existing_content_preview": (
+                                existing_doc[:200] + "..."
+                                if len(existing_doc) > 200
+                                else existing_doc
+                            ),
+                        }
+        except Exception:
+            pass  # Dedup failure should not block writes
 
     try:
         col.upsert(
@@ -391,8 +430,12 @@ def tool_delete_drawer(drawer_id: str):
         return {"success": False, "error": f"Drawer not found: {drawer_id}"}
 
     # Log the deletion with the content being removed for audit trail
-    deleted_content = existing.get("documents", [""])[0] if existing.get("documents") else ""
-    deleted_meta = existing.get("metadatas", [{}])[0] if existing.get("metadatas") else {}
+    deleted_content = (
+        existing.get("documents", [""])[0] if existing.get("documents") else ""
+    )
+    deleted_meta = (
+        existing.get("metadatas", [{}])[0] if existing.get("metadatas") else {}
+    )
     _wal_log(
         "delete_drawer",
         {
@@ -420,7 +463,11 @@ def tool_kg_query(entity: str, as_of: str = None, direction: str = "both"):
 
 
 def tool_kg_add(
-    subject: str, predicate: str, object: str, valid_from: str = None, source_closet: str = None
+    subject: str,
+    predicate: str,
+    object: str,
+    valid_from: str = None,
+    source_closet: str = None,
 ):
     """Add a relationship to the knowledge graph."""
     try:
@@ -443,7 +490,11 @@ def tool_kg_add(
     triple_id = _kg.add_triple(
         subject, predicate, object, valid_from=valid_from, source_closet=source_closet
     )
-    return {"success": True, "triple_id": triple_id, "fact": f"{subject} → {predicate} → {object}"}
+    return {
+        "success": True,
+        "triple_id": triple_id,
+        "fact": f"{subject} → {predicate} → {object}",
+    }
 
 
 def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = None):
@@ -495,7 +546,9 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
         return _no_palace()
 
     now = datetime.now()
-    entry_id = f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S')}_{hashlib.sha256(entry[:50].encode()).hexdigest()[:12]}"
+    entry_id = (
+        f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S')}_{hashlib.sha256(entry[:50].encode()).hexdigest()[:12]}"
+    )
 
     _wal_log(
         "diary_write",
@@ -558,7 +611,11 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
         )
 
         if not results["ids"]:
-            return {"agent": agent_name, "entries": [], "message": "No diary entries yet."}
+            return {
+                "agent": agent_name,
+                "entries": [],
+                "message": "No diary entries yet.",
+            }
 
         # Combine and sort by timestamp
         entries = []
@@ -603,7 +660,10 @@ TOOLS = {
         "input_schema": {
             "type": "object",
             "properties": {
-                "wing": {"type": "string", "description": "Wing to list rooms for (optional)"},
+                "wing": {
+                    "type": "string",
+                    "description": "Wing to list rooms for (optional)",
+                },
             },
         },
         "handler": tool_list_rooms,
@@ -645,12 +705,18 @@ TOOLS = {
         "input_schema": {
             "type": "object",
             "properties": {
-                "subject": {"type": "string", "description": "The entity doing/being something"},
+                "subject": {
+                    "type": "string",
+                    "description": "The entity doing/being something",
+                },
                 "predicate": {
                     "type": "string",
                     "description": "The relationship type (e.g. 'loves', 'works_on', 'daughter_of')",
                 },
-                "object": {"type": "string", "description": "The entity being connected to"},
+                "object": {
+                    "type": "string",
+                    "description": "The entity being connected to",
+                },
                 "valid_from": {
                     "type": "string",
                     "description": "When this became true (YYYY-MM-DD, optional)",
@@ -763,7 +829,7 @@ TOOLS = {
         "handler": tool_check_duplicate,
     },
     "mempalace_add_drawer": {
-        "description": "File verbatim content into the palace. Checks for duplicates first.",
+        "description": "File verbatim content into the palace. Rejects semantic near-duplicates (threshold 0.92) unless force=True.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -776,8 +842,22 @@ TOOLS = {
                     "type": "string",
                     "description": "Verbatim content to store — exact words, never summarized",
                 },
-                "source_file": {"type": "string", "description": "Where this came from (optional)"},
-                "added_by": {"type": "string", "description": "Who is filing this (default: mcp)"},
+                "source_file": {
+                    "type": "string",
+                    "description": "Where this came from (optional)",
+                },
+                "added_by": {
+                    "type": "string",
+                    "description": "Who is filing this (default: mcp)",
+                },
+                "dedup_threshold": {
+                    "type": "number",
+                    "description": "Semantic similarity threshold for auto-dedup (0-1, default 0.92)",
+                },
+                "force": {
+                    "type": "boolean",
+                    "description": "If true, skip semantic dedup and force the add",
+                },
             },
             "required": ["wing", "room", "content"],
         },
@@ -788,7 +868,10 @@ TOOLS = {
         "input_schema": {
             "type": "object",
             "properties": {
-                "drawer_id": {"type": "string", "description": "ID of the drawer to delete"},
+                "drawer_id": {
+                    "type": "string",
+                    "description": "ID of the drawer to delete",
+                },
             },
             "required": ["drawer_id"],
         },
@@ -874,7 +957,11 @@ def handle_request(request):
             "id": req_id,
             "result": {
                 "tools": [
-                    {"name": n, "description": t["description"], "inputSchema": t["input_schema"]}
+                    {
+                        "name": n,
+                        "description": t["description"],
+                        "inputSchema": t["input_schema"],
+                    }
                     for n, t in TOOLS.items()
                 ]
             },
@@ -904,7 +991,9 @@ def handle_request(request):
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "result": {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]},
+                "result": {
+                    "content": [{"type": "text", "text": json.dumps(result, indent=2)}]
+                },
             }
         except Exception:
             logger.exception(f"Tool error in {tool_name}")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -89,7 +89,9 @@ class TestHandleRequest:
     def test_notifications_initialized_returns_none(self):
         from mempalace.mcp_server import handle_request
 
-        resp = handle_request({"method": "notifications/initialized", "id": None, "params": {}})
+        resp = handle_request(
+            {"method": "notifications/initialized", "id": None, "params": {}}
+        )
         assert resp is None
 
     def test_tools_list(self):
@@ -103,7 +105,9 @@ class TestHandleRequest:
         assert "mempalace_add_drawer" in names
         assert "mempalace_kg_add" in names
 
-    def test_null_arguments_does_not_hang(self, monkeypatch, config, palace_path, seeded_kg):
+    def test_null_arguments_does_not_hang(
+        self, monkeypatch, config, palace_path, seeded_kg
+    ):
         """Sending arguments: null should return a result, not hang (#394)."""
         _patch_mcp_server(monkeypatch, config, seeded_kg)
         from mempalace.mcp_server import handle_request
@@ -172,7 +176,9 @@ class TestReadTools:
         assert result["total_drawers"] == 0
         assert result["wings"] == {}
 
-    def test_status_with_data(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_status_with_data(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_status
 
@@ -189,7 +195,9 @@ class TestReadTools:
         assert result["wings"]["project"] == 3
         assert result["wings"]["notes"] == 1
 
-    def test_list_rooms_all(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_list_rooms_all(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_list_rooms
 
@@ -198,7 +206,9 @@ class TestReadTools:
         assert "frontend" in result["rooms"]
         assert "planning" in result["rooms"]
 
-    def test_list_rooms_filtered(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_list_rooms_filtered(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_list_rooms
 
@@ -206,7 +216,9 @@ class TestReadTools:
         assert "backend" in result["rooms"]
         assert "planning" not in result["rooms"]
 
-    def test_get_taxonomy(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_get_taxonomy(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_get_taxonomy
 
@@ -227,7 +239,9 @@ class TestReadTools:
 
 
 class TestSearchTool:
-    def test_search_basic(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_search_basic(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_search
 
@@ -238,14 +252,18 @@ class TestSearchTool:
         top = result["results"][0]
         assert "JWT" in top["text"] or "authentication" in top["text"].lower()
 
-    def test_search_with_wing_filter(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_search_with_wing_filter(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_search
 
         result = tool_search(query="planning", wing="notes")
         assert all(r["wing"] == "notes" for r in result["results"])
 
-    def test_search_with_room_filter(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_search_with_room_filter(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_search
 
@@ -287,7 +305,9 @@ class TestWriteTools:
         assert result2["success"] is True
         assert result2["reason"] == "already_exists"
 
-    def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_delete_drawer(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_delete_drawer
 
@@ -295,14 +315,18 @@ class TestWriteTools:
         assert result["success"] is True
         assert seeded_collection.count() == 3
 
-    def test_delete_drawer_not_found(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_delete_drawer_not_found(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_delete_drawer
 
         result = tool_delete_drawer("nonexistent_drawer")
         assert result["success"] is False
 
-    def test_check_duplicate(self, monkeypatch, config, palace_path, seeded_collection, kg):
+    def test_check_duplicate(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_check_duplicate
 
@@ -320,6 +344,76 @@ class TestWriteTools:
             threshold=0.99,
         )
         assert result["is_duplicate"] is False
+
+    def test_add_drawer_semantic_dedup_rejects(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(
+            wing="project",
+            room="backend",
+            content="The authentication module uses JWT tokens for session management. "
+            "Tokens expire after 24 hours. Refresh tokens are stored in HttpOnly cookies.",
+            dedup_threshold=0.5,
+        )
+        assert result["success"] is True
+        assert result["reason"] == "semantic_duplicate"
+        assert "existing_drawer_id" in result
+        assert result["similarity"] >= 0.5
+        assert "existing_content_preview" in result
+
+    def test_add_drawer_force_bypasses_dedup(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(
+            wing="project",
+            room="backend",
+            content="The authentication module uses JWT tokens for session management. "
+            "Tokens expire after 24 hours. Refresh tokens are stored in HttpOnly cookies.",
+            dedup_threshold=0.5,
+            force=True,
+        )
+        assert result["success"] is True
+        assert result.get("reason") != "semantic_duplicate"
+        assert "drawer_id" in result
+
+    def test_add_drawer_dedup_threshold_high_passes(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(
+            wing="project",
+            room="backend",
+            content="JWT authentication tokens expire after a full day and refresh tokens "
+            "use HttpOnly cookies for storage.",
+            dedup_threshold=0.99,
+        )
+        assert result["success"] is True
+        assert result.get("reason") != "semantic_duplicate"
+        assert "drawer_id" in result
+
+    def test_add_drawer_unrelated_content_passes(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(
+            wing="science",
+            room="physics",
+            content="Black holes emit Hawking radiation near the event horizon "
+            "due to quantum effects in curved spacetime.",
+        )
+        assert result["success"] is True
+        assert result.get("reason") != "semantic_duplicate"
+        assert "drawer_id" in result
 
 
 # ── KG Tools ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #464

## What does this PR do?

Wires existing semantic similarity logic into `tool_add_drawer` so near-duplicate content is automatically rejected before upsert. This prevents the silent accumulation of near-identical drawers from auto-save hooks, which fire every ~15 messages and tend to restate the same decisions in slightly different words.

### Changes

- **`mempalace/mcp_server.py`**: After the existing exact-match ID check (cheap hash lookup), queries ChromaDB for the single nearest semantic match. If similarity >= threshold, returns a structured rejection with the existing drawer's ID, similarity score, and content preview.
  - `dedup_threshold` param (float, default 0.92) — stricter than `check_duplicate`'s 0.9 since silent rejection requires higher confidence
  - `force` param (bool, default False) — bypasses semantic dedup entirely
  - `col.count() > 0` guard to avoid ChromaDB errors on empty collections
  - Wrapped in `except Exception: pass` — dedup failure never blocks writes
- **MCP tool schema**: Updated description + added `dedup_threshold` and `force` as optional properties
- **`tests/test_mcp_server.py`**: 4 new tests — semantic rejection, force bypass, threshold control, unrelated content pass-through

### Response on rejection

```json
{
  "success": true,
  "reason": "semantic_duplicate",
  "existing_drawer_id": "drawer_proj_backend_aaa",
  "similarity": 0.95,
  "existing_content_preview": "The authentication module uses JWT tokens..."
}
```

## Performance

Benchmarked `col.query(n_results=1)` against a real palace with 41,187 drawers (ChromaDB 1.5.6):

| Metric | Time |
|---|---|
| `col.query(n_results=1)` avg | 75.6ms |
| `col.query(n_results=1)` p50 | 74.9ms |
| `col.count()` avg | 2.2ms |
| **Total dedup overhead** | **~78ms** |

The dedup check adds ~78ms to each `add_drawer` call (on top of ~60ms for the upsert itself). This is imperceptible for an MCP tool call that fires at most every 15 messages. Performance is very consistent (72–82ms range, no outliers) and scales with HNSW index size, not collection size, so it should remain stable as palaces grow.

## How to test

```bash
python -m pytest tests/test_mcp_server.py::TestWriteTools -v
```

## Checklist

- [x] Tests pass (`python -m pytest tests/ -v`) — 571 passed
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
- [x] No new dependencies