### PR TITLE
fix: rotate WAL file at 10 MB to prevent unbounded growth

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -79,10 +79,32 @@ try:
 except (OSError, NotImplementedError):
     pass
 _WAL_FILE = _WAL_DIR / "write_log.jsonl"
+_WAL_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _wal_rotate():
+    """Rotate WAL file when it exceeds _WAL_MAX_BYTES.
+
+    Keeps one backup (write_log.jsonl.1). Older backups are discarded.
+    """
+    try:
+        if not _WAL_FILE.exists() or _WAL_FILE.stat().st_size < _WAL_MAX_BYTES:
+            return
+        backup = _WAL_FILE.with_suffix(".jsonl.1")
+        if backup.exists():
+            backup.unlink()
+        _WAL_FILE.rename(backup)
+        try:
+            backup.chmod(0o600)
+        except (OSError, NotImplementedError):
+            pass
+    except Exception as e:
+        logger.error("WAL rotation failed: %s", e)
 
 
 def _wal_log(operation: str, params: dict, result: dict = None):
     """Append a write operation to the write-ahead log."""
+    _wal_rotate()
     entry = {
         "timestamp": datetime.now().isoformat(),
         "operation": operation,
@@ -97,7 +119,7 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         except (OSError, NotImplementedError):
             pass
     except Exception as e:
-        logger.error(f"WAL write failed: {e}")
+        logger.error("WAL write failed: %s", e)
 
 
 _client_cache = None


### PR DESCRIPTION
## Summary

- Added WAL file rotation to `_wal_log()` — rotates `write_log.jsonl` when it exceeds 10 MB
- Keeps one backup (`write_log.jsonl.1`), discards older backups on next rotation

## Problem

The write-ahead log (`~/.mempalace/wal/write_log.jsonl`) appends every write operation forever with no rotation or size limit. Over months of heavy use with frequent `add_drawer`, `kg_add`, and `diary_write` calls, this file can grow to gigabytes, consuming disk space silently.

## Fix

- New `_wal_rotate()` function checks file size before each write
- Rotates at 10 MB threshold (configurable via `_WAL_MAX_BYTES`)
- Keeps exactly one backup (`.jsonl.1`) for recent audit trail
- Rotation errors are logged but never block write operations
- Backup file inherits `0o600` permissions

## Test plan

- [ ] WAL file under 10 MB — no rotation, writes normally
- [ ] WAL file at 10 MB — rotated to `.jsonl.1`, new file created
- [ ] Existing `.jsonl.1` backup — overwritten on next rotation
- [ ] Permission errors on rotation — logged, write continues