### PR TITLE
fix: ignore unexpected MCP tool args during handler dispatch

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -18,6 +18,7 @@ Tools (write):
 """
 
 import argparse
+import inspect
 import os
 import sys
 import json
@@ -900,7 +901,10 @@ def handle_request(request):
             elif declared_type == "number" and not isinstance(value, (int, float)):
                 tool_args[key] = float(value)
         try:
-            result = TOOLS[tool_name]["handler"](**tool_args)
+            handler = TOOLS[tool_name]["handler"]
+            valid_params = set(inspect.signature(handler).parameters.keys())
+            filtered_args = {k: v for k, v in tool_args.items() if k in valid_params}
+            result = handler(**filtered_args)
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -157,6 +157,30 @@ class TestHandleRequest:
         content = json.loads(resp["result"]["content"][0]["text"])
         assert "total_drawers" in content
 
+    def test_mcp_dispatch_ignores_unexpected_tool_arguments(
+        self, monkeypatch, config, palace_path, seeded_kg
+    ):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import handle_request
+
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+
+        resp = handle_request(
+            {
+                "method": "tools/call",
+                "id": 11,
+                "params": {
+                    "name": "mempalace_status",
+                    "arguments": {"unexpected": "ignored"},
+                },
+            }
+        )
+
+        assert "error" not in resp
+        content = json.loads(resp["result"]["content"][0]["text"])
+        assert "total_drawers" in content
+
 
 # ── Read Tools ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

This PR makes the MCP dispatcher more defensive by filtering incoming tool
arguments against the target Python handler signature before dispatch.

Today, the dispatcher forwards all client-provided arguments directly to the
handler. If the client sends an extra or mismatched parameter, the call fails
with a Python `TypeError`, which is surfaced to the MCP client as
`-32000 Internal tool error`. :contentReference[oaicite:0]{index=0}

This patch keeps valid behavior unchanged while preventing unexpected extra
arguments from crashing tool execution. :contentReference[oaicite:1]{index=1}

## Problem

The current dispatch path effectively does this:

```python
handler(**tool_args)
````

That means any client-side mismatch immediately becomes a runtime failure if
the handler does not accept one of the provided keywords. According to the
reproduction already collected, this is the root cause of several MCP tool
failures returning `-32000 Internal tool error`. 

## Reproduction

A concrete reproduced case is `mempalace_search`.

Client request arguments:

```json
{
  "query": "test",
  "wing": "flexweld",
  "room": "architecture",
  "top_k": 3
}
```

Observed handler signature:

```python
mempalace_search(query, limit, wing, room)
```

Because `top_k` is not accepted by the handler, dispatch fails with:

```text
TypeError: got an unexpected keyword argument 'top_k'
```

and the MCP client receives:

```text
-32000 Internal tool error
```

The same mismatch pattern was also observed on other tools where the client
sends extra arguments not accepted by the underlying handler, including:

* `mempalace_check_duplicate`
* `mempalace_kg_add`
* `mempalace_traverse` 

## Root cause

There is a mismatch between the arguments sent by the MCP client and the
actual Python handler signatures.

The dispatcher does not currently filter or normalize arguments before calling
the handler, so unexpected keywords propagate directly into Python function
calls and raise `TypeError`. 

## Fix

Filter incoming arguments using the target handler signature before dispatch.

Conceptually:

```python
import inspect

handler = TOOLS[tool_name]["handler"]
valid_params = set(inspect.signature(handler).parameters.keys())
filtered_args = {k: v for k, v in tool_args.items() if k in valid_params}
result = handler(**filtered_args)
```

This makes dispatch resilient to extra client-side arguments while preserving
normal behavior for all valid parameters. 

## Validation

I confirmed the issue by reproducing a direct `tools/call` request path for
`mempalace_search` using `top_k`, which fails under the current dispatcher. I
also confirmed that the same flow succeeds when either:

1. `top_k` is replaced with the correct handler parameter `limit`, or
2. unexpected arguments are filtered before handler dispatch. 

This indicates the failure is in the MCP dispatch layer rather than in
ChromaDB or the underlying search implementation. 

## Scope

This PR is intentionally small and defensive.

It does **not**:

* refactor tool schemas
* rename parameters globally
* change handler signatures
* modify search, embedding, or database behavior

It only prevents unexpected extra arguments from crashing the dispatcher.

## Future work

Possible follow-up improvements, outside the scope of this PR:

* align tool schemas and handler signatures more strictly
* normalize aliases such as `top_k -> limit`
* add stricter schema-based validation or clearer client-facing errors