### PR TITLE
fix: remove chromadb <0.7 upper bound — blocks 1.x installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "chromadb>=0.5.0,<0.7",
+    "chromadb>=0.5.0",
     "pyyaml>=6.0,<7",
 ]
 


### PR DESCRIPTION
## Problem

`pyproject.toml` pins `chromadb>=0.5.0,<0.7`, so `pip install mempalace` resolves to chromadb 0.6.x. However, palaces created with chromadb 1.x (which `uv.lock` in this repo actually uses — 1.5.7) have an incompatible SQLite schema. chromadb 0.6.x fails with `KeyError: '_type'` inside `CollectionConfigurationInternal.from_json_str` when trying to open a 1.x collection.

This means a fresh `pip install mempalace` gives users a chromadb that **cannot read palaces created in the maintainer's own dev environment**.

## Reproduction

```bash
python3 -m venv .venv && source .venv/bin/activate
pip install mempalace          # installs chromadb 0.6.3 (highest allowed by <0.7)
export MEMPALACE_PALACE_PATH=/path/to/palace-created-with-chromadb-1.x
python -c "from mempalace.mcp_server import tool_status; print(tool_status())"
# -> {"error": "No palace found", "hint": "Run: mempalace init <dir> && mempalace mine <dir>"}

pip install --force-reinstall chromadb==1.5.7
python -c "from mempalace.mcp_server import tool_status; print(tool_status())"
# -> {"total_drawers": 26524, "wings": {"omega": 10000}, ...}  (real data)
```

Tested on macOS 14, Python 3.12.13 and 3.14.0a6, mempalace 3.1.0.

## Fix

Remove the `<0.7` upper bound so pip can install chromadb 1.x. One-line change in `pyproject.toml`.

I considered pinning `>=1.0.0` instead (since 0.6.x schemas are incompatible with 1.x anyway), but that would break users who have working 0.5/0.6 palaces. Removing only the upper bound is the least disruptive fix — users with 0.6.x palaces keep working, and users with 1.x palaces stop getting a broken install.