### PR TITLE
docs: add return type hints and docstring to knowledge_graph.py

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -106,7 +106,7 @@ class KnowledgeGraph:
 
     # ── Write operations ──────────────────────────────────────────────────
 
-    def add_entity(self, name: str, entity_type: str = "unknown", properties: dict = None):
+    def add_entity(self, name: str, entity_type: str = "unknown", properties: dict = None) -> str:
         """Add or update an entity node."""
         eid = self._entity_id(name)
         props = json.dumps(properties or {})
@@ -279,7 +279,7 @@ class KnowledgeGraph:
             )
         return results
 
-    def timeline(self, entity_name: str = None):
+    def timeline(self, entity_name: str = None) -> list:
         """Get all facts in chronological order, optionally filtered by entity."""
         conn = self._conn()
         if entity_name:
@@ -320,7 +320,8 @@ class KnowledgeGraph:
 
     # ── Stats ─────────────────────────────────────────────────────────────
 
-    def stats(self):
+    def stats(self) -> dict:
+        """Return summary statistics for the knowledge graph."""
         conn = self._conn()
         entities = conn.execute("SELECT COUNT(*) as cnt FROM entities").fetchone()["cnt"]
         triples = conn.execute("SELECT COUNT(*) as cnt FROM triples").fetchone()["cnt"]


### PR DESCRIPTION
## Summary

- Added `-> str` return type to `add_entity()`
- Added `-> list` return type to `timeline()`
- Added `-> dict` return type and docstring to `stats()`

## Why

These public functions in `knowledge_graph.py` are used by the MCP server and other callers but lacked return type annotations, making it harder for contributors to understand the API contract without reading the implementation.

## Test plan

- [ ] `ruff check` passes
- [ ] `ruff format` passes
- [ ] No logic changes — type hints and docstring only