### PR TITLE
Add version flag to the command-line interface

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -34,6 +34,7 @@ import argparse
 from pathlib import Path
 
 from .config import MempalaceConfig
+from .version import __version__
 
 
 def cmd_init(args):
@@ -393,12 +394,25 @@ def cmd_compress(args):
         print("  (dry run -- nothing stored)")
 
 
+def cmd_version(args):
+    del args
+    print(f"mempalace {__version__}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="MemPalace — Give your AI a memory. No API key required.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        help="Show installed version and exit",
+    )
+
     parser.add_argument(
         "--palace",
         default=None,
@@ -553,6 +567,10 @@ def main():
     sub.add_parser("status", help="Show what's been filed")
 
     args = parser.parse_args()
+
+    if args.version:
+        cmd_version(args)
+        return
 
     if not args.command:
         parser.print_help()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mempalace import __version__
 from mempalace.cli import (
     cmd_compress,
     cmd_hook,
@@ -17,9 +18,27 @@ from mempalace.cli import (
     cmd_search,
     cmd_split,
     cmd_status,
+    cmd_version,
     cmd_wakeup,
     main,
 )
+
+# ── cmd_version ─────────────────────────────────────────────────────────
+
+
+def test_cmd_version(capsys):
+    cmd_version(argparse.Namespace())
+    out = capsys.readouterr().out.strip()
+    assert out == f"mempalace {__version__}"
+
+
+@pytest.mark.parametrize("flag", ["-v", "--version"])
+def test_main_version_flag(flag, capsys):
+    with patch.object(sys, "argv", ["mempalace", flag]):
+        main()
+
+    out = capsys.readouterr().out.strip()
+    assert out == f"mempalace {__version__}"
 
 
 # ── cmd_status ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Introduce `-v` and `--version` flags to allow users to easily check the currently installed version. This improves the user experience by providing a flags to verify the tool's version.

## How to test

new cases for the version flag test is added on [`/tests/test_cli.py`](https://github.com/milla-jovovich/mempalace/pull/623/changes#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR26-R42)

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
