### PR TITLE
fix: correct token count estimate in compress summary

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -386,8 +386,9 @@ def cmd_compress(args):
 
     # Summary
     ratio = total_original / max(total_compressed, 1)
-    orig_tokens = Dialect.count_tokens("x" * total_original)
-    comp_tokens = Dialect.count_tokens("x" * total_compressed)
+    # Estimate tokens from char count (~3.8 chars/token for English text)
+    orig_tokens = max(1, int(total_original / 3.8))
+    comp_tokens = max(1, int(total_compressed / 3.8))
     print(f"  Total: {orig_tokens:,}t -> {comp_tokens:,}t ({ratio:.1f}x compression)")
     if args.dry_run:
         print("  (dry run -- nothing stored)")


### PR DESCRIPTION
## Problem

`cli.py:389-390` — the compress command summary always prints `1t -> 1t` regardless of actual content size.

`Dialect.count_tokens("x" * total_original)` builds a string of N identical characters with no whitespace. `count_tokens()` splits on spaces, gets 1 word, returns `max(1, int(1 * 1.3))` = 1 every time. Secondary issue: allocates a potentially huge string (`"x" * total_original`) for no reason.

## Fix

Replace with a direct char-to-token estimate using the same underlying heuristic (`~1.3 tokens/word`, `~3.8 chars/token`):

```python
orig_tokens = max(1, int(total_original / 3.8))
comp_tokens = max(1, int(total_compressed / 3.8))
```

No string allocation, correct output.

## Test plan

- [x] `pytest tests/test_cli.py -v` — all 40 tests pass
- [x] `ruff check` + `ruff format` clean
- [ ] Run `mempalace compress --dry-run --wing <wing>` on a real palace and verify token counts are reasonable