### PR TITLE
fix: mine --dry-run TypeError on files with room=None (#586)

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -416,16 +416,16 @@ def process_file(
     # Skip if already filed
     source_file = str(filepath)
     if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
-        return 0, None
+        return 0, "general"
 
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")
     except OSError:
-        return 0, None
+        return 0, "general"
 
     content = content.strip()
     if len(content) < MIN_CHUNK_SIZE:
-        return 0, None
+        return 0, "general"
 
     room = detect_room(filepath, content, rooms, project_path)
     chunks = chunk_text(content, source_file)

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -269,9 +269,7 @@ def test_mine_dry_run_with_tiny_file_no_crash():
         project_root = Path(tmpdir).resolve()
 
         # One normal file and one that falls below MIN_CHUNK_SIZE
-        write_file(
-            project_root / "good.py", "def main():\n    print('hello world')\n" * 20
-        )
+        write_file(project_root / "good.py", "def main():\n    print('hello world')\n" * 20)
         write_file(project_root / "tiny.txt", "x")
 
         with open(project_root / "mempalace.yaml", "w") as f:

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -262,6 +262,34 @@ def test_file_already_mined_check_mtime():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_mine_dry_run_with_tiny_file_no_crash():
+    """Dry-run must not crash when process_file returns 0 drawers (room was None)."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        # One normal file and one that falls below MIN_CHUNK_SIZE
+        write_file(
+            project_root / "good.py", "def main():\n    print('hello world')\n" * 20
+        )
+        write_file(project_root / "tiny.txt", "x")
+
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "general", "description": "General"}],
+                },
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        # Should not raise TypeError on the summary print
+        mine(str(project_root), str(palace_path), dry_run=True)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def test_status_missing_palace_does_not_create_empty_collection(tmp_path, capsys):
     palace_path = tmp_path / "missing-palace"
 


### PR DESCRIPTION
Closes #586.

`mempalace mine --dry-run` crashes with a TypeError in the summary printer when `process_file()` returns `(0, None)` for unreadable or too-short files. In real mine mode the `drawers == 0 and not dry_run` guard skips these entries before they reach `room_counts`, but in dry-run mode the guard does not fire and `None` ends up as a dict key. The f-string format `{room:20}` then raises `TypeError: unsupported format string passed to NoneType.__format__`.

**Fix (2 files, +31/-3):**

`mempalace/miner.py`:
- Three `return 0, None` paths in `process_file()` (already-mined, OSError, below MIN_CHUNK_SIZE) now return `return 0, "general"` instead. This makes the function contract explicit -- it always returns `(int, str)`.

`tests/test_miner.py`:
- New `test_mine_dry_run_with_tiny_file_no_crash` -- creates a project with one normal file and one below MIN_CHUNK_SIZE, runs `mine()` with `dry_run=True`, verifies no crash.

Matches the Option 2 consensus from the issue thread (normalize at the source rather than patching the caller).