### PR TITLE
ci: trigger tests on develop branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   test-linux:


### PR DESCRIPTION
CI was only configured to run on PRs targeting `main`. Since `develop` is now the default branch, no PRs were getting CI checks.

One-line change: adds `develop` to both `push` and `pull_request` branch triggers in `ci.yml`.