### PR TITLE
fix: sanitize SESSION_ID in precompact hook (closes #110)

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -57,7 +57,13 @@ MEMPAL_DIR=""
 # Read JSON input from stdin
 INPUT=$(cat)
 
-SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+sid = data.get('session_id', 'unknown')
+safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\\-~]', '', str(s))
+print(safe(sid))
+" 2>/dev/null)
 
 echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
 

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -61,7 +61,7 @@ SESSION_ID=$(echo "$INPUT" | python3 -c "
 import sys, json, re
 data = json.load(sys.stdin)
 sid = data.get('session_id', 'unknown')
-safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\\-~]', '', str(s))
+safe = lambda s: re.sub(r'[^a-zA-Z0-9_-]', '', str(s))
 print(safe(sid))
 " 2>/dev/null)
 


### PR DESCRIPTION
The \mempal_save_hook.sh\ already sanitizes values via a \safe()\ regex before use. This PR applies the same pattern to \mempal_precompact_hook.sh\, where \SESSION_ID\ was extracted without sanitization and used directly in a shell string.\n\nFix: strip non-alphanumeric characters from \session_id\ before assignment, consistent with the approach in the save hook.