### PR TITLE
Support claude.ai privacy export format with sender field

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -28,7 +28,10 @@ CONVO_EXTENSIONS = {
 }
 
 MIN_CHUNK_SIZE = 30
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
+# Default cap for individual conversation files. claude.ai privacy exports of
+# ~100+ conversations routinely produce 20–50 MB JSON files, so the default is
+# generous enough to ingest a typical export without manual splitting.
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB — skip files larger than this
 
 
 # =============================================================================
@@ -202,7 +205,11 @@ def detect_convo_room(content: str) -> str:
 
 
 def scan_convos(convo_dir: str) -> list:
-    """Find all potential conversation files."""
+    """Find all potential conversation files.
+
+    Files larger than ``MAX_FILE_SIZE`` are skipped with a warning so users
+    can spot the limit instead of getting silently zero drawers.
+    """
     convo_path = Path(convo_dir).expanduser().resolve()
     files = []
     for root, dirs, filenames in os.walk(convo_path):
@@ -216,9 +223,17 @@ def scan_convos(convo_dir: str) -> list:
                 if filepath.is_symlink():
                     continue
                 try:
-                    if filepath.stat().st_size > MAX_FILE_SIZE:
-                        continue
+                    file_size = filepath.stat().st_size
                 except OSError:
+                    continue
+                if file_size > MAX_FILE_SIZE:
+                    size_mb = file_size / (1024 * 1024)
+                    limit_mb = MAX_FILE_SIZE / (1024 * 1024)
+                    print(
+                        f"  ⚠ Skipping large file ({size_mb:.1f} MB > "
+                        f"{limit_mb:.0f} MB limit): {filepath}",
+                        file=sys.stderr,
+                    )
                     continue
                 files.append(filepath)
     return files

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -154,7 +154,12 @@ def _try_codex_jsonl(content: str) -> Optional[str]:
 
 
 def _try_claude_ai_json(data) -> Optional[str]:
-    """Claude.ai JSON export: flat messages list or privacy export with chat_messages."""
+    """Claude.ai JSON export: flat messages list or privacy export with chat_messages.
+
+    The claude.ai privacy export uses ``sender`` rather than ``role`` to identify
+    message authors and stores the rendered message in a top-level ``text`` field
+    in addition to the structured ``content`` blocks. Both are supported here.
+    """
     if isinstance(data, dict):
         data = data.get("messages", data.get("chat_messages", []))
     if not isinstance(data, list):
@@ -168,14 +173,9 @@ def _try_claude_ai_json(data) -> Optional[str]:
                 continue
             chat_msgs = convo.get("chat_messages", [])
             for item in chat_msgs:
-                if not isinstance(item, dict):
-                    continue
-                role = item.get("role", "")
-                text = _extract_content(item.get("content", ""))
-                if role in ("user", "human") and text:
-                    all_messages.append(("user", text))
-                elif role in ("assistant", "ai") and text:
-                    all_messages.append(("assistant", text))
+                msg = _extract_claude_ai_message(item)
+                if msg:
+                    all_messages.append(msg)
         if len(all_messages) >= 2:
             return _messages_to_transcript(all_messages)
         return None
@@ -183,16 +183,34 @@ def _try_claude_ai_json(data) -> Optional[str]:
     # Flat messages list
     messages = []
     for item in data:
-        if not isinstance(item, dict):
-            continue
-        role = item.get("role", "")
-        text = _extract_content(item.get("content", ""))
-        if role in ("user", "human") and text:
-            messages.append(("user", text))
-        elif role in ("assistant", "ai") and text:
-            messages.append(("assistant", text))
+        msg = _extract_claude_ai_message(item)
+        if msg:
+            messages.append(msg)
     if len(messages) >= 2:
         return _messages_to_transcript(messages)
+    return None
+
+
+def _extract_claude_ai_message(item) -> Optional[tuple]:
+    """Pull (role, text) from a single claude.ai message dict.
+
+    Accepts ``role`` or ``sender`` as the author field, and falls back to the
+    top-level ``text`` field when ``content`` blocks yield nothing.
+    """
+    if not isinstance(item, dict):
+        return None
+    role = item.get("role") or item.get("sender") or ""
+    text = _extract_content(item.get("content", ""))
+    if not text:
+        fallback = item.get("text", "")
+        if isinstance(fallback, str):
+            text = fallback.strip()
+    if not text:
+        return None
+    if role in ("user", "human"):
+        return ("user", text)
+    if role in ("assistant", "ai"):
+        return ("assistant", text)
     return None
 
 

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -1,5 +1,8 @@
 """Unit tests for convo_miner pure functions (no chromadb needed)."""
 
+from unittest.mock import patch
+
+from mempalace import convo_miner
 from mempalace.convo_miner import (
     chunk_exchanges,
     detect_convo_room,
@@ -100,3 +103,18 @@ class TestScanConvos:
     def test_scan_empty_dir(self, tmp_path):
         files = scan_convos(str(tmp_path))
         assert files == []
+
+    def test_scan_default_limit_accepts_typical_claude_ai_export(self, tmp_path):
+        """Default limit must accommodate ~38 MB claude.ai privacy exports."""
+        assert convo_miner.MAX_FILE_SIZE >= 50 * 1024 * 1024
+
+    def test_scan_warns_on_oversized_file(self, tmp_path, capsys):
+        """Skipped large files emit a visible warning."""
+        big = tmp_path / "conversations.json"
+        big.write_text("{}", encoding="utf-8")
+        with patch.object(convo_miner, "MAX_FILE_SIZE", 1):
+            files = scan_convos(str(tmp_path))
+        assert files == []
+        captured = capsys.readouterr()
+        assert "Skipping large file" in captured.err
+        assert "conversations.json" in captured.err

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -297,6 +297,61 @@ def test_claude_ai_privacy_export_non_dict_items():
     assert result is not None
 
 
+def test_claude_ai_privacy_export_sender_field():
+    """Real claude.ai privacy export uses 'sender' rather than 'role'."""
+    data = [
+        {
+            "uuid": "convo-1",
+            "chat_messages": [
+                {
+                    "uuid": "msg-1",
+                    "sender": "human",
+                    "content": [{"type": "text", "text": "What is memory?"}],
+                    "text": "What is memory?",
+                },
+                {
+                    "uuid": "msg-2",
+                    "sender": "assistant",
+                    "content": [{"type": "text", "text": "Memory is persistence."}],
+                    "text": "Memory is persistence.",
+                },
+            ],
+        }
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> What is memory?" in result
+    assert "Memory is persistence." in result
+
+
+def test_claude_ai_privacy_export_text_field_fallback():
+    """Falls back to top-level 'text' when 'content' yields nothing."""
+    data = [
+        {
+            "chat_messages": [
+                {"sender": "human", "content": [], "text": "Q via text"},
+                {"sender": "assistant", "content": [], "text": "A via text"},
+            ]
+        }
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> Q via text" in result
+    assert "A via text" in result
+
+
+def test_claude_ai_flat_messages_sender_field():
+    """Flat messages list with 'sender' field is also supported."""
+    data = [
+        {"sender": "human", "content": "Hello"},
+        {"sender": "assistant", "content": "Hi there"},
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> Hello" in result
+    assert "Hi there" in result
+
+
 # ── _try_chatgpt_json ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes milla-jovovich/mempalace#602

## What does this PR do?

Extends Claude.ai JSON export support to handle the actual privacy export format, which uses `sender` instead of `role` and stores rendered messages in a top-level `text` field alongside structured `content` blocks.

**Key changes:**
- Refactored message extraction into `_extract_claude_ai_message()` helper that:
  - Accepts both `role` and `sender` fields for author identification
  - Falls back to top-level `text` field when `content` blocks are empty
  - Handles both nested (privacy export) and flat message list formats
- Increased `MAX_FILE_SIZE` from 10 MB to 100 MB to accommodate typical claude.ai privacy exports (20–50 MB)
- Added user-visible warnings when files exceed the size limit instead of silently skipping them
- Improved docstrings to document the supported formats

## How to test

Run the test suite:
```bash
python -m pytest tests/test_normalize.py::test_claude_ai_privacy_export_sender_field -v
python -m pytest tests/test_normalize.py::test_claude_ai_privacy_export_text_field_fallback -v
python -m pytest tests/test_normalize.py::test_claude_ai_flat_messages_sender_field -v
python -m pytest tests/test_convo_miner_unit.py::TestScanConvos::test_scan_warns_on_oversized_file -v
python -m pytest tests/ -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

https://claude.ai/code/session_01GUH8MeAt6jAjKpbQ227AcC