### PR TITLE
chore: remove duplicate cache declarations and no-op exception handler

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -100,10 +100,6 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         logger.error(f"WAL write failed: {e}")
 
 
-_client_cache = None
-_collection_cache = None
-
-
 def _get_client():
     """Return a singleton ChromaDB PersistentClient."""
     global _client_cache

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -375,28 +375,25 @@ def add_drawer(
 ):
     """Add one drawer to the palace."""
     drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(chunk_index)).encode()).hexdigest()[:24]}"
+    metadata = {
+        "wing": wing,
+        "room": room,
+        "source_file": source_file,
+        "chunk_index": chunk_index,
+        "added_by": agent,
+        "filed_at": datetime.now().isoformat(),
+    }
+    # Store file mtime so we can detect modifications later.
     try:
-        metadata = {
-            "wing": wing,
-            "room": room,
-            "source_file": source_file,
-            "chunk_index": chunk_index,
-            "added_by": agent,
-            "filed_at": datetime.now().isoformat(),
-        }
-        # Store file mtime so we can detect modifications later.
-        try:
-            metadata["source_mtime"] = os.path.getmtime(source_file)
-        except OSError:
-            pass
-        collection.upsert(
-            documents=[content],
-            ids=[drawer_id],
-            metadatas=[metadata],
-        )
-        return True
-    except Exception:
-        raise
+        metadata["source_mtime"] = os.path.getmtime(source_file)
+    except OSError:
+        pass
+    collection.upsert(
+        documents=[content],
+        ids=[drawer_id],
+        metadatas=[metadata],
+    )
+    return True
 
 
 # =============================================================================


### PR DESCRIPTION
## Changes

Two dead code removals:

**1. `mcp_server.py:103-104` — duplicate variable declarations**

`_client_cache = None` and `_collection_cache = None` are declared at line 66-67 and again at 103-104. The second pair silently overwrites the first. Removed the duplicate.

**2. `miner.py:397-399` — no-op exception handler**

```python
try:
    ...
except Exception:
    raise
```

A `try/except` that catches `Exception` and immediately re-raises does nothing. Removed the wrapper, keeping the body at correct indentation.

## Test plan

- [x] `pytest tests/test_mcp_server.py tests/test_miner.py -v` — all 46 tests pass
- [x] `ruff check` + `ruff format` clean