### PR TITLE
fix: store full AI response in convo_miner exchange chunking

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -70,7 +70,7 @@ def _chunk_by_exchange(lines: list) -> list:
                     ai_lines.append(next_line.strip())
                 i += 1
 
-            ai_response = " ".join(ai_lines[:8])
+            ai_response = " ".join(ai_lines)
             content = f"{user_turn}\n{ai_response}" if ai_response else user_turn
 
             if len(content.strip()) > MIN_CHUNK_SIZE:

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -47,6 +47,17 @@ class TestChunkExchanges:
         # Too short to produce chunks (below MIN_CHUNK_SIZE)
         assert isinstance(chunks, list)
 
+    def test_long_ai_response_not_truncated(self):
+        """AI responses longer than 8 lines must be stored in full (verbatim principle)."""
+        lines = [f"Step {i}: important detail that must be stored" for i in range(1, 14)]
+        content = "> How do I implement authentication?\n" + "\n".join(lines)
+        chunks = chunk_exchanges(content)
+        assert len(chunks) >= 1
+        stored = chunks[0]["content"]
+        # All 13 lines must be present — none silently dropped
+        for i in range(1, 14):
+            assert f"Step {i}:" in stored, f"Step {i} was truncated and not stored"
+
 
 class TestDetectConvoRoom:
     def test_technical_room(self):


### PR DESCRIPTION
Fixes #692

## What does this PR do?

Removes an undocumented 8-line cap on AI responses in `_chunk_by_exchange()`
inside `convo_miner.py`.

**Before:**
```python
ai_response = " ".join(ai_lines[:8])
```

**After:**
```python
ai_response = " ".join(ai_lines)
```

The `[:8]` slice silently discarded everything beyond the 8th line of any AI
response, violating the project's core **"verbatim first"** principle
(CONTRIBUTING.md). The fallback `_chunk_by_paragraph()` path has no equivalent
cap, making this inconsistency a likely unintentional oversight from the initial
commit.

## How to test

```bash
# Run the targeted unit tests
python -m pytest tests/test_convo_miner_unit.py tests/test_convo_miner.py -v

# Run the full suite
python -m pytest tests/ -v
```

A new regression test `test_long_ai_response_not_truncated` in
`tests/test_convo_miner_unit.py` verifies that a 13-line AI response is stored
in full.

> **Note:** Targeting `develop` branch per CONTRIBUTING.md PR guidelines.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
