### PR TITLE
fix: parse Claude.ai privacy export with messages key and sender field (#677)

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -190,40 +190,50 @@ def _try_claude_ai_json(data) -> Optional[str]:
     if not isinstance(data, list):
         return None
 
-    # Privacy export: array of conversation objects with chat_messages inside each
-    if data and isinstance(data[0], dict) and "chat_messages" in data[0]:
-        all_messages = []
+    # Privacy export: array of conversation objects, each containing its own
+    # message list under "chat_messages" or "messages" (both variants seen in the wild).
+    if (
+        data
+        and isinstance(data[0], dict)
+        and ("chat_messages" in data[0] or "messages" in data[0])
+    ):
+        transcripts = []
         for convo in data:
             if not isinstance(convo, dict):
                 continue
-            chat_msgs = convo.get("chat_messages", [])
-            for item in chat_msgs:
-                if not isinstance(item, dict):
-                    continue
-                role = item.get("role", "")
-                text = _extract_content(item.get("content", ""))
-                if role in ("user", "human") and text:
-                    all_messages.append(("user", text))
-                elif role in ("assistant", "ai") and text:
-                    all_messages.append(("assistant", text))
-        if len(all_messages) >= 2:
-            return _messages_to_transcript(all_messages)
+            chat_msgs = convo.get("chat_messages") or convo.get("messages", [])
+            messages = _collect_claude_messages(chat_msgs)
+            if len(messages) >= 2:
+                transcripts.append(_messages_to_transcript(messages))
+        if transcripts:
+            return "\n\n".join(transcripts)
         return None
 
     # Flat messages list
+    messages = _collect_claude_messages(data)
+    if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    return None
+
+
+def _collect_claude_messages(items) -> list:
+    """Extract (role, text) pairs from a Claude.ai message list.
+
+    Accepts both ``role`` (API format) and ``sender`` (privacy export) as the
+    author field, and falls back to a top-level ``text`` key when the
+    ``content`` blocks are empty or absent.
+    """
     messages = []
-    for item in data:
+    for item in items:
         if not isinstance(item, dict):
             continue
-        role = item.get("role", "")
-        text = _extract_content(item.get("content", ""))
+        role = item.get("role") or item.get("sender", "")
+        text = _extract_content(item.get("content", "")) or item.get("text", "").strip()
         if role in ("user", "human") and text:
             messages.append(("user", text))
         elif role in ("assistant", "ai") and text:
             messages.append(("assistant", text))
-    if len(messages) >= 2:
-        return _messages_to_transcript(messages)
-    return None
+    return messages
 
 
 def _try_chatgpt_json(data) -> Optional[str]:

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -30,7 +30,7 @@ def normalize(filepath: str) -> str:
     except OSError as e:
         raise IOError(f"Could not read {filepath}: {e}")
     if file_size > 500 * 1024 * 1024:  # 500 MB safety limit
-        raise IOError(f"File too large ({file_size // (1024*1024)} MB): {filepath}")
+        raise IOError(f"File too large ({file_size // (1024 * 1024)} MB): {filepath}")
     try:
         with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             content = f.read()
@@ -192,11 +192,7 @@ def _try_claude_ai_json(data) -> Optional[str]:
 
     # Privacy export: array of conversation objects, each containing its own
     # message list under "chat_messages" or "messages" (both variants seen in the wild).
-    if (
-        data
-        and isinstance(data[0], dict)
-        and ("chat_messages" in data[0] or "messages" in data[0])
-    ):
+    if data and isinstance(data[0], dict) and ("chat_messages" in data[0] or "messages" in data[0]):
         transcripts = []
         for convo in data:
             if not isinstance(convo, dict):

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -224,7 +224,7 @@ def _collect_claude_messages(items) -> list:
         if not isinstance(item, dict):
             continue
         role = item.get("role") or item.get("sender", "")
-        text = _extract_content(item.get("content", "")) or item.get("text", "").strip()
+        text = _extract_content(item.get("content", "")) or (item.get("text") or "").strip()
         if role in ("user", "human") and text:
             messages.append(("user", text))
         elif role in ("assistant", "ai") and text:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -524,6 +524,104 @@ def test_claude_ai_privacy_export_non_dict_items():
     assert result is not None
 
 
+def test_claude_ai_privacy_export_messages_key():
+    """Privacy export using 'messages' key instead of 'chat_messages'."""
+    data = [
+        {
+            "uuid": "abc-123",
+            "name": "Test convo",
+            "messages": [
+                {"role": "human", "content": "Q1"},
+                {"role": "ai", "content": "A1"},
+            ],
+        }
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> Q1" in result
+
+
+def test_claude_ai_privacy_export_sender_field():
+    """Privacy export using 'sender' instead of 'role'."""
+    data = [
+        {
+            "chat_messages": [
+                {"sender": "human", "content": "Q1"},
+                {"sender": "assistant", "content": "A1"},
+            ]
+        }
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> Q1" in result
+
+
+def test_claude_ai_privacy_export_text_fallback():
+    """Privacy export where content is empty but text field has the message."""
+    data = [
+        {
+            "chat_messages": [
+                {"sender": "human", "text": "Q1", "content": []},
+                {"sender": "assistant", "text": "A1", "content": []},
+            ]
+        }
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> Q1" in result
+
+
+def test_claude_ai_privacy_export_per_conversation():
+    """Multiple conversations produce separate transcripts."""
+    data = [
+        {
+            "uuid": "convo-1",
+            "chat_messages": [
+                {"role": "human", "content": "Q1"},
+                {"role": "ai", "content": "A1"},
+            ],
+        },
+        {
+            "uuid": "convo-2",
+            "chat_messages": [
+                {"role": "human", "content": "Q2"},
+                {"role": "ai", "content": "A2"},
+            ],
+        },
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> Q1" in result
+    assert "> Q2" in result
+    # each conversation is a separate transcript block
+    parts = result.split("\n\n")
+    q1_parts = [p for p in parts if "> Q1" in p]
+    q2_parts = [p for p in parts if "> Q2" in p]
+    assert len(q1_parts) >= 1
+    assert len(q2_parts) >= 1
+
+
+def test_claude_ai_privacy_export_skips_empty_conversations():
+    """Conversations with <2 messages are skipped."""
+    data = [
+        {
+            "chat_messages": [
+                {"role": "human", "content": "lonely message"},
+            ],
+        },
+        {
+            "chat_messages": [
+                {"role": "human", "content": "Q1"},
+                {"role": "ai", "content": "A1"},
+            ],
+        },
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "lonely message" not in result
+    assert "> Q1" in result
+
+
 # ── _try_chatgpt_json ─────────────────────────────────────────────────
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -571,6 +571,21 @@ def test_claude_ai_privacy_export_text_fallback():
     assert "> Q1" in result
 
 
+def test_claude_ai_privacy_export_null_text():
+    """Privacy export where text field is explicitly null must not crash."""
+    data = [
+        {
+            "chat_messages": [
+                {"sender": "human", "text": None, "content": "Q1"},
+                {"sender": "assistant", "text": None, "content": "A1"},
+            ]
+        }
+    ]
+    result = _try_claude_ai_json(data)
+    assert result is not None
+    assert "> Q1" in result
+
+
 def test_claude_ai_privacy_export_per_conversation():
     """Multiple conversations produce separate transcripts."""
     data = [


### PR DESCRIPTION
Closes #677.

Claude.ai's **Settings > Privacy > Export Data** produces a `conversations.json` that `_try_claude_ai_json` can fail to parse for two reasons:

1. **Key variant** -- the privacy-export guard only checks for `"chat_messages"` in each conversation object. If an export uses `"messages"` instead (as described in #676), the guard misses it. The array of conversation objects falls through to the flat-messages parser, which expects `{role, content}` dicts and silently skips the `{uuid, name, messages}` objects. The function returns `None` and the raw JSON gets filed as a single plain-text drawer.

2. **Author field variant** -- some privacy exports may use `"sender": "human"/"assistant"` instead of `"role"` (as described in #605). When the outer guard matches but the inner loop only checks `item.get("role")`, every message is skipped, producing an empty transcript.

Both failure modes result in the behavior reported in #677: a multi-MB file mined as one drawer classified "emotional."

**Changes (2 files, +129/-21):**

`mempalace/normalize.py`:
- Outer guard now accepts both `"chat_messages"` and `"messages"` keys
- Inner extraction: `convo.get("chat_messages") or convo.get("messages", [])`
- Author field: `item.get("role") or item.get("sender", "")` handles both variants
- Text fallback: tries `item.get("text")` when content blocks are empty
- Per-conversation transcripts instead of concatenating everything into one blob
- Shared `_collect_claude_messages()` helper to deduplicate extraction logic

`tests/test_normalize.py`:
- 6 new tests: `messages` key, `sender` field, `text` fallback, per-conversation separation, empty-conversation skipping

**Scope note:** this PR only touches the normalizer. It does not change `convo_miner.py` -- the 10 MB `MAX_FILE_SIZE` limit is unrelated to the parsing failure in #677 (the reported file is 8 MB) but is addressed separately in #605 and #676.

**Related PRs:** #605 (carlito1979) adds `sender` support, `text` fallback, and raises `MAX_FILE_SIZE`. #676 (z3tz3r0) adds `messages` key detection, per-conversation separation, and also raises `MAX_FILE_SIZE`. Both touch `convo_miner.py` which this PR does not. This PR combines the `normalize.py` parsing fixes from both approaches and adds the missing cross-coverage (neither PR alone handles both the key variant and the author field variant).