### PR TITLE
docs: add personal operating system memory example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,11 @@ Thanks for wanting to help. MemPalace is open source and we welcome contribution
 ## Getting Started
 
 ```bash
-git clone https://github.com/milla-jovovich/mempalace.git
+# Fork the repo on GitHub first, then clone your fork
+git clone https://github.com/<your-username>/mempalace.git
 cd mempalace
+git remote add upstream https://github.com/milla-jovovich/mempalace.git
+
 pip install -e ".[dev]"    # installs with dev dependencies (pytest, build, twine)
 ```
 

--- a/examples/personal_operating_system_memory.md
+++ b/examples/personal_operating_system_memory.md
@@ -1,0 +1,83 @@
+# Personal Operating System Memory
+
+MemPalace is a strong fit for local-first personal operating systems because these tools accumulate important context across time, not just in one task list or one chat.
+
+Examples include:
+
+- captures
+- task follow-ups
+- shopping reminders
+- meeting notes
+- daily reviews
+- next-action outputs
+
+The challenge is that these artifacts often become compressed too early. A short task title may remain visible, while the surrounding context that made it meaningful disappears.
+
+MemPalace helps by keeping that broader context retrievable without forcing the product to abandon its own structured store.
+
+## A useful role for MemPalace
+
+For this kind of app, MemPalace works well as:
+
+- a continuity layer
+- a related-memory surface
+- a retrieval layer for review and wake-up flows
+
+It does not need to become the app's primary task database to be useful.
+
+## Example room model
+
+One practical structure could look like:
+
+- `captures`
+- `tasks`
+- `notes`
+- `meetings`
+- `reviews`
+- `shopping`
+
+These rooms map well to the kinds of artifacts a personal operating system already creates.
+
+## High-value retrieval moments
+
+### Home wake-up
+
+When the user opens the app, memory can surface:
+
+- a forgotten follow-up
+- a related review note
+- a capture that explains why something is still open
+
+### Task detail or workbench view
+
+When a task title has been compressed too far, memory can restore:
+
+- the original capture
+- related notes
+- nearby meeting or review artifacts
+
+### Daily review and next-action flows
+
+This is often the best fit.
+
+Review loops benefit from retrieval across:
+
+- recent captures
+- unresolved tasks
+- shopping context
+- prior review outputs
+
+That lets the active review stay small while the broader continuity surface remains available.
+
+## Why this matters
+
+For executive-function support tools and personal operating systems, the problem is often not capture. The problem is continuity.
+
+MemPalace is useful here because it makes prior context:
+
+- durable
+- retrievable
+- local-first
+- usable at the moment the user needs it again
+
+That makes it a practical example domain beyond software engineering, while still matching the same core strength: structured memory that stays available across time.

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -72,6 +72,6 @@ fi
 cat << 'HOOKJSON'
 {
   "decision": "block",
-  "reason": "COMPACTION IMMINENT. Save ALL topics, decisions, quotes, code, and important context from this session to your memory system. Be thorough — after compaction, detailed context will be lost. Organize into appropriate categories. Use verbatim quotes where possible. Save everything, then allow compaction to proceed."
+  "reason": "COMPACTION IMMINENT (MemPalace). Save ALL session content before context is lost:\n1. mempalace_diary_write — thorough AAAK-compressed session summary\n2. mempalace_add_drawer — ALL verbatim quotes, decisions, code, context\n3. mempalace_kg_add — entity relationships (optional)\nBe thorough — after compaction, detailed context will be lost. Do NOT write to Claude Code's native auto-memory (.md files). Save everything to MemPalace, then allow compaction to proceed."
 }
 HOOKJSON

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -145,7 +145,7 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     cat << 'HOOKJSON'
 {
   "decision": "block",
-  "reason": "AUTO-SAVE checkpoint. Save key topics, decisions, quotes, and code from this session to your memory system. Organize into appropriate categories. Use verbatim quotes where possible. Continue conversation after saving."
+  "reason": "AUTO-SAVE checkpoint (MemPalace). Save this session's key content:\n1. mempalace_diary_write — AAAK-compressed session summary\n2. mempalace_add_drawer — verbatim quotes, decisions, code snippets\n3. mempalace_kg_add — entity relationships (optional)\nDo NOT write to Claude Code's native auto-memory (.md files). Continue conversation after saving."
 }
 HOOKJSON
 else

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -18,18 +18,22 @@ SAVE_INTERVAL = 15
 STATE_DIR = Path.home() / ".mempalace" / "hook_state"
 
 STOP_BLOCK_REASON = (
-    "AUTO-SAVE checkpoint. Save key topics, decisions, quotes, and code "
-    "from this session to your memory system. Organize into appropriate "
-    "categories. Use verbatim quotes where possible. Continue conversation "
-    "after saving."
+    "AUTO-SAVE checkpoint (MemPalace). Save this session's key content:\n"
+    "1. mempalace_diary_write — AAAK-compressed session summary\n"
+    "2. mempalace_add_drawer — verbatim quotes, decisions, code snippets\n"
+    "3. mempalace_kg_add — entity relationships (optional)\n"
+    "Do NOT write to Claude Code's native auto-memory (.md files). "
+    "Continue conversation after saving."
 )
 
 PRECOMPACT_BLOCK_REASON = (
-    "COMPACTION IMMINENT. Save ALL topics, decisions, quotes, code, and "
-    "important context from this session to your memory system. Be thorough "
-    "\u2014 after compaction, detailed context will be lost. Organize into "
-    "appropriate categories. Use verbatim quotes where possible. Save "
-    "everything, then allow compaction to proceed."
+    "COMPACTION IMMINENT (MemPalace). Save ALL session content before context is lost:\n"
+    "1. mempalace_diary_write — thorough AAAK-compressed session summary\n"
+    "2. mempalace_add_drawer — ALL verbatim quotes, decisions, code, context\n"
+    "3. mempalace_kg_add — entity relationships (optional)\n"
+    "Be thorough \u2014 after compaction, detailed context will be lost. "
+    "Do NOT write to Claude Code's native auto-memory (.md files). "
+    "Save everything to MemPalace, then allow compaction to proceed."
 )
 
 


### PR DESCRIPTION
## Summary
- add a new example for using MemPalace in a local-first personal operating system
- frame MemPalace as a continuity and related-memory layer rather than the primary task database
- keep the example focused on executive-function support workflows like wake-up, task detail, and daily review

## Why
The existing public examples are strongest around software and MCP setup. This adds a second concrete domain where the same MemPalace strengths apply: structured, local-first continuity across time.

## Testing
- docs only