### PR TITLE
Fix KeyError in cmd_compress: stats dict key mismatch

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -349,7 +349,7 @@ def cmd_compress(args):
         stats = dialect.compression_stats(doc, compressed)
 
         total_original += stats["original_chars"]
-        total_compressed += stats["compressed_chars"]
+        total_compressed += stats["summary_chars"]
 
         compressed_entries.append((doc_id, compressed, meta, stats))
 
@@ -359,7 +359,7 @@ def cmd_compress(args):
             source = Path(meta.get("source_file", "?")).name
             print(f"  [{wing_name}/{room_name}] {source}")
             print(
-                f"    {stats['original_tokens']}t -> {stats['compressed_tokens']}t ({stats['ratio']:.1f}x)"
+                f"    {stats['original_tokens_est']}t -> {stats['summary_tokens_est']}t ({stats['size_ratio']:.1f}x)"
             )
             print(f"    {compressed}")
             print()
@@ -370,8 +370,8 @@ def cmd_compress(args):
             comp_col = client.get_or_create_collection("mempalace_compressed")
             for doc_id, compressed, meta, stats in compressed_entries:
                 comp_meta = dict(meta)
-                comp_meta["compression_ratio"] = round(stats["ratio"], 1)
-                comp_meta["original_tokens"] = stats["original_tokens"]
+                comp_meta["compression_ratio"] = round(stats["size_ratio"], 1)
+                comp_meta["original_tokens"] = stats["original_tokens_est"]
                 comp_col.upsert(
                     ids=[doc_id],
                     documents=[compressed],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,10 +546,10 @@ def test_cmd_compress_dry_run(mock_config_cls, capsys):
     mock_dialect.compress.return_value = "compressed"
     mock_dialect.compression_stats.return_value = {
         "original_chars": 100,
-        "compressed_chars": 30,
-        "original_tokens": 25,
-        "compressed_tokens": 8,
-        "ratio": 3.3,
+        "summary_chars": 30,
+        "original_tokens_est": 25,
+        "summary_tokens_est": 8,
+        "size_ratio": 3.3,
     }
     mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
 
@@ -619,10 +619,10 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     mock_dialect.compress.return_value = "compressed"
     mock_dialect.compression_stats.return_value = {
         "original_chars": 100,
-        "compressed_chars": 30,
-        "original_tokens": 25,
-        "compressed_tokens": 8,
-        "ratio": 3.3,
+        "summary_chars": 30,
+        "original_tokens_est": 25,
+        "summary_tokens_est": 8,
+        "size_ratio": 3.3,
     }
     mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
 


### PR DESCRIPTION
## Summary
- `mempalace compress` crashes with `KeyError: 'compressed_chars'` because `cmd_compress` in `cli.py` references stale dictionary keys that no longer match what `Dialect.compression_stats()` returns
- Updated 6 key references in `cli.py` and 2 test mock dictionaries in `test_cli.py` to use the correct keys: `summary_chars`, `original_tokens_est`, `summary_tokens_est`, `size_ratio`

## Key mapping

| cli.py used (old) | dialect.py returns (correct) |
|---|---|
| `compressed_chars` | `summary_chars` |
| `original_tokens` | `original_tokens_est` |
| `compressed_tokens` | `summary_tokens_est` |
| `ratio` | `size_ratio` |

## Repro
```
$ mempalace compress
KeyError: 'compressed_chars'
```

## Test plan
- [x] All 6 compress-related tests pass (`pytest tests/test_cli.py -k compress`)
- [x] Verified `mempalace compress --dry-run` works against a real palace with 21K+ drawers

🤖 Generated with [Claude Code](https://claude.com/claude-code)