### PR TITLE
fix: stale HNSW index detection when external process writes to chroma

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -64,10 +64,6 @@ else:
     _kg = KnowledgeGraph()
 
 
-_client_cache = None
-_collection_cache = None
-
-
 # ==================== WRITE-AHEAD LOG ====================
 # Every write operation is logged to a JSONL file before execution.
 # This provides an audit trail for detecting memory poisoning and
@@ -103,14 +99,55 @@ def _wal_log(operation: str, params: dict, result: dict = None):
 
 _client_cache = None
 _collection_cache = None
+_last_known_count = 0
 
 
 def _get_client():
-    """Return a singleton ChromaDB PersistentClient."""
-    global _client_cache
+    """Return a ChromaDB PersistentClient, rebuilding if the DB changed externally.
+
+    When another process (e.g. ``mempalace mine``) writes to the same
+    chroma.sqlite3, the in-process HNSW index becomes stale and vector
+    queries fail with "Error finding id".  We detect this by comparing the
+    SQLite embedding count against the last value we saw.  On mismatch we
+    tear down the cached client and build a fresh one.
+    """
+    global _client_cache, _collection_cache, _last_known_count
+
     if _client_cache is None:
         _client_cache = chromadb.PersistentClient(path=_config.palace_path)
+        _last_known_count = _sqlite_embedding_count()
+        return _client_cache
+
+    db_count = _sqlite_embedding_count()
+    if db_count != _last_known_count and _last_known_count > 0:
+        logger.info(
+            "Stale index detected (%d → %d). Rebuilding chroma client.",
+            _last_known_count, db_count,
+        )
+        try:
+            _client_cache.clear_system_cache()
+        except Exception:
+            pass
+        _client_cache = chromadb.PersistentClient(path=_config.palace_path)
+        _collection_cache = None
+
+    _last_known_count = db_count
     return _client_cache
+
+
+def _sqlite_embedding_count() -> int:
+    """Read the raw embedding count straight from SQLite (bypasses chroma cache)."""
+    import sqlite3 as _sqlite3
+    try:
+        db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+        conn = _sqlite3.connect(db_path)
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM embeddings")
+        count = cur.fetchone()[0]
+        conn.close()
+        return count
+    except Exception:
+        return _last_known_count  # fallback: assume unchanged
 
 
 def _get_collection(create=False):

--- a/tests/test_hnsw_stale.py
+++ b/tests/test_hnsw_stale.py
@@ -1,0 +1,148 @@
+"""
+test_hnsw_stale.py — Regression tests for stale HNSW index detection.
+
+When another process writes embeddings to chroma.sqlite3 while the MCP
+server is running, the in-process HNSW index becomes stale and vector
+queries fail with "Error finding id". mcp_server._get_client() detects
+this by comparing the SQLite embedding count against a cached value,
+and rebuilds the chromadb client on mismatch.
+
+These tests exercise that detection path.
+"""
+
+import os
+
+import chromadb
+
+
+def _reset_hnsw_globals():
+    """Reset the stale-index detection state between assertions."""
+    from mempalace import mcp_server
+
+    mcp_server._client_cache = None
+    mcp_server._collection_cache = None
+    mcp_server._last_known_count = 0
+
+
+class TestSqliteEmbeddingCount:
+    def test_returns_zero_when_db_missing(self, monkeypatch, config):
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_config", config)
+        _reset_hnsw_globals()
+
+        # Fresh palace, no chroma.sqlite3 yet
+        assert mcp_server._sqlite_embedding_count() == 0
+
+    def test_returns_actual_count_after_add(self, monkeypatch, config, palace_path):
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_config", config)
+        _reset_hnsw_globals()
+
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_or_create_collection("mempalace_drawers")
+        col.add(
+            ids=["d1", "d2"],
+            documents=["first drawer", "second drawer"],
+            metadatas=[{"wing": "test"}, {"wing": "test"}],
+        )
+        del client
+
+        assert mcp_server._sqlite_embedding_count() >= 2
+
+
+class TestStaleIndexDetection:
+    def test_rebuilds_when_external_process_adds_embeddings(
+        self, monkeypatch, config, palace_path
+    ):
+        """Simulates `mempalace mine` writing to chroma while MCP holds a
+        cached client. _get_client() should detect the count mismatch and
+        build a fresh client."""
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_config", config)
+        _reset_hnsw_globals()
+
+        # 1. Seed the palace with one drawer via a throwaway client so the
+        #    sqlite file and embeddings table exist before we cache.
+        seed_client = chromadb.PersistentClient(path=palace_path)
+        seed_col = seed_client.get_or_create_collection("mempalace_drawers")
+        seed_col.add(
+            ids=["seed"],
+            documents=["seed drawer"],
+            metadatas=[{"wing": "test"}],
+        )
+        del seed_col
+        del seed_client
+
+        # 2. First _get_client() call caches a client + snapshots the count
+        first_client = mcp_server._get_client()
+        assert first_client is not None
+        first_count = mcp_server._last_known_count
+        assert first_count >= 1
+
+        # 3. External process writes more embeddings to the same palace
+        external = chromadb.PersistentClient(path=palace_path)
+        ext_col = external.get_or_create_collection("mempalace_drawers")
+        ext_col.add(
+            ids=["external_1", "external_2"],
+            documents=["ghost drawer one", "ghost drawer two"],
+            metadatas=[{"wing": "test"}, {"wing": "test"}],
+        )
+        del ext_col
+        del external
+
+        # 4. Next _get_client() should notice the count mismatch and rebuild
+        second_client = mcp_server._get_client()
+        assert second_client is not first_client, (
+            "client should have been rebuilt after external write"
+        )
+        assert mcp_server._last_known_count > first_count
+        assert mcp_server._collection_cache is None, (
+            "collection cache should be cleared on rebuild"
+        )
+
+    def test_no_rebuild_when_count_unchanged(self, monkeypatch, config, palace_path):
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_config", config)
+        _reset_hnsw_globals()
+
+        seed = chromadb.PersistentClient(path=palace_path)
+        col = seed.get_or_create_collection("mempalace_drawers")
+        col.add(ids=["only"], documents=["only drawer"], metadatas=[{"wing": "t"}])
+        del col
+        del seed
+
+        first_client = mcp_server._get_client()
+        second_client = mcp_server._get_client()
+
+        assert first_client is second_client, (
+            "client should be cached when embedding count is stable"
+        )
+
+    def test_rebuild_skipped_on_first_call_even_if_db_exists(
+        self, monkeypatch, config, palace_path
+    ):
+        """First _get_client() call should NOT rebuild, even though
+        _last_known_count was 0 before — the initial call just snapshots."""
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_config", config)
+        _reset_hnsw_globals()
+
+        seed = chromadb.PersistentClient(path=palace_path)
+        col = seed.get_or_create_collection("mempalace_drawers")
+        col.add(
+            ids=["a", "b", "c"],
+            documents=["one", "two", "three"],
+            metadatas=[{"wing": "t"}] * 3,
+        )
+        del col
+        del seed
+
+        client = mcp_server._get_client()
+        assert client is not None
+        # After first call, we should have snapshotted the non-zero count
+        assert mcp_server._last_known_count >= 3


### PR DESCRIPTION
## Problem

When another process (e.g. `mempalace mine` from a CLI, or a second MCP session pointed at the same palace) writes embeddings to `chroma.sqlite3` while an MCP server is already serving queries, the in-process HNSW index becomes stale. Subsequent vector searches fail with:

```
Error finding id <uuid> in HNSW index
```

**Repro:** run `mempalace mine ~/some-dir` in one shell while the MCP server holds a cached `PersistentClient` in another. Vector search crashes on the next query.

I hit this in a setup where an autonomous agent runs the MCP server continuously and a cron job does `mempalace mine` every few hours — the MCP server would start failing silently mid-session until restarted.

## Fix

On every `_get_client()` call, compare the raw SQLite embedding count (read straight from `chroma.sqlite3` via `sqlite3`, bypassing chroma's own cache) against a cached snapshot stored in a new `_last_known_count` module global.

- First call: build a fresh client and snapshot the count. No rebuild.
- Subsequent calls with the same count: return the cached client (no change from prior behavior).
- Subsequent calls with a changed count: clear chroma's system cache, tear down the cached `PersistentClient`, drop the `_collection_cache`, and build a fresh client. Update the snapshot.

The check is cheap — one `SELECT COUNT(*) FROM embeddings` against SQLite — so it won't slow down hot paths.

## Tests

New `tests/test_hnsw_stale.py` with five regression tests:

- `TestSqliteEmbeddingCount::test_returns_zero_when_db_missing` — helper handles a palace directory with no chroma.sqlite3 yet.
- `TestSqliteEmbeddingCount::test_returns_actual_count_after_add` — helper returns the true count once embeddings are present.
- `TestStaleIndexDetection::test_rebuilds_when_external_process_adds_embeddings` — main regression. Seeds the palace, caches a client via `_get_client()`, simulates an external process by opening a second `chromadb.PersistentClient` and adding more embeddings, then verifies the next `_get_client()` call returns a new client instance and clears `_collection_cache`.
- `TestStaleIndexDetection::test_no_rebuild_when_count_unchanged` — stable count returns the cached client identity.
- `TestStaleIndexDetection::test_rebuild_skipped_on_first_call_even_if_db_exists` — first call snapshots without a spurious rebuild.

All 33 existing `test_mcp_server.py` tests still pass locally.

## Notes

- The fix is localized to `_get_client()` / `_sqlite_embedding_count()` in `mempalace/mcp_server.py` — no API changes, no new dependencies.
- `_last_known_count` starts at 0; the first-call branch explicitly returns early after snapshotting to avoid treating "was 0, is now N" as a stale-index event on cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)