### PR TITLE
fix: skip arg whitelist for handlers accepting **kwargs (#572)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1350,8 +1350,18 @@ def handle_request(request):
             }
         # Whitelist arguments to declared schema properties only.
         # Prevents callers from spoofing internal params like added_by/source_file.
+        # Skip filtering for handlers that accept **kwargs — they intentionally
+        # handle arbitrary arguments (e.g., pass-through to ChromaDB).
+        import inspect
+
+        handler = TOOLS[tool_name]["handler"]
+        sig = inspect.signature(handler)
+        accepts_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        )
         schema_props = TOOLS[tool_name]["input_schema"].get("properties", {})
-        tool_args = {k: v for k, v in tool_args.items() if k in schema_props}
+        if not accepts_var_keyword:
+            tool_args = {k: v for k, v in tool_args.items() if k in schema_props}
         # Coerce argument types based on input_schema.
         # MCP JSON transport may deliver integers as floats or strings;
         # ChromaDB and Python slicing require native int.

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1350,16 +1350,19 @@ def handle_request(request):
             }
         # Whitelist arguments to declared schema properties only.
         # Prevents callers from spoofing internal params like added_by/source_file.
-        # Skip filtering for handlers that accept **kwargs — they intentionally
-        # handle arbitrary arguments (e.g., pass-through to ChromaDB).
+        # Skip filtering if handler explicitly accepts **kwargs (pass-through).
+        # Default to filtering on inspect failure (safe fallback).
         import inspect
 
-        handler = TOOLS[tool_name]["handler"]
-        sig = inspect.signature(handler)
-        accepts_var_keyword = any(
-            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
-        )
         schema_props = TOOLS[tool_name]["input_schema"].get("properties", {})
+        try:
+            handler = TOOLS[tool_name]["handler"]
+            sig = inspect.signature(handler)
+            accepts_var_keyword = any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+            )
+        except (ValueError, TypeError):
+            accepts_var_keyword = False
         if not accepts_var_keyword:
             tool_args = {k: v for k, v in tool_args.items() if k in schema_props}
         # Coerce argument types based on input_schema.


### PR DESCRIPTION
## Summary
- The schema-based argument filter (from #647) strips all kwargs not declared in \`input_schema\`. This breaks handlers that accept \`**kwargs\` for pass-through to backends.
- Add \`inspect.Parameter.VAR_KEYWORD\` check before filtering — handlers with \`**kwargs\` receive all arguments unfiltered, while handlers with explicit parameters still get the security whitelist.

Per @bensig's feedback on #626: "needs a VAR_KEYWORD check before filtering."

## Files changed
- \`mempalace/mcp_server.py\` — \`handle_request()\` tools/call dispatch

## Test plan
- [x] 49 MCP server tests pass
- [ ] Verify tool calls with unexpected args (e.g., \`top_k\`) still succeed
- [ ] Verify handlers with \`**kwargs\` receive all arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)