### PR TITLE
fix: handle large claude.ai exports and multi-conversation "messages" key

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -28,7 +28,7 @@ CONVO_EXTENSIONS = {
 }
 
 MIN_CHUNK_SIZE = 30
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB — claude.ai exports routinely exceed 10 MB
 
 
 # =============================================================================
@@ -216,7 +216,9 @@ def scan_convos(convo_dir: str) -> list:
                 if filepath.is_symlink():
                     continue
                 try:
-                    if filepath.stat().st_size > MAX_FILE_SIZE:
+                    fsize = filepath.stat().st_size
+                    if fsize > MAX_FILE_SIZE:
+                        print(f"  ⚠ Skipping {filepath.name} ({fsize // (1024*1024)} MB > {MAX_FILE_SIZE // (1024*1024)} MB limit)")
                         continue
                 except OSError:
                     continue

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -160,24 +160,30 @@ def _try_claude_ai_json(data) -> Optional[str]:
     if not isinstance(data, list):
         return None
 
-    # Privacy export: array of conversation objects with chat_messages inside each
-    if data and isinstance(data[0], dict) and "chat_messages" in data[0]:
-        all_messages = []
+    # Multi-conversation export: array of conversation objects with messages inside each.
+    # Claude.ai uses "chat_messages" (privacy export) or "messages" (standard export).
+    if data and isinstance(data[0], dict) and ("chat_messages" in data[0] or "messages" in data[0]):
+        transcripts = []
         for convo in data:
             if not isinstance(convo, dict):
                 continue
-            chat_msgs = convo.get("chat_messages", [])
+            chat_msgs = convo.get("chat_messages") or convo.get("messages", [])
+            if not isinstance(chat_msgs, list):
+                continue
+            convo_messages = []
             for item in chat_msgs:
                 if not isinstance(item, dict):
                     continue
                 role = item.get("role", "")
                 text = _extract_content(item.get("content", ""))
                 if role in ("user", "human") and text:
-                    all_messages.append(("user", text))
+                    convo_messages.append(("user", text))
                 elif role in ("assistant", "ai") and text:
-                    all_messages.append(("assistant", text))
-        if len(all_messages) >= 2:
-            return _messages_to_transcript(all_messages)
+                    convo_messages.append(("assistant", text))
+            if len(convo_messages) >= 2:
+                transcripts.append(_messages_to_transcript(convo_messages))
+        if transcripts:
+            return "\n\n".join(transcripts)
         return None
 
     # Flat messages list

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -297,6 +297,76 @@ def test_claude_ai_privacy_export_non_dict_items():
     assert result is not None
 
 
+def test_claude_ai_multi_convo_with_messages_key():
+    """Multi-conversation export using 'messages' key (not 'chat_messages')."""
+    data = [
+        {
+            "uuid": "convo-1",
+            "messages": [
+                {"role": "user", "content": "First question"},
+                {"role": "assistant", "content": "First answer"},
+            ],
+        },
+        {
+            "uuid": "convo-2",
+            "messages": [
+                {"role": "user", "content": "Second question"},
+                {"role": "assistant", "content": "Second answer"},
+            ],
+        },
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> First question" in result
+    assert "> Second question" in result
+
+
+def test_claude_ai_multi_convo_per_conversation_separation():
+    """Each conversation produces a separate transcript section."""
+    data = [
+        {
+            "chat_messages": [
+                {"role": "human", "content": "Conv1 Q"},
+                {"role": "ai", "content": "Conv1 A"},
+            ]
+        },
+        {
+            "chat_messages": [
+                {"role": "human", "content": "Conv2 Q"},
+                {"role": "ai", "content": "Conv2 A"},
+            ]
+        },
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> Conv1 Q" in result
+    assert "> Conv2 Q" in result
+    # Both conversations should be present as separate sections
+    assert result.count("> Conv1 Q") == 1
+    assert result.count("> Conv2 Q") == 1
+
+
+def test_claude_ai_multi_convo_skips_short_conversations():
+    """Conversations with fewer than 2 messages are skipped."""
+    data = [
+        {
+            "messages": [
+                {"role": "user", "content": "Only one message"},
+            ],
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "Good question"},
+                {"role": "assistant", "content": "Good answer"},
+            ],
+        },
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "Only one message" not in result
+    assert "> Good question" in result
+
+
 # ── _try_chatgpt_json ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **Root cause 1**: `MAX_FILE_SIZE` in `convo_miner.py` was 10 MB — claude.ai exports routinely exceed this (21+ MB for active users). Files were silently skipped with zero feedback. Raised to 100 MB and added a warning when files are skipped.
- **Root cause 2**: `_try_claude_ai_json` in `normalize.py` only detected multi-conversation exports using the `"chat_messages"` key (privacy export). Standard claude.ai exports use `"messages"` — these fell through to the flat-messages parser which failed silently (conversation dicts have no `"role"` at top level), producing 0 drawers.
- **Parser fix**: Now checks for both `"chat_messages"` and `"messages"` at the conversation object level, and processes each conversation into a separate transcript section instead of concatenating all 844+ conversations into one.
- **Tests**: 3 new test cases for multi-conversation parsing (`"messages"` key, per-conversation separation, short conversation filtering).

Note: #646 was closed via #667, but #667 addresses paginated export/read-back — it does not touch `convo_miner.py` or the `MAX_FILE_SIZE` skip, nor the `"messages"` key mismatch in the parser. The two root causes reported in #646 remain unfixed on `main`.

## Test plan

- [x] `pytest tests/ -v` — 592 passed (589 base + 3 new), 0 failed
- [x] New tests verify: `"messages"` key parsing, per-conversation separation, short conversation filtering
- [ ] Mine a real claude.ai `conversations.json` export (> 10 MB) and verify drawers are created per conversation

Addresses #646