### PR TITLE
fix: align cmd_compress dict keys with compression_stats() return values

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -349,7 +349,7 @@ def cmd_compress(args):
         stats = dialect.compression_stats(doc, compressed)
 
         total_original += stats["original_chars"]
-        total_compressed += stats["compressed_chars"]
+        total_compressed += stats["summary_chars"]
 
         compressed_entries.append((doc_id, compressed, meta, stats))
 
@@ -359,7 +359,7 @@ def cmd_compress(args):
             source = Path(meta.get("source_file", "?")).name
             print(f"  [{wing_name}/{room_name}] {source}")
             print(
-                f"    {stats['original_tokens']}t -> {stats['compressed_tokens']}t ({stats['ratio']:.1f}x)"
+                f"    {stats['original_tokens_est']}t -> {stats['summary_tokens_est']}t ({stats['size_ratio']:.1f}x)"
             )
             print(f"    {compressed}")
             print()
@@ -370,8 +370,8 @@ def cmd_compress(args):
             comp_col = client.get_or_create_collection("mempalace_compressed")
             for doc_id, compressed, meta, stats in compressed_entries:
                 comp_meta = dict(meta)
-                comp_meta["compression_ratio"] = round(stats["ratio"], 1)
-                comp_meta["original_tokens"] = stats["original_tokens"]
+                comp_meta["compression_ratio"] = round(stats["size_ratio"], 1)
+                comp_meta["original_tokens"] = stats["original_tokens_est"]
                 comp_col.upsert(
                     ids=[doc_id],
                     documents=[compressed],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -565,6 +565,7 @@ def test_cmd_compress_dry_run(mock_config_cls, capsys):
     out = capsys.readouterr().out
     assert "dry run" in out.lower()
     assert "Compressing" in out
+    assert "Total:" in out
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -638,24 +639,8 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
         cmd_compress(args)
     out = capsys.readouterr().out
     assert "Stored" in out
+    assert "Total:" in out
     mock_comp_col.upsert.assert_called_once()
-
-
-def test_compression_stats_keys_match_dialect():
-    """Verify cmd_compress uses the same keys that Dialect.compression_stats() returns."""
-    from mempalace.dialect import Dialect
-
-    d = Dialect()
-    stats = d.compression_stats("hello world this is a test", "HW:test")
-    expected_keys = {
-        "original_chars",
-        "summary_chars",
-        "original_tokens_est",
-        "summary_tokens_est",
-        "size_ratio",
-        "note",
-    }
-    assert set(stats.keys()) == expected_keys
 
 
 def test_cmd_repair_trailing_slash_does_not_recurse():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,10 +546,11 @@ def test_cmd_compress_dry_run(mock_config_cls, capsys):
     mock_dialect.compress.return_value = "compressed"
     mock_dialect.compression_stats.return_value = {
         "original_chars": 100,
-        "compressed_chars": 30,
-        "original_tokens": 25,
-        "compressed_tokens": 8,
-        "ratio": 3.3,
+        "summary_chars": 30,
+        "original_tokens_est": 25,
+        "summary_tokens_est": 8,
+        "size_ratio": 3.3,
+        "note": "Estimates only.",
     }
     mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
 
@@ -619,10 +620,11 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     mock_dialect.compress.return_value = "compressed"
     mock_dialect.compression_stats.return_value = {
         "original_chars": 100,
-        "compressed_chars": 30,
-        "original_tokens": 25,
-        "compressed_tokens": 8,
-        "ratio": 3.3,
+        "summary_chars": 30,
+        "original_tokens_est": 25,
+        "summary_tokens_est": 8,
+        "size_ratio": 3.3,
+        "note": "Estimates only.",
     }
     mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
 
@@ -637,6 +639,23 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     out = capsys.readouterr().out
     assert "Stored" in out
     mock_comp_col.upsert.assert_called_once()
+
+
+def test_compression_stats_keys_match_dialect():
+    """Verify cmd_compress uses the same keys that Dialect.compression_stats() returns."""
+    from mempalace.dialect import Dialect
+
+    d = Dialect()
+    stats = d.compression_stats("hello world this is a test", "HW:test")
+    expected_keys = {
+        "original_chars",
+        "summary_chars",
+        "original_tokens_est",
+        "summary_tokens_est",
+        "size_ratio",
+        "note",
+    }
+    assert set(stats.keys()) == expected_keys
 
 
 def test_cmd_repair_trailing_slash_does_not_recurse():

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -115,6 +115,20 @@ class TestCompressionStats:
     def test_count_tokens(self):
         assert Dialect.count_tokens("hello world") == 2
 
+    def test_compression_stats_keys(self):
+        """Verify compression_stats() returns the expected key set."""
+        d = Dialect()
+        stats = d.compression_stats("hello world this is a test", "HW:test")
+        expected_keys = {
+            "original_chars",
+            "summary_chars",
+            "original_tokens_est",
+            "summary_tokens_est",
+            "size_ratio",
+            "note",
+        }
+        assert set(stats.keys()) == expected_keys
+
 
 class TestZettelEncoding:
     def test_encode_zettel(self):


### PR DESCRIPTION
## Summary

- Fixed `cmd_compress` in `cli.py` to use the correct dict keys returned by `Dialect.compression_stats()`

## Problem

`cmd_compress` accesses `stats["compressed_chars"]`, `stats["original_tokens"]`, `stats["compressed_tokens"]`, and `stats["ratio"]` — but `compression_stats()` returns `"summary_chars"`, `"original_tokens_est"`, `"summary_tokens_est"`, and `"size_ratio"`. This causes a `KeyError` crash every time `mempalace compress` is run.

## Changes

| Old key (broken) | New key (matches `compression_stats()`) |
|---|---|
| `compressed_chars` | `summary_chars` |
| `original_tokens` | `original_tokens_est` |
| `compressed_tokens` | `summary_tokens_est` |
| `ratio` | `size_ratio` |

`original_chars` was already correct and unchanged.

## Test plan

- [ ] Run `mempalace compress --dry-run` — should display stats without crashing
- [ ] Run `mempalace compress` — should store compressed drawers with correct metadata