### PR TITLE
fix: preserve MCP unicode and remove remaining read caps

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -40,6 +40,11 @@ logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
 logger = logging.getLogger("mempalace_mcp")
 
 
+def _json_dumps(payload, **kwargs):
+    """Serialize MCP payloads without ASCII-escaping Unicode content."""
+    return json.dumps(payload, ensure_ascii=False, default=str, **kwargs)
+
+
 def _parse_args():
     parser = argparse.ArgumentParser(description="MemPalace MCP Server")
     parser.add_argument(
@@ -115,7 +120,7 @@ def _wal_log(operation: str, params: dict, result: dict = None):
     try:
         fd = os.open(str(_WAL_FILE), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
         with os.fdopen(fd, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, default=str) + "\n")
+            f.write(_json_dumps(entry) + "\n")
     except Exception as e:
         logger.error(f"WAL write failed: {e}")
 
@@ -487,6 +492,10 @@ def tool_add_drawer(
                     "chunk_index": 0,
                     "added_by": added_by,
                     "filed_at": datetime.now().isoformat(),
+                    "source_type": "manual_drawer",
+                    "hall": "hall_manual",
+                    "memory_type": "manual_drawer",
+                    "source_updated_at": "",
                 }
             ],
         )
@@ -828,11 +837,26 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
         return _no_palace()
 
     try:
-        results = col.get(
-            where={"$and": [{"wing": wing}, {"room": "diary"}]},
-            include=["documents", "metadatas"],
-            limit=10000,
-        )
+        results = {"ids": [], "documents": [], "metadatas": []}
+        batch_size = 5000
+        offset = 0
+
+        while True:
+            batch = col.get(
+                where={"$and": [{"wing": wing}, {"room": "diary"}]},
+                include=["documents", "metadatas"],
+                limit=batch_size,
+                offset=offset,
+            )
+            batch_ids = batch.get("ids", [])
+            if not batch_ids:
+                break
+            results["ids"].extend(batch_ids)
+            results["documents"].extend(batch.get("documents", []))
+            results["metadatas"].extend(batch.get("metadatas", []))
+            offset += len(batch_ids)
+            if len(batch_ids) < batch_size:
+                break
 
         if not results["ids"]:
             return {"agent": agent_name, "entries": [], "message": "No diary entries yet."}
@@ -1354,7 +1378,7 @@ def handle_request(request):
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "result": {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]},
+                "result": {"content": [{"type": "text", "text": _json_dumps(result, indent=2)}]},
             }
         except Exception:
             logger.exception(f"Tool error in {tool_name}")
@@ -1387,7 +1411,7 @@ def main():
             request = json.loads(line)
             response = handle_request(request)
             if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
+                sys.stdout.write(_json_dumps(response) + "\n")
                 sys.stdout.flush()
         except KeyboardInterrupt:
             break

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,9 @@ via monkeypatch to avoid touching real data.
 import json
 
 
+LARGE_COLLECTION_SIZE = 10_050
+
+
 def _patch_mcp_server(monkeypatch, config, kg):
     """Patch the mcp_server module globals to use test fixtures."""
     from mempalace import mcp_server
@@ -29,6 +32,30 @@ def _get_collection(palace_path, create=False):
     if create:
         return client, client.get_or_create_collection("mempalace_drawers")
     return client, client.get_collection("mempalace_drawers")
+
+
+def _seed_large_collection(collection, total=LARGE_COLLECTION_SIZE):
+    ids = [f"drawer_large_{i:05d}" for i in range(total)]
+    documents = [f"Large drawer {i} mentions café number {i}." for i in range(total)]
+    metadatas = [
+        {
+            "wing": f"wing_{i % 3}",
+            "room": f"room_{i % 5}",
+            "source_file": f"source_{i}.md",
+            "chunk_index": 0,
+            "added_by": "miner",
+            "filed_at": f"2026-02-{(i % 28) + 1:02d}T00:00:00",
+        }
+        for i in range(total)
+    ]
+    batch_size = 1000
+    for offset in range(0, total, batch_size):
+        end = offset + batch_size
+        collection.add(
+            ids=ids[offset:end],
+            documents=documents[offset:end],
+            metadatas=metadatas[offset:end],
+        )
 
 
 # ── Protocol Layer ──────────────────────────────────────────────────────
@@ -98,6 +125,14 @@ class TestHandleRequest:
         resp = handle_request({"method": "ping", "id": 11, "params": {}})
         assert resp["id"] == 11
         assert resp["result"] == {}
+
+    def test_json_dumps_preserves_unicode(self):
+        from mempalace.mcp_server import _json_dumps
+
+        payload = {"message": "café ☕"}
+        rendered = _json_dumps(payload)
+        assert "café ☕" in rendered
+        assert "\\u" not in rendered
 
     def test_tools_list(self):
         from mempalace.mcp_server import handle_request
@@ -200,6 +235,29 @@ class TestHandleRequest:
         content = json.loads(resp["result"]["content"][0]["text"])
         assert "total_drawers" in content
 
+    def test_tools_call_preserves_unicode(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request(
+            {
+                "method": "tools/call",
+                "id": 12,
+                "params": {
+                    "name": "mempalace_get_aaak_spec",
+                    "arguments": {},
+                },
+            }
+        )
+
+        text = resp["result"]["content"][0]["text"]
+        assert "♡" in text
+        assert "→" in text
+        assert "\\u2661" not in text
+        assert "\\u2192" not in text
+
 
 # ── Read Tools ──────────────────────────────────────────────────────────
 
@@ -257,6 +315,29 @@ class TestReadTools:
         assert result["taxonomy"]["project"]["backend"] == 2
         assert result["taxonomy"]["project"]["frontend"] == 1
         assert result["taxonomy"]["notes"]["planning"] == 1
+
+    def test_status_scans_beyond_10k_drawers(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, collection = _get_collection(palace_path, create=True)
+        _seed_large_collection(collection)
+        del _client
+        from mempalace.mcp_server import tool_status
+
+        result = tool_status()
+        assert result["total_drawers"] == LARGE_COLLECTION_SIZE
+        assert sum(result["wings"].values()) == LARGE_COLLECTION_SIZE
+
+    def test_get_taxonomy_scans_beyond_10k_drawers(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, collection = _get_collection(palace_path, create=True)
+        _seed_large_collection(collection)
+        del _client
+        from mempalace.mcp_server import tool_get_taxonomy
+
+        result = tool_get_taxonomy()
+        total = sum(sum(rooms.values()) for rooms in result["taxonomy"].values())
+        assert total == LARGE_COLLECTION_SIZE
+        assert result["taxonomy"]["wing_0"]["room_0"] == 670
 
     def test_no_palace_returns_error(self, monkeypatch, config, kg):
         _patch_mcp_server(monkeypatch, config, kg)
@@ -343,6 +424,23 @@ class TestWriteTools:
         result2 = tool_add_drawer(wing="w", room="r", content=content)
         assert result2["success"] is True
         assert result2["reason"] == "already_exists"
+
+    def test_add_drawer_sets_empty_source_updated_at_for_manual_drawers(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, collection = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(wing="test_wing", room="manual_room", content="naïve café note")
+        stored = collection.get(ids=[result["drawer_id"]], include=["metadatas"])
+        metadata = stored["metadatas"][0]
+
+        assert metadata["source_type"] == "manual_drawer"
+        assert metadata["hall"] == "hall_manual"
+        assert metadata["memory_type"] == "manual_drawer"
+        assert metadata["source_updated_at"] == ""
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
@@ -551,3 +649,34 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+    def test_diary_read_scans_beyond_10k_entries(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        class FakeDiaryCollection:
+            def __init__(self, total):
+                self.total = total
+
+            def get(self, where=None, include=None, limit=5000, offset=0):
+                if offset >= self.total:
+                    return {"ids": [], "documents": [], "metadatas": []}
+                end = min(offset + limit, self.total)
+                ids = [f"diary_{i}" for i in range(offset, end)]
+                documents = [f"entry {i}" for i in range(offset, end)]
+                metadatas = [
+                    {
+                        "date": "2026-03-01",
+                        "filed_at": f"2026-03-01T00:00:{i % 60:02d}",
+                        "topic": "load-test",
+                    }
+                    for i in range(offset, end)
+                ]
+                return {"ids": ids, "documents": documents, "metadatas": metadatas}
+
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda create=False: FakeDiaryCollection(10050))
+
+        result = mcp_server.tool_diary_read(agent_name="TestAgent", last_n=3)
+        assert result["total"] == 10050
+        assert result["showing"] == 3
+        assert len(result["entries"]) == 3


### PR DESCRIPTION
Summary:
- preserve Unicode in MCP JSON responses and WAL writes
- keep manual drawer metadata stable with empty source_updated_at
- add >10k regression coverage for status/taxonomy/diary reads

Issue alignment:
- closes #359
- helps address #503
- regression coverage for #603 and related taxonomy/status truncation concerns
- ping already exists upstream; this PR does not change ping behavior

Validation:
- /home/mikeb/work/mempalace/.venv-hermes/bin/python -m pytest tests/test_mcp_server.py -q