### PR TITLE
fix: resolve Python interpreter in hook scripts instead of hardcoding python3

### DIFF
--- a/.claude-plugin/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin/hooks/mempal-precompact-hook.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 # MemPalace PreCompact Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
+find_python() {
+    if [ -n "${MEMPALACE_PYTHON:-}" ]; then echo "$MEMPALACE_PYTHON"
+    elif command -v python3 &>/dev/null; then echo "python3"
+    elif command -v python &>/dev/null; then echo "python"
+    else echo "python3"; fi
+}
+PYTHON=$(find_python)
 INPUT=$(cat)
-echo "$INPUT" | python3 -m mempalace hook run --hook precompact --harness claude-code
+echo "$INPUT" | $PYTHON -m mempalace hook run --hook precompact --harness claude-code

--- a/.claude-plugin/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin/hooks/mempal-stop-hook.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 # MemPalace Stop Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
+find_python() {
+    if [ -n "${MEMPALACE_PYTHON:-}" ]; then echo "$MEMPALACE_PYTHON"
+    elif command -v python3 &>/dev/null; then echo "python3"
+    elif command -v python &>/dev/null; then echo "python"
+    else echo "python3"; fi
+}
+PYTHON=$(find_python)
 INPUT=$(cat)
-echo "$INPUT" | python3 -m mempalace hook run --hook stop --harness claude-code
+echo "$INPUT" | $PYTHON -m mempalace hook run --hook stop --harness claude-code

--- a/.codex-plugin/hooks/mempal-hook.sh
+++ b/.codex-plugin/hooks/mempal-hook.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 HOOK_NAME="${1:?Usage: mempal-hook.sh <hook-name>}"
+find_python() {
+    if [ -n "${MEMPALACE_PYTHON:-}" ]; then echo "$MEMPALACE_PYTHON"
+    elif command -v python3 &>/dev/null; then echo "python3"
+    elif command -v python &>/dev/null; then echo "python"
+    else echo "python3"; fi
+}
+PYTHON=$(find_python)
 INPUT_FILE=$(mktemp) || { echo "Failed to create temp file" >&2; exit 1; }
 cat > "$INPUT_FILE"
-cat "$INPUT_FILE" | python3 -m mempalace hook run --hook "$HOOK_NAME" --harness codex
+cat "$INPUT_FILE" | $PYTHON -m mempalace hook run --hook "$HOOK_NAME" --harness codex
 EXIT_CODE=$?
 rm -f "$INPUT_FILE" 2>/dev/null
 exit $EXIT_CODE

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -54,10 +54,19 @@ mkdir -p "$STATE_DIR"
 # Leave empty to skip auto-ingest (AI handles saving via the block reason).
 MEMPAL_DIR=""
 
+# Find the right Python interpreter (fixes #545 — bare python3 breaks on Windows/pipx/uv)
+find_python() {
+    if [ -n "${MEMPALACE_PYTHON:-}" ]; then echo "$MEMPALACE_PYTHON"
+    elif command -v python3 &>/dev/null; then echo "python3"
+    elif command -v python &>/dev/null; then echo "python"
+    else echo "python3"; fi
+}
+PYTHON=$(find_python)
+
 # Read JSON input from stdin
 INPUT=$(cat)
 
-SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
 
 echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
 
@@ -65,7 +74,7 @@ echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     REPO_DIR="$(dirname "$SCRIPT_DIR")"
-    python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
+    $PYTHON -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
 # Always block — compaction = save everything

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -61,11 +61,20 @@ mkdir -p "$STATE_DIR"
 # Leave empty to skip auto-ingest (AI handles saving via the block reason).
 MEMPAL_DIR=""
 
+# Find the right Python interpreter (fixes #545 — bare python3 breaks on Windows/pipx/uv)
+find_python() {
+    if [ -n "${MEMPALACE_PYTHON:-}" ]; then echo "$MEMPALACE_PYTHON"
+    elif command -v python3 &>/dev/null; then echo "python3"
+    elif command -v python &>/dev/null; then echo "python"
+    else echo "python3"; fi
+}
+PYTHON=$(find_python)
+
 # Read JSON input from stdin
 INPUT=$(cat)
 
 # Parse all fields in a single Python call (3x faster than separate invocations)
-eval $(echo "$INPUT" | python3 -c "
+eval $(echo "$INPUT" | $PYTHON -c "
 import sys, json
 data = json.load(sys.stdin)
 sid = data.get('session_id', 'unknown')
@@ -92,7 +101,7 @@ fi
 # Count human messages in the JSONL transcript
 # SECURITY: Pass transcript path as sys.argv to avoid shell injection via crafted paths
 if [ -f "$TRANSCRIPT_PATH" ]; then
-    EXCHANGE_COUNT=$(python3 - "$TRANSCRIPT_PATH" <<'PYEOF'
+    EXCHANGE_COUNT=$($PYTHON - "$TRANSCRIPT_PATH" <<'PYEOF'
 import json, sys
 count = 0
 with open(sys.argv[1]) as f:
@@ -137,7 +146,7 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         REPO_DIR="$(dirname "$SCRIPT_DIR")"
-        python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
+        $PYTHON -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 
     # Block the AI and tell it to save

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -26,6 +26,27 @@ import hashlib
 from datetime import datetime
 from pathlib import Path
 
+# Python version guard — chromadb 0.5-0.6.x uses pydantic v1 which is
+# incompatible with Python 3.14+ (type inference fails at import time).
+# Emit a clear message instead of a cryptic pydantic ConfigError.
+if sys.version_info >= (3, 14):
+    print(
+        json.dumps({
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {
+                "code": -32002,
+                "message": (
+                    f"MemPalace requires Python 3.9-3.13 but found {sys.version.split()[0]}. "
+                    "ChromaDB is incompatible with Python 3.14+. "
+                    "Set MEMPALACE_PYTHON to a supported interpreter or install in a 3.13 venv."
+                ),
+            },
+        }),
+        flush=True,
+    )
+    sys.exit(1)
+
 from .config import MempalaceConfig, sanitize_name, sanitize_content
 from .version import __version__
 from .query_sanitizer import sanitize_query


### PR DESCRIPTION
## Summary

- **Root cause**: All hook shell scripts hardcode `python3`, which breaks on Windows (`python3` doesn't exist or resolves to Python 3.14 via Windows Store), pipx/uv-tool installs (`python3` resolves to system Python instead of the install venv), and non-standard environments.
- **`hooks/mempal_save_hook.sh`**, **`hooks/mempal_precompact_hook.sh`**: Add `find_python()` that checks `MEMPALACE_PYTHON` env var, then `python3`, then `python`. Replace all 5 hardcoded `python3` calls with `$PYTHON`.
- **`.claude-plugin/hooks/*.sh`**, **`.codex-plugin/hooks/*.sh`**: Same `find_python()` added to all 3 plugin hook wrappers.
- **`mempalace/mcp_server.py`**: Add Python 3.14+ version guard — emits a clear JSON-RPC error ("MemPalace requires Python 3.9-3.13") instead of crashing with a cryptic pydantic `ConfigError` from chromadb.

## Test plan

- [x] `pytest tests/ -v` — 589 passed, 0 failed
- [x] `grep` confirms zero bare `python3` command invocations in hook scripts
- [ ] On Windows: set `MEMPALACE_PYTHON=python` and verify hooks resolve correctly
- [ ] On Windows: run MCP server with Python 3.14 and verify the version guard emits a clear error

Addresses #545, #650