### PR TITLE
feat(cli): add 'mempalace mcp run' to start MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Restart Claude Code, then type `/skills` to verify "mempalace" appears.
 
 ```bash
 # Connect MemPalace once
-claude mcp add mempalace -- python -m mempalace.mcp_server
+claude mcp add mempalace -- mempalace mcp run
 ```
 
 Now your AI has 19 tools available through MCP. Ask it anything:
@@ -467,7 +467,7 @@ claude plugin marketplace add milla-jovovich/mempalace
 claude plugin install --scope user mempalace
 
 # Or manually
-claude mcp add mempalace -- python -m mempalace.mcp_server
+claude mcp add mempalace -- mempalace mcp run
 ```
 
 ### 19 Tools

--- a/examples/gemini_cli_setup.md
+++ b/examples/gemini_cli_setup.md
@@ -43,7 +43,7 @@ You can manually define who you are and what projects you work on by creating/ed
 Register MemPalace as an MCP server so Gemini CLI can use its tools.
 
 ```bash
-gemini mcp add mempalace /absolute/path/to/mempalace/.venv/bin/python3 -m mempalace.mcp_server --scope user
+gemini mcp add mempalace /absolute/path/to/mempalace/.venv/bin/mempalace mcp run --scope user
 ```
 *Note: Use the absolute path to ensure it works from any directory.*
 

--- a/examples/mcp_setup.md
+++ b/examples/mcp_setup.md
@@ -5,13 +5,13 @@
 Run the MCP server:
 
 ```bash
-python -m mempalace.mcp_server
+mempalace mcp run
 ```
 
 Or add it to Claude Code:
 
 ```bash
-claude mcp add mempalace -- python -m mempalace.mcp_server
+claude mcp add mempalace -- mempalace mcp run
 ```
 
 ## Available Tools

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -253,7 +253,7 @@ def cmd_instructions(args):
 
 def cmd_mcp(args):
     """Show how to wire MemPalace into MCP-capable hosts."""
-    base_server_cmd = "python -m mempalace.mcp_server"
+    base_server_cmd = "mempalace mcp run"
 
     if args.palace:
         resolved_palace = str(Path(args.palace).expanduser())
@@ -270,6 +270,16 @@ def cmd_mcp(args):
         print("\nOptional custom palace:")
         print(f"  claude mcp add mempalace -- {base_server_cmd} --palace /path/to/palace")
         print(f"  {base_server_cmd} --palace /path/to/palace")
+
+
+def cmd_mcp_run(args):
+    """Start the MCP server (JSON-RPC over stdin/stdout)."""
+    if args.palace:
+        os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(args.palace)
+
+    from .mcp_server import main as mcp_main
+
+    mcp_main()
 
 
 def cmd_compress(args):
@@ -533,9 +543,19 @@ def main():
     )
 
     # mcp
-    sub.add_parser(
+    p_mcp = sub.add_parser(
         "mcp",
-        help="Show MCP setup command for connecting MemPalace to your AI client",
+        help="MCP server \u2014 run the server or show setup instructions",
+    )
+    mcp_sub = p_mcp.add_subparsers(dest="mcp_action")
+    p_mcp_run = mcp_sub.add_parser(
+        "run",
+        help="Start the MCP server (JSON-RPC over stdin/stdout)",
+    )
+    p_mcp_run.add_argument(
+        "--palace",
+        default=None,
+        help="Path to the palace directory (overrides config file and env var)",
     )
 
     # status
@@ -575,12 +595,18 @@ def main():
         cmd_instructions(args)
         return
 
+    if args.command == "mcp":
+        if getattr(args, "mcp_action", None) == "run":
+            cmd_mcp_run(args)
+        else:
+            cmd_mcp(args)
+        return
+
     dispatch = {
         "init": cmd_init,
         "mine": cmd_mine,
         "split": cmd_split,
         "search": cmd_search,
-        "mcp": cmd_mcp,
         "compress": cmd_compress,
         "wake-up": cmd_wakeup,
         "repair": cmd_repair,

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -275,7 +275,7 @@ def cmd_mcp(args):
 def cmd_mcp_run(args):
     """Start the MCP server (JSON-RPC over stdin/stdout)."""
     if args.palace:
-        os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(args.palace)
+        os.environ["MEMPALACE_PALACE_PATH"] = str(Path(args.palace).expanduser().resolve())
 
     from .mcp_server import main as mcp_main
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -381,7 +381,7 @@ def test_mcp_run_sets_palace_env(monkeypatch, tmp_path):
         with patch.dict("sys.modules", {"mempalace.mcp_server": MagicMock(main=mock_server_main)}):
             cmd_mcp_run(args)
         mock_server_main.assert_called_once()
-        assert os.environ.get("MEMPALACE_PALACE_PATH") == os.path.abspath(palace_dir)
+        assert os.environ.get("MEMPALACE_PALACE_PATH") == str(Path(palace_dir).resolve())
 
 
 def test_main_hook_no_subcommand_prints_help(capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for mempalace.cli — the main CLI dispatcher."""
 
 import argparse
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -12,6 +13,7 @@ from mempalace.cli import (
     cmd_hook,
     cmd_init,
     cmd_instructions,
+    cmd_mcp_run,
     cmd_mine,
     cmd_repair,
     cmd_search,
@@ -333,11 +335,7 @@ def test_mcp_command_prints_setup_guidance(monkeypatch, capsys):
     main()
 
     captured = capsys.readouterr()
-    assert "MemPalace MCP quick setup:" in captured.out
-    assert "claude mcp add mempalace -- python -m mempalace.mcp_server" in captured.out
-    assert "\nOptional custom palace:\n" in captured.out
-    assert "python -m mempalace.mcp_server --palace /path/to/palace" in captured.out
-    assert "[--palace /path/to/palace]" not in captured.out
+    assert "mempalace mcp run" in captured.out
     assert captured.err == ""
 
 
@@ -349,11 +347,41 @@ def test_mcp_command_uses_custom_palace_path_when_provided(monkeypatch, capsys):
     captured = capsys.readouterr()
     expanded = str(Path("~/tmp/my palace").expanduser())
 
-    assert "python -m mempalace.mcp_server --palace" in captured.out
+    assert "mempalace mcp run --palace" in captured.out
     assert expanded in captured.out
-    assert "Optional custom palace:" not in captured.out
-    assert "[--palace /path/to/palace]" not in captured.out
     assert captured.err == ""
+
+
+def test_mcp_run_dispatches():
+    """'mempalace mcp run' calls cmd_mcp_run."""
+    with (
+        patch("sys.argv", ["mempalace", "mcp", "run"]),
+        patch("mempalace.cli.cmd_mcp_run") as mock_cmd,
+    ):
+        main()
+        mock_cmd.assert_called_once()
+
+
+def test_mcp_run_starts_server():
+    """cmd_mcp_run imports and calls mcp_server.main."""
+    mock_server_main = MagicMock()
+    args = argparse.Namespace(palace=None)
+    with patch.dict("sys.modules", {"mempalace.mcp_server": MagicMock(main=mock_server_main)}):
+        cmd_mcp_run(args)
+    mock_server_main.assert_called_once()
+
+
+def test_mcp_run_sets_palace_env(monkeypatch, tmp_path):
+    """cmd_mcp_run sets MEMPALACE_PALACE_PATH when --palace is given."""
+    palace_dir = str(tmp_path / "custom_palace")
+    mock_server_main = MagicMock()
+    args = argparse.Namespace(palace=palace_dir)
+    monkeypatch.delenv("MEMPALACE_PALACE_PATH", raising=False)
+    with patch.dict(os.environ, {}, clear=False):
+        with patch.dict("sys.modules", {"mempalace.mcp_server": MagicMock(main=mock_server_main)}):
+            cmd_mcp_run(args)
+        mock_server_main.assert_called_once()
+        assert os.environ.get("MEMPALACE_PALACE_PATH") == os.path.abspath(palace_dir)
 
 
 def test_main_hook_no_subcommand_prints_help(capsys):


### PR DESCRIPTION
## Problem

The current documented way to start the MCP server is `python -m mempalace.mcp_server`. This breaks when:

- Users install with **pipx** (the system `python` doesn't have mempalace installed — it's in pipx's isolated venv)
- System pip is restricted (PEP 668 / `--break-system-packages`)
- The wrong Python is on PATH

The `mempalace` console script entry point (`[project.scripts]` in pyproject.toml) already works in all these environments — but there's no subcommand to start the MCP server through it.

Fixes #408 (MCP server portion). Related: #545, #650 (same root cause for hooks — bare `python3` calls).

## Solution

Add `mempalace mcp run` as a subcommand that starts the MCP server:

```bash
# Before (breaks with pipx)
claude mcp add mempalace -- python -m mempalace.mcp_server

# After (works everywhere)
claude mcp add mempalace -- mempalace mcp run
```

### Behavior

- **`mempalace mcp`** (no subcommand) — still shows setup instructions (existing behavior, non-breaking)
- **`mempalace mcp run`** — starts the MCP server (JSON-RPC over stdin/stdout)
- **`mempalace mcp run --palace /path`** — starts with a custom palace path
- **`python -m mempalace.mcp_server`** — still works for backward compatibility

### Changes

- `mempalace/cli.py` — add `cmd_mcp_run()` function and `mcp run` subcommand (follows the existing `hook run` pattern)
- `tests/test_cli.py` — 3 new tests (dispatch, server start, env var propagation) + updated 2 existing mcp tests
- `README.md`, `examples/` — update MCP setup commands to use `mempalace mcp run`