### PR TITLE
fix: align query_entity default direction with MCP documentation

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -193,7 +193,7 @@ class KnowledgeGraph:
 
     # ── Query operations ──────────────────────────────────────────────────
 
-    def query_entity(self, name: str, as_of: str = None, direction: str = "outgoing"):
+    def query_entity(self, name: str, as_of: str = None, direction: str = "both"):
         """
         Get all relationships for an entity.
 


### PR DESCRIPTION
## Problem

API contract mismatch between the KG class and MCP tool description:

- `knowledge_graph.py:196` defaults to `direction="outgoing"`
- `mcp_server.py:635` documents `"default: both"` in the MCP tool schema

Users calling `mempalace_kg_query` via MCP without specifying direction get outgoing-only results, but the tool description promises both directions.

## Fix

Change the default in `query_entity()` from `"outgoing"` to `"both"` to match the documented MCP behavior.

## Test plan

- [x] `pytest tests/test_knowledge_graph.py tests/test_knowledge_graph_extra.py -v` — all 28 tests pass
- [x] `ruff check` + `ruff format` clean
- [ ] Query an entity via MCP without direction param — should return both incoming and outgoing relationships