### PR TITLE
fix: remove no-op ORT_DISABLE_COREML env var (#397)

### DIFF
--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -1,8 +1,6 @@
 """MemPalace — Give your AI a memory. No API key required."""
 
 import logging
-import os
-import platform
 
 from .cli import main  # noqa: E402
 from .version import __version__  # noqa: E402
@@ -13,9 +11,18 @@ from .version import __version__  # noqa: E402
 # 1 positional argument but 3 were given").  Silence just that logger.
 logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
 
-# ONNX Runtime's CoreML provider segfaults during vector queries on Apple Silicon.
-# Force CPU execution unless the user has explicitly set a preference.
-if platform.machine() == "arm64" and platform.system() == "Darwin":
-    os.environ.setdefault("ORT_DISABLE_COREML", "1")
+# NOTE: the previous block set ``ORT_DISABLE_COREML=1`` on macOS arm64 as a
+# supposed workaround for the #74 ARM64 segfault.  Two problems:
+#
+# 1. ONNX Runtime does not read that env var -- it has no global way to
+#    disable a single execution provider, so the setdefault was a no-op.
+# 2. #74 is a null-pointer crash in ``chromadb_rust_bindings.abi3.so``, not
+#    an ONNX issue, so disabling CoreML would not have fixed it anyway.
+#
+# #521 has since traced the actual macOS arm64 crashes (both in mine and
+# search paths) to the 0.x chromadb hnswlib binding.  Filtering
+# CoreMLExecutionProvider at the ONNX layer leaves the hnswlib C++ crash
+# intact, so the real fix is upgrading chromadb to 1.5.4+, which #581
+# proposes.  See #397 for the history of this line.
 
 __all__ = ["main", "__version__"]


### PR DESCRIPTION
## What does this PR do?

Closes #397. `ORT_DISABLE_COREML` is not a recognized ONNX Runtime environment variable, so the `os.environ.setdefault` in `mempalace/__init__.py` was a silent no-op. ONNX Runtime does not expose a global way to disable a specific execution provider -- providers are selected per session via the `providers` argument to `InferenceSession`. The CoreMLExecutionProvider was still loaded on Apple Silicon, so the code claimed a mitigation that never worked.

## Why the old mitigation never helped

The line was added in df33550 (v3.1.0) with the stated goal of fixing the #74 ARM64 segfault. In practice:

- The env var does nothing, as noted above.
- #74 is a null-pointer crash in `chromadb_rust_bindings.abi3.so`, not in ONNX Runtime, so disabling CoreML would not have fixed it anyway.
- #521 has since traced the actual macOS ARM64 crashes (both `mine` and `search` paths) to the 0.x chromadb hnswlib binding. Filtering CoreMLExecutionProvider at the ONNX layer leaves the hnswlib C++ crash intact, so the real fix is upgrading chromadb to 1.5.4+, which #581 proposes.

## Fix

- Remove the `os.environ.setdefault("ORT_DISABLE_COREML", "1")` call.
- Drop the now-unused `os` and `platform` imports.
- Leave a NOTE comment pointing at #74 / #521 / #581 so the history isn't lost.

## Test plan

```bash
python -m pytest tests/ -q
ruff check mempalace/__init__.py
ruff format --check mempalace/__init__.py
```

598 tests pass, file is format-clean.

## Conflict check vs #581

#581 also touches `mempalace/__init__.py`, but only the posthog telemetry comment block. The ORT block lives a few lines below and is not in #581's hunk, so the two PRs modify non-overlapping regions and can merge in either order without a hard conflict.
