### PR TITLE
docs: fix stale org URLs and PR branch target in contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for wanting to help. MemPalace is open source and we welcome contribution
 ## Getting Started
 
 ```bash
-git clone https://github.com/milla-jovovich/mempalace.git
+git clone https://github.com/MemPalace/mempalace.git
 cd mempalace
 pip install -e ".[dev]"    # installs with dev dependencies (pytest, build, twine)
 ```
@@ -52,7 +52,7 @@ assets/             ← logo + brand
    - `fix: handle empty transcript files`
    - `docs: update MCP tool descriptions`
    - `bench: add LoCoMo turn-level metrics`
-6. Push to your fork and open a PR against `main`
+6. Push to your fork and open a PR against `develop`
 
 ## Code Style
 
@@ -64,7 +64,7 @@ assets/             ← logo + brand
 
 ## Good First Issues
 
-Check the [Issues](https://github.com/milla-jovovich/mempalace/issues) tab. Great starting points:
+Check the [Issues](https://github.com/MemPalace/mempalace/issues) tab. Great starting points:
 
 - **New chat formats**: Add import support for Cursor, Copilot, or other AI tool exports
 - **Room detection**: Improve pattern matching in `room_detector_local.py`

--- a/examples/gemini_cli_setup.md
+++ b/examples/gemini_cli_setup.md
@@ -13,7 +13,7 @@ On many Linux systems, installing Python packages globally is restricted. We rec
 
 ```bash
 # Clone the repository (if you haven't already)
-git clone https://github.com/milla-jovovich/mempalace.git
+git clone https://github.com/MemPalace/mempalace.git
 cd mempalace
 
 # Create a virtual environment

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -2,7 +2,7 @@
 name: mempalace
 description: "MemPalace — Local AI memory with 96.6% recall. Semantic search, temporal knowledge graph, palace architecture (wings/rooms/drawers). Free, no cloud, no API keys."
 version: 3.1.0
-homepage: https://github.com/milla-jovovich/mempalace
+homepage: https://github.com/MemPalace/mempalace
 user-invocable: true
 metadata:
   openclaw:
@@ -151,4 +151,4 @@ claude mcp add mempalace -- python -m mempalace.mcp_server
 
 ## License
 
-[MemPalace](https://github.com/milla-jovovich/mempalace) is MIT licensed. Created by Milla Jovovich, Ben Sigman, Igor Lins e Silva, and contributors.
+[MemPalace](https://github.com/MemPalace/mempalace) is MIT licensed. Created by Milla Jovovich, Ben Sigman, Igor Lins e Silva, and contributors.


### PR DESCRIPTION
Several docs still reference the old `milla-jovovich` GitHub org after the rename to `MemPalace`. Also, `CONTRIBUTING.md` tells contributors to PR against `main`, but the actual workflow targets `develop` (confirmed in ROADMAP.md branch model section).

**Changes (3 files, 6 line swaps):**

- `CONTRIBUTING.md` -- clone URL, issues link, PR target branch (`main` -> `develop`)
- `examples/gemini_cli_setup.md` -- clone URL
- `integrations/openclaw/SKILL.md` -- homepage and license link

Deliberately left out of scope:
- `README.md` -- has several open PRs already (#641, #578)
- `pyproject.toml` / plugin manifests -- package metadata, maintainer call
- `.github/CODEOWNERS` -- GitHub usernames, not repo URLs

Note: orthogonal to #580 which fixes test commands and project structure listing in CONTRIBUTING.md. Different hunks, should merge cleanly in either order.