### PR TITLE
fix: implement MCP ping health checks

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -951,6 +951,8 @@ def handle_request(request):
                 "serverInfo": {"name": "mempalace", "version": __version__},
             },
         }
+    elif method == "ping":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {}}
     elif method == "notifications/initialized":
         return None
     elif method == "tools/list":

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -92,6 +92,13 @@ class TestHandleRequest:
         resp = handle_request({"method": "notifications/initialized", "id": None, "params": {}})
         assert resp is None
 
+    def test_ping_returns_empty_result(self):
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request({"method": "ping", "id": 11, "params": {}})
+        assert resp["id"] == 11
+        assert resp["result"] == {}
+
     def test_tools_list(self):
         from mempalace.mcp_server import handle_request
 


### PR DESCRIPTION
## What
- add base-protocol `ping` handling to `mempalace.mcp_server.handle_request`
- return the MCP-spec empty result object `{}` for health checks
- add a focused regression test for the `ping` dispatch path

## Why
AnythingLLM v1.12.0 now sends `ping` before accepting an MCP server connection. MemPalace currently falls through to `-32601 Unknown method: ping`, which causes repeated restart loops and prevents the server from appearing in Agent Skills.

## Validation
- `pytest tests/test_mcp_server.py -q`
- `ruff check mempalace/mcp_server.py tests/test_mcp_server.py`

## Risk Notes
- narrow protocol-compatibility fix only
- no dependency changes
- no tool behavior changes beyond supporting the standard health check