### PR TITLE
fix: remove silent 8-line AI response truncation in convo_miner

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -28,6 +28,7 @@ CONVO_EXTENSIONS = {
 }
 
 MIN_CHUNK_SIZE = 30
+CHUNK_SIZE = 800  # chars per drawer — align with miner.py
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
 
 
@@ -51,7 +52,12 @@ def chunk_exchanges(content: str) -> list:
 
 
 def _chunk_by_exchange(lines: list) -> list:
-    """One user turn (>) + the AI response that follows = one chunk."""
+    """One user turn (>) + the AI response that follows = one or more chunks.
+
+    The full AI response is preserved verbatim.  When the combined
+    user-turn + response exceeds CHUNK_SIZE the response is split across
+    consecutive drawers so nothing is silently discarded.
+    """
     chunks = []
     i = 0
 
@@ -70,10 +76,27 @@ def _chunk_by_exchange(lines: list) -> list:
                     ai_lines.append(next_line.strip())
                 i += 1
 
-            ai_response = " ".join(ai_lines[:8])
+            ai_response = " ".join(ai_lines)
             content = f"{user_turn}\n{ai_response}" if ai_response else user_turn
 
-            if len(content.strip()) > MIN_CHUNK_SIZE:
+            # Split into multiple drawers when the exchange exceeds CHUNK_SIZE
+            if len(content) > CHUNK_SIZE:
+                # First chunk: user turn + as much response as fits
+                first_part = content[:CHUNK_SIZE]
+                if len(first_part.strip()) > MIN_CHUNK_SIZE:
+                    chunks.append(
+                        {"content": first_part, "chunk_index": len(chunks)}
+                    )
+                # Remaining response in CHUNK_SIZE-sized continuation drawers
+                remainder = content[CHUNK_SIZE:]
+                while remainder:
+                    part = remainder[:CHUNK_SIZE]
+                    remainder = remainder[CHUNK_SIZE:]
+                    if len(part.strip()) > MIN_CHUNK_SIZE:
+                        chunks.append(
+                            {"content": part, "chunk_index": len(chunks)}
+                        )
+            elif len(content.strip()) > MIN_CHUNK_SIZE:
                 chunks.append(
                     {
                         "content": content,


### PR DESCRIPTION
## Summary

Fixes #692

`_chunk_by_exchange()` in `convo_miner.py` was silently truncating AI responses to 8 lines (`ai_lines[:8]` on line 73). Any content beyond line 8 was permanently discarded during mining, violating the project's core principle of verbatim storage.

## What changed

- **Removed the `[:8]` slice** — the full AI response is now preserved
- **Added `CHUNK_SIZE = 800`** (aligned with `miner.py`) to `convo_miner.py`
- **Long exchanges are split across multiple drawers** instead of being truncated — when a user-turn + AI response exceeds `CHUNK_SIZE`, it is chunked into consecutive drawers so nothing is lost

## Why this matters

Conversations with detailed AI responses (code explanations, architecture discussions, multi-step instructions) were losing most of their content. Only the first ~8 lines survived mining. This made the palace unreliable for recall on any non-trivial exchange.

## Test results

All 14 existing unit tests pass:

```
tests/test_convo_miner_unit.py — 14 passed in 0.03s
```