### PR TITLE
feat: two-layer hook capture, auto-mine transcripts, hook settings

### DIFF
--- a/.claude-plugin/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin/hooks/mempal-precompact-hook.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 # MemPalace PreCompact Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
+#
+# Python resolution order:
+#   1. MEMPALACE_PYTHON env var (user override)
+#   2. Plugin root's venv (development installs)
+#   3. System python3 (pip install --user / pipx)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+
+if [ -n "$MEMPALACE_PYTHON" ] && [ -x "$MEMPALACE_PYTHON" ]; then
+    PYTHON="$MEMPALACE_PYTHON"
+elif [ -x "$PLUGIN_ROOT/venv/bin/python3" ]; then
+    PYTHON="$PLUGIN_ROOT/venv/bin/python3"
+else
+    PYTHON="python3"
+fi
 INPUT=$(cat)
-echo "$INPUT" | python3 -m mempalace hook run --hook precompact --harness claude-code
+echo "$INPUT" | "$PYTHON" -m mempalace hook run --hook precompact --harness claude-code

--- a/.claude-plugin/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin/hooks/mempal-stop-hook.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 # MemPalace Stop Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
+#
+# Python resolution order:
+#   1. MEMPALACE_PYTHON env var (user override)
+#   2. Plugin root's venv (development installs)
+#   3. System python3 (pip install --user / pipx)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+
+if [ -n "$MEMPALACE_PYTHON" ] && [ -x "$MEMPALACE_PYTHON" ]; then
+    PYTHON="$MEMPALACE_PYTHON"
+elif [ -x "$PLUGIN_ROOT/venv/bin/python3" ]; then
+    PYTHON="$PLUGIN_ROOT/venv/bin/python3"
+else
+    PYTHON="python3"
+fi
 INPUT=$(cat)
-echo "$INPUT" | python3 -m mempalace hook run --hook stop --harness claude-code
+echo "$INPUT" | "$PYTHON" -m mempalace hook run --hook stop --harness claude-code

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.14",
+  "version": "3.1.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.14",
+  "version": "3.1.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/examples/HOOKS_TUTORIAL.md
+++ b/examples/HOOKS_TUTORIAL.md
@@ -26,3 +26,18 @@ Add this to your configuration file to enable automatic background saving:
     ]
   }
 }
+```
+
+### 3. What changed (v3.1.0+)
+
+Both hooks now have **two-layer capture**:
+
+1. **Auto-mine**: Before blocking the AI, the hook runs the normalizer on the JSONL transcript and upserts chunks directly into the palace. This captures raw tool output (Bash results, search findings, build errors) that the AI would otherwise summarize away.
+
+2. **Updated reason messages**: The block reason now explicitly tells the AI to save tool output verbatim — not just topics and decisions.
+
+### 4. Configuration
+
+- **`SAVE_INTERVAL=15`** — How many human messages between saves
+- **`MEMPAL_PYTHON`** — Python interpreter with mempalace + chromadb. Auto-detects: env var → repo venv → system python3
+- **`MEMPAL_DIR`** — Optional directory for auto-ingest via `mempalace mine`

--- a/examples/HOOKS_TUTORIAL.md
+++ b/examples/HOOKS_TUTORIAL.md
@@ -36,7 +36,15 @@ Both hooks now have **two-layer capture**:
 
 2. **Updated reason messages**: The block reason now explicitly tells the AI to save tool output verbatim — not just topics and decisions.
 
-### 4. Configuration
+### 4. Backfill past conversations (one-time)
+
+The hooks capture conversations going forward, but you probably have months of past sessions. Run this once to mine them all:
+
+```bash
+mempalace mine ~/.claude/projects/ --mode convos
+```
+
+### 5. Configuration
 
 - **`SAVE_INTERVAL=15`** — How many human messages between saves
 - **`MEMPALACE_PYTHON`** — Python interpreter with mempalace + chromadb. Auto-detects: env var → repo venv → system python3

--- a/examples/HOOKS_TUTORIAL.md
+++ b/examples/HOOKS_TUTORIAL.md
@@ -39,5 +39,5 @@ Both hooks now have **two-layer capture**:
 ### 4. Configuration
 
 - **`SAVE_INTERVAL=15`** — How many human messages between saves
-- **`MEMPAL_PYTHON`** — Python interpreter with mempalace + chromadb. Auto-detects: env var → repo venv → system python3
+- **`MEMPALACE_PYTHON`** — Python interpreter with mempalace + chromadb. Auto-detects: env var → repo venv → system python3
 - **`MEMPAL_DIR`** — Optional directory for auto-ingest via `mempalace mine`

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,10 +6,10 @@ These hook scripts make MemPalace save automatically. No manual "save" commands 
 
 | Hook | When It Fires | What Happens |
 |------|--------------|-------------|
-| **Save Hook** | Every 15 human messages | Blocks the AI, tells it to save key topics/decisions/quotes to the palace |
-| **PreCompact Hook** | Right before context compaction | Emergency save — forces the AI to save EVERYTHING before losing context |
+| **Save Hook** | Every 15 human messages | Auto-mines transcript (tool output included), then blocks the AI to save topics/decisions/quotes |
+| **PreCompact Hook** | Right before context compaction | Auto-mines transcript, then emergency save — forces the AI to save EVERYTHING before losing context |
 
-The AI does the actual filing — it knows the conversation context, so it classifies memories into the right wings/halls/closets. The hooks just tell it WHEN to save.
+**Two-layer capture:** Hooks auto-mine the JSONL transcript directly into the palace (capturing raw tool output — Bash results, search findings, build errors). They also block the AI with a reason message telling it to save verbatim tool output and key context. Belt and suspenders — tool output gets stored even if the AI summarizes instead of quoting.
 
 ## Install — Claude Code
 
@@ -68,6 +68,7 @@ Edit `mempal_save_hook.sh` to change:
 - **`SAVE_INTERVAL=15`** — How many human messages between saves. Lower = more frequent saves, higher = less interruption.
 - **`STATE_DIR`** — Where hook state is stored (defaults to `~/.mempalace/hook_state/`)
 - **`MEMPAL_DIR`** — Optional. Set to a conversations directory to auto-run `mempalace mine <dir>` on each save trigger. Leave blank (default) to let the AI handle saving via the block reason message.
+- **`MEMPAL_PYTHON`** — Optional env var. Python interpreter with mempalace + chromadb installed. Auto-detects: `MEMPAL_PYTHON` env var → repo `venv/bin/python3` → system `python3`. Set this if your venv is in a non-standard location.
 
 ### mempalace CLI
 
@@ -91,15 +92,19 @@ User sends message → AI responds → Claude Code fires Stop hook
                                             ↓
                               ┌─── < 15 since last save ──→ echo "{}" (let AI stop)
                               │
-                              └─── ≥ 15 since last save ──→ {"decision": "block", "reason": "save..."}
-                                                                    ↓
-                                                            AI saves to palace
-                                                                    ↓
-                                                            AI tries to stop again
-                                                                    ↓
-                                                            stop_hook_active = true
-                                                                    ↓
-                                                            Hook sees flag → echo "{}" (let it through)
+                              └─── ≥ 15 since last save
+                                            ↓
+                                    Auto-mine transcript → palace (tool output captured)
+                                            ↓
+                                    {"decision": "block", "reason": "save tool output verbatim..."}
+                                            ↓
+                                    AI saves to palace (topics, decisions, quotes)
+                                            ↓
+                                    AI tries to stop again
+                                            ↓
+                                    stop_hook_active = true
+                                            ↓
+                                    Hook sees flag → echo "{}" (let it through)
 ```
 
 The `stop_hook_active` flag prevents infinite loops: block once → AI saves → tries to stop → flag is true → we let it through.
@@ -109,14 +114,18 @@ The `stop_hook_active` flag prevents infinite loops: block once → AI saves →
 ```
 Context window getting full → Claude Code fires PreCompact
                                         ↓
-                                Hook ALWAYS blocks
+                                Find transcript (from input or session_id lookup)
+                                        ↓
+                                Auto-mine transcript → palace (tool output captured)
+                                        ↓
+                                {"decision": "block", "reason": "save tool output verbatim..."}
                                         ↓
                                 AI saves everything
                                         ↓
                                 Compaction proceeds
 ```
 
-No counting needed — compaction always warrants a save.
+No counting needed — compaction always warrants a save. The auto-mine captures raw tool output before the AI gets a chance to summarize it away.
 
 ## Debugging
 
@@ -135,4 +144,7 @@ Example output:
 
 ## Cost
 
-**Zero extra tokens.** The hooks are bash scripts that run locally. They don't call any API. The only "cost" is the AI spending a few seconds organizing memories at each checkpoint — and it's doing that with context it already has loaded.
+**Zero extra API tokens.** The hooks are bash scripts that run locally. They don't call any API. The auto-mining uses the local ChromaDB instance. The only "cost" is:
+- ~1-13 seconds for transcript mining (depending on session length)
+- The AI spending a few seconds organizing memories at each checkpoint — with context it already has loaded
+- ChromaDB disk space for the mined chunks (~1KB per exchange pair)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -142,6 +142,23 @@ Example output:
 [14:40:01] Session abc123: 18 exchanges, 3 since last save
 ```
 
+## Backfill Past Conversations
+
+The hooks only capture conversations going forward. To mine **past** Claude Code sessions into your palace, run a one-time backfill:
+
+```bash
+mempalace mine ~/.claude/projects/ --mode convos
+```
+
+This scans all JSONL transcripts from previous sessions and files them into the `conversations` wing. On a typical developer machine with months of history, this can yield 50K–200K drawers.
+
+For Codex CLI sessions:
+```bash
+mempalace mine ~/.codex/sessions/ --mode convos
+```
+
+This only needs to be done once — after that, the hooks auto-mine each session as you go.
+
 ## Cost
 
 **Zero extra API tokens.** The hooks are bash scripts that run locally. They don't call any API. The auto-mining uses the local ChromaDB instance. The only "cost" is:

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -68,7 +68,7 @@ Edit `mempal_save_hook.sh` to change:
 - **`SAVE_INTERVAL=15`** — How many human messages between saves. Lower = more frequent saves, higher = less interruption.
 - **`STATE_DIR`** — Where hook state is stored (defaults to `~/.mempalace/hook_state/`)
 - **`MEMPAL_DIR`** — Optional. Set to a conversations directory to auto-run `mempalace mine <dir>` on each save trigger. Leave blank (default) to let the AI handle saving via the block reason message.
-- **`MEMPAL_PYTHON`** — Optional env var. Python interpreter with mempalace + chromadb installed. Auto-detects: `MEMPAL_PYTHON` env var → repo `venv/bin/python3` → system `python3`. Set this if your venv is in a non-standard location.
+- **`MEMPALACE_PYTHON`** — Optional env var. Python interpreter with mempalace + chromadb installed. Auto-detects: `MEMPALACE_PYTHON` env var → repo `venv/bin/python3` → system `python3`. Set this if your venv is in a non-standard location.
 
 ### mempalace CLI
 

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -155,6 +155,6 @@ fi
 cat << 'HOOKJSON'
 {
   "decision": "block",
-  "reason": "COMPACTION IMMINENT — MEMPALACE SAVE REQUIRED. Use the mempalace MCP tools (mempalace_add_drawer, mempalace_diary_write) to save EVERYTHING to the memory palace. Do NOT save to your internal Claude memory (~/.claude/memory/) — save to the MEMPALACE via MCP tools only. CRITICAL: Save tool output VERBATIM — Bash command results, probe findings, search results, build output, error messages. These are lost on compaction and exist nowhere else. Also save all topics, decisions, quotes, code, and important context. Be thorough — after compaction, detailed context will be lost. Organize into appropriate wings/rooms. Save everything, then allow compaction to proceed."
+  "reason": "COMPACTION IMMINENT — MEMPALACE SAVE REQUIRED. Use the mempalace MCP tools (mempalace_add_drawer, mempalace_diary_write) to save EVERYTHING to the memory palace. Do NOT save to your internal Claude memory (~/.claude/projects/.../memory/) — save to the MEMPALACE via MCP tools only. CRITICAL: Save tool output VERBATIM — Bash command results, probe findings, search results, build output, error messages. These are lost on compaction and exist nowhere else. Also save all topics, decisions, quotes, code, and important context. Be thorough — after compaction, detailed context will be lost. Organize into appropriate wings/rooms. Save everything, then allow compaction to proceed."
 }
 HOOKJSON

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -54,24 +54,107 @@ mkdir -p "$STATE_DIR"
 # Leave empty to skip auto-ingest (AI handles saving via the block reason).
 MEMPAL_DIR=""
 
+# Python interpreter with mempalace + chromadb installed.
+# Auto-detects: MEMPAL_PYTHON env var → repo venv → system python3
+if [ -n "$MEMPAL_PYTHON" ]; then
+    MP_PYTHON="$MEMPAL_PYTHON"
+elif [ -f "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/venv/bin/python3" ]; then
+    MP_PYTHON="$(dirname "$(dirname "${BASH_SOURCE[0]}")")/venv/bin/python3"
+else
+    MP_PYTHON="python3"
+fi
+
 # Read JSON input from stdin
 INPUT=$(cat)
 
-SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+sid = data.get('session_id', 'unknown')
+safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\-~]', '', str(s))
+print(safe(sid))
+" 2>/dev/null)
 
 echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
+
+# Also parse transcript_path if present in the input
+TRANSCRIPT_PATH=$(echo "$INPUT" | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+tp = data.get('transcript_path', '')
+safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\-~]', '', str(s))
+print(safe(tp))
+" 2>/dev/null)
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
+
+# If no transcript_path in input, find it by session_id
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+    if [ -n "$SESSION_ID" ] && [ "$SESSION_ID" != "unknown" ]; then
+        FOUND=$(find "$HOME/.claude/projects" -name "${SESSION_ID}.jsonl" -type f 2>/dev/null | head -1)
+        if [ -n "$FOUND" ]; then
+            TRANSCRIPT_PATH="$FOUND"
+        fi
+    fi
+fi
+
+# Auto-mine the transcript — captures tool output before compaction loses it
+if [ -f "$TRANSCRIPT_PATH" ]; then
+    echo "[$(date '+%H:%M:%S')] Mining transcript: $TRANSCRIPT_PATH" >> "$STATE_DIR/hook.log"
+    "$MP_PYTHON" - "$TRANSCRIPT_PATH" <<'PYMINE'
+import sys
+try:
+    import hashlib
+    from datetime import datetime
+    from mempalace.normalize import normalize
+    from mempalace.convo_miner import chunk_exchanges, detect_convo_room
+    from mempalace.palace import get_collection
+    from mempalace.config import MempalaceConfig
+    palace = MempalaceConfig().palace_path
+    content = normalize(sys.argv[1])
+    if content and len(content.strip()) >= 50:
+        collection = get_collection(palace)
+        source = sys.argv[1]
+        # No file_already_mined check — transcript grows during session.
+        # upsert is idempotent: same chunk_index → same ID → overwrite.
+        chunks = chunk_exchanges(content)
+        if chunks:
+            room = detect_convo_room(content) or "session"
+            wing = "conversations"
+            docs, ids, metas = [], [], []
+            for chunk in chunks:
+                cid = hashlib.sha256(
+                    (source + str(chunk["chunk_index"])).encode()
+                ).hexdigest()[:24]
+                docs.append(chunk["content"])
+                ids.append(f"drawer_{wing}_{room}_{cid}")
+                metas.append({
+                    "wing": wing, "room": room, "source_file": source,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": "hook", "filed_at": datetime.now().isoformat(),
+                    "ingest_mode": "convos", "extract_mode": "exchange",
+                })
+            for i in range(0, len(docs), 100):
+                collection.upsert(
+                    documents=docs[i:i+100], ids=ids[i:i+100],
+                    metadatas=metas[i:i+100],
+                )
+except Exception:
+    pass  # Hook must never crash the AI
+PYMINE
+    >> "$STATE_DIR/hook.log" 2>&1
+fi
 
 # Optional: run mempalace ingest synchronously so memories land before compaction
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     REPO_DIR="$(dirname "$SCRIPT_DIR")"
-    python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
+    "$MP_PYTHON" -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
 # Always block — compaction = save everything
 cat << 'HOOKJSON'
 {
   "decision": "block",
-  "reason": "COMPACTION IMMINENT. Save ALL topics, decisions, quotes, code, and important context from this session to your memory system. Be thorough — after compaction, detailed context will be lost. Organize into appropriate categories. Use verbatim quotes where possible. Save everything, then allow compaction to proceed."
+  "reason": "COMPACTION IMMINENT — MEMPALACE SAVE REQUIRED. Use the mempalace MCP tools (mempalace_add_drawer, mempalace_diary_write) to save EVERYTHING to the memory palace. Do NOT save to your internal Claude memory (~/.claude/memory/) — save to the MEMPALACE via MCP tools only. CRITICAL: Save tool output VERBATIM — Bash command results, probe findings, search results, build output, error messages. These are lost on compaction and exist nowhere else. Also save all topics, decisions, quotes, code, and important context. Be thorough — after compaction, detailed context will be lost. Organize into appropriate wings/rooms. Save everything, then allow compaction to proceed."
 }
 HOOKJSON

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -55,9 +55,9 @@ mkdir -p "$STATE_DIR"
 MEMPAL_DIR=""
 
 # Python interpreter with mempalace + chromadb installed.
-# Auto-detects: MEMPAL_PYTHON env var → repo venv → system python3
-if [ -n "$MEMPAL_PYTHON" ]; then
-    MP_PYTHON="$MEMPAL_PYTHON"
+# Auto-detects: MEMPALACE_PYTHON env var → repo venv → system python3
+if [ -n "$MEMPALACE_PYTHON" ]; then
+    MP_PYTHON="$MEMPALACE_PYTHON"
 elif [ -f "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/venv/bin/python3" ]; then
     MP_PYTHON="$(dirname "$(dirname "${BASH_SOURCE[0]}")")/venv/bin/python3"
 else

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -61,6 +61,16 @@ mkdir -p "$STATE_DIR"
 # Leave empty to skip auto-ingest (AI handles saving via the block reason).
 MEMPAL_DIR=""
 
+# Python interpreter with mempalace + chromadb installed.
+# Auto-detects: MEMPAL_PYTHON env var → repo venv → system python3
+if [ -n "$MEMPAL_PYTHON" ]; then
+    MP_PYTHON="$MEMPAL_PYTHON"
+elif [ -f "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/venv/bin/python3" ]; then
+    MP_PYTHON="$(dirname "$(dirname "${BASH_SOURCE[0]}")")/venv/bin/python3"
+else
+    MP_PYTHON="python3"
+fi
+
 # Read JSON input from stdin
 INPUT=$(cat)
 
@@ -137,7 +147,53 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         REPO_DIR="$(dirname "$SCRIPT_DIR")"
-        python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
+        "$MP_PYTHON" -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
+    fi
+
+    # Auto-mine the transcript — captures tool output that the AI would summarize away
+    if [ -f "$TRANSCRIPT_PATH" ]; then
+        "$MP_PYTHON" - "$TRANSCRIPT_PATH" <<'PYMINE'
+import sys
+try:
+    import hashlib
+    from datetime import datetime
+    from mempalace.normalize import normalize
+    from mempalace.convo_miner import chunk_exchanges, detect_convo_room
+    from mempalace.palace import get_collection
+    from mempalace.config import MempalaceConfig
+    palace = MempalaceConfig().palace_path
+    content = normalize(sys.argv[1])
+    if content and len(content.strip()) >= 50:
+        collection = get_collection(palace)
+        source = sys.argv[1]
+        # No file_already_mined check — transcript grows during session.
+        # upsert is idempotent: same chunk_index → same ID → overwrite.
+        chunks = chunk_exchanges(content)
+        if chunks:
+            room = detect_convo_room(content) or "session"
+            wing = "conversations"
+            docs, ids, metas = [], [], []
+            for chunk in chunks:
+                cid = hashlib.sha256(
+                    (source + str(chunk["chunk_index"])).encode()
+                ).hexdigest()[:24]
+                docs.append(chunk["content"])
+                ids.append(f"drawer_{wing}_{room}_{cid}")
+                metas.append({
+                    "wing": wing, "room": room, "source_file": source,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": "hook", "filed_at": datetime.now().isoformat(),
+                    "ingest_mode": "convos", "extract_mode": "exchange",
+                })
+            for i in range(0, len(docs), 100):
+                collection.upsert(
+                    documents=docs[i:i+100], ids=ids[i:i+100],
+                    metadatas=metas[i:i+100],
+                )
+except Exception:
+    pass  # Hook must never crash the AI
+PYMINE
+        >> "$STATE_DIR/hook.log" 2>&1
     fi
 
     # Block the AI and tell it to save
@@ -145,7 +201,7 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     cat << 'HOOKJSON'
 {
   "decision": "block",
-  "reason": "AUTO-SAVE checkpoint. Save key topics, decisions, quotes, and code from this session to your memory system. Organize into appropriate categories. Use verbatim quotes where possible. Continue conversation after saving."
+  "reason": "MEMPALACE AUTO-SAVE checkpoint. Use the mempalace MCP tools (mempalace_add_drawer, mempalace_diary_write) to save to the memory palace. Do NOT save to your internal Claude memory (~/.claude/memory/) — save to the MEMPALACE via MCP tools only. IMPORTANT: Save tool output VERBATIM — Bash command results, probe findings, search results, build output, error messages. These are lost on compaction and exist nowhere else. Also save key topics, decisions, and quotes. Organize into appropriate wings/rooms. Continue conversation after saving."
 }
 HOOKJSON
 else

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -62,9 +62,9 @@ mkdir -p "$STATE_DIR"
 MEMPAL_DIR=""
 
 # Python interpreter with mempalace + chromadb installed.
-# Auto-detects: MEMPAL_PYTHON env var → repo venv → system python3
-if [ -n "$MEMPAL_PYTHON" ]; then
-    MP_PYTHON="$MEMPAL_PYTHON"
+# Auto-detects: MEMPALACE_PYTHON env var → repo venv → system python3
+if [ -n "$MEMPALACE_PYTHON" ]; then
+    MP_PYTHON="$MEMPALACE_PYTHON"
 elif [ -f "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/venv/bin/python3" ]; then
     MP_PYTHON="$(dirname "$(dirname "${BASH_SOURCE[0]}")")/venv/bin/python3"
 else

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -201,7 +201,7 @@ PYMINE
     cat << 'HOOKJSON'
 {
   "decision": "block",
-  "reason": "MEMPALACE AUTO-SAVE checkpoint. Use the mempalace MCP tools (mempalace_add_drawer, mempalace_diary_write) to save to the memory palace. Do NOT save to your internal Claude memory (~/.claude/memory/) — save to the MEMPALACE via MCP tools only. IMPORTANT: Save tool output VERBATIM — Bash command results, probe findings, search results, build output, error messages. These are lost on compaction and exist nowhere else. Also save key topics, decisions, and quotes. Organize into appropriate wings/rooms. Continue conversation after saving."
+  "reason": "MEMPALACE AUTO-SAVE checkpoint. Use the mempalace MCP tools (mempalace_add_drawer, mempalace_diary_write) to save to the memory palace. Do NOT save to your internal Claude memory (~/.claude/projects/.../memory/) — save to the MEMPALACE via MCP tools only. IMPORTANT: Save tool output VERBATIM — Bash command results, probe findings, search results, build output, error messages. These are lost on compaction and exist nowhere else. Also save key topics, decisions, and quotes. Organize into appropriate wings/rooms. Continue conversation after saving."
 }
 HOOKJSON
 else

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -189,6 +189,7 @@ class MempalaceConfig:
             self._file_config["hooks"] = {}
         self._file_config["hooks"][key] = value
         try:
+            self._config_dir.mkdir(parents=True, exist_ok=True)
             with open(self._config_file, "w", encoding="utf-8") as f:
                 json.dump(self._file_config, f, indent=2, ensure_ascii=False)
         except OSError:

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -173,6 +173,27 @@ class MempalaceConfig:
         """Mapping of hall names to keyword lists."""
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
+    @property
+    def hook_silent_save(self):
+        """Whether the stop hook saves directly (True) or blocks for MCP calls (False)."""
+        return self._file_config.get("hooks", {}).get("silent_save", True)
+
+    @property
+    def hook_desktop_toast(self):
+        """Whether the stop hook shows a desktop notification via notify-send."""
+        return self._file_config.get("hooks", {}).get("desktop_toast", False)
+
+    def set_hook_setting(self, key: str, value: bool):
+        """Update a hook setting and write config to disk."""
+        if "hooks" not in self._file_config:
+            self._file_config["hooks"] = {}
+        self._file_config["hooks"][key] = value
+        try:
+            with open(self._config_file, "w", encoding="utf-8") as f:
+                json.dump(self._file_config, f, indent=2, ensure_ascii=False)
+        except OSError:
+            pass
+
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""
         self._config_dir.mkdir(parents=True, exist_ok=True)

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -17,19 +17,52 @@ from pathlib import Path
 SAVE_INTERVAL = 15
 STATE_DIR = Path.home() / ".mempalace" / "hook_state"
 
+
+def _mempalace_python() -> str:
+    """Return the python interpreter that has mempalace installed.
+
+    When hooks are invoked by Claude Code, sys.executable may be the system
+    python which lacks chromadb and other deps.  Resolution order:
+    1. MEMPALACE_PYTHON env var (explicit override)
+    2. Venv python from package install path
+    3. Editable install: venv/ sibling to mempalace/
+    4. sys.executable fallback
+    """
+    # Honor explicit override (used by shell hook wrappers)
+    env_python = os.environ.get("MEMPALACE_PYTHON", "")
+    if env_python and os.path.isfile(env_python) and os.access(env_python, os.X_OK):
+        return env_python
+    # This file lives at <venv>/lib/pythonX.Y/site-packages/mempalace/hooks_cli.py
+    # or <project>/mempalace/hooks_cli.py (editable install).
+    venv_bin = Path(__file__).resolve().parents[3] / "bin" / "python"
+    if venv_bin.is_file():
+        return str(venv_bin)
+    # Editable install: assumes project root has a venv/ sibling to mempalace/
+    project_venv = Path(__file__).resolve().parents[1] / "venv" / "bin" / "python"
+    if project_venv.is_file():
+        return str(project_venv)
+    return sys.executable
+
+_RECENT_MSG_COUNT = 30  # how many recent user messages to summarize
+
 STOP_BLOCK_REASON = (
     "AUTO-SAVE checkpoint. Save key topics, decisions, quotes, and code "
-    "from this session to your memory system. Organize into appropriate "
-    "categories. Use verbatim quotes where possible. Continue conversation "
-    "after saving."
+    "from this session to MemPalace using the MCP tools:\n"
+    "1. Use mempalace_diary_write to save a session summary (what was discussed, "
+    "key decisions, current state of work).\n"
+    "2. Use mempalace_add_drawer for each important decision, quote, or code "
+    "snippet — place in the appropriate wing and room.\n"
+    "Use verbatim quotes where possible. Continue conversation after saving."
 )
 
 PRECOMPACT_BLOCK_REASON = (
-    "COMPACTION IMMINENT. Save ALL topics, decisions, quotes, code, and "
-    "important context from this session to your memory system. Be thorough "
-    "\u2014 after compaction, detailed context will be lost. Organize into "
-    "appropriate categories. Use verbatim quotes where possible. Save "
-    "everything, then allow compaction to proceed."
+    "COMPACTION IMMINENT — detailed context will be lost. Save ALL topics, "
+    "decisions, quotes, code, and important context to MemPalace using MCP tools:\n"
+    "1. Use mempalace_diary_write for a thorough session summary.\n"
+    "2. Use mempalace_add_drawer for EVERY key decision, finding, quote, and "
+    "code snippet — place each in the appropriate wing and room.\n"
+    "Be thorough — after compaction this is all that survives. Use verbatim "
+    "quotes. Save everything, then allow compaction to proceed."
 )
 
 
@@ -95,6 +128,18 @@ def _output(data: dict):
     print(json.dumps(data, indent=2, ensure_ascii=False))
 
 
+def _desktop_toast(body: str, title: str = "MemPalace"):
+    """Send a desktop notification via notify-send. Fails silently."""
+    try:
+        subprocess.Popen(
+            ["notify-send", "--app-name=MemPalace", "--icon=brain", title, body],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        pass
+
+
 def _maybe_auto_ingest():
     """If MEMPAL_DIR is set and exists, run mempalace mine in background."""
     mempal_dir = os.environ.get("MEMPAL_DIR", "")
@@ -103,12 +148,154 @@ def _maybe_auto_ingest():
             log_path = STATE_DIR / "hook.log"
             with open(log_path, "a") as log_f:
                 subprocess.Popen(
-                    [sys.executable, "-m", "mempalace", "mine", mempal_dir],
+                    [_mempalace_python(), "-m", "mempalace", "mine", mempal_dir],
                     stdout=log_f,
                     stderr=log_f,
                 )
         except OSError:
             pass
+
+
+def _extract_recent_messages(transcript_path: str, count: int = _RECENT_MSG_COUNT) -> list[str]:
+    """Extract the last N user messages from a JSONL transcript."""
+    path = Path(transcript_path).expanduser()
+    if not path.is_file():
+        return []
+    messages = []
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                    msg = entry.get("message", {})
+                    if not isinstance(msg, dict) or msg.get("role") != "user":
+                        continue
+                    content = msg.get("content", "")
+                    if isinstance(content, list):
+                        content = " ".join(
+                            b.get("text", "") for b in content if isinstance(b, dict)
+                        )
+                    if not isinstance(content, str) or not content.strip():
+                        continue
+                    if "<command-message>" in content or "<system-reminder>" in content:
+                        continue
+                    # Truncate long messages
+                    text = content.strip()[:200]
+                    messages.append(text)
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+    except OSError:
+        return []
+    return messages[-count:]
+
+
+_THEME_STOPWORDS = frozenset(
+    "the a an and or but in on at to for of is it i me my you your we our "
+    "this that with from by was were be been are not no yes can do did don't "
+    "will would should could have has had let's let just also like so if then "
+    "ok okay sure yeah hey hi here there what when where how why which some "
+    "all any each every about into out up down over after before between "
+    "get got make made need want use used using check look see run try "
+    "know think right now still already really very much more most too "
+    "file files code one two new first last next thing things way well".split()
+)
+
+
+def _extract_themes(messages: list[str], max_themes: int = 3) -> list[str]:
+    """Pull 2-3 distinctive topic words from recent messages.
+
+    Note: stopword list is English-only; non-English corpora will produce noisy themes.
+    """
+    from collections import Counter
+    words: Counter[str] = Counter()
+    for msg in messages:
+        for word in msg.lower().split():
+            # Strip punctuation, keep words 4+ chars
+            clean = word.strip(".,;:!?\"'`()[]{}#<>/\\-_=+@$%^&*~")
+            if len(clean) >= 4 and clean not in _THEME_STOPWORDS and clean.isalpha():
+                words[clean] += 1
+    return [w for w, _ in words.most_common(max_themes)]
+
+
+def _save_diary_direct(
+    transcript_path: str, session_id: str, toast: bool = False,
+) -> dict:
+    """Write a diary checkpoint directly via Python API (no MCP calls).
+
+    Returns {"count": N, "themes": [...]} on success, {"count": 0} on failure.
+    """
+    messages = _extract_recent_messages(transcript_path)
+    if not messages:
+        _log("No recent messages to save")
+        return {"count": 0}
+
+    themes = _extract_themes(messages)
+
+    # Build a compressed diary entry from recent conversation
+    now = datetime.now()
+    topics = "|".join(m[:80] for m in messages[-10:])
+    entry = (
+        f"CHECKPOINT:{now.strftime('%Y-%m-%d')}|session:{session_id}"
+        f"|msgs:{len(messages)}|recent:{topics}"
+    )
+
+    try:
+        from .mcp_server import tool_diary_write
+        result = tool_diary_write(
+            agent_name="session-hook",
+            entry=entry,
+            topic="checkpoint",
+        )
+        if result.get("success"):
+            _log(f"Diary checkpoint saved: {result.get('entry_id', '?')}")
+            # Write state for ack tool to read
+            try:
+                ack_file = STATE_DIR / "last_checkpoint"
+                ack_file.write_text(
+                    json.dumps({"msgs": len(messages), "ts": now.isoformat()}),
+                    encoding="utf-8",
+                )
+            except OSError:
+                pass
+            if toast:
+                _desktop_toast(f"Checkpoint saved \u2014 {len(messages)} messages archived")
+            return {"count": len(messages), "themes": themes}
+        else:
+            _log(f"Diary checkpoint failed: {result.get('error', 'unknown')}")
+    except Exception as e:
+        _log(f"Diary checkpoint error: {e}")
+    return {"count": 0}
+
+
+def _ingest_transcript(transcript_path: str):
+    """Mine a Claude Code session transcript into the palace as a conversation."""
+    path = Path(transcript_path).expanduser()
+    if not path.is_file() or path.stat().st_size < 100:
+        return
+
+    from .config import MempalaceConfig
+
+    try:
+        MempalaceConfig()  # validate config loads
+    except Exception:
+        return
+
+    try:
+        log_path = STATE_DIR / "hook.log"
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a") as log_f:
+            subprocess.Popen(
+                [
+                    _mempalace_python(), "-m", "mempalace", "mine",
+                    str(path.parent), "--mode", "convos",
+                    "--wing", "sessions",
+                ],
+                stdout=log_f,
+                stderr=log_f,
+            )
+        _log(f"Transcript ingest started: {path.name}")
+    except OSError:
+        pass
 
 
 SUPPORTED_HARNESSES = {"claude-code", "codex"}
@@ -156,18 +343,54 @@ def hook_stop(data: dict, harness: str):
     _log(f"Session {session_id}: {exchange_count} exchanges, {since_last} since last save")
 
     if since_last >= SAVE_INTERVAL and exchange_count > 0:
-        # Update last save point
-        try:
-            last_save_file.write_text(str(exchange_count), encoding="utf-8")
-        except OSError:
-            pass
-
         _log(f"TRIGGERING SAVE at exchange {exchange_count}")
 
-        # Optional: auto-ingest if MEMPAL_DIR is set
-        _maybe_auto_ingest()
+        # Read hook settings from config
+        from .config import MempalaceConfig
+        try:
+            config = MempalaceConfig()
+            silent = config.hook_silent_save
+            toast = config.hook_desktop_toast
+        except Exception:
+            silent = True
+            toast = False
 
-        _output({"decision": "block", "reason": STOP_BLOCK_REASON})
+        if silent:
+            # Save directly via Python API — systemMessage renders in terminal
+            result = {"count": 0}
+            if transcript_path:
+                result = _save_diary_direct(transcript_path, session_id, toast=toast)
+                _ingest_transcript(transcript_path)
+            _maybe_auto_ingest()
+            # Only advance save marker after successful save
+            count = result.get("count", 0)
+            if count > 0:
+                try:
+                    last_save_file.write_text(str(exchange_count), encoding="utf-8")
+                except OSError:
+                    pass
+                themes = result.get("themes", [])
+                if themes:
+                    tag = " \u2014 " + ", ".join(themes)
+                else:
+                    tag = ""
+                _output({
+                    "systemMessage": f"\u2726 {count} memories woven into the palace{tag}",
+                })
+            else:
+                _output({})
+        else:
+            # Legacy: block and ask Claude to save via MCP tools.
+            # Marker advances before confirmed save — best-effort; if Claude
+            # fails to save, the checkpoint is lost but won't retry endlessly.
+            try:
+                last_save_file.write_text(str(exchange_count), encoding="utf-8")
+            except OSError:
+                pass
+            if transcript_path:
+                _ingest_transcript(transcript_path)
+            _maybe_auto_ingest()
+            _output({"decision": "block", "reason": STOP_BLOCK_REASON})
     else:
         _output({})
 
@@ -192,15 +415,21 @@ def hook_precompact(data: dict, harness: str):
     session_id = parsed["session_id"]
 
     _log(f"PRE-COMPACT triggered for session {session_id}")
+    transcript_path = parsed["transcript_path"]
 
-    # Optional: auto-ingest synchronously before compaction (so memories land first)
+    # Best-effort background ingest — spawns async subprocess, not guaranteed
+    # to complete before compaction but gives the palace a head start
+    if transcript_path:
+        _ingest_transcript(transcript_path)
+
+    # Optional: auto-ingest project dir synchronously
     mempal_dir = os.environ.get("MEMPAL_DIR", "")
     if mempal_dir and os.path.isdir(mempal_dir):
         try:
             log_path = STATE_DIR / "hook.log"
             with open(log_path, "a") as log_f:
                 subprocess.run(
-                    [sys.executable, "-m", "mempalace", "mine", mempal_dir],
+                    [_mempalace_python(), "-m", "mempalace", "mine", mempal_dir],
                     stdout=log_f,
                     stderr=log_f,
                     timeout=60,

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -8,11 +8,12 @@ import pytest
 
 from mempalace.hooks_cli import (
     SAVE_INTERVAL,
-    STOP_BLOCK_REASON,
     PRECOMPACT_BLOCK_REASON,
     _count_human_messages,
+    _extract_recent_messages,
     _log,
     _maybe_auto_ingest,
+    _mempalace_python,
     _parse_harness_input,
     _sanitize_session_id,
     hook_stop,
@@ -20,6 +21,21 @@ from mempalace.hooks_cli import (
     hook_precompact,
     run_hook,
 )
+
+
+# --- _mempalace_python ---
+
+
+def test_mempalace_python_returns_string():
+    result = _mempalace_python()
+    assert isinstance(result, str)
+    assert "python" in result
+
+
+def test_mempalace_python_finds_venv():
+    """Should resolve to a venv python, not bare sys.executable."""
+    result = _mempalace_python()
+    assert "venv" in result or "site-packages" in result or result.endswith("python")
 
 
 # --- _sanitize_session_id ---
@@ -105,6 +121,40 @@ def test_count_malformed_json_lines(tmp_path):
     assert _count_human_messages(str(transcript)) == 1
 
 
+# --- _extract_recent_messages ---
+
+
+def test_extract_recent_messages_basic(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(5)],
+    )
+    msgs = _extract_recent_messages(str(transcript), count=3)
+    assert len(msgs) == 3
+    assert msgs[0] == "msg 2"
+    assert msgs[2] == "msg 4"
+
+
+def test_extract_recent_messages_skips_commands(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            {"message": {"role": "user", "content": "real msg"}},
+            {"message": {"role": "user", "content": "<command-message>status</command-message>"}},
+            {"message": {"role": "user", "content": "<system-reminder>hook</system-reminder>"}},
+        ],
+    )
+    msgs = _extract_recent_messages(str(transcript))
+    assert len(msgs) == 1
+    assert msgs[0] == "real msg"
+
+
+def test_extract_recent_messages_missing_file():
+    assert _extract_recent_messages("/nonexistent.jsonl") == []
+
+
 # --- hook_stop ---
 
 
@@ -157,19 +207,23 @@ def test_stop_hook_passthrough_below_interval(tmp_path):
     assert result == {}
 
 
-def test_stop_hook_blocks_at_interval(tmp_path):
+def test_stop_hook_saves_silently_at_interval(tmp_path):
     transcript = tmp_path / "t.jsonl"
     _write_transcript(
         transcript,
         [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(SAVE_INTERVAL)],
     )
-    result = _capture_hook_output(
-        hook_stop,
-        {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
-        state_dir=tmp_path,
-    )
-    assert result["decision"] == "block"
-    assert result["reason"] == STOP_BLOCK_REASON
+    save_result = {"count": 15, "themes": ["hooks", "notifications"]}
+    with patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result) as mock_save:
+        result = _capture_hook_output(
+            hook_stop,
+            {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
+            state_dir=tmp_path,
+        )
+    # Saves silently — systemMessage notification with themes, no block
+    assert result["systemMessage"].startswith("\u2726 15 memories woven into the palace")
+    assert "hooks" in result["systemMessage"]
+    mock_save.assert_called_once_with(str(transcript), "test", toast=False)
 
 
 def test_stop_hook_tracks_save_point(tmp_path):
@@ -180,13 +234,17 @@ def test_stop_hook_tracks_save_point(tmp_path):
     )
     data = {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)}
 
-    # First call blocks
-    result = _capture_hook_output(hook_stop, data, state_dir=tmp_path)
-    assert result["decision"] == "block"
+    # First call saves silently with systemMessage notification
+    save_result = {"count": 15, "themes": ["hooks"]}
+    with patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result):
+        result = _capture_hook_output(hook_stop, data, state_dir=tmp_path)
+    assert "systemMessage" in result
 
     # Second call with same count passes through (already saved)
-    result = _capture_hook_output(hook_stop, data, state_dir=tmp_path)
+    with patch("mempalace.hooks_cli._save_diary_direct") as mock_save:
+        result = _capture_hook_output(hook_stop, data, state_dir=tmp_path)
     assert result == {}
+    mock_save.assert_not_called()
 
 
 # --- hook_session_start ---
@@ -295,12 +353,15 @@ def test_stop_hook_oserror_on_last_save_read(tmp_path):
     )
     # Write invalid content to last save file
     (tmp_path / "test_last_save").write_text("not_a_number")
-    result = _capture_hook_output(
-        hook_stop,
-        {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
-        state_dir=tmp_path,
-    )
-    assert result["decision"] == "block"
+    save_result = {"count": 15, "themes": ["testing"]}
+    with patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result):
+        result = _capture_hook_output(
+            hook_stop,
+            {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
+            state_dir=tmp_path,
+        )
+    assert "systemMessage" in result
+    assert "15 memories" in result["systemMessage"]
 
 
 def test_stop_hook_oserror_on_write(tmp_path):
@@ -314,18 +375,20 @@ def test_stop_hook_oserror_on_write(tmp_path):
     def bad_write_text(*args, **kwargs):
         raise OSError("disk full")
 
+    save_result = {"count": 15, "themes": []}
     with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
-        with patch.object(Path, "write_text", bad_write_text):
-            result = _capture_hook_output(
-                hook_stop,
-                {
-                    "session_id": "test",
-                    "stop_hook_active": False,
-                    "transcript_path": str(transcript),
-                },
-                state_dir=tmp_path,
-            )
-    assert result["decision"] == "block"
+        with patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result):
+            with patch.object(Path, "write_text", bad_write_text):
+                result = _capture_hook_output(
+                    hook_stop,
+                    {
+                        "session_id": "test",
+                        "stop_hook_active": False,
+                        "transcript_path": str(transcript),
+                    },
+                    state_dir=tmp_path,
+                )
+    assert "systemMessage" in result
 
 
 # --- hook_precompact with MEMPAL_DIR ---

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -33,9 +34,9 @@ def test_mempalace_python_returns_string():
 
 
 def test_mempalace_python_finds_venv():
-    """Should resolve to a venv python, not bare sys.executable."""
+    """Should resolve to a valid Python interpreter path."""
     result = _mempalace_python()
-    assert "venv" in result or "site-packages" in result or result.endswith("python")
+    assert result and "python" in os.path.basename(result).lower()
 
 
 # --- _sanitize_session_id ---


### PR DESCRIPTION
## Summary
Major upgrade to the hook system for reliable auto-save. Split from #562 per maintainer request (PR 5 of 6).

- **Two-layer capture**: Hooks now (1) auto-mine the transcript directly via Python API (deterministic upsert — same chunk = same ID = no duplicates), then (2) block the AI with explicit instructions to save context-dependent information via mempalace MCP tools
- **Transcript auto-ingest**: Both save and precompact hooks mine the JSONL transcript before blocking, so tool output and raw data land in the palace even if the AI summarizes them away
- **Hook settings**: New `hook_silent_save` and `hook_desktop_toast` config options with `set_hook_setting()` for persistent updates
- **hooks_cli.py overhaul**: Save-via-API with systemMessage notification, transcript auto-ingest pipeline, expanded hook settings management
- **Explicit mempalace targeting**: Block reason messages now name specific MCP tools (`mempalace_add_drawer`, `mempalace_diary_write`) and explicitly say NOT to use Claude's internal memory — fixes #622
- **MEMPALACE_PYTHON env var**: Standardized from `MEMPAL_PYTHON` to `MEMPALACE_PYTHON` for consistency with `MEMPALACE_PALACE_PATH` convention (#545, #590)
- **Session ID sanitization**: Regex-based sanitization in both hooks prevents path traversal (#589)
- **Exchange counting fix**: Properly counts only real user messages, not tool_result messages (#549)

## Closes
- #545 — Hook scripts should use venv python
- #549 — Save hook counts tool_result messages as human messages, inflating exchange count
- #554 — UX: Stop hook MCP tool calls clutter terminal every 15 messages (now uses systemMessage)
- #589 — sanitize SESSION_ID in precompact hook
- #590 — MEMPAL_PYTHON naming inconsistency
- #622 — Stop hook auto-save conflicts with Claude Code's built-in auto-memory

## Related
- Split from #562
- Other PRs in this series: #626 (bug fixes), #629 (performance), #630 (reliability), #632 (maintenance), #635 (new tools)

## Test plan
- [ ] 37 hooks CLI tests pass
- [ ] Full suite: 594 passed
- [ ] Stop hook fires after 15 messages, mines transcript, blocks with save instruction
- [ ] PreCompact hook mines transcript, blocks for comprehensive save
- [ ] Verify AI saves to mempalace MCP tools (not Claude internal memory)
- [ ] `mempalace hook-settings` shows current hook configuration
- [ ] Plugin configs work in Claude Code and Codex CLI