### PR TITLE
fix: add --yes flag to init instructions for non-interactive use (#534)

### DIFF
--- a/mempalace/instructions/init.md
+++ b/mempalace/instructions/init.md
@@ -41,7 +41,7 @@ before continuing.
 
 ## Step 5: Initialize the palace
 
-Run `mempalace init <dir>` where `<dir>` is the directory from Step 4.
+Run `mempalace init --yes <dir>` where `<dir>` is the directory from Step 4.
 
 If this fails, report the error and stop.
 


### PR DESCRIPTION
## Summary
- Add `--yes` flag to `mempalace init` in `instructions/init.md`
- AI agents calling `mempalace init` hang on the interactive confirmation prompt — `--yes` skips it

## Files changed
- `mempalace/instructions/init.md` — line 44

## Test plan
- [x] Existing tests pass
- [ ] Verify `mempalace init --yes <dir>` completes without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)