### PR TITLE
feat: hybrid search fallback via keyword text-match

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -390,6 +390,7 @@ def tool_search(
     max_distance: float = 1.5,
     min_similarity: float = None,
     context: str = None,
+    keyword: str = None,
 ):
     limit = max(1, min(limit, _MAX_RESULTS))
     try:
@@ -410,6 +411,7 @@ def tool_search(
         room=room,
         n_results=limit,
         max_distance=dist,
+        keyword=keyword,
     )
     # Attach sanitizer metadata for transparency
     if sanitized["was_sanitized"]:
@@ -1206,6 +1208,10 @@ TOOLS = {
                 "context": {
                     "type": "string",
                     "description": "Background context for the search (optional). NOT used for embedding — only for future re-ranking.",
+                },
+                "keyword": {
+                    "type": "string",
+                    "description": "Explicit keyword for text-match fallback. Use for exact terms (error codes, config keys, identifiers) that vector search may miss. Auto-extracted from query if omitted and vector results are poor.",
                 },
             },
             "required": ["query"],

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -29,12 +29,18 @@ def _extract_keyword(query: str) -> str:
     Picks the longest non-stopword token.  Prefers tokens that look like
     identifiers (contain digits, dots, underscores, or are ALLCAPS).
     """
-    tokens = re.findall(r"[\w.]+", query.lower())
-    candidates = [t for t in tokens if t not in _STOPWORDS and len(t) > 2]
+    raw_tokens = re.findall(r"[\w.]+", query)
+    # Prefer ALLCAPS identifier-like tokens (before lowercasing loses the signal)
+    upper_tokens = [t for t in raw_tokens if t.isupper() and len(t) > 2]
+    if upper_tokens:
+        return upper_tokens[0]
+    # Fall back to longest non-stopword token (lowercased)
+    lower_tokens = [t.lower() for t in raw_tokens]
+    candidates = [t for t in lower_tokens if t not in _STOPWORDS and len(t) > 2]
     if not candidates:
         return ""
     # Prefer identifier-looking tokens (error codes, config keys, etc.)
-    ids = [t for t in candidates if re.search(r"\d|_|\.", t) or t.isupper()]
+    ids = [t for t in candidates if re.search(r"\d|_|\.", t)]
     if ids:
         return max(ids, key=len)
     return max(candidates, key=len)
@@ -208,7 +214,7 @@ def search_memories(
             for kid, kdoc, kmeta, kdist in zip(kw_ids, kw_docs, kw_metas, kw_dists):
                 kw_hits_by_id[kid] = (kdoc, kmeta, kdist)
         except Exception:
-            pass  # keyword fallback is best-effort
+            logger.debug("Keyword fallback query failed for keyword=%r", kw)
 
     # Build hit list from vector results
     seen_ids = set()
@@ -254,6 +260,6 @@ def search_memories(
         "query": query,
         "filters": {"wing": wing, "room": room},
         "total_before_filter": len(docs),
-        "keyword_fallback": kw if kw_hits_by_id else None,
+        "keyword_fallback": kw if kw else None,
         "results": hits,
     }

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -2,14 +2,43 @@
 """
 searcher.py — Find anything. Exact words.
 
-Semantic search against the palace.
+Semantic search against the palace with keyword fallback.
 Returns verbatim text — the actual words, never summaries.
 """
 
 import logging
+import re
 from pathlib import Path
 
 from .palace import get_collection
+
+
+# Common words to skip when extracting keywords for fallback search
+_STOPWORDS = frozenset(
+    "a an the is was were be been am are being do does did have has had "
+    "will would shall should may might can could get got it its i me my we "
+    "our you your he she they them his her this that these those of in to "
+    "for on with at by from as into about between through after before "
+    "what when where how who which why all any each no not or and but if".split()
+)
+
+
+def _extract_keyword(query: str) -> str:
+    """Extract the most distinctive token from a query for keyword fallback.
+
+    Picks the longest non-stopword token.  Prefers tokens that look like
+    identifiers (contain digits, dots, underscores, or are ALLCAPS).
+    """
+    tokens = re.findall(r"[\w.]+", query.lower())
+    candidates = [t for t in tokens if t not in _STOPWORDS and len(t) > 2]
+    if not candidates:
+        return ""
+    # Prefer identifier-looking tokens (error codes, config keys, etc.)
+    ids = [t for t in candidates if re.search(r"\d|_|\.", t) or t.isupper()]
+    if ids:
+        return max(ids, key=len)
+    return max(candidates, key=len)
+
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -100,10 +129,15 @@ def search_memories(
     room: str = None,
     n_results: int = 5,
     max_distance: float = 0.0,
+    keyword: str = None,
 ) -> dict:
     """Programmatic search — returns a dict instead of printing.
 
     Used by the MCP server and other callers that need data.
+
+    Hybrid search: runs vector search first, then falls back to keyword
+    matching via ChromaDB where_document if the vector results are poor
+    (best distance > 1.0) or if an explicit keyword is provided.
 
     Args:
         query: Natural language search query.
@@ -115,6 +149,8 @@ def search_memories(
             cosine distance (hnsw:space=cosine) — 0 = identical, 2 = opposite.
             Results with distance > this value are filtered out. A value of
             0.0 disables filtering. Typical useful range: 0.3–1.0.
+        keyword: Explicit keyword for text-match fallback. If omitted,
+            extracted automatically from query when vector results are poor.
     """
     try:
         col = get_collection(palace_path, create=False)
@@ -144,11 +180,45 @@ def search_memories(
     metas = results["metadatas"][0]
     dists = results["distances"][0]
 
+    # --- Keyword fallback for hybrid search ---
+    # If vector results are poor (best > 1.0) or empty, or an explicit
+    # keyword was requested, try text-match via where_document.$contains.
+    kw = keyword or ""
+    best_dist = dists[0] if dists else 2.0
+    needs_fallback = not docs or best_dist > 1.0
+    if needs_fallback and not kw:
+        kw = _extract_keyword(query)
+
+    kw_hits_by_id = {}
+    if kw:
+        try:
+            kw_kwargs = {
+                "query_texts": [query],
+                "n_results": n_results,
+                "include": ["documents", "metadatas", "distances"],
+                "where_document": {"$contains": kw},
+            }
+            if where:
+                kw_kwargs["where"] = where
+            kw_results = col.query(**kw_kwargs)
+            kw_docs = kw_results["documents"][0]
+            kw_metas = kw_results["metadatas"][0]
+            kw_dists = kw_results["distances"][0]
+            kw_ids = kw_results["ids"][0] if kw_results.get("ids") else [""] * len(kw_docs)
+            for kid, kdoc, kmeta, kdist in zip(kw_ids, kw_docs, kw_metas, kw_dists):
+                kw_hits_by_id[kid] = (kdoc, kmeta, kdist)
+        except Exception:
+            pass  # keyword fallback is best-effort
+
+    # Build hit list from vector results
+    seen_ids = set()
     hits = []
-    for doc, meta, dist in zip(docs, metas, dists):
+    vec_ids = results["ids"][0] if results.get("ids") else [""] * len(docs)
+    for did, doc, meta, dist in zip(vec_ids, docs, metas, dists):
         # Filter on raw distance before rounding to avoid precision loss
         if max_distance > 0.0 and dist > max_distance:
             continue
+        seen_ids.add(did)
         hits.append(
             {
                 "text": doc,
@@ -160,9 +230,30 @@ def search_memories(
             }
         )
 
+    # Merge keyword hits that weren't in vector results
+    for kid, (kdoc, kmeta, kdist) in kw_hits_by_id.items():
+        if kid in seen_ids:
+            continue
+        hits.append(
+            {
+                "text": kdoc,
+                "wing": kmeta.get("wing", "unknown"),
+                "room": kmeta.get("room", "unknown"),
+                "source_file": Path(kmeta.get("source_file", "?")).name,
+                "similarity": round(1 - kdist, 3),
+                "distance": round(kdist, 4),
+                "keyword_match": kw,
+            }
+        )
+
+    # Sort merged results by distance
+    hits.sort(key=lambda h: h["distance"])
+    hits = hits[:n_results]
+
     return {
         "query": query,
         "filters": {"wing": wing, "room": room},
         "total_before_filter": len(docs),
+        "keyword_fallback": kw if kw_hits_by_id else None,
         "results": hits,
     }

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mempalace.searcher import SearchError, search, search_memories
+from mempalace.searcher import SearchError, _extract_keyword, search, search_memories
 
 
 # ── search_memories (API) ──────────────────────────────────────────────
@@ -119,3 +119,170 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         # Should have output with at least one result block
         assert "[1]" in captured.out
+
+
+# ── _extract_keyword ───────────────────────────────────────────────────
+
+
+class TestExtractKeyword:
+    def test_picks_longest_non_stopword(self):
+        assert _extract_keyword("how do I use authentication") == "authentication"
+
+    def test_prefers_identifier_token(self):
+        # "pgbouncer" contains no digit/underscore/dot but "pg_pool_size" does
+        kw = _extract_keyword("what is pg_pool_size for pgbouncer")
+        assert kw == "pg_pool_size"
+
+    def test_prefers_dotted_token(self):
+        kw = _extract_keyword("where is config.json stored")
+        assert kw == "config.json"
+
+    def test_empty_query_returns_empty(self):
+        assert _extract_keyword("") == ""
+
+    def test_all_stopwords_returns_empty(self):
+        assert _extract_keyword("what is it") == ""
+
+    def test_short_tokens_skipped(self):
+        # All tokens <= 2 chars or stopwords
+        assert _extract_keyword("do it") == ""
+
+
+# ── hybrid search fallback ─────────────────────────────────────────────
+
+
+class TestHybridSearchFallback:
+    def test_keyword_fallback_triggered_on_poor_vector_results(self):
+        """When best vector distance > 1.0, keyword fallback runs."""
+        # Vector search returns one poor result; keyword search finds a better match
+        mock_col = MagicMock()
+
+        poor_vector = {
+            "documents": [["some unrelated text"]],
+            "metadatas": [[{"wing": "w", "room": "r", "source_file": "f.py"}]],
+            "distances": [[1.5]],  # poor — triggers fallback
+            "ids": [["vec_id_1"]],
+        }
+        keyword_hit = {
+            "documents": [["pgbouncer connection pooling config"]],
+            "metadatas": [[{"wing": "infra", "room": "db", "source_file": "db.md"}]],
+            "distances": [[0.4]],
+            "ids": [["kw_id_1"]],
+        }
+
+        # First call = vector search, second call = keyword fallback
+        mock_col.query.side_effect = [poor_vector, keyword_hit]
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("pgbouncer config", "/fake/path")
+
+        assert result.get("keyword_fallback") is not None
+        # Keyword hit should appear in results (merged in)
+        texts = [h["text"] for h in result["results"]]
+        assert any("pgbouncer" in t for t in texts)
+
+    def test_explicit_keyword_always_triggers_fallback(self):
+        """Passing keyword= forces keyword search even with good vector results."""
+        mock_col = MagicMock()
+
+        good_vector = {
+            "documents": [["some relevant text"]],
+            "metadatas": [[{"wing": "w", "room": "r", "source_file": "f.py"}]],
+            "distances": [[0.3]],  # good distance — no auto-fallback
+            "ids": [["vec_id_1"]],
+        }
+        keyword_hit = {
+            "documents": [["jwt_secret rotation schedule"]],
+            "metadatas": [[{"wing": "infra", "room": "secrets", "source_file": "sec.md"}]],
+            "distances": [[0.5]],
+            "ids": [["kw_id_2"]],
+        }
+
+        mock_col.query.side_effect = [good_vector, keyword_hit]
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("authentication tokens", "/fake/path", keyword="jwt_secret")
+
+        # keyword_fallback should be set since we passed keyword explicitly
+        assert result.get("keyword_fallback") == "jwt_secret"
+
+    def test_fallback_deduplicates_results(self):
+        """IDs returned by both vector and keyword searches appear only once."""
+        mock_col = MagicMock()
+
+        shared_doc = "JWT tokens expire after 24 hours"
+        shared_meta = {"wing": "project", "room": "backend", "source_file": "auth.py"}
+
+        poor_vector = {
+            "documents": [[shared_doc]],
+            "metadatas": [[shared_meta]],
+            "distances": [[1.2]],
+            "ids": [["shared_id"]],
+        }
+        keyword_with_overlap = {
+            "documents": [[shared_doc]],
+            "metadatas": [[shared_meta]],
+            "distances": [[1.2]],
+            "ids": [["shared_id"]],  # same ID
+        }
+
+        mock_col.query.side_effect = [poor_vector, keyword_with_overlap]
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("jwt tokens", "/fake/path")
+
+        # shared_id appears only once
+        assert len(result["results"]) == 1
+
+    def test_fallback_not_triggered_on_good_vector_results(self):
+        """When best distance <= 1.0 and no explicit keyword, fallback is skipped."""
+        mock_col = MagicMock()
+
+        good_vector = {
+            "documents": [["JWT tokens and authentication"]],
+            "metadatas": [[{"wing": "project", "room": "backend", "source_file": "auth.py"}]],
+            "distances": [[0.25]],
+            "ids": [["vec_id_1"]],
+        }
+
+        mock_col.query.return_value = good_vector
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("jwt authentication", "/fake/path")
+
+        # Only one query call — no keyword fallback
+        assert mock_col.query.call_count == 1
+        assert result.get("keyword_fallback") is None
+
+    def test_result_includes_distance_field(self, palace_path, seeded_collection):
+        """Results now expose a 'distance' field alongside 'similarity'."""
+        result = search_memories("JWT authentication", palace_path)
+        assert len(result["results"]) > 0
+        hit = result["results"][0]
+        assert "distance" in hit
+        assert isinstance(hit["distance"], float)
+
+    def test_keyword_fallback_is_best_effort(self):
+        """A failing keyword query does not crash search_memories."""
+        mock_col = MagicMock()
+
+        poor_vector = {
+            "documents": [["unrelated text"]],
+            "metadatas": [[{"wing": "w", "room": "r", "source_file": "f.py"}]],
+            "distances": [[1.8]],
+            "ids": [["vid1"]],
+        }
+
+        def side_effect(**kwargs):
+            if "where_document" in kwargs:
+                raise RuntimeError("keyword query failed")
+            return poor_vector
+
+        mock_col.query.side_effect = side_effect
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("something obscure", "/fake/path")
+
+        # Should still return vector results without crashing
+        assert "results" in result
+        assert len(result["results"]) == 1


### PR DESCRIPTION
## Summary

When vector search returns poor results (best cosine distance > 1.0) or an explicit keyword is provided, fall back to ChromaDB's built-in `where_document={"$contains": kw}` text-match and merge results.

- **`searcher.py`**: Add `_extract_keyword(query)` — picks the longest non-stopword token, preferring identifier-looking tokens (digits, underscores, dots, ALLCAPS). Modify `search_memories()` to accept an optional `keyword` param, run keyword fallback on poor/empty vector results, merge and deduplicate by ID, sort merged list by distance, and expose `keyword_fallback` and `distance` fields in the response.
- **`mcp_server.py`**: Add `keyword` to `mempalace_search` input schema and thread it through `tool_search()` → `search_memories()`.
- **`tests/test_searcher.py`**: 12 new tests across `TestExtractKeyword` (6) and `TestHybridSearchFallback` (6) — covering auto-trigger on poor results, explicit keyword, deduplication, no-trigger on good results, `distance` field presence, and graceful failure of keyword query.

## Motivation

Vector search can miss exact identifiers (error codes, config keys, function names) when the embedding model lacks domain-specific vocabulary. The keyword fallback catches these cases without requiring a separate full-text index — ChromaDB's `where_document.$contains` filter is already available.

## Test plan

- [ ] `python -m pytest tests/test_searcher.py -x -q` — all 29 tests pass
- [ ] `ruff check mempalace/searcher.py mempalace/mcp_server.py tests/test_searcher.py` — clean
- [ ] Keyword fallback triggers when best vector distance > 1.0
- [ ] Explicit `keyword=` param forces fallback even on good vector results
- [ ] Duplicate IDs from both searches appear only once, sorted by distance

🤖 Generated with [Claude Code](https://claude.com/claude-code)