### PR TITLE
docs: add CHANGELOG.md with v3.0.0 and v3.1.0 history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.1.0] - 2026-04-09
+
+### Added
+
+- `mempalace migrate` command to recover palaces from different ChromaDB versions
+- OpenClaw/ClawHub skill integration
+- Codex plugin support with hooks and commands
+- `mempalace mcp` command with setup guidance
+- AGENTS.md and CODEOWNERS
+- Dependabot configuration
+
+### Fixed
+
+- HNSW index bloat from duplicate add() calls
+- Stale drawer purge before re-mine to avoid hnswlib segfault
+- Codex hook message counting
+- MCP null args hang, repair infinite recursion, OOM on large files
+- Windows mtime test compatibility
+- Shell injection in hooks
+- MCP protocol version negotiation (hardcoded to negotiated)
+
+### Changed
+
+- Honest AAAK stats with word-based token estimator and lossy labels
+- Test coverage increased from 30% to 85%
+- Coverage threshold set to 80%
+- ChromaDB version range tightened
+
+## [3.0.0] - 2026-04-07
+
+### Added
+
+- Initial public release
+- Palace architecture: wings, halls, rooms, closets, drawers
+- 4-layer memory stack (L0-L3)
+- MCP server with 19 tools
+- Knowledge graph with temporal triples
+- AAAK dialect compression
+- Conversation and project mining
+- Benchmark suite (LongMemEval, LoCoMo, MemBench)
+- Claude Code plugin
+
+[3.1.0]: https://github.com/milla-jovovich/mempalace/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/milla-jovovich/mempalace/releases/tag/v3.0.0


### PR DESCRIPTION
## Summary

- Added `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
- Documents v3.0.0 (initial release) and v3.1.0 (current) changes

## Why

The project has no version history documentation. Users upgrading from v3.0.0 to v3.1.0 have no way to see what changed, what was fixed, or what was added without reading the full git log. A changelog is standard practice for any published package.

## Contents

- **v3.1.0**: migrate command, OpenClaw integration, Codex plugin, 8 bug fixes, honest AAAK stats, test coverage increase to 85%
- **v3.0.0**: initial release with palace architecture, MCP server, knowledge graph, AAAK dialect, benchmarks

## Test plan

- [ ] No code changes — documentation only
- [ ] Changelog entries match actual git history