### PR TITLE
ci: fix github pages publishing

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,9 +2,10 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
-      - 'website/**'
+      - ".github/workflows/deploy-docs.yml"
+      - "website/**"
   workflow_dispatch:
 
 permissions:
@@ -13,16 +14,22 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -30,10 +37,13 @@ jobs:
 
       - name: Install dependencies
         working-directory: website
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build docs
         working-directory: website
+        env:
+          DOCS_BASE: ${{ steps.pages.outputs.base_path }}
+          DOCS_EDIT_BRANCH: ${{ github.ref_name }}
         run: bun run docs:build
 
       - uses: actions/upload-pages-artifact@v3
@@ -41,11 +51,15 @@ jobs:
           path: website/.vitepress/dist
 
   deploy:
+    if: github.ref_name == 'main' || github.ref_name == 'develop'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[build]
-  base = "website"
-  command = "bun run docs:build"
-  publish = ".vitepress/dist"
-
-[build.environment]
-  DOCS_BASE = "/"

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -1,7 +1,16 @@
 import { defineConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 
-const docsBase = process.env.DOCS_BASE || '/mempalace/'
+function normalizeBase(base?: string): string {
+  if (!base || base === '/') {
+    return '/'
+  }
+
+  return base.endsWith('/') ? base : `${base}/`
+}
+
+const docsBase = normalizeBase(process.env.DOCS_BASE || '/mempalace/')
+const editBranch = process.env.DOCS_EDIT_BRANCH || 'main'
 
 export default withMermaid(
   defineConfig({
@@ -91,7 +100,7 @@ export default withMermaid(
       },
 
       editLink: {
-        pattern: 'https://github.com/milla-jovovich/mempalace/edit/main/website/:path',
+        pattern: `https://github.com/milla-jovovich/mempalace/edit/${editBranch}/website/:path`,
         text: 'Edit this page on GitHub',
       },
     },


### PR DESCRIPTION
This pull request updates the documentation deployment workflow and related configuration to support deployments from both the `main` and `develop` branches, improves deployment robustness, and simplifies environment management. The key changes are grouped below:

**GitHub Actions workflow improvements:**

* The `.github/workflows/deploy-docs.yml` workflow now triggers on pushes to both `main` and `develop` branches and on changes to the workflow file itself. It also enables manual dispatch.
* Concurrency is improved by scoping deployments to the branch (`group: pages-${{ github.ref }}`) and enabling cancellation of in-progress runs.
* The build and deploy jobs now explicitly set required permissions for better security and compatibility.
* The build step passes the deployment base path and current branch to the docs build process, ensuring correct URLs and edit links.
* The deploy job is restricted to run only on `main` or `develop` branches.

**Documentation configuration enhancements:**

* The `website/.vitepress/config.mts` file now normalizes the docs base path and dynamically sets the edit link branch based on the deployment environment, ensuring correct navigation and edit links for both branches. [[1]](diffhunk://#diff-c232597c0fa1978358c42340173ed67de23ae0c7c4325bf7c34c7d5d457e462cL4-R13) [[2]](diffhunk://#diff-c232597c0fa1978358c42340173ed67de23ae0c7c4325bf7c34c7d5d457e462cL94-R103)

**Cleanup and simplification:**

* The legacy `netlify.toml` configuration is removed, as deployment is now handled exclusively via GitHub Actions.