### PR TITLE
feat: add git-mine command to index commits and PRs into the palace

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -98,6 +98,26 @@ def cmd_mine(args):
         )
 
 
+def cmd_git_mine(args):
+    from .git_miner import mine_git
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    mine_git(
+        repo_dir=args.repo_dir,
+        palace_path=palace_path,
+        wing=args.wing,
+        room=args.room,
+        agent=args.agent,
+        max_commits=args.max_commits,
+        max_prs=args.max_prs,
+        since=args.since,
+        include_all=args.all_commits,
+        no_reviews=args.no_reviews,
+        decision_only=args.decision_only,
+        dry_run=args.dry_run,
+    )
+
+
 def cmd_search(args):
     from .searcher import search, SearchError
 
@@ -552,6 +572,47 @@ def main():
 
     sub.add_parser("status", help="Show what's been filed")
 
+    # git-mine
+    p_git_mine = sub.add_parser(
+        "git-mine",
+        help="Mine git commits and GitHub PRs into the palace",
+    )
+    p_git_mine.add_argument("repo_dir", help="Path to the git repository root")
+    p_git_mine.add_argument(
+        "--wing", default="wing_code", help="Wing to file into (default: wing_code)"
+    )
+    p_git_mine.add_argument(
+        "--room", default="git-decisions", help="Room to file into (default: git-decisions)"
+    )
+    p_git_mine.add_argument(
+        "--agent", default="git-mine", help="Agent name recorded in metadata"
+    )
+    p_git_mine.add_argument(
+        "--since", default="", help="Only include commits after this date (e.g. 2025-01-01)"
+    )
+    p_git_mine.add_argument(
+        "--max-commits", type=int, default=0, help="Max commits to process (0 = all)"
+    )
+    p_git_mine.add_argument(
+        "--max-prs", type=int, default=25, help="Max PRs to fetch via gh (default: 25)"
+    )
+    p_git_mine.add_argument(
+        "--no-reviews", action="store_true", help="Skip per-PR review thread fetching"
+    )
+    p_git_mine.add_argument(
+        "--all-commits",
+        action="store_true",
+        help="Include commits without a body or decision signal",
+    )
+    p_git_mine.add_argument(
+        "--decision-only",
+        action="store_true",
+        help="Only file entries matching decision-signal keywords",
+    )
+    p_git_mine.add_argument(
+        "--dry-run", action="store_true", help="Show what would be filed without filing"
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -578,6 +639,7 @@ def main():
     dispatch = {
         "init": cmd_init,
         "mine": cmd_mine,
+        "git-mine": cmd_git_mine,
         "split": cmd_split,
         "search": cmd_search,
         "mcp": cmd_mcp,

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -115,6 +115,7 @@ def cmd_git_mine(args):
         no_reviews=args.no_reviews,
         decision_only=args.decision_only,
         dry_run=args.dry_run,
+        diff_summary=args.diff_summary,
     )
 
 
@@ -579,7 +580,7 @@ def main():
     )
     p_git_mine.add_argument("repo_dir", help="Path to the git repository root")
     p_git_mine.add_argument(
-        "--wing", default="wing_code", help="Wing to file into (default: wing_code)"
+        "--wing", default=None, help="Wing to file into (default: repo directory name)"
     )
     p_git_mine.add_argument(
         "--room", default="git-decisions", help="Room to file into (default: git-decisions)"
@@ -597,7 +598,13 @@ def main():
         "--max-prs", type=int, default=25, help="Max PRs to fetch via gh (default: 25)"
     )
     p_git_mine.add_argument(
-        "--no-reviews", action="store_true", help="Skip per-PR review thread fetching"
+        "--diff-summary",
+        default="always",
+        choices=["always", "fallback", "never"],
+        help="Append structured diff summary to PR drawers: always (default), fallback (only when no description), never",
+    )
+    p_git_mine.add_argument(
+        "--no-reviews", action="store_true", help="Skip folding review threads into PR drawers"
     )
     p_git_mine.add_argument(
         "--all-commits",

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -599,9 +599,9 @@ def main():
     )
     p_git_mine.add_argument(
         "--diff-summary",
-        default="always",
+        default="fallback",
         choices=["always", "fallback", "never"],
-        help="Append structured diff summary to PR drawers: always (default), fallback (only when no description), never",
+        help="Append structured diff summary to PR drawers: fallback (default, only when no description), always (every PR — one extra gh api call per PR), never",
     )
     p_git_mine.add_argument(
         "--no-reviews", action="store_true", help="Skip folding review threads into PR drawers"

--- a/mempalace/git_miner.py
+++ b/mempalace/git_miner.py
@@ -2,11 +2,14 @@
 """
 git_miner.py — Mine git commit history and GitHub PR data into the palace.
 
-Parses commit messages from ``git log`` (no auth required) and, when the
-``gh`` CLI is installed and authenticated, fetches merged PR titles, bodies,
-and review threads.
+Structure produced:
 
-All entries are filed under ``wing_code / git-decisions`` by default.
+    wing: <repo-name>  (derived from repo directory base name)
+      room: git-decisions
+        drawer: one per merged PR — title + body + review threads + diff summary
+        drawer: one per commit not associated with any fetched PR
+
+Callers can override wing and room via CLI flags or the MCP tool parameters.
 Commit mining requires only ``git``; PR and review mining requires ``gh``
 (https://cli.github.com) to be installed and authenticated.
 """
@@ -17,8 +20,7 @@ import re
 import shutil
 import subprocess
 import sys
-from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .palace import get_collection
@@ -27,38 +29,163 @@ from .config import sanitize_name, sanitize_content
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 
-DEFAULT_WING = "wing_code"
+_FALLBACK_WING = "wing_code"
 DEFAULT_ROOM = "git-decisions"
 
-# Record separator unlikely to appear in real commit messages.
-_LOG_SEP = ">>MP<<"
+# NUL byte as record separator — cannot appear in git commit messages.
+_LOG_SEP = "\x00"
 
 # Keywords that signal a decision, rationale, or architectural choice.
 _DECISION_RE = re.compile(
     r"\b(decided|because|instead of|rather than|trade-?off|"
     r"approach|strategy|architecture|chose|went with|"
+    r"over\b.{0,40}\bbecause|"
     r"migrate|refactor|deprecat|introduced|removed|replaced|switched)\b",
     re.IGNORECASE,
 )
 
+# Diff summary modes.
+DIFF_SUMMARY_ALWAYS = "always"
+DIFF_SUMMARY_FALLBACK = "fallback"
+DIFF_SUMMARY_NEVER = "never"
+
+# Hunk header context regex — extracts the function/method name from a unified
+# diff @@ header line, e.g.: @@ -98,6 +98,26 @@ def cmd_mine(args):
+_HUNK_CONTEXT_RE = re.compile(r"^@@[^@]*@@\s*(.+)$")
+
+# Minimum PR body length (non-whitespace chars) to be considered "has a description"
+# for the "fallback" mode.
+_BODY_MIN_LEN = 30
+
 MAX_FILE_SIZE = 10 * 1024 * 1024  # not used for git, kept for parity
+
+
+# ── Wing derivation ────────────────────────────────────────────────────────────
+
+
+def _default_wing(repo_dir: str) -> str:
+    """Derive a wing name from the repository directory name.
+
+    Lower-cases the directory name and replaces spaces and hyphens with
+    underscores, mirroring convo_miner.py.  Falls back to ``wing_code`` if the
+    result fails ``sanitize_name`` validation.
+    """
+    name = Path(repo_dir).resolve().name.lower().replace(" ", "_").replace("-", "_")
+    try:
+        return sanitize_name(name, "wing")
+    except ValueError:
+        return _FALLBACK_WING
+
+
+# ── Diff summary ───────────────────────────────────────────────────────────────
+
+
+def _parse_diff_summary(files: list) -> str:
+    """Convert a list of PR file dicts (from the GitHub REST API) into a
+    compact, human-readable summary of what changed.
+
+    Example output::
+
+        mempalace/cli.py        modified  +62    → cmd_mine, main
+        mempalace/git_miner.py  added     +467
+        tests/test_git_miner.py added     +426
+
+    Function context is extracted from unified diff hunk headers when present.
+    No raw diff content is stored.
+
+    Args:
+        files: List of dicts with keys ``filename``, ``status``,
+               ``additions``, ``deletions``, and optionally ``patch``.
+    """
+    if not files:
+        return ""
+
+    lines = []
+    for f in files:
+        filename = f.get("filename", "")
+        status = f.get("status", "")
+        additions = f.get("additions", 0)
+        deletions = f.get("deletions", 0)
+        patch = f.get("patch", "") or ""
+
+        # Collect unique function/method names from hunk headers, preserving order.
+        seen_ctx: set = set()
+        ctx_list: list = []
+        for line in patch.splitlines():
+            m = _HUNK_CONTEXT_RE.match(line.strip())
+            if m:
+                ctx = m.group(1).strip()
+                if ctx and ctx not in seen_ctx:
+                    seen_ctx.add(ctx)
+                    ctx_list.append(ctx)
+
+        stat = f"+{additions}"
+        if deletions:
+            stat += f" -{deletions}"
+
+        line = f"  {filename:<45}  {status:<8}  {stat}"
+        if ctx_list:
+            line += "   → " + ", ".join(ctx_list)
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def _fetch_pr_files(repo_dir: str, pr_number: int) -> list:
+    """Fetch changed file metadata for a PR via ``gh api``.
+
+    Uses the GitHub REST endpoint which includes the ``patch`` field (unified
+    diff text) needed to extract hunk context. Returns an empty list on any
+    error so callers can degrade gracefully.
+
+    Args:
+        repo_dir: Path to the git repository root.
+        pr_number: PR number to fetch files for.
+    """
+    try:
+        raw = subprocess.run(
+            [
+                "gh", "api",
+                f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/files",
+                "--paginate",
+            ],
+            cwd=repo_dir,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            check=True,
+        )
+        return json.loads(raw.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return []
 
 
 # ── Public data class ──────────────────────────────────────────────────────────
 
 
 class GitEntry:
-    """One mined piece of content — a commit, PR summary, or review thread."""
+    """One mined piece of content — a merged PR (with reviews folded in) or a
+    standalone commit not covered by any fetched PR."""
 
-    __slots__ = ("source", "ref", "title", "body", "author", "date")
+    __slots__ = ("source", "ref", "title", "body", "author", "date", "git_sha")
 
-    def __init__(self, source: str, ref: str, title: str, body: str, author: str, date: str):
-        self.source = source  # "commit" | "pr" | "review"
-        self.ref = ref  # short SHA or PR number string
+    def __init__(
+        self,
+        source: str,
+        ref: str,
+        title: str,
+        body: str,
+        author: str,
+        date: str,
+        git_sha: str = "",
+    ):
+        self.source = source   # "commit" | "pr"
+        self.ref = ref         # short SHA or PR number string
         self.title = title
         self.body = body
         self.author = author
         self.date = date
+        self.git_sha = git_sha  # full 40-char SHA for commits; "" for PRs
 
     def has_decision_signal(self) -> bool:
         return bool(_DECISION_RE.search(self.title) or _DECISION_RE.search(self.body))
@@ -69,16 +196,13 @@ class GitEntry:
         if self.source == "commit":
             lines.append(f"COMMIT {self.ref} | {self.author} | {self.date}")
             lines.append(f"Subject: {self.title}")
-        elif self.source == "pr":
+        else:  # pr
             lines.append(f"PR #{self.ref} | {self.author} | {self.date}")
             lines.append(f"Title: {self.title}")
-        else:
-            lines.append(f"REVIEW {self.ref} | {self.author} | {self.date}")
-            lines.append(f"PR: {self.title}")
+        text = "\n".join(lines) + "\n"
         if self.body:
-            lines.append("")
-            lines.append(self.body)
-        return "\n".join(lines)
+            text += f"\n{self.body}\n"
+        return text
 
     def drawer_id(self, wing: str, room: str) -> str:
         """Content-addressed, deterministic drawer ID — idempotent upserts."""
@@ -94,17 +218,22 @@ def collect_commits(
     max_commits: int = 0,
     since: str = "",
     include_all: bool = False,
+    pr_shas: set = None,
 ) -> list:
-    """Return a list of GitEntry objects parsed from ``git log``.
+    """Return GitEntry objects parsed from ``git log``, skipping any commit
+    whose full SHA appears in *pr_shas* (already covered by a PR drawer).
 
     Args:
         repo_dir: Path to the git repository root.
         max_commits: Cap on commits returned (0 = all).
-        since: Only include commits after this date string (e.g. ``"2025-01-01"``).
-        include_all: If ``False`` (default), skip commits that have no body and
-            no decision signal in the subject.
+        since: Only include commits after this date string.
+        include_all: If ``False``, skip commits with no body and no signal.
+        pr_shas: Set of full commit SHAs that belong to fetched PRs.
     """
-    fmt = f"--pretty=format:{_LOG_SEP}%H|%an|%aI|%s|%b{_LOG_SEP}"
+    if pr_shas is None:
+        pr_shas = set()
+
+    fmt = "--pretty=format:%x00%H|%an|%aI|%s|%b%x00"
     args = ["git", "log", fmt, "--no-merges"]
     if since:
         args.append(f"--since={since}")
@@ -130,17 +259,26 @@ def collect_commits(
         parts = block.split("|", 4)
         if len(parts) < 4:
             continue
-        sha, author, date, subject = parts[0].strip(), parts[1].strip(), parts[2].strip(), parts[3].strip()
+        sha = parts[0].strip()
+        author = parts[1].strip()
+        date = parts[2].strip()
+        subject = parts[3].strip()
         body = parts[4].strip() if len(parts) == 5 else ""
         if not sha or not subject:
             continue
+
+        # Skip commits already covered by a fetched PR.
+        if sha in pr_shas:
+            continue
+
         entry = GitEntry(
             source="commit",
-            ref=sha[:12],
+            ref=sha[:12] if len(sha) >= 12 else sha,
             title=subject,
             body=body,
             author=author,
             date=date,
+            git_sha=sha,
         )
         if not include_all and not body and not entry.has_decision_signal():
             continue
@@ -160,26 +298,37 @@ def collect_prs(
     repo_dir: str,
     max_prs: int = 25,
     no_reviews: bool = False,
+    diff_summary: str = DIFF_SUMMARY_ALWAYS,
 ) -> tuple:
-    """Return ``(pr_entries, review_entries)`` fetched via ``gh``.
+    """Return ``(pr_entries, pr_shas)`` fetched via ``gh``.
 
-    Returns empty lists (with a warning printed) when ``gh`` is unavailable or
-    not authenticated — PR mining is optional and degrades gracefully.
+    Each PR entry has its review threads and diff summary folded into ``body``
+    according to *diff_summary* mode.
+    *pr_shas* is a set of full commit SHAs belonging to the fetched PRs so
+    that ``collect_commits`` can skip them.
+
+    Returns empty list and empty set (with a warning) when ``gh`` is
+    unavailable or not authenticated.
 
     Args:
-        repo_dir: Path to the git repository root (used as cwd for ``gh``).
+        repo_dir: Path to the git repository root.
         max_prs: Maximum number of merged PRs to fetch (default 25).
-        no_reviews: Skip per-PR review thread fetching when ``True``.
+        no_reviews: Skip folding review threads into PR bodies.
+        diff_summary: When to append the structured diff summary:
+            ``"always"`` (default), ``"fallback"`` (only when PR body is
+            absent/short), or ``"never"``.
     """
+    pr_shas: set = set()
+
     if not _gh_available():
         print(
             "  [git-mine] gh CLI not found — skipping PR mining. "
             "Install from https://cli.github.com to enable PR indexing.",
             file=sys.stderr,
         )
-        return [], []
+        return [], pr_shas
 
-    limit = max(1, max_prs)
+    limit = max_prs if max_prs > 0 else 25
 
     try:
         raw = subprocess.run(
@@ -191,6 +340,7 @@ def collect_prs(
             ],
             cwd=repo_dir,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             check=True,
         )
@@ -199,68 +349,107 @@ def collect_prs(
             f"  [git-mine] gh pr list failed — skipping PR mining: {exc.stderr.strip()!r}",
             file=sys.stderr,
         )
-        return [], []
+        return [], pr_shas
 
     try:
         prs = json.loads(raw.stdout)
     except json.JSONDecodeError:
-        return [], []
+        return [], pr_shas
 
     pr_entries = []
-    review_entries = []
 
     for pr in prs:
-        body = (pr.get("body") or "").strip()
+        pr_body = (pr.get("body") or "").strip()
+        reviews = []
+
+        if not no_reviews:
+            reviews, commit_shas = _fetch_pr_detail(repo_dir, pr["number"])
+            pr_shas.update(commit_shas)
+
+        # Fetch diff summary according to mode.
+        summary = ""
+        if diff_summary != DIFF_SUMMARY_NEVER:
+            body_is_short = len(pr_body.strip()) < _BODY_MIN_LEN
+            if diff_summary == DIFF_SUMMARY_ALWAYS or (diff_summary == DIFF_SUMMARY_FALLBACK and body_is_short):
+                files = _fetch_pr_files(repo_dir, pr["number"])
+                summary = _parse_diff_summary(files)
+
         pr_entries.append(
             GitEntry(
                 source="pr",
                 ref=str(pr["number"]),
                 title=pr.get("title", ""),
-                body=body,
+                body=_build_pr_body(pr_body, reviews, summary),
                 author=(pr.get("author") or {}).get("login", ""),
                 date=pr.get("createdAt", ""),
             )
         )
 
-        if not no_reviews:
-            review_entries.extend(_fetch_reviews(repo_dir, pr["number"], pr.get("title", "")))
-
-    return pr_entries, review_entries
+    return pr_entries, pr_shas
 
 
-def _fetch_reviews(repo_dir: str, pr_number: int, pr_title: str) -> list:
-    """Fetch non-empty review bodies for one PR."""
+def _fetch_pr_detail(repo_dir: str, pr_number: int) -> tuple:
+    """Fetch review threads and commit SHAs for one PR.
+
+    Returns ``(reviews, commit_shas)`` where *reviews* is a list of
+    ``{"author": str, "body": str}`` dicts and *commit_shas* is a set of
+    full SHA strings.
+    """
     try:
         raw = subprocess.run(
             [
                 "gh", "pr", "view", str(pr_number),
-                "--json", "reviews",
+                "--json", "reviews,commits",
             ],
             cwd=repo_dir,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             check=True,
         )
         detail = json.loads(raw.stdout)
     except (subprocess.CalledProcessError, json.JSONDecodeError):
-        return []
+        return [], set()
 
-    entries = []
-    for i, rev in enumerate(detail.get("reviews", [])):
+    reviews = []
+    for rev in detail.get("reviews", []):
         body = (rev.get("body") or "").strip()
-        if not body:
-            continue
-        entries.append(
-            GitEntry(
-                source="review",
-                ref=f"{pr_number}.{i}",
-                title=f"Review on PR #{pr_number}: {pr_title}",
-                body=body,
-                author=(rev.get("author") or {}).get("login", ""),
-                date=rev.get("createdAt", ""),
-            )
-        )
-    return entries
+        if body:
+            reviews.append({
+                "author": (rev.get("author") or {}).get("login", ""),
+                "body": body,
+            })
+
+    commit_shas = {
+        c["oid"] for c in detail.get("commits", []) if c.get("oid")
+    }
+
+    return reviews, commit_shas
+
+
+def _build_pr_body(pr_body: str, reviews: list, diff_summary: str = "") -> str:
+    """Assemble the final drawer body for a PR.
+
+    Sections (each omitted when empty):
+
+    1. PR description
+    2. ``--- Review threads ---`` block
+    3. ``--- Code changes ---`` block
+    """
+    parts = []
+    if pr_body:
+        parts.append(pr_body)
+
+    if reviews:
+        review_lines = ["\n--- Review threads ---"]
+        for rev in reviews:
+            review_lines.append(f"[{rev['author']}] {rev['body']}")
+        parts.append("\n".join(review_lines))
+
+    if diff_summary:
+        parts.append(f"\n--- Code changes ---\n{diff_summary}")
+
+    return "\n".join(parts).strip()
 
 
 # ── Core pipeline ──────────────────────────────────────────────────────────────
@@ -274,14 +463,26 @@ def collect_entries(
     include_all: bool = False,
     no_reviews: bool = False,
     decision_only: bool = False,
+    diff_summary: str = DIFF_SUMMARY_ALWAYS,
 ) -> list:
     """Collect all git entries without writing to the palace.
 
+    PRs (with reviews and diff summary folded in) are collected first; commits
+    that belong to those PRs are then excluded from the commit scan.
+
     Useful for dry-run previews and testing.
     """
-    entries = collect_commits(repo_dir, max_commits=max_commits, since=since, include_all=include_all)
-    pr_entries, review_entries = collect_prs(repo_dir, max_prs=max_prs, no_reviews=no_reviews)
-    entries = entries + pr_entries + review_entries
+    pr_entries, pr_shas = collect_prs(
+        repo_dir, max_prs=max_prs, no_reviews=no_reviews, diff_summary=diff_summary
+    )
+    commit_entries = collect_commits(
+        repo_dir,
+        max_commits=max_commits,
+        since=since,
+        include_all=include_all,
+        pr_shas=pr_shas,
+    )
+    entries = pr_entries + commit_entries
 
     if decision_only:
         entries = [e for e in entries if e.has_decision_signal()]
@@ -292,7 +493,7 @@ def collect_entries(
 def mine_git(
     repo_dir: str,
     palace_path: str,
-    wing: str = DEFAULT_WING,
+    wing: str = None,
     room: str = DEFAULT_ROOM,
     agent: str = "git-mine",
     max_commits: int = 0,
@@ -302,33 +503,40 @@ def mine_git(
     no_reviews: bool = False,
     decision_only: bool = False,
     dry_run: bool = False,
+    diff_summary: str = DIFF_SUMMARY_ALWAYS,
 ) -> dict:
     """Mine a git repository and file entries into the palace.
 
     Args:
         repo_dir: Path to the git repository root.
         palace_path: Path to the ChromaDB palace directory.
-        wing: Wing to file into (default: ``wing_code``).
+        wing: Wing to file into. Defaults to the repository directory name
+            (e.g. ``mempalace`` for ``/path/to/mempalace``), falling back to
+            ``wing_code`` if the name cannot be sanitized.
         room: Room to file into (default: ``git-decisions``).
         agent: Agent name recorded in drawer metadata.
         max_commits: Cap on commits (0 = all).
         max_prs: Cap on PRs fetched via gh (default 25).
         since: Only include commits after this date (e.g. ``"2025-01-01"``).
         include_all: Include commits with no body and no decision signal.
-        no_reviews: Skip per-PR review thread fetching.
+        no_reviews: Skip folding review threads into PR drawers.
         decision_only: Only file entries matching decision-signal keywords.
+        dry_run: Print entries without writing to the palace.
+        diff_summary: When to append structured diff summary to PR drawers:
+            ``"always"`` (default), ``"fallback"`` (only when no description),
+            or ``"never"``.
         dry_run: Print entries without writing to the palace.
 
     Returns:
-        A dict with keys ``commits``, ``prs``, ``reviews``, ``filed``, ``errors``.
+        A dict with keys ``commits``, ``prs``, ``filed``, ``errors``, ``wing``.
     """
+    repo_path = str(Path(repo_dir).expanduser().resolve())
+    resolved_wing = wing if wing is not None else _default_wing(repo_path)
     try:
-        wing = sanitize_name(wing, "wing")
+        resolved_wing = sanitize_name(resolved_wing, "wing")
         room = sanitize_name(room, "room")
     except ValueError as exc:
         return {"error": str(exc)}
-
-    repo_path = str(Path(repo_dir).expanduser().resolve())
 
     entries = collect_entries(
         repo_path,
@@ -338,57 +546,60 @@ def mine_git(
         include_all=include_all,
         no_reviews=no_reviews,
         decision_only=decision_only,
+        diff_summary=diff_summary,
     )
 
-    commits = sum(1 for e in entries if e.source == "commit")
     prs = sum(1 for e in entries if e.source == "pr")
-    reviews = sum(1 for e in entries if e.source == "review")
+    commits = sum(1 for e in entries if e.source == "commit")
 
-    _print_header(repo_path, wing, room, len(entries), dry_run)
+    _print_header(repo_path, resolved_wing, room, len(entries), dry_run)
 
     if dry_run:
         for i, entry in enumerate(entries, 1):
             print(f"  [{i:4}] {entry.source.upper():6} {entry.ref:12} {entry.author:20} {entry.title[:55]}")
         print(f"\n  Total: {len(entries)} entries (not written)")
-        _print_footer(wing)
-        return {"commits": commits, "prs": prs, "reviews": reviews, "filed": 0, "errors": []}
+        _print_footer(resolved_wing)
+        return {"commits": commits, "prs": prs, "filed": 0, "errors": [], "wing": resolved_wing}
 
     collection = get_collection(palace_path)
     filed = 0
     errors = []
-    room_counts = defaultdict(int)
 
     for entry in entries:
         content = entry.format()
         try:
             content = sanitize_content(content)
-        except ValueError:
+        except ValueError as exc:
+            print(
+                f"  [git-mine] skipping {entry.source} {entry.ref} — content rejected by sanitize_content: {exc}",
+                file=sys.stderr,
+            )
             continue
 
-        drawer_id = entry.drawer_id(wing, room)
+        drawer_id = entry.drawer_id(resolved_wing, room)
+        metadata: dict = {
+            "wing": resolved_wing,
+            "room": room,
+            "source_file": f"{entry.source}:{entry.ref}",
+            "chunk_index": 0,
+            "added_by": agent,
+            "filed_at": datetime.now(timezone.utc).isoformat(),
+            "ingest_mode": "git-mine",
+        }
+        if entry.git_sha:
+            metadata["git_sha"] = entry.git_sha
         try:
             collection.upsert(
                 ids=[drawer_id],
                 documents=[content],
-                metadatas=[
-                    {
-                        "wing": wing,
-                        "room": room,
-                        "source_file": f"{entry.source}:{entry.ref}",
-                        "chunk_index": 0,
-                        "added_by": agent,
-                        "filed_at": datetime.now().isoformat(),
-                        "ingest_mode": "git-mine",
-                    }
-                ],
+                metadatas=[metadata],
             )
             filed += 1
-            room_counts[room] += 1
         except Exception as exc:
             errors.append(f"{entry.source} {entry.ref}: {exc}")
 
-    _print_results(commits, prs, reviews, filed, wing, room, errors)
-    return {"commits": commits, "prs": prs, "reviews": reviews, "filed": filed, "errors": errors}
+    _print_results(commits, prs, filed, resolved_wing, room, errors)
+    return {"commits": commits, "prs": prs, "filed": filed, "errors": errors, "wing": resolved_wing}
 
 
 # ── Output helpers ─────────────────────────────────────────────────────────────
@@ -408,12 +619,11 @@ def _print_header(repo_path: str, wing: str, room: str, total: int, dry_run: boo
 
 
 def _print_results(
-    commits: int, prs: int, reviews: int, filed: int, wing: str, room: str, errors: list
+    commits: int, prs: int, filed: int, wing: str, room: str, errors: list
 ) -> None:
     print(f"\n{'=' * 55}")
     print(f"  Commits scanned:  {commits}")
     print(f"  PRs scanned:      {prs}")
-    print(f"  Reviews scanned:  {reviews}")
     print(f"  Drawers filed:    {filed}")
     print(f"  Destination:      {wing} / {room}")
     if errors:
@@ -438,12 +648,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Mine git history into the palace.")
     parser.add_argument("repo_dir", help="Path to the git repository root")
     parser.add_argument("--palace", default=None, help="Palace directory path")
-    parser.add_argument("--wing", default=DEFAULT_WING)
+    parser.add_argument("--wing", default=None, help="Wing to file into (default: repo directory name)")
     parser.add_argument("--room", default=DEFAULT_ROOM)
     parser.add_argument("--since", default="", help="Only commits after this date")
     parser.add_argument("--max-commits", type=int, default=0)
     parser.add_argument("--max-prs", type=int, default=25)
-    parser.add_argument("--no-reviews", action="store_true")
+    parser.add_argument("--no-reviews", action="store_true", help="Skip folding review threads into PR drawers")
     parser.add_argument("--all-commits", action="store_true")
     parser.add_argument("--decision-only", action="store_true")
     parser.add_argument("--dry-run", action="store_true")

--- a/mempalace/git_miner.py
+++ b/mempalace/git_miner.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""
+git_miner.py — Mine git commit history and GitHub PR data into the palace.
+
+Parses commit messages from ``git log`` (no auth required) and, when the
+``gh`` CLI is installed and authenticated, fetches merged PR titles, bodies,
+and review threads.
+
+All entries are filed under ``wing_code / git-decisions`` by default.
+Commit mining requires only ``git``; PR and review mining requires ``gh``
+(https://cli.github.com) to be installed and authenticated.
+"""
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+from .palace import get_collection
+from .config import sanitize_name, sanitize_content
+
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+DEFAULT_WING = "wing_code"
+DEFAULT_ROOM = "git-decisions"
+
+# Record separator unlikely to appear in real commit messages.
+_LOG_SEP = ">>MP<<"
+
+# Keywords that signal a decision, rationale, or architectural choice.
+_DECISION_RE = re.compile(
+    r"\b(decided|because|instead of|rather than|trade-?off|"
+    r"approach|strategy|architecture|chose|went with|"
+    r"migrate|refactor|deprecat|introduced|removed|replaced|switched)\b",
+    re.IGNORECASE,
+)
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # not used for git, kept for parity
+
+
+# ── Public data class ──────────────────────────────────────────────────────────
+
+
+class GitEntry:
+    """One mined piece of content — a commit, PR summary, or review thread."""
+
+    __slots__ = ("source", "ref", "title", "body", "author", "date")
+
+    def __init__(self, source: str, ref: str, title: str, body: str, author: str, date: str):
+        self.source = source  # "commit" | "pr" | "review"
+        self.ref = ref  # short SHA or PR number string
+        self.title = title
+        self.body = body
+        self.author = author
+        self.date = date
+
+    def has_decision_signal(self) -> bool:
+        return bool(_DECISION_RE.search(self.title) or _DECISION_RE.search(self.body))
+
+    def format(self) -> str:
+        """Produce the verbatim text stored in a drawer."""
+        lines = []
+        if self.source == "commit":
+            lines.append(f"COMMIT {self.ref} | {self.author} | {self.date}")
+            lines.append(f"Subject: {self.title}")
+        elif self.source == "pr":
+            lines.append(f"PR #{self.ref} | {self.author} | {self.date}")
+            lines.append(f"Title: {self.title}")
+        else:
+            lines.append(f"REVIEW {self.ref} | {self.author} | {self.date}")
+            lines.append(f"PR: {self.title}")
+        if self.body:
+            lines.append("")
+            lines.append(self.body)
+        return "\n".join(lines)
+
+    def drawer_id(self, wing: str, room: str) -> str:
+        """Content-addressed, deterministic drawer ID — idempotent upserts."""
+        key = wing + room + self.source + self.ref + self.title
+        return f"drawer_{wing}_{room}_git_{hashlib.sha256(key.encode()).hexdigest()[:24]}"
+
+
+# ── git log ────────────────────────────────────────────────────────────────────
+
+
+def collect_commits(
+    repo_dir: str,
+    max_commits: int = 0,
+    since: str = "",
+    include_all: bool = False,
+) -> list:
+    """Return a list of GitEntry objects parsed from ``git log``.
+
+    Args:
+        repo_dir: Path to the git repository root.
+        max_commits: Cap on commits returned (0 = all).
+        since: Only include commits after this date string (e.g. ``"2025-01-01"``).
+        include_all: If ``False`` (default), skip commits that have no body and
+            no decision signal in the subject.
+    """
+    fmt = f"--pretty=format:{_LOG_SEP}%H|%an|%aI|%s|%b{_LOG_SEP}"
+    args = ["git", "log", fmt, "--no-merges"]
+    if since:
+        args.append(f"--since={since}")
+    if max_commits > 0:
+        args.append(f"-n{max_commits}")
+
+    try:
+        result = subprocess.run(
+            args,
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise RuntimeError(f"git log failed in {repo_dir}: {exc}") from exc
+
+    entries = []
+    for block in result.stdout.split(_LOG_SEP):
+        block = block.strip()
+        if not block:
+            continue
+        parts = block.split("|", 4)
+        if len(parts) < 4:
+            continue
+        sha, author, date, subject = parts[0].strip(), parts[1].strip(), parts[2].strip(), parts[3].strip()
+        body = parts[4].strip() if len(parts) == 5 else ""
+        if not sha or not subject:
+            continue
+        entry = GitEntry(
+            source="commit",
+            ref=sha[:12],
+            title=subject,
+            body=body,
+            author=author,
+            date=date,
+        )
+        if not include_all and not body and not entry.has_decision_signal():
+            continue
+        entries.append(entry)
+
+    return entries
+
+
+# ── gh PRs ─────────────────────────────────────────────────────────────────────
+
+
+def _gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def collect_prs(
+    repo_dir: str,
+    max_prs: int = 25,
+    no_reviews: bool = False,
+) -> tuple:
+    """Return ``(pr_entries, review_entries)`` fetched via ``gh``.
+
+    Returns empty lists (with a warning printed) when ``gh`` is unavailable or
+    not authenticated — PR mining is optional and degrades gracefully.
+
+    Args:
+        repo_dir: Path to the git repository root (used as cwd for ``gh``).
+        max_prs: Maximum number of merged PRs to fetch (default 25).
+        no_reviews: Skip per-PR review thread fetching when ``True``.
+    """
+    if not _gh_available():
+        print(
+            "  [git-mine] gh CLI not found — skipping PR mining. "
+            "Install from https://cli.github.com to enable PR indexing.",
+            file=sys.stderr,
+        )
+        return [], []
+
+    limit = max(1, max_prs)
+
+    try:
+        raw = subprocess.run(
+            [
+                "gh", "pr", "list",
+                "--state", "merged",
+                "--limit", str(limit),
+                "--json", "number,title,body,author,createdAt",
+            ],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"  [git-mine] gh pr list failed — skipping PR mining: {exc.stderr.strip()!r}",
+            file=sys.stderr,
+        )
+        return [], []
+
+    try:
+        prs = json.loads(raw.stdout)
+    except json.JSONDecodeError:
+        return [], []
+
+    pr_entries = []
+    review_entries = []
+
+    for pr in prs:
+        body = (pr.get("body") or "").strip()
+        pr_entries.append(
+            GitEntry(
+                source="pr",
+                ref=str(pr["number"]),
+                title=pr.get("title", ""),
+                body=body,
+                author=(pr.get("author") or {}).get("login", ""),
+                date=pr.get("createdAt", ""),
+            )
+        )
+
+        if not no_reviews:
+            review_entries.extend(_fetch_reviews(repo_dir, pr["number"], pr.get("title", "")))
+
+    return pr_entries, review_entries
+
+
+def _fetch_reviews(repo_dir: str, pr_number: int, pr_title: str) -> list:
+    """Fetch non-empty review bodies for one PR."""
+    try:
+        raw = subprocess.run(
+            [
+                "gh", "pr", "view", str(pr_number),
+                "--json", "reviews",
+            ],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        detail = json.loads(raw.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return []
+
+    entries = []
+    for i, rev in enumerate(detail.get("reviews", [])):
+        body = (rev.get("body") or "").strip()
+        if not body:
+            continue
+        entries.append(
+            GitEntry(
+                source="review",
+                ref=f"{pr_number}.{i}",
+                title=f"Review on PR #{pr_number}: {pr_title}",
+                body=body,
+                author=(rev.get("author") or {}).get("login", ""),
+                date=rev.get("createdAt", ""),
+            )
+        )
+    return entries
+
+
+# ── Core pipeline ──────────────────────────────────────────────────────────────
+
+
+def collect_entries(
+    repo_dir: str,
+    max_commits: int = 0,
+    max_prs: int = 25,
+    since: str = "",
+    include_all: bool = False,
+    no_reviews: bool = False,
+    decision_only: bool = False,
+) -> list:
+    """Collect all git entries without writing to the palace.
+
+    Useful for dry-run previews and testing.
+    """
+    entries = collect_commits(repo_dir, max_commits=max_commits, since=since, include_all=include_all)
+    pr_entries, review_entries = collect_prs(repo_dir, max_prs=max_prs, no_reviews=no_reviews)
+    entries = entries + pr_entries + review_entries
+
+    if decision_only:
+        entries = [e for e in entries if e.has_decision_signal()]
+
+    return entries
+
+
+def mine_git(
+    repo_dir: str,
+    palace_path: str,
+    wing: str = DEFAULT_WING,
+    room: str = DEFAULT_ROOM,
+    agent: str = "git-mine",
+    max_commits: int = 0,
+    max_prs: int = 25,
+    since: str = "",
+    include_all: bool = False,
+    no_reviews: bool = False,
+    decision_only: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """Mine a git repository and file entries into the palace.
+
+    Args:
+        repo_dir: Path to the git repository root.
+        palace_path: Path to the ChromaDB palace directory.
+        wing: Wing to file into (default: ``wing_code``).
+        room: Room to file into (default: ``git-decisions``).
+        agent: Agent name recorded in drawer metadata.
+        max_commits: Cap on commits (0 = all).
+        max_prs: Cap on PRs fetched via gh (default 25).
+        since: Only include commits after this date (e.g. ``"2025-01-01"``).
+        include_all: Include commits with no body and no decision signal.
+        no_reviews: Skip per-PR review thread fetching.
+        decision_only: Only file entries matching decision-signal keywords.
+        dry_run: Print entries without writing to the palace.
+
+    Returns:
+        A dict with keys ``commits``, ``prs``, ``reviews``, ``filed``, ``errors``.
+    """
+    try:
+        wing = sanitize_name(wing, "wing")
+        room = sanitize_name(room, "room")
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    repo_path = str(Path(repo_dir).expanduser().resolve())
+
+    entries = collect_entries(
+        repo_path,
+        max_commits=max_commits,
+        max_prs=max_prs,
+        since=since,
+        include_all=include_all,
+        no_reviews=no_reviews,
+        decision_only=decision_only,
+    )
+
+    commits = sum(1 for e in entries if e.source == "commit")
+    prs = sum(1 for e in entries if e.source == "pr")
+    reviews = sum(1 for e in entries if e.source == "review")
+
+    _print_header(repo_path, wing, room, len(entries), dry_run)
+
+    if dry_run:
+        for i, entry in enumerate(entries, 1):
+            print(f"  [{i:4}] {entry.source.upper():6} {entry.ref:12} {entry.author:20} {entry.title[:55]}")
+        print(f"\n  Total: {len(entries)} entries (not written)")
+        _print_footer(wing)
+        return {"commits": commits, "prs": prs, "reviews": reviews, "filed": 0, "errors": []}
+
+    collection = get_collection(palace_path)
+    filed = 0
+    errors = []
+    room_counts = defaultdict(int)
+
+    for entry in entries:
+        content = entry.format()
+        try:
+            content = sanitize_content(content)
+        except ValueError:
+            continue
+
+        drawer_id = entry.drawer_id(wing, room)
+        try:
+            collection.upsert(
+                ids=[drawer_id],
+                documents=[content],
+                metadatas=[
+                    {
+                        "wing": wing,
+                        "room": room,
+                        "source_file": f"{entry.source}:{entry.ref}",
+                        "chunk_index": 0,
+                        "added_by": agent,
+                        "filed_at": datetime.now().isoformat(),
+                        "ingest_mode": "git-mine",
+                    }
+                ],
+            )
+            filed += 1
+            room_counts[room] += 1
+        except Exception as exc:
+            errors.append(f"{entry.source} {entry.ref}: {exc}")
+
+    _print_results(commits, prs, reviews, filed, wing, room, errors)
+    return {"commits": commits, "prs": prs, "reviews": reviews, "filed": filed, "errors": errors}
+
+
+# ── Output helpers ─────────────────────────────────────────────────────────────
+
+
+def _print_header(repo_path: str, wing: str, room: str, total: int, dry_run: bool) -> None:
+    print(f"\n{'=' * 55}")
+    print("  MemPalace Git-Mine" + (" — Dry Run" if dry_run else ""))
+    print(f"{'=' * 55}")
+    print(f"  Repo:    {repo_path}")
+    print(f"  Wing:    {wing}")
+    print(f"  Room:    {room}")
+    print(f"  Entries: {total}")
+    if dry_run:
+        print("  DRY RUN — nothing will be filed")
+    print(f"{'-' * 55}\n")
+
+
+def _print_results(
+    commits: int, prs: int, reviews: int, filed: int, wing: str, room: str, errors: list
+) -> None:
+    print(f"\n{'=' * 55}")
+    print(f"  Commits scanned:  {commits}")
+    print(f"  PRs scanned:      {prs}")
+    print(f"  Reviews scanned:  {reviews}")
+    print(f"  Drawers filed:    {filed}")
+    print(f"  Destination:      {wing} / {room}")
+    if errors:
+        print("\n  Warnings:")
+        for err in errors:
+            print(f"    - {err}")
+    print(f'\n  Next: mempalace search "architecture decision" --wing {wing}')
+    print(f"{'=' * 55}\n")
+
+
+def _print_footer(wing: str) -> None:
+    print(f"\n  Next: mempalace search \"architecture decision\" --wing {wing}")
+    print(f"{'=' * 55}\n")
+
+
+# ── CLI entry point ────────────────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Mine git history into the palace.")
+    parser.add_argument("repo_dir", help="Path to the git repository root")
+    parser.add_argument("--palace", default=None, help="Palace directory path")
+    parser.add_argument("--wing", default=DEFAULT_WING)
+    parser.add_argument("--room", default=DEFAULT_ROOM)
+    parser.add_argument("--since", default="", help="Only commits after this date")
+    parser.add_argument("--max-commits", type=int, default=0)
+    parser.add_argument("--max-prs", type=int, default=25)
+    parser.add_argument("--no-reviews", action="store_true")
+    parser.add_argument("--all-commits", action="store_true")
+    parser.add_argument("--decision-only", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    from .config import MempalaceConfig
+
+    palace = args.palace or MempalaceConfig().palace_path
+    mine_git(
+        args.repo_dir,
+        palace,
+        wing=args.wing,
+        room=args.room,
+        max_commits=args.max_commits,
+        max_prs=args.max_prs,
+        since=args.since,
+        include_all=args.all_commits,
+        no_reviews=args.no_reviews,
+        decision_only=args.decision_only,
+        dry_run=args.dry_run,
+    )

--- a/mempalace/git_miner.py
+++ b/mempalace/git_miner.py
@@ -298,7 +298,7 @@ def collect_prs(
     repo_dir: str,
     max_prs: int = 25,
     no_reviews: bool = False,
-    diff_summary: str = DIFF_SUMMARY_ALWAYS,
+    diff_summary: str = DIFF_SUMMARY_FALLBACK,
 ) -> tuple:
     """Return ``(pr_entries, pr_shas)`` fetched via ``gh``.
 
@@ -315,8 +315,9 @@ def collect_prs(
         max_prs: Maximum number of merged PRs to fetch (default 25).
         no_reviews: Skip folding review threads into PR bodies.
         diff_summary: When to append the structured diff summary:
-            ``"always"`` (default), ``"fallback"`` (only when PR body is
-            absent/short), or ``"never"``.
+            ``"fallback"`` (default, only when PR body is absent/short),
+            ``"always"`` (every PR, costs one extra ``gh api`` call per PR),
+            or ``"never"``.
     """
     pr_shas: set = set()
 
@@ -463,7 +464,7 @@ def collect_entries(
     include_all: bool = False,
     no_reviews: bool = False,
     decision_only: bool = False,
-    diff_summary: str = DIFF_SUMMARY_ALWAYS,
+    diff_summary: str = DIFF_SUMMARY_FALLBACK,
 ) -> list:
     """Collect all git entries without writing to the palace.
 
@@ -503,7 +504,7 @@ def mine_git(
     no_reviews: bool = False,
     decision_only: bool = False,
     dry_run: bool = False,
-    diff_summary: str = DIFF_SUMMARY_ALWAYS,
+    diff_summary: str = DIFF_SUMMARY_FALLBACK,
 ) -> dict:
     """Mine a git repository and file entries into the palace.
 
@@ -523,7 +524,9 @@ def mine_git(
         decision_only: Only file entries matching decision-signal keywords.
         dry_run: Print entries without writing to the palace.
         diff_summary: When to append structured diff summary to PR drawers:
-            ``"always"`` (default), ``"fallback"`` (only when no description),
+            ``"fallback"`` (default, only when PR has no description),
+            ``"always"`` (every PR — costs one extra ``gh api`` call per PR;
+            can hit GitHub rate limits on repos with many PRs),
             or ``"never"``.
         dry_run: Print entries without writing to the palace.
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -585,6 +585,90 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
         return {"error": str(e)}
 
 
+# ==================== GIT MINE ====================
+
+
+def tool_git_mine(
+    repo_dir: str,
+    wing: str = "wing_code",
+    room: str = "git-decisions",
+    since: str = "",
+    max_commits: int = 0,
+    max_prs: int = 25,
+    all_commits: bool = False,
+    no_reviews: bool = False,
+    decision_only: bool = False,
+    dry_run: bool = False,
+):
+    """
+    Mine a git repository for commits, PR descriptions, and review threads
+    and file them into the palace.
+
+    Commit mining uses ``git log`` (no auth required). PR and review mining
+    requires the ``gh`` CLI to be installed and authenticated. When ``gh``
+    is unavailable the tool still files commits and reports the gap.
+    """
+    from .git_miner import mine_git, collect_entries
+
+    palace_path = _config.palace_path
+
+    if dry_run:
+        try:
+            from pathlib import Path
+
+            entries = collect_entries(
+                str(Path(repo_dir).expanduser().resolve()),
+                max_commits=max_commits,
+                max_prs=max_prs,
+                since=since,
+                include_all=all_commits,
+                no_reviews=no_reviews,
+                decision_only=decision_only,
+            )
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+        preview = [
+            {
+                "source": e.source,
+                "ref": e.ref,
+                "author": e.author,
+                "date": e.date,
+                "title": e.title,
+                "body": e.body[:200] if e.body else "",
+            }
+            for e in entries
+        ]
+        return {"dry_run": True, "entries": preview, "total": len(entries)}
+
+    result = mine_git(
+        repo_dir=repo_dir,
+        palace_path=palace_path,
+        wing=wing,
+        room=room,
+        max_commits=max_commits,
+        max_prs=max_prs,
+        since=since,
+        include_all=all_commits,
+        no_reviews=no_reviews,
+        decision_only=decision_only,
+        dry_run=False,
+    )
+    if "error" in result:
+        return {"success": False, "error": result["error"]}
+
+    return {
+        "success": True,
+        "commits_scanned": result["commits"],
+        "prs_scanned": result["prs"],
+        "reviews_scanned": result["reviews"],
+        "drawers_filed": result["filed"],
+        "wing": wing,
+        "room": room,
+        "errors": result.get("errors", []),
+    }
+
+
 # ==================== MCP PROTOCOL ====================
 
 TOOLS = {
@@ -833,6 +917,62 @@ TOOLS = {
             "required": ["agent_name"],
         },
         "handler": tool_diary_read,
+    },
+    "mempalace_git_mine": {
+        "description": (
+            "Mine a git repository for commits, PR descriptions, and review threads "
+            "and file them into the palace under wing_code/git-decisions. "
+            "Commit mining requires only git. PR and review mining requires the gh CLI "
+            "(https://cli.github.com) to be installed and authenticated — it degrades "
+            "gracefully when gh is unavailable."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo_dir": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the git repository root",
+                },
+                "wing": {
+                    "type": "string",
+                    "description": "Wing to file into (default: wing_code)",
+                },
+                "room": {
+                    "type": "string",
+                    "description": "Room to file into (default: git-decisions)",
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Only include commits after this date (e.g. 2025-01-01)",
+                },
+                "max_commits": {
+                    "type": "integer",
+                    "description": "Max commits to process (0 = all)",
+                },
+                "max_prs": {
+                    "type": "integer",
+                    "description": "Max PRs to fetch via gh (default: 25)",
+                },
+                "all_commits": {
+                    "type": "boolean",
+                    "description": "Include commits without a body or decision signal",
+                },
+                "no_reviews": {
+                    "type": "boolean",
+                    "description": "Skip per-PR review thread fetching (faster for large repos)",
+                },
+                "decision_only": {
+                    "type": "boolean",
+                    "description": "Only file entries matching decision-signal keywords",
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "Return entries without writing to the palace",
+                },
+            },
+            "required": ["repo_dir"],
+        },
+        "handler": tool_git_mine,
     },
 }
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -599,7 +599,7 @@ def tool_git_mine(
     no_reviews: bool = False,
     decision_only: bool = False,
     dry_run: bool = False,
-    diff_summary: str = "always",
+    diff_summary: str = "fallback",
 ):
     """
     Mine a git repository for merged PRs (with review threads and diff summary
@@ -950,7 +950,7 @@ TOOLS = {
                 },
                 "diff_summary": {
                     "type": "string",
-                    "description": "When to append structured diff summary (changed files + touched functions) to PR drawers: 'always' (default), 'fallback' (only when PR has no description), or 'never'",
+                    "description": "When to append structured diff summary (changed files + touched functions) to PR drawers: 'fallback' (default, only when PR has no description), 'always' (every PR — one extra gh api call per PR, may hit rate limits on large repos), or 'never'",
                 },
                 "max_commits": {
                     "type": "integer",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -590,7 +590,7 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
 
 def tool_git_mine(
     repo_dir: str,
-    wing: str = "wing_code",
+    wing: str = None,
     room: str = "git-decisions",
     since: str = "",
     max_commits: int = 0,
@@ -599,10 +599,11 @@ def tool_git_mine(
     no_reviews: bool = False,
     decision_only: bool = False,
     dry_run: bool = False,
+    diff_summary: str = "always",
 ):
     """
-    Mine a git repository for commits, PR descriptions, and review threads
-    and file them into the palace.
+    Mine a git repository for merged PRs (with review threads and diff summary
+    folded in) and standalone commits, filing one drawer per entry into the palace.
 
     Commit mining uses ``git log`` (no auth required). PR and review mining
     requires the ``gh`` CLI to be installed and authenticated. When ``gh``
@@ -624,6 +625,7 @@ def tool_git_mine(
                 include_all=all_commits,
                 no_reviews=no_reviews,
                 decision_only=decision_only,
+                diff_summary=diff_summary,
             )
         except Exception as exc:
             return {"success": False, "error": str(exc)}
@@ -653,6 +655,7 @@ def tool_git_mine(
         no_reviews=no_reviews,
         decision_only=decision_only,
         dry_run=False,
+        diff_summary=diff_summary,
     )
     if "error" in result:
         return {"success": False, "error": result["error"]}
@@ -661,9 +664,8 @@ def tool_git_mine(
         "success": True,
         "commits_scanned": result["commits"],
         "prs_scanned": result["prs"],
-        "reviews_scanned": result["reviews"],
         "drawers_filed": result["filed"],
-        "wing": wing,
+        "wing": result.get("wing", wing),
         "room": room,
         "errors": result.get("errors", []),
     }
@@ -920,8 +922,9 @@ TOOLS = {
     },
     "mempalace_git_mine": {
         "description": (
-            "Mine a git repository for commits, PR descriptions, and review threads "
-            "and file them into the palace under wing_code/git-decisions. "
+            "Mine a git repository for merged PRs (with review threads folded into each PR drawer) "
+            "and standalone commits, filing one drawer per entry into the palace under the "
+            "repository's own wing (derived from the repo directory name) in git-decisions. "
             "Commit mining requires only git. PR and review mining requires the gh CLI "
             "(https://cli.github.com) to be installed and authenticated — it degrades "
             "gracefully when gh is unavailable."
@@ -935,7 +938,7 @@ TOOLS = {
                 },
                 "wing": {
                     "type": "string",
-                    "description": "Wing to file into (default: wing_code)",
+                    "description": "Wing to file into (default: derived from repo directory name, e.g. 'mempalace' for /path/to/mempalace)",
                 },
                 "room": {
                     "type": "string",
@@ -944,6 +947,10 @@ TOOLS = {
                 "since": {
                     "type": "string",
                     "description": "Only include commits after this date (e.g. 2025-01-01)",
+                },
+                "diff_summary": {
+                    "type": "string",
+                    "description": "When to append structured diff summary (changed files + touched functions) to PR drawers: 'always' (default), 'fallback' (only when PR has no description), or 'never'",
                 },
                 "max_commits": {
                     "type": "integer",
@@ -959,7 +966,7 @@ TOOLS = {
                 },
                 "no_reviews": {
                     "type": "boolean",
-                    "description": "Skip per-PR review thread fetching (faster for large repos)",
+                    "description": "Skip folding review threads into PR drawers (faster for large repos)",
                 },
                 "decision_only": {
                     "type": "boolean",

--- a/tests/test_git_miner.py
+++ b/tests/test_git_miner.py
@@ -5,18 +5,23 @@ All tests mock subprocess.run so they require no git binary, no gh CLI,
 and no network access.
 """
 
-import hashlib
 import shutil
 import subprocess
 import tempfile
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import chromadb
 import pytest
 
 from mempalace.git_miner import (
     DEFAULT_ROOM,
-    DEFAULT_WING,
+    DIFF_SUMMARY_ALWAYS,
+    DIFF_SUMMARY_FALLBACK,
+    DIFF_SUMMARY_NEVER,
+    _FALLBACK_WING,
+    _build_pr_body,
+    _default_wing,
+    _parse_diff_summary,
     GitEntry,
     _DECISION_RE,
     collect_commits,
@@ -28,7 +33,7 @@ from mempalace.git_miner import (
 
 # ── Fixtures ───────────────────────────────────────────────────────────────────
 
-LOG_SEP = ">>MP<<"
+LOG_SEP = "\x00"
 
 
 def _make_log_output(*records):
@@ -40,15 +45,15 @@ def _make_log_output(*records):
 
 
 FAKE_LOG = _make_log_output(
-    ("abc123def456", "Alice", "2026-01-01T00:00:00Z", "refactor: extract auth module", ""),
+    ("abc123def456" + "a" * 28, "Alice", "2026-01-01T00:00:00Z", "refactor: extract auth module", ""),
     (
-        "111222333444",
+        "111222333444" + "b" * 28,
         "Bob",
         "2026-01-02T00:00:00Z",
         "feat: add rate limiter",
         "Decided to use token bucket instead of leaky bucket because it handles burst traffic better.",
     ),
-    ("deadbeefcafe", "Carol", "2026-01-03T00:00:00Z", "chore: bump deps", ""),
+    ("deadbeefcafe" + "c" * 28, "Carol", "2026-01-03T00:00:00Z", "chore: bump deps", ""),
 )
 
 FAKE_PR_LIST = """[
@@ -68,18 +73,48 @@ FAKE_PR_LIST = """[
   }
 ]"""
 
-FAKE_PR_REVIEWS = """{"reviews": [
+# PR detail response: reviews + commits (commits are used to populate pr_shas)
+FAKE_PR_DETAIL_42 = """{
+  "reviews": [
+    {
+      "author": {"login": "carol"},
+      "body": "Why not use REST here? The team decided on gRPC for performance reasons.",
+      "createdAt": "2026-01-10T12:00:00Z"
+    },
+    {
+      "author": {"login": "dan"},
+      "body": "",
+      "createdAt": "2026-01-10T13:00:00Z"
+    }
+  ],
+  "commits": [
+    {"oid": "abc123def456aaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+    {"oid": "deadbeefcafecccccccccccccccccccccccccccc"}
+  ]
+}"""
+
+FAKE_PR_DETAIL_43 = '{"reviews": [], "commits": []}'
+
+# Fake GitHub REST API /pulls/{n}/files response with patch text including
+# hunk context so we can test diff summary extraction.
+FAKE_PR_FILES_42 = """[
   {
-    "author": {"login": "carol"},
-    "body": "Why not use REST here? The team decided on gRPC for performance reasons.",
-    "createdAt": "2026-01-10T12:00:00Z"
+    "filename": "mempalace/cli.py",
+    "status": "modified",
+    "additions": 62,
+    "deletions": 0,
+    "patch": "@@ -98,6 +98,26 @@ def cmd_mine(args):\\n+new line\\n @@ -552,6 +572,47 @@ def main():\\n+other"
   },
   {
-    "author": {"login": "dan"},
-    "body": "",
-    "createdAt": "2026-01-10T13:00:00Z"
+    "filename": "mempalace/git_miner.py",
+    "status": "added",
+    "additions": 467,
+    "deletions": 0,
+    "patch": "@@ -0,0 +1,467 @@"
   }
-]}"""
+]"""
+
+FAKE_PR_FILES_43 = "[]"
 
 
 def _mock_run(stdout="", returncode=0):
@@ -87,6 +122,120 @@ def _mock_run(stdout="", returncode=0):
     m.stdout = stdout
     m.returncode = returncode
     return m
+
+
+# ── _default_wing ─────────────────────────────────────────────────────────────
+
+
+class TestDefaultWing:
+    def test_derives_from_repo_name(self):
+        assert _default_wing("/path/to/mempalace") == "mempalace"
+
+    def test_lowercases_name(self):
+        assert _default_wing("/path/to/MyProject") == "myproject"
+
+    def test_replaces_hyphens(self):
+        assert _default_wing("/path/to/my-repo") == "my_repo"
+
+    def test_replaces_spaces(self):
+        assert _default_wing("/path/to/my repo") == "my_repo"
+
+    def test_fallback_on_invalid_name(self):
+        # A repo directory starting with '_' fails sanitize_name → fallback
+        assert _default_wing("/path/to/_hidden") == _FALLBACK_WING
+
+
+# ── _parse_diff_summary ────────────────────────────────────────────────────────
+
+
+class TestParseDiffSummary:
+    def test_empty_returns_empty(self):
+        assert _parse_diff_summary([]) == ""
+        assert _parse_diff_summary(None) == ""
+
+    def test_no_hunk_context(self):
+        files = [{"filename": "go.sum", "status": "modified", "additions": 10, "deletions": 5, "patch": ""}]
+        result = _parse_diff_summary(files)
+        assert "go.sum" in result
+        assert "modified" in result
+        assert "+10" in result
+        assert "-5" in result
+        assert "→" not in result
+
+    def test_extracts_hunk_context(self):
+        patch = "@@ -98,6 +98,26 @@ def cmd_mine(args):\n+new\n@@ -200,3 +220,5 @@ def main():\n+other"
+        files = [{"filename": "cli.py", "status": "modified", "additions": 28, "deletions": 0, "patch": patch}]
+        result = _parse_diff_summary(files)
+        assert "→" in result
+        assert "def cmd_mine(args):" in result
+        assert "def main():" in result
+
+    def test_deduplicates_context(self):
+        patch = "@@ -10,3 +10,5 @@ def foo():\n+x\n@@ -20,3 +22,5 @@ def foo():\n+y"
+        files = [{"filename": "a.py", "status": "modified", "additions": 2, "deletions": 0, "patch": patch}]
+        result = _parse_diff_summary(files)
+        assert result.count("def foo():") == 1
+
+    def test_new_file_no_context(self):
+        files = [{"filename": "new.py", "status": "added", "additions": 120, "deletions": 0, "patch": "@@ -0,0 +1,120 @@"}]
+        result = _parse_diff_summary(files)
+        assert "new.py" in result
+        assert "added" in result
+        assert "+120" in result
+
+    def test_multiple_files_one_line_each(self):
+        files = [
+            {"filename": "a.py", "status": "modified", "additions": 5, "deletions": 2, "patch": ""},
+            {"filename": "b.py", "status": "added", "additions": 10, "deletions": 0, "patch": ""},
+        ]
+        lines = _parse_diff_summary(files).splitlines()
+        assert len(lines) == 2
+
+
+# ── _build_pr_body ─────────────────────────────────────────────────────────────
+
+
+class TestBuildPRBody:
+    def test_no_reviews_no_diff(self):
+        assert _build_pr_body("description", [], "") == "description"
+
+    def test_reviews_folded_in(self):
+        reviews = [
+            {"author": "alice", "body": "Looks good."},
+            {"author": "bob", "body": "Why not gRPC?"},
+        ]
+        body = _build_pr_body("Switch to gRPC.", reviews, "")
+        assert "Switch to gRPC." in body
+        assert "--- Review threads ---" in body
+        assert "[alice] Looks good." in body
+        assert "[bob] Why not gRPC?" in body
+
+    def test_diff_summary_appended(self):
+        summary = "  cli.py  modified  +5"
+        body = _build_pr_body("desc", [], summary)
+        assert "--- Code changes ---" in body
+        assert "cli.py" in body
+
+    def test_all_three_sections_in_order(self):
+        reviews = [{"author": "x", "body": "LGTM"}]
+        summary = "  a.py  modified  +1"
+        body = _build_pr_body("desc", reviews, summary)
+        desc_idx = body.index("desc")
+        review_idx = body.index("--- Review threads ---")
+        code_idx = body.index("--- Code changes ---")
+        assert desc_idx < review_idx < code_idx
+
+    def test_empty_pr_body_with_reviews(self):
+        reviews = [{"author": "carol", "body": "LGTM"}]
+        body = _build_pr_body("", reviews, "")
+        assert not body.startswith("\n"), "should not start with newline when PR body is empty"
+        assert "[carol] LGTM" in body
+
+    def test_diff_only_no_description(self):
+        summary = "  main.py  modified  +5"
+        body = _build_pr_body("", [], summary)
+        assert not body.startswith("\n")
+        assert "--- Code changes ---" in body
 
 
 # ── GitEntry ───────────────────────────────────────────────────────────────────
@@ -100,23 +249,19 @@ class TestGitEntry:
         assert "Subject: fix: auth bug" in text
         assert "Body text" in text
 
-    def test_format_pr(self):
-        e = GitEntry("pr", "42", "feat: add feature", "PR body", "bob", "2026-01-01")
+    def test_format_pr_with_reviews_folded(self):
+        body = "Switch to gRPC.\n\n--- Review threads ---\n[alice] LGTM"
+        e = GitEntry("pr", "42", "feat: add gRPC", body, "bob", "2026-01-01")
         text = e.format()
         assert "PR #42" in text
-        assert "Title: feat: add feature" in text
-
-    def test_format_review(self):
-        e = GitEntry("review", "42.0", "Review on PR #42: feat", "Review body", "carol", "2026-01-01")
-        text = e.format()
-        assert "REVIEW 42.0" in text
-        assert "Review body" in text
+        assert "Title: feat: add gRPC" in text
+        assert "--- Review threads ---" in text
+        assert "[alice] LGTM" in text
 
     def test_format_no_body(self):
         e = GitEntry("commit", "abc", "subject only", "", "Alice", "2026-01-01")
         text = e.format()
         assert "subject only" in text
-        # No blank body section appended
         assert text.count("\n\n") == 0
 
     def test_has_decision_signal_title(self):
@@ -159,21 +304,33 @@ class TestCollectCommits:
         entries = collect_commits("/fake/repo", include_all=True)
         assert len(entries) == 3
         assert all(e.source == "commit" for e in entries)
-        assert entries[0].ref == "abc123def456"[:12]
+        assert entries[0].ref == "abc123def456"
         assert entries[0].title == "refactor: extract auth module"
         assert entries[1].body.startswith("Decided")
+
+    @patch("subprocess.run")
+    def test_git_sha_populated(self, mock_run):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        entries = collect_commits("/fake/repo", include_all=True)
+        for e in entries:
+            assert len(e.git_sha) == 40, f"expected 40-char SHA, got {e.git_sha!r}"
 
     @patch("subprocess.run")
     def test_filters_trivial_commits_by_default(self, mock_run):
         mock_run.return_value = _mock_run(FAKE_LOG)
         entries = collect_commits("/fake/repo", include_all=False)
-        # abc123 has no body and no decision signal → excluded
-        # deadbeef has no body and no decision signal → excluded
-        # 111222 has a body with decision signal → included
-        # Also "refactor" in abc123 title matches → included
         titles = [e.title for e in entries]
-        assert "chore: bump deps" not in titles  # no body, no signal
+        assert "chore: bump deps" not in titles
         assert "feat: add rate limiter" in titles
+
+    @patch("subprocess.run")
+    def test_pr_shas_excluded(self, mock_run):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        # Exclude the first commit's SHA
+        sha = "abc123def456" + "a" * 28
+        entries = collect_commits("/fake/repo", include_all=True, pr_shas={sha})
+        refs = [e.ref for e in entries]
+        assert "abc123def456" not in refs
 
     @patch("subprocess.run")
     def test_max_commits_passed_to_git(self, mock_run):
@@ -208,20 +365,19 @@ class TestCollectCommits:
 class TestCollectPRs:
     @patch("shutil.which", return_value=None)
     def test_no_gh_returns_empty(self, mock_which):
-        prs, reviews = collect_prs("/fake/repo")
+        prs, pr_shas = collect_prs("/fake/repo")
         assert prs == []
-        assert reviews == []
+        assert pr_shas == set()
 
     @patch("shutil.which", return_value="/usr/bin/gh")
     @patch("subprocess.run")
     def test_parses_prs(self, mock_run, mock_which):
-        # First call: pr list; subsequent: pr view per PR
         mock_run.side_effect = [
             _mock_run(FAKE_PR_LIST),
-            _mock_run(FAKE_PR_REVIEWS),  # reviews for PR 42
-            _mock_run('{"reviews": []}'),  # reviews for PR 43
+            _mock_run(FAKE_PR_DETAIL_42),
+            _mock_run(FAKE_PR_DETAIL_43),
         ]
-        prs, reviews = collect_prs("/fake/repo")
+        prs, _ = collect_prs("/fake/repo", diff_summary=DIFF_SUMMARY_NEVER)
         assert len(prs) == 2
         assert prs[0].ref == "42"
         assert prs[0].title == "feat: switch to gRPC instead of REST"
@@ -229,42 +385,114 @@ class TestCollectPRs:
 
     @patch("shutil.which", return_value="/usr/bin/gh")
     @patch("subprocess.run")
-    def test_reviews_fetched_per_pr(self, mock_run, mock_which):
+    def test_reviews_folded_into_pr_body(self, mock_run, mock_which):
         mock_run.side_effect = [
             _mock_run(FAKE_PR_LIST),
-            _mock_run(FAKE_PR_REVIEWS),
-            _mock_run('{"reviews": []}'),
+            _mock_run(FAKE_PR_DETAIL_42),
+            _mock_run(FAKE_PR_DETAIL_43),
         ]
-        prs, reviews = collect_prs("/fake/repo")
-        # One non-empty review body from PR 42
-        assert len(reviews) == 1
-        assert reviews[0].source == "review"
-        assert "gRPC" in reviews[0].body
+        prs, _ = collect_prs("/fake/repo", diff_summary=DIFF_SUMMARY_NEVER)
+        assert "--- Review threads ---" in prs[0].body
+        assert "[carol]" in prs[0].body
+        assert "gRPC" in prs[0].body
+        assert "[dan]" not in prs[0].body
 
     @patch("shutil.which", return_value="/usr/bin/gh")
     @patch("subprocess.run")
-    def test_no_reviews_flag_skips_review_fetch(self, mock_run, mock_which):
+    def test_no_review_source_entries(self, mock_run, mock_which):
+        """collect_prs must never return entries with source=='review'."""
+        mock_run.side_effect = [
+            _mock_run(FAKE_PR_LIST),
+            _mock_run(FAKE_PR_DETAIL_42),
+            _mock_run(FAKE_PR_DETAIL_43),
+        ]
+        prs, _ = collect_prs("/fake/repo", diff_summary=DIFF_SUMMARY_NEVER)
+        assert all(e.source == "pr" for e in prs)
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_pr_shas_populated(self, mock_run, mock_which):
+        """pr_shas should contain commit OIDs from the fetched PR detail."""
+        mock_run.side_effect = [
+            _mock_run(FAKE_PR_LIST),
+            _mock_run(FAKE_PR_DETAIL_42),
+            _mock_run(FAKE_PR_DETAIL_43),
+        ]
+        _, pr_shas = collect_prs("/fake/repo", diff_summary=DIFF_SUMMARY_NEVER)
+        assert "abc123def456" + "a" * 28 in pr_shas
+        assert "deadbeefcafe" + "c" * 28 in pr_shas
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_no_reviews_flag_skips_detail_fetch(self, mock_run, mock_which):
+        # no_reviews=True AND diff_summary=never → only pr list call
         mock_run.return_value = _mock_run(FAKE_PR_LIST)
-        prs, reviews = collect_prs("/fake/repo", no_reviews=True)
-        assert reviews == []
-        # Only one subprocess call (pr list), no pr view calls
+        prs, pr_shas = collect_prs("/fake/repo", no_reviews=True, diff_summary=DIFF_SUMMARY_NEVER)
         assert mock_run.call_count == 1
+        assert pr_shas == set()
 
     @patch("shutil.which", return_value="/usr/bin/gh")
     @patch("subprocess.run")
     def test_gh_failure_returns_empty(self, mock_run, mock_which):
         mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr=b"auth error")
-        prs, reviews = collect_prs("/fake/repo")
+        prs, pr_shas = collect_prs("/fake/repo")
         assert prs == []
-        assert reviews == []
+        assert pr_shas == set()
 
     @patch("shutil.which", return_value="/usr/bin/gh")
     @patch("subprocess.run")
     def test_max_prs_limit_passed_to_gh(self, mock_run, mock_which):
         mock_run.side_effect = [_mock_run("[]")]
-        collect_prs("/fake/repo", max_prs=10)
+        collect_prs("/fake/repo", max_prs=10, diff_summary=DIFF_SUMMARY_NEVER)
         args = mock_run.call_args[0][0]
         assert "10" in args
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_diff_summary_always_fetches_files(self, mock_run, mock_which):
+        """diff_summary=always calls gh api /files for each PR."""
+        mock_run.side_effect = [
+            _mock_run(FAKE_PR_LIST),          # pr list
+            _mock_run(FAKE_PR_DETAIL_42),     # pr view 42
+            _mock_run(FAKE_PR_FILES_42),      # gh api files 42
+            _mock_run(FAKE_PR_DETAIL_43),     # pr view 43
+            _mock_run(FAKE_PR_FILES_43),      # gh api files 43
+        ]
+        prs, _ = collect_prs("/fake/repo", diff_summary=DIFF_SUMMARY_ALWAYS)
+        assert "--- Code changes ---" in prs[0].body
+        assert "mempalace/cli.py" in prs[0].body
+        # PR 43 has empty body (short) — diff summary present but files empty
+        assert "--- Code changes ---" not in prs[1].body
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_diff_summary_fallback_only_when_no_body(self, mock_run, mock_which):
+        """diff_summary=fallback: only fetch files for PR 43 (empty body)."""
+        mock_run.side_effect = [
+            _mock_run(FAKE_PR_LIST),          # pr list
+            _mock_run(FAKE_PR_DETAIL_42),     # pr view 42 (has body — no files fetch)
+            _mock_run(FAKE_PR_DETAIL_43),     # pr view 43 (no body — files fetch)
+            _mock_run(FAKE_PR_FILES_43),      # gh api files 43
+        ]
+        prs, _ = collect_prs("/fake/repo", diff_summary=DIFF_SUMMARY_FALLBACK)
+        # PR 42 has a description → no diff appended
+        assert "--- Code changes ---" not in prs[0].body
+        # PR 43 has no description → diff appended (but files fixture is empty)
+        # (No code-changes block because FAKE_PR_FILES_43 = "[]")
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_diff_summary_never_skips_files(self, mock_run, mock_which):
+        """diff_summary=never: no gh api /files calls."""
+        mock_run.side_effect = [
+            _mock_run(FAKE_PR_LIST),
+            _mock_run(FAKE_PR_DETAIL_42),
+            _mock_run(FAKE_PR_DETAIL_43),
+        ]
+        prs, _ = collect_prs("/fake/repo", diff_summary=DIFF_SUMMARY_NEVER)
+        assert "--- Code changes ---" not in prs[0].body
+        assert "--- Code changes ---" not in prs[1].body
+        assert mock_run.call_count == 3  # list + 2x pr view, no files calls
 
 
 # ── collect_entries ────────────────────────────────────────────────────────────
@@ -281,11 +509,27 @@ class TestCollectEntries:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
-    def test_all_sources_combined(self, mock_run, mock_which):
+    def test_only_commit_and_pr_sources(self, mock_run, mock_which):
         mock_run.return_value = _mock_run(FAKE_LOG)
         entries = collect_entries("/fake/repo", include_all=True)
-        sources = {e.source for e in entries}
-        assert "commit" in sources  # no gh → only commits
+        for e in entries:
+            assert e.source in ("commit", "pr"), f"Unexpected source: {e.source!r}"
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_pr_commits_excluded_from_commit_entries(self, mock_run, mock_which):
+        """Commits that belong to a fetched PR must not appear as separate drawers."""
+        mock_run.side_effect = [
+            _mock_run(FAKE_PR_LIST),
+            _mock_run(FAKE_PR_DETAIL_42),
+            _mock_run(FAKE_PR_DETAIL_43),
+            _mock_run(FAKE_LOG),
+        ]
+        entries = collect_entries("/fake/repo", include_all=True, diff_summary=DIFF_SUMMARY_NEVER)
+        commit_refs = [e.ref for e in entries if e.source == "commit"]
+        assert "abc123def456" not in commit_refs
+        assert "deadbeefcafe" not in commit_refs
+        assert "111222333444" in commit_refs
 
 
 # ── mine_git (integration via tempdir palace) ──────────────────────────────────
@@ -305,7 +549,6 @@ class TestMineGit:
             )
             assert result["filed"] == 3
             assert result["commits"] == 3
-            # Verify drawers landed in ChromaDB
             client = chromadb.PersistentClient(path=tmpdir)
             col = client.get_collection("mempalace_drawers")
             assert col.count() == 3
@@ -325,9 +568,7 @@ class TestMineGit:
                 dry_run=True,
             )
             assert result["filed"] == 0
-            # No palace directory created by ChromaDB
             import os
-
             assert not os.path.exists(os.path.join(tmpdir, "chroma.sqlite3"))
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
@@ -335,7 +576,6 @@ class TestMineGit:
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_idempotent_upsert(self, mock_run, mock_which):
-        """Filing the same repo twice should not duplicate drawers."""
         mock_run.return_value = _mock_run(FAKE_LOG)
         tmpdir = tempfile.mkdtemp()
         try:
@@ -357,8 +597,10 @@ class TestMineGit:
             client = chromadb.PersistentClient(path=tmpdir)
             col = client.get_collection("mempalace_drawers")
             metas = col.get(include=["metadatas"])["metadatas"]
-            assert all(m["wing"] == DEFAULT_WING for m in metas)
+            expected_wing = _default_wing("/fake/repo")
+            assert all(m["wing"] == expected_wing for m in metas)
             assert all(m["room"] == DEFAULT_ROOM for m in metas)
+            assert result["wing"] == expected_wing
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -371,16 +613,26 @@ class TestMineGit:
     def test_decision_only_reduces_count(self, mock_run, mock_which):
         mock_run.return_value = _mock_run(FAKE_LOG)
         tmpdir = tempfile.mkdtemp()
+        tmpdir2 = tempfile.mkdtemp()
         try:
             result_all = mine_git("/fake/repo", tmpdir, include_all=True)
-            shutil.rmtree(tmpdir)
-
-            tmpdir2 = tempfile.mkdtemp()
             result_dec = mine_git("/fake/repo", tmpdir2, include_all=True, decision_only=True)
             assert result_dec["filed"] <= result_all["filed"]
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
             shutil.rmtree(tmpdir2, ignore_errors=True)
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_no_reviews_key_in_result(self, mock_run, mock_which):
+        """result dict must not contain 'reviews' — that field was removed."""
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        tmpdir = tempfile.mkdtemp()
+        try:
+            result = mine_git("/fake/repo", tmpdir, include_all=True)
+            assert "reviews" not in result
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 # ── MCP tool ───────────────────────────────────────────────────────────────────
@@ -394,14 +646,13 @@ class TestToolGitMine:
         tmpdir = tempfile.mkdtemp()
         try:
             import os
-
             with patch.dict(os.environ, {"MEMPALACE_PALACE_PATH": tmpdir}):
-                # Re-import to pick up patched env (config reads at call time)
                 from mempalace.mcp_server import tool_git_mine
-
                 result = tool_git_mine(repo_dir="/fake/repo", all_commits=True)
             assert result["success"] is True
             assert result["drawers_filed"] == 3
+            assert "reviews_scanned" not in result
+
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -410,7 +661,6 @@ class TestToolGitMine:
     def test_mcp_tool_dry_run(self, mock_run, mock_which):
         mock_run.return_value = _mock_run(FAKE_LOG)
         from mempalace.mcp_server import tool_git_mine
-
         result = tool_git_mine(repo_dir="/fake/repo", all_commits=True, dry_run=True)
         assert result["dry_run"] is True
         assert result["total"] == 3
@@ -418,7 +668,6 @@ class TestToolGitMine:
 
     def test_mcp_tool_in_tools_registry(self):
         from mempalace.mcp_server import TOOLS
-
         assert "mempalace_git_mine" in TOOLS
         schema = TOOLS["mempalace_git_mine"]["input_schema"]
         assert "repo_dir" in schema["required"]

--- a/tests/test_git_miner.py
+++ b/tests/test_git_miner.py
@@ -1,0 +1,426 @@
+"""
+tests/test_git_miner.py — Tests for mempalace.git_miner.
+
+All tests mock subprocess.run so they require no git binary, no gh CLI,
+and no network access.
+"""
+
+import hashlib
+import shutil
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, call, patch
+
+import chromadb
+import pytest
+
+from mempalace.git_miner import (
+    DEFAULT_ROOM,
+    DEFAULT_WING,
+    GitEntry,
+    _DECISION_RE,
+    collect_commits,
+    collect_entries,
+    collect_prs,
+    mine_git,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+LOG_SEP = ">>MP<<"
+
+
+def _make_log_output(*records):
+    """Build a fake ``git log`` stdout from (sha, author, date, subject, body) tuples."""
+    parts = []
+    for sha, author, date, subject, body in records:
+        parts.append(f"{sha}|{author}|{date}|{subject}|{body}")
+    return LOG_SEP + LOG_SEP.join(parts) + LOG_SEP
+
+
+FAKE_LOG = _make_log_output(
+    ("abc123def456", "Alice", "2026-01-01T00:00:00Z", "refactor: extract auth module", ""),
+    (
+        "111222333444",
+        "Bob",
+        "2026-01-02T00:00:00Z",
+        "feat: add rate limiter",
+        "Decided to use token bucket instead of leaky bucket because it handles burst traffic better.",
+    ),
+    ("deadbeefcafe", "Carol", "2026-01-03T00:00:00Z", "chore: bump deps", ""),
+)
+
+FAKE_PR_LIST = """[
+  {
+    "number": 42,
+    "title": "feat: switch to gRPC instead of REST",
+    "body": "We chose gRPC over REST because of better performance and streaming support.",
+    "author": {"login": "alice"},
+    "createdAt": "2026-01-10T00:00:00Z"
+  },
+  {
+    "number": 43,
+    "title": "chore: update dependencies",
+    "body": "",
+    "author": {"login": "bob"},
+    "createdAt": "2026-01-11T00:00:00Z"
+  }
+]"""
+
+FAKE_PR_REVIEWS = """{"reviews": [
+  {
+    "author": {"login": "carol"},
+    "body": "Why not use REST here? The team decided on gRPC for performance reasons.",
+    "createdAt": "2026-01-10T12:00:00Z"
+  },
+  {
+    "author": {"login": "dan"},
+    "body": "",
+    "createdAt": "2026-01-10T13:00:00Z"
+  }
+]}"""
+
+
+def _mock_run(stdout="", returncode=0):
+    m = MagicMock()
+    m.stdout = stdout
+    m.returncode = returncode
+    return m
+
+
+# ── GitEntry ───────────────────────────────────────────────────────────────────
+
+
+class TestGitEntry:
+    def test_format_commit(self):
+        e = GitEntry("commit", "abc123", "fix: auth bug", "Body text", "Alice", "2026-01-01")
+        text = e.format()
+        assert "COMMIT abc123" in text
+        assert "Subject: fix: auth bug" in text
+        assert "Body text" in text
+
+    def test_format_pr(self):
+        e = GitEntry("pr", "42", "feat: add feature", "PR body", "bob", "2026-01-01")
+        text = e.format()
+        assert "PR #42" in text
+        assert "Title: feat: add feature" in text
+
+    def test_format_review(self):
+        e = GitEntry("review", "42.0", "Review on PR #42: feat", "Review body", "carol", "2026-01-01")
+        text = e.format()
+        assert "REVIEW 42.0" in text
+        assert "Review body" in text
+
+    def test_format_no_body(self):
+        e = GitEntry("commit", "abc", "subject only", "", "Alice", "2026-01-01")
+        text = e.format()
+        assert "subject only" in text
+        # No blank body section appended
+        assert text.count("\n\n") == 0
+
+    def test_has_decision_signal_title(self):
+        e = GitEntry("commit", "abc", "refactor: migrate to new auth", "", "Alice", "2026-01-01")
+        assert e.has_decision_signal()
+
+    def test_has_decision_signal_body(self):
+        e = GitEntry("commit", "abc", "feat: add thing", "We decided to use X because Y.", "A", "")
+        assert e.has_decision_signal()
+
+    def test_no_decision_signal(self):
+        e = GitEntry("commit", "abc", "chore: bump deps", "", "Alice", "2026-01-01")
+        assert not e.has_decision_signal()
+
+    def test_drawer_id_deterministic(self):
+        e = GitEntry("commit", "abc123", "fix: bug", "", "Alice", "2026-01-01")
+        id1 = e.drawer_id("wing_code", "git-decisions")
+        id2 = e.drawer_id("wing_code", "git-decisions")
+        assert id1 == id2
+
+    def test_drawer_id_includes_wing_room(self):
+        e = GitEntry("commit", "abc", "fix", "", "A", "")
+        id_a = e.drawer_id("wing_a", "room_a")
+        id_b = e.drawer_id("wing_b", "room_b")
+        assert id_a != id_b
+
+    def test_drawer_id_format(self):
+        e = GitEntry("pr", "99", "title", "", "A", "")
+        drawer_id = e.drawer_id("wing_code", "git-decisions")
+        assert drawer_id.startswith("drawer_wing_code_git-decisions_git_")
+
+
+# ── collect_commits ────────────────────────────────────────────────────────────
+
+
+class TestCollectCommits:
+    @patch("subprocess.run")
+    def test_parses_commits(self, mock_run):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        entries = collect_commits("/fake/repo", include_all=True)
+        assert len(entries) == 3
+        assert all(e.source == "commit" for e in entries)
+        assert entries[0].ref == "abc123def456"[:12]
+        assert entries[0].title == "refactor: extract auth module"
+        assert entries[1].body.startswith("Decided")
+
+    @patch("subprocess.run")
+    def test_filters_trivial_commits_by_default(self, mock_run):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        entries = collect_commits("/fake/repo", include_all=False)
+        # abc123 has no body and no decision signal → excluded
+        # deadbeef has no body and no decision signal → excluded
+        # 111222 has a body with decision signal → included
+        # Also "refactor" in abc123 title matches → included
+        titles = [e.title for e in entries]
+        assert "chore: bump deps" not in titles  # no body, no signal
+        assert "feat: add rate limiter" in titles
+
+    @patch("subprocess.run")
+    def test_max_commits_passed_to_git(self, mock_run):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        collect_commits("/fake/repo", max_commits=5)
+        args = mock_run.call_args[0][0]
+        assert "-n5" in args
+
+    @patch("subprocess.run")
+    def test_since_passed_to_git(self, mock_run):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        collect_commits("/fake/repo", since="2025-01-01")
+        args = mock_run.call_args[0][0]
+        assert "--since=2025-01-01" in args
+
+    @patch("subprocess.run")
+    def test_git_failure_raises(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(128, "git")
+        with pytest.raises(RuntimeError, match="git log failed"):
+            collect_commits("/fake/repo")
+
+    @patch("subprocess.run")
+    def test_empty_repo(self, mock_run):
+        mock_run.return_value = _mock_run("")
+        entries = collect_commits("/fake/repo")
+        assert entries == []
+
+
+# ── collect_prs ────────────────────────────────────────────────────────────────
+
+
+class TestCollectPRs:
+    @patch("shutil.which", return_value=None)
+    def test_no_gh_returns_empty(self, mock_which):
+        prs, reviews = collect_prs("/fake/repo")
+        assert prs == []
+        assert reviews == []
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_parses_prs(self, mock_run, mock_which):
+        # First call: pr list; subsequent: pr view per PR
+        mock_run.side_effect = [
+            _mock_run(FAKE_PR_LIST),
+            _mock_run(FAKE_PR_REVIEWS),  # reviews for PR 42
+            _mock_run('{"reviews": []}'),  # reviews for PR 43
+        ]
+        prs, reviews = collect_prs("/fake/repo")
+        assert len(prs) == 2
+        assert prs[0].ref == "42"
+        assert prs[0].title == "feat: switch to gRPC instead of REST"
+        assert prs[0].author == "alice"
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_reviews_fetched_per_pr(self, mock_run, mock_which):
+        mock_run.side_effect = [
+            _mock_run(FAKE_PR_LIST),
+            _mock_run(FAKE_PR_REVIEWS),
+            _mock_run('{"reviews": []}'),
+        ]
+        prs, reviews = collect_prs("/fake/repo")
+        # One non-empty review body from PR 42
+        assert len(reviews) == 1
+        assert reviews[0].source == "review"
+        assert "gRPC" in reviews[0].body
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_no_reviews_flag_skips_review_fetch(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_PR_LIST)
+        prs, reviews = collect_prs("/fake/repo", no_reviews=True)
+        assert reviews == []
+        # Only one subprocess call (pr list), no pr view calls
+        assert mock_run.call_count == 1
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_gh_failure_returns_empty(self, mock_run, mock_which):
+        mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr=b"auth error")
+        prs, reviews = collect_prs("/fake/repo")
+        assert prs == []
+        assert reviews == []
+
+    @patch("shutil.which", return_value="/usr/bin/gh")
+    @patch("subprocess.run")
+    def test_max_prs_limit_passed_to_gh(self, mock_run, mock_which):
+        mock_run.side_effect = [_mock_run("[]")]
+        collect_prs("/fake/repo", max_prs=10)
+        args = mock_run.call_args[0][0]
+        assert "10" in args
+
+
+# ── collect_entries ────────────────────────────────────────────────────────────
+
+
+class TestCollectEntries:
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_decision_only_filters(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        entries = collect_entries("/fake/repo", include_all=True, decision_only=True)
+        for e in entries:
+            assert e.has_decision_signal(), f"Entry without signal: {e.title!r}"
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_all_sources_combined(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        entries = collect_entries("/fake/repo", include_all=True)
+        sources = {e.source for e in entries}
+        assert "commit" in sources  # no gh → only commits
+
+
+# ── mine_git (integration via tempdir palace) ──────────────────────────────────
+
+
+class TestMineGit:
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_files_drawers_to_palace(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        tmpdir = tempfile.mkdtemp()
+        try:
+            result = mine_git(
+                repo_dir="/fake/repo",
+                palace_path=tmpdir,
+                include_all=True,
+            )
+            assert result["filed"] == 3
+            assert result["commits"] == 3
+            # Verify drawers landed in ChromaDB
+            client = chromadb.PersistentClient(path=tmpdir)
+            col = client.get_collection("mempalace_drawers")
+            assert col.count() == 3
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_dry_run_does_not_write(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        tmpdir = tempfile.mkdtemp()
+        try:
+            result = mine_git(
+                repo_dir="/fake/repo",
+                palace_path=tmpdir,
+                include_all=True,
+                dry_run=True,
+            )
+            assert result["filed"] == 0
+            # No palace directory created by ChromaDB
+            import os
+
+            assert not os.path.exists(os.path.join(tmpdir, "chroma.sqlite3"))
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_idempotent_upsert(self, mock_run, mock_which):
+        """Filing the same repo twice should not duplicate drawers."""
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        tmpdir = tempfile.mkdtemp()
+        try:
+            mine_git("/fake/repo", tmpdir, include_all=True)
+            mine_git("/fake/repo", tmpdir, include_all=True)
+            client = chromadb.PersistentClient(path=tmpdir)
+            col = client.get_collection("mempalace_drawers")
+            assert col.count() == 3  # not 6
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_default_wing_room(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        tmpdir = tempfile.mkdtemp()
+        try:
+            result = mine_git("/fake/repo", tmpdir, include_all=True)
+            client = chromadb.PersistentClient(path=tmpdir)
+            col = client.get_collection("mempalace_drawers")
+            metas = col.get(include=["metadatas"])["metadatas"]
+            assert all(m["wing"] == DEFAULT_WING for m in metas)
+            assert all(m["room"] == DEFAULT_ROOM for m in metas)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_invalid_wing_returns_error(self):
+        result = mine_git("/fake/repo", "/fake/palace", wing="bad/wing")
+        assert "error" in result
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_decision_only_reduces_count(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        tmpdir = tempfile.mkdtemp()
+        try:
+            result_all = mine_git("/fake/repo", tmpdir, include_all=True)
+            shutil.rmtree(tmpdir)
+
+            tmpdir2 = tempfile.mkdtemp()
+            result_dec = mine_git("/fake/repo", tmpdir2, include_all=True, decision_only=True)
+            assert result_dec["filed"] <= result_all["filed"]
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            shutil.rmtree(tmpdir2, ignore_errors=True)
+
+
+# ── MCP tool ───────────────────────────────────────────────────────────────────
+
+
+class TestToolGitMine:
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_mcp_tool_returns_success(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        tmpdir = tempfile.mkdtemp()
+        try:
+            import os
+
+            with patch.dict(os.environ, {"MEMPALACE_PALACE_PATH": tmpdir}):
+                # Re-import to pick up patched env (config reads at call time)
+                from mempalace.mcp_server import tool_git_mine
+
+                result = tool_git_mine(repo_dir="/fake/repo", all_commits=True)
+            assert result["success"] is True
+            assert result["drawers_filed"] == 3
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_mcp_tool_dry_run(self, mock_run, mock_which):
+        mock_run.return_value = _mock_run(FAKE_LOG)
+        from mempalace.mcp_server import tool_git_mine
+
+        result = tool_git_mine(repo_dir="/fake/repo", all_commits=True, dry_run=True)
+        assert result["dry_run"] is True
+        assert result["total"] == 3
+        assert all("title" in e for e in result["entries"])
+
+    def test_mcp_tool_in_tools_registry(self):
+        from mempalace.mcp_server import TOOLS
+
+        assert "mempalace_git_mine" in TOOLS
+        schema = TOOLS["mempalace_git_mine"]["input_schema"]
+        assert "repo_dir" in schema["required"]
+        assert "repo_dir" in schema["properties"]
+        assert "dry_run" in schema["properties"]


### PR DESCRIPTION
## What does this PR do?

Adds a \`git-mine\` command that mines a git repository's commit history and GitHub PR data into the palace, filing decision-relevant content as searchable drawers.

**Three surfaces:**
- \`mempalace/git_miner.py\` — core pipeline
- \`mempalace git-mine <repo>\` — CLI subcommand
- \`mempalace_git_mine\` — MCP tool

**Storage model:** one drawer per merged PR (with review threads and a structured diff summary folded in), plus one drawer per standalone commit not covered by any fetched PR.

**How it works:**
1. Fetches merged PRs via \`gh pr list\`; fetches review threads and commit SHAs per PR via \`gh pr view --json reviews,commits\`
2. Optionally fetches \`gh api /pulls/{n}/files\` to build a structured diff summary (changed files + touched function names from hunk headers)
3. Parses \`git log\`; skips commits whose SHA belongs to a fetched PR to avoid duplication
4. Filters entries with a decision-signal regex (\`decided\`, \`because\`, \`instead of\`, \`refactor\`, etc.)
5. Files content as idempotent upserts using a deterministic content-addressed drawer ID

**Key flags:**
\`\`\`
mempalace git-mine <repo>
  --wing            Wing to file into (default: repo directory name)
  --room            Room to file into (default: git-decisions)
  --since           Only commits after this date (e.g. 2025-01-01)
  --max-commits     Cap on commits (0 = all)
  --max-prs         Cap on PRs fetched via gh (default: 25)
  --no-reviews      Skip folding review threads into PR drawers
  --diff-summary    Append structured diff summary: fallback (default), always, never
  --all-commits     Include commits without a body or decision signal
  --decision-only   Only file entries matching decision-signal keywords
  --dry-run         Preview without writing
\`\`\`

`--diff-summary=fallback` (default) fetches file metadata only for PRs with no description — the case where it adds the most value. Use `--diff-summary=always` to include it on every PR; note this costs one extra `gh api` call per PR and can hit GitHub rate limits on large repos.

The MCP tool (\`mempalace_git_mine\`) exposes the same options.

## How to test

\`\`\`bash
# Dry-run against any local repo
mempalace git-mine /path/to/your/repo --dry-run

# Mine with PR data (requires gh auth)
mempalace git-mine /path/to/your/repo --max-commits 100

# Search what was filed
mempalace search "architecture decision" --wing <repo-name>
\`\`\`

## Checklist
- [x] Tests pass (\`python -m pytest tests/ -v\`) — 58 tests
- [x] No hardcoded paths
- [x] Linter passes (\`ruff check .\`)