### PR TITLE
fix: use correct registry key in spellcheck entity lookup

### DIFF
--- a/mempalace/spellcheck.py
+++ b/mempalace/spellcheck.py
@@ -119,8 +119,8 @@ def _load_known_names() -> set:
 
         reg = EntityRegistry.load()
         names = set()
-        for entity in reg._data.get("entities", {}).values():
-            names.add(entity.get("canonical", "").lower())
+        for name, entity in reg._data.get("people", {}).items():
+            names.add(name.lower())
             for alias in entity.get("aliases", []):
                 names.add(alias.lower())
         return names


### PR DESCRIPTION
## Summary

- Fixed `_load_known_names()` in `spellcheck.py` to read from `"people"` key instead of non-existent `"entities"` key
- Fixed canonical name extraction: the name IS the dict key, not a `"canonical"` field

## Problem

`spellcheck.py:122` reads entity data with:
```python
for entity in reg._data.get("entities", {}).values():
    names.add(entity.get("canonical", "").lower())
```

But `EntityRegistry` uses `"people"` as the key (not `"entities"`), and each person entry has no `"canonical"` field — the canonical name is the dict key itself:
```python
{"people": {"Riley": {"source": "onboarding", "aliases": [...], ...}}}
```

This means `_load_known_names()` always returns an empty set, so the spellchecker never protects registered entity names from over-correction.

## Fix

```python
for name, entity in reg._data.get("people", {}).items():
    names.add(name.lower())
    for alias in entity.get("aliases", []):
        names.add(alias.lower())
```

## Test plan

- [ ] Register a person via onboarding (e.g., "Mempalace")
- [ ] Run spellcheck on text containing that name — it should NOT be "corrected"
- [ ] Aliases should also be protected