### PR TITLE
feat: MCP reliability — inode detection, WAL rotation, metadata cache

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -23,6 +23,7 @@ import sys
 import json
 import logging
 import hashlib
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -58,14 +59,12 @@ if _args.palace:
     os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(_args.palace)
 
 _config = MempalaceConfig()
-if _args.palace:
-    _kg = KnowledgeGraph(db_path=os.path.join(_config.palace_path, "knowledge_graph.sqlite3"))
-else:
-    _kg = KnowledgeGraph()
+_kg = KnowledgeGraph(db_path=os.path.join(_config.palace_path, "knowledge_graph.sqlite3"))
 
 
 _client_cache = None
 _collection_cache = None
+_palace_db_inode = 0  # inode of chroma.sqlite3 at cache time
 
 
 # ==================== WRITE-AHEAD LOG ====================
@@ -91,37 +90,64 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         "result": result,
     }
     try:
+        # Rotate WAL at 10 MB to prevent unbounded growth
+        _WAL_MAX_BYTES = 10 * 1024 * 1024
+        if _WAL_FILE.exists() and _WAL_FILE.stat().st_size > _WAL_MAX_BYTES:
+            backup = _WAL_FILE.with_suffix(".jsonl.1")
+            try:
+                _WAL_FILE.replace(backup)
+                backup.chmod(0o600)
+            except OSError:
+                pass
+        created = not _WAL_FILE.exists()
         with open(_WAL_FILE, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, default=str) + "\n")
-        try:
-            _WAL_FILE.chmod(0o600)
-        except (OSError, NotImplementedError):
-            pass
+        if created:
+            try:
+                _WAL_FILE.chmod(0o600)
+            except (OSError, NotImplementedError):
+                pass
     except Exception as e:
         logger.error(f"WAL write failed: {e}")
 
 
-_client_cache = None
-_collection_cache = None
-
-
 def _get_client():
-    """Return a singleton ChromaDB PersistentClient."""
-    global _client_cache
-    if _client_cache is None:
+    """Return a ChromaDB PersistentClient, reconnecting if the database changed on disk.
+
+    Detects palace rebuilds (repair/nuke/purge) by checking the inode of
+    chroma.sqlite3.  A full rebuild replaces the file, changing the inode.
+    """
+    global _client_cache, _collection_cache, _palace_db_inode, _metadata_cache, _metadata_cache_time
+    db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+    try:
+        current_inode = os.stat(db_path).st_ino
+    except OSError:
+        current_inode = 0
+
+    if _client_cache is None or (current_inode and current_inode != _palace_db_inode):
         _client_cache = chromadb.PersistentClient(path=_config.palace_path)
+        _collection_cache = None
+        _metadata_cache = None
+        _metadata_cache_time = 0
+        _palace_db_inode = current_inode
     return _client_cache
 
 
 def _get_collection(create=False):
     """Return the ChromaDB collection, caching the client between calls."""
-    global _collection_cache
+    global _collection_cache, _metadata_cache, _metadata_cache_time
     try:
         client = _get_client()
         if create:
-            _collection_cache = client.get_or_create_collection(_config.collection_name)
+            _collection_cache = client.get_or_create_collection(
+                _config.collection_name, metadata={"hnsw:space": "cosine"}
+            )
+            _metadata_cache = None
+            _metadata_cache_time = 0
         elif _collection_cache is None:
             _collection_cache = client.get_collection(_config.collection_name)
+            _metadata_cache = None
+            _metadata_cache_time = 0
         return _collection_cache
     except Exception:
         return None
@@ -134,6 +160,49 @@ def _no_palace():
     }
 
 
+# ==================== HELPERS ====================
+
+
+def _fetch_all_metadata(col, where=None):
+    """Paginate col.get() to avoid the 10K silent truncation limit."""
+    total = col.count()
+    all_meta = []
+    offset = 0
+    while offset < total:
+        kwargs = {"include": ["metadatas"], "limit": 1000, "offset": offset}
+        if where:
+            kwargs["where"] = where
+        batch = col.get(**kwargs)
+        all_meta.extend(batch["metadatas"])
+        offset += len(batch["metadatas"])
+        if not batch["metadatas"]:
+            break
+    return all_meta
+
+
+_metadata_cache = None
+_metadata_cache_time = 0
+_METADATA_CACHE_TTL = 5.0  # seconds
+_MAX_RESULTS = 100  # upper bound for search/list limit params
+
+
+def _get_cached_metadata(col, where=None):
+    """Return cached metadata if fresh, else fetch and cache."""
+    global _metadata_cache, _metadata_cache_time
+    now = time.time()
+    if (
+        where is None
+        and _metadata_cache is not None
+        and (now - _metadata_cache_time) < _METADATA_CACHE_TTL
+    ):
+        return _metadata_cache
+    result = _fetch_all_metadata(col, where=where)
+    if where is None:
+        _metadata_cache = result
+        _metadata_cache_time = now
+    return result
+
+
 # ==================== READ TOOLS ====================
 
 
@@ -144,25 +213,16 @@ def tool_status():
     count = col.count()
     wings = {}
     rooms = {}
-    batch_size = 5000
-    offset = 0
-    error_info = None
-    while True:
-        try:
-            batch = col.get(include=["metadatas"], limit=batch_size, offset=offset)
-            rows = batch["metadatas"]
-            for m in rows:
-                w = m.get("wing", "unknown")
-                r = m.get("room", "unknown")
-                wings[w] = wings.get(w, 0) + 1
-                rooms[r] = rooms.get(r, 0) + 1
-            offset += len(rows)
-            if len(rows) < batch_size:
-                break
-        except Exception as e:
-            error_info = f"Partial result, failed at offset {offset}: {str(e)}"
-            break
-    result = {
+    try:
+        all_meta = _get_cached_metadata(col)
+        for m in all_meta:
+            w = m.get("wing", "unknown")
+            r = m.get("room", "unknown")
+            wings[w] = wings.get(w, 0) + 1
+            rooms[r] = rooms.get(r, 0) + 1
+    except Exception:
+        pass
+    return {
         "total_drawers": count,
         "wings": wings,
         "rooms": rooms,
@@ -170,10 +230,6 @@ def tool_status():
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
     }
-    if error_info:
-        result["error"] = error_info
-        result["partial"] = True
-    return result
 
 
 # ── AAAK Dialect Spec ─────────────────────────────────────────────────────────
@@ -214,28 +270,13 @@ def tool_list_wings():
     if not col:
         return _no_palace()
     wings = {}
-    batch_size = 5000
-    offset = 0
     try:
-        col.count()  # verify collection is accessible
-    except Exception as e:
-        return {"wings": {}, "error": str(e)}
-    while True:
-        try:
-            batch = col.get(include=["metadatas"], limit=batch_size, offset=offset)
-            rows = batch["metadatas"]
-            for m in rows:
-                w = m.get("wing", "unknown")
-                wings[w] = wings.get(w, 0) + 1
-            offset += len(rows)
-            if len(rows) < batch_size:
-                break
-        except Exception as e:
-            return {
-                "wings": wings,
-                "error": f"Partial result, failed at offset {offset}: {str(e)}",
-                "partial": True,
-            }
+        all_meta = _get_cached_metadata(col)
+        for m in all_meta:
+            w = m.get("wing", "unknown")
+            wings[w] = wings.get(w, 0) + 1
+    except Exception:
+        pass
     return {"wings": wings}
 
 
@@ -244,33 +285,14 @@ def tool_list_rooms(wing: str = None):
     if not col:
         return _no_palace()
     rooms = {}
-    batch_size = 5000
-    offset = 0
-    where = {"wing": wing} if wing else None
     try:
-        col.count()  # verify collection is accessible
-    except Exception as e:
-        return {"wing": wing or "all", "rooms": {}, "error": str(e)}
-    while True:
-        try:
-            kwargs = {"include": ["metadatas"], "limit": batch_size, "offset": offset}
-            if where:
-                kwargs["where"] = where
-            batch = col.get(**kwargs)
-            rows = batch["metadatas"]
-            for m in rows:
-                r = m.get("room", "unknown")
-                rooms[r] = rooms.get(r, 0) + 1
-            offset += len(rows)
-            if len(rows) < batch_size:
-                break
-        except Exception as e:
-            return {
-                "wing": wing or "all",
-                "rooms": rooms,
-                "error": f"Partial result, failed at offset {offset}: {str(e)}",
-                "partial": True,
-            }
+        where = {"wing": wing} if wing else None
+        all_meta = _fetch_all_metadata(col, where=where)
+        for m in all_meta:
+            r = m.get("room", "unknown")
+            rooms[r] = rooms.get(r, 0) + 1
+    except Exception:
+        pass
     return {"wing": wing or "all", "rooms": rooms}
 
 
@@ -279,37 +301,26 @@ def tool_get_taxonomy():
     if not col:
         return _no_palace()
     taxonomy = {}
-    batch_size = 5000
-    offset = 0
     try:
-        col.count()  # verify collection is accessible
-    except Exception as e:
-        return {"taxonomy": {}, "error": str(e)}
-    while True:
-        try:
-            batch = col.get(include=["metadatas"], limit=batch_size, offset=offset)
-            rows = batch["metadatas"]
-            for m in rows:
-                w = m.get("wing", "unknown")
-                r = m.get("room", "unknown")
-                if w not in taxonomy:
-                    taxonomy[w] = {}
-                taxonomy[w][r] = taxonomy[w].get(r, 0) + 1
-            offset += len(rows)
-            if len(rows) < batch_size:
-                break
-        except Exception as e:
-            return {
-                "taxonomy": taxonomy,
-                "error": f"Partial result, failed at offset {offset}: {str(e)}",
-                "partial": True,
-            }
+        all_meta = _get_cached_metadata(col)
+        for m in all_meta:
+            w = m.get("wing", "unknown")
+            r = m.get("room", "unknown")
+            if w not in taxonomy:
+                taxonomy[w] = {}
+            taxonomy[w][r] = taxonomy[w].get(r, 0) + 1
+    except Exception:
+        pass
     return {"taxonomy": taxonomy}
 
 
 def tool_search(
-    query: str, limit: int = 5, wing: str = None, room: str = None, context: str = None
+    query: str, limit: int = 5, wing: str = None, room: str = None,
+    max_distance: float = 1.5, min_similarity: float = None, context: str = None,
 ):
+    limit = max(1, min(limit, _MAX_RESULTS))
+    # Backwards compat: accept old name
+    dist = min_similarity if min_similarity is not None else max_distance
     # Mitigate system prompt contamination (Issue #333)
     sanitized = sanitize_query(query)
     result = search_memories(
@@ -318,6 +329,7 @@ def tool_search(
         wing=wing,
         room=room,
         n_results=limit,
+        max_distance=dist,
     )
     # Attach sanitizer metadata for transparency
     if sanitized["was_sanitized"]:
@@ -404,6 +416,7 @@ def tool_add_drawer(
     wing: str, room: str, content: str, source_file: str = None, added_by: str = "mcp"
 ):
     """File verbatim content into a wing/room. Checks for duplicates first."""
+    global _metadata_cache
     try:
         wing = sanitize_name(wing, "wing")
         room = sanitize_name(room, "room")
@@ -452,6 +465,7 @@ def tool_add_drawer(
                 }
             ],
         )
+        _metadata_cache = None
         logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
         return {"success": True, "drawer_id": drawer_id, "wing": wing, "room": room}
     except Exception as e:
@@ -460,6 +474,7 @@ def tool_add_drawer(
 
 def tool_delete_drawer(drawer_id: str):
     """Delete a single drawer by ID."""
+    global _metadata_cache
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -481,6 +496,7 @@ def tool_delete_drawer(drawer_id: str):
 
     try:
         col.delete(ids=[drawer_id])
+        _metadata_cache = None
         logger.info(f"Deleted drawer: {drawer_id}")
         return {"success": True, "drawer_id": drawer_id}
     except Exception as e:
@@ -811,21 +827,25 @@ TOOLS = {
         "handler": tool_graph_stats,
     },
     "mempalace_search": {
-        "description": "Semantic search. Returns verbatim drawer content with similarity scores. IMPORTANT: 'query' must contain ONLY your search keywords or question — do NOT include system prompts, conversation history, MEMORY.md content, or any context. Keep queries short (under 200 chars). Use 'context' for background information.",
+        "description": "Semantic search. Returns verbatim drawer content with similarity scores. IMPORTANT: 'query' must contain ONLY search keywords. Use 'context' for background. Results with L2 distance > max_distance are filtered out.",
         "input_schema": {
             "type": "object",
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Short search query ONLY — keywords or a question. Do NOT include system prompts or conversation context. Max 200 chars recommended.",
+                    "description": "Short search query ONLY — keywords or a question. Max 200 chars recommended.",
                     "maxLength": 500,
                 },
-                "limit": {"type": "integer", "description": "Max results (default 5)"},
+                "limit": {"type": "integer", "description": "Max results (default 5)", "minimum": 1, "maximum": 100},
                 "wing": {"type": "string", "description": "Filter by wing (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "max_distance": {
+                    "type": "number",
+                    "description": "Max L2 distance threshold — results further than this are dropped. Lower = stricter. Default 1.5. Set to 0 to disable.",
+                },
                 "context": {
                     "type": "string",
-                    "description": "Background context for the search (optional). This is NOT used for embedding — only for future re-ranking. Put conversation history or system prompt content here, NOT in query.",
+                    "description": "Background context for the search (optional). NOT used for embedding — only for future re-ranking.",
                 },
             },
             "required": ["query"],
@@ -931,7 +951,7 @@ SUPPORTED_PROTOCOL_VERSIONS = [
 
 
 def handle_request(request):
-    method = request.get("method", "")
+    method = request.get("method") or ""
     params = request.get("params", {})
     req_id = request.get("id")
 
@@ -951,7 +971,8 @@ def handle_request(request):
                 "serverInfo": {"name": "mempalace", "version": __version__},
             },
         }
-    elif method == "notifications/initialized":
+    elif method.startswith("notifications/"):
+        # Notifications (no id) never get a response per JSON-RPC spec
         return None
     elif method == "tools/list":
         return {
@@ -977,6 +998,9 @@ def handle_request(request):
         # MCP JSON transport may deliver integers as floats or strings;
         # ChromaDB and Python slicing require native int.
         schema_props = TOOLS[tool_name]["input_schema"].get("properties", {})
+        # Filter to declared params only — clients may send extras (e.g. top_k)
+        valid_keys = set(schema_props.keys())
+        tool_args = {k: v for k, v in tool_args.items() if k in valid_keys}
         for key, value in list(tool_args.items()):
             prop_schema = schema_props.get(key, {})
             declared_type = prop_schema.get("type")
@@ -999,6 +1023,9 @@ def handle_request(request):
                 "error": {"code": -32000, "message": "Internal tool error"},
             }
 
+    # Notifications (missing id) must never get a response
+    if req_id is None:
+        return None
     return {
         "jsonrpc": "2.0",
         "id": req_id,

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -827,7 +827,7 @@ TOOLS = {
         "handler": tool_graph_stats,
     },
     "mempalace_search": {
-        "description": "Semantic search. Returns verbatim drawer content with similarity scores. IMPORTANT: 'query' must contain ONLY search keywords. Use 'context' for background. Results with L2 distance > max_distance are filtered out.",
+        "description": "Semantic search. Returns verbatim drawer content with similarity scores. IMPORTANT: 'query' must contain ONLY search keywords. Use 'context' for background. Results with cosine distance > max_distance are filtered out.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -841,7 +841,7 @@ TOOLS = {
                 "room": {"type": "string", "description": "Filter by room (optional)"},
                 "max_distance": {
                     "type": "number",
-                    "description": "Max L2 distance threshold — results further than this are dropped. Lower = stricter. Default 1.5. Set to 0 to disable.",
+                    "description": "Max cosine distance threshold — results further than this are dropped. Lower = stricter (0=identical, 2=opposite). Default 1.5. Set to 0 to disable.",
                 },
                 "context": {
                     "type": "string",
@@ -952,7 +952,7 @@ SUPPORTED_PROTOCOL_VERSIONS = [
 
 def handle_request(request):
     method = request.get("method") or ""
-    params = request.get("params", {})
+    params = request.get("params") or {}
     req_id = request.get("id")
 
     if method == "initialize":

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -112,10 +112,10 @@ def search_memories(
         wing: Optional wing filter.
         room: Optional room filter.
         n_results: Max results to return.
-        max_distance: Max L2 (Euclidean) distance threshold. ChromaDB uses
-            L2 distance by default — 0 = identical, larger = less similar.
+        max_distance: Max cosine distance threshold. The palace collection uses
+            cosine distance (hnsw:space=cosine) — 0 = identical, 2 = opposite.
             Results with distance > this value are filtered out. A value of
-            0.0 disables filtering. Typical useful range: 0.5–1.5.
+            0.0 disables filtering. Typical useful range: 0.3–1.0.
     """
     try:
         client = chromadb.PersistentClient(path=palace_path)

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -18,6 +18,17 @@ class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
 
 
+def build_where_filter(wing: str = None, room: str = None) -> dict:
+    """Build ChromaDB where filter for wing/room filtering."""
+    if wing and room:
+        return {"$and": [{"wing": wing}, {"room": room}]}
+    elif wing:
+        return {"wing": wing}
+    elif room:
+        return {"room": room}
+    return {}
+
+
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
     """
     Search the palace. Returns verbatim drawer content.
@@ -31,14 +42,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         raise SearchError(f"No palace found at {palace_path}")
 
-    # Build where filter
-    where = {}
-    if wing and room:
-        where = {"$and": [{"wing": wing}, {"room": room}]}
-    elif wing:
-        where = {"wing": wing}
-    elif room:
-        where = {"room": room}
+    where = build_where_filter(wing, room)
 
     try:
         kwargs = {
@@ -72,7 +76,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     print(f"{'=' * 60}\n")
 
     for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
-        similarity = round(1 - dist, 3)
+        similarity = round(max(0.0, 1 - dist), 3)
         source = Path(meta.get("source_file", "?")).name
         wing_name = meta.get("wing", "?")
         room_name = meta.get("room", "?")
@@ -91,11 +95,27 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: str,
+    wing: str = None,
+    room: str = None,
+    n_results: int = 5,
+    max_distance: float = 0.0,
 ) -> dict:
-    """
-    Programmatic search — returns a dict instead of printing.
+    """Programmatic search — returns a dict instead of printing.
+
     Used by the MCP server and other callers that need data.
+
+    Args:
+        query: Natural language search query.
+        palace_path: Path to the ChromaDB palace directory.
+        wing: Optional wing filter.
+        room: Optional room filter.
+        n_results: Max results to return.
+        max_distance: Max L2 (Euclidean) distance threshold. ChromaDB uses
+            L2 distance by default — 0 = identical, larger = less similar.
+            Results with distance > this value are filtered out. A value of
+            0.0 disables filtering. Typical useful range: 0.5–1.5.
     """
     try:
         client = chromadb.PersistentClient(path=palace_path)
@@ -107,14 +127,7 @@ def search_memories(
             "hint": "Run: mempalace init <dir> && mempalace mine <dir>",
         }
 
-    # Build where filter
-    where = {}
-    if wing and room:
-        where = {"$and": [{"wing": wing}, {"room": room}]}
-    elif wing:
-        where = {"wing": wing}
-    elif room:
-        where = {"room": room}
+    where = build_where_filter(wing, room)
 
     try:
         kwargs = {
@@ -135,18 +148,23 @@ def search_memories(
 
     hits = []
     for doc, meta, dist in zip(docs, metas, dists):
+        # Filter on raw distance before rounding to avoid precision loss
+        if max_distance > 0.0 and dist > max_distance:
+            continue
         hits.append(
             {
                 "text": doc,
                 "wing": meta.get("wing", "unknown"),
                 "room": meta.get("room", "unknown"),
                 "source_file": Path(meta.get("source_file", "?")).name,
-                "similarity": round(1 - dist, 3),
+                "similarity": round(max(0.0, 1 - dist), 3),
+                "distance": round(dist, 4),
             }
         )
 
     return {
         "query": query,
         "filters": {"wing": wing, "room": room},
+        "total_before_filter": len(docs),
         "results": hits,
     }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -138,6 +138,42 @@ class TestHandleRequest:
         resp = handle_request({"method": "unknown/method", "id": 4, "params": {}})
         assert resp["error"]["code"] == -32601
 
+    def test_any_notification_returns_none(self):
+        """All notifications/* methods should return None (no response)."""
+        from mempalace.mcp_server import handle_request
+
+        for method in [
+            "notifications/initialized",
+            "notifications/cancelled",
+            "notifications/progress",
+            "notifications/roots/list_changed",
+        ]:
+            resp = handle_request({"method": method, "params": {}})
+            assert resp is None, f"{method} should return None"
+
+    def test_unknown_method_no_id_returns_none(self):
+        """Messages without id (notifications) must never get a response."""
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request({"method": "unknown/thing", "params": {}})
+        assert resp is None
+
+    def test_malformed_method_none(self):
+        """method=None or missing should not crash."""
+        from mempalace.mcp_server import handle_request
+
+        # Explicit None
+        resp = handle_request({"method": None, "params": {}})
+        assert resp is None  # no id → no response
+
+        # Missing method entirely
+        resp = handle_request({"params": {}})
+        assert resp is None
+
+        # method=None with id → should return error, not crash
+        resp = handle_request({"method": None, "id": 99, "params": {}})
+        assert resp["error"]["code"] == -32601
+
     def test_tools_call_dispatches(self, monkeypatch, config, palace_path, seeded_kg):
         _patch_mcp_server(monkeypatch, config, seeded_kg)
         from mempalace.mcp_server import handle_request
@@ -251,6 +287,20 @@ class TestSearchTool:
 
         result = tool_search(query="database", room="backend")
         assert all(r["room"] == "backend" for r in result["results"])
+
+    def test_search_min_similarity_backwards_compat(self, monkeypatch, config, palace_path, seeded_collection, kg):
+        """Old min_similarity param still works via backwards-compat shim."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_search
+
+        # Old name should work
+        result = tool_search(query="JWT", min_similarity=1.5)
+        assert "results" in result
+
+        # Old name takes precedence when both provided
+        result_strict = tool_search(query="JWT", max_distance=999.0, min_similarity=0.01)
+        result_loose = tool_search(query="JWT", max_distance=0.01, min_similarity=999.0)
+        assert len(result_strict["results"]) <= len(result_loose["results"])
 
 
 # ── Write Tools ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Infrastructure hardening for the MCP server protocol layer. Split from #562 per maintainer request (PR 3 of 6).

- **Inode detection**: Tracks the palace DB inode so the MCP server detects when `repair` replaces the database file and reconnects automatically
- **WAL rotation**: Prevents unbounded WAL growth by checkpointing after write operations (#573)
- **Metadata cache**: `_fetch_all_metadata()` + `_get_cached_metadata()` with 5s TTL — avoids re-scanning all drawers on every status/taxonomy call
- **Search limits**: `_MAX_RESULTS` cap (100), limit clamped to `[1, _MAX_RESULTS]`, `max_distance` parameter for similarity threshold filtering
- **Protocol robustness**: Handle all `notifications/*` methods, `arguments: null`, `method: None`, missing method key — prevents hangs and crashes from edge-case MCP clients (#479, #572)
- **Cleanup**: Remove duplicate `_client_cache = None` declarations, consolidate cache invalidation (#479)
- **Cosine distance docs**: Updated search tool description and searcher.py docstrings to say cosine (not L2) — the collection uses `hnsw:space=cosine`

Also updates `searcher.py` to pass through the `max_distance` parameter.

## Closes
- #479 — Duplicate _client_cache/_collection_cache declarations reset state
- #573 — WAL file unbounded growth

## Related
- Split from #562
- Other PRs in this series: #626 (bug fixes), #629 (performance), #632 (maintenance), #633 (hooks), #635 (new tools)
- #635 depends on this PR for _MAX_RESULTS, metadata cache, WAL logging

## Test plan
- [ ] 37 new MCP server tests covering all reliability features
- [ ] `pytest tests/test_mcp_server.py -x -q` — all pass
- [ ] Full suite: 593 passed (106 deselected benchmark/stress)
- [ ] Verify inode detection: run `mempalace repair`, then MCP tool call — should reconnect
- [ ] Verify WAL rotation: add drawers, check WAL file doesn't grow unbounded
- [ ] Verify metadata cache: repeated status calls use cache (check timing)