### PR TITLE
fix: use epsilon comparison for mtime to prevent unnecessary re-mining

### DIFF
--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -65,7 +65,7 @@ def file_already_mined(collection, source_file: str, check_mtime: bool = False) 
             if stored_mtime is None:
                 return False
             current_mtime = os.path.getmtime(source_file)
-            return float(stored_mtime) == current_mtime
+            return abs(float(stored_mtime) - current_mtime) < 0.001
         return True
     except Exception:
         return False


### PR DESCRIPTION
## Problem

`palace.py:68` — float equality comparison for file modification times:

```python
return float(stored_mtime) == current_mtime
```

ChromaDB stores metadata values through serialization/deserialization cycles that can introduce floating-point precision loss. This causes `==` to return `False` for files that haven't actually changed, triggering unnecessary re-mining on every run.

## Fix

Replace exact equality with epsilon comparison:

```python
return abs(float(stored_mtime) - current_mtime) < 0.001
```

Sub-millisecond precision is more than sufficient for file modification timestamps.

## Test plan

- [x] `pytest tests/ -v --ignore=tests/benchmarks` — all 80 tests pass (including `test_file_already_mined_check_mtime`)
- [x] `ruff check` + `ruff format` clean
- [ ] Mine a project twice — second run should skip unchanged files