### PR TITLE
fix: allow Unicode in KG triple fields

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -18,6 +18,9 @@ from pathlib import Path
 MAX_NAME_LENGTH = 128
 _SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_ .'-]{0,126}[a-zA-Z0-9]?$")
 
+MAX_KG_VALUE_LENGTH = 256
+_UNSAFE_KG_RE = re.compile(r"[\x00-\x1f\\/]")
+
 
 def sanitize_name(value: str, field_name: str = "name") -> str:
     """Validate and sanitize a wing/room/entity name.
@@ -42,6 +45,36 @@ def sanitize_name(value: str, field_name: str = "name") -> str:
 
     # Enforce safe character set
     if not _SAFE_NAME_RE.match(value):
+        raise ValueError(f"{field_name} contains invalid characters")
+
+    return value
+
+
+def sanitize_kg_value(value: str, field_name: str = "value") -> str:
+    """Validate a knowledge graph triple field (subject/predicate/object).
+
+    More permissive than sanitize_name: allows Unicode (CJK, etc.) and
+    common punctuation like commas, colons, and parentheses.  KG values
+    are stored in SQLite, not used as file paths, so the ASCII-only
+    restriction from sanitize_name is unnecessary here.
+
+    Still blocks control characters, path separators (/ \\), path
+    traversal (..), and null bytes.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+    value = value.strip()
+
+    if len(value) > MAX_KG_VALUE_LENGTH:
+        raise ValueError(
+            f"{field_name} exceeds maximum length of {MAX_KG_VALUE_LENGTH} characters"
+        )
+
+    if ".." in value:
+        raise ValueError(f"{field_name} contains invalid path characters")
+
+    if _UNSAFE_KG_RE.search(value):
         raise ValueError(f"{field_name} contains invalid characters")
 
     return value

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -27,7 +27,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from .config import MempalaceConfig, sanitize_name, sanitize_content
+from .config import MempalaceConfig, sanitize_name, sanitize_kg_value, sanitize_content
 from .version import __version__
 import chromadb
 from .query_sanitizer import sanitize_query
@@ -690,9 +690,9 @@ def tool_kg_add(
 ):
     """Add a relationship to the knowledge graph."""
     try:
-        subject = sanitize_name(subject, "subject")
-        predicate = sanitize_name(predicate, "predicate")
-        object = sanitize_name(object, "object")
+        subject = sanitize_kg_value(subject, "subject")
+        predicate = sanitize_kg_value(predicate, "predicate")
+        object = sanitize_kg_value(object, "object")
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
@@ -715,9 +715,9 @@ def tool_kg_add(
 def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = None):
     """Mark a fact as no longer true (set end date)."""
     try:
-        subject = sanitize_name(subject, "subject")
-        predicate = sanitize_name(predicate, "predicate")
-        object = sanitize_name(object, "object")
+        subject = sanitize_kg_value(subject, "subject")
+        predicate = sanitize_kg_value(predicate, "predicate")
+        object = sanitize_kg_value(object, "object")
     except ValueError as e:
         return {"success": False, "error": str(e)}
     _wal_log(


### PR DESCRIPTION
## Summary

- `kg_add` and `kg_invalidate` reject non-ASCII characters (Chinese, Japanese, Korean, accented chars, etc.) because they use `sanitize_name()`, which enforces an ASCII-only regex designed for wing/room names that map to filesystem paths
- KG triples are stored in SQLite, not used as file paths, so the ASCII restriction is unnecessary
- Added `sanitize_kg_value()` with a permissive Unicode policy while still blocking control characters, null bytes, path separators, and path traversal

## Reproduction

```python
# This fails with "object contains invalid characters"
kg_add(subject="Project_X", predicate="status", object="告警记录与投递分层")

# Also fails - commas blocked
kg_add(subject="Project_X", predicate="note", object="Record, Delivery split")
```

## Root cause

`config.py:19`:
```python
_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_ .'-]{0,126}[a-zA-Z0-9]?$")
```

This regex is correct for wing/room names (filesystem paths), but `mcp_server.py` also applies it to KG subject/predicate/object fields which only need SQLite safety.

## Fix

New `sanitize_kg_value()` function:
- Allows Unicode characters and common punctuation (commas, colons, parentheses, etc.)
- Max length 256 (vs 128 for path names)
- Still blocks: control chars (`\x00-\x1f`), path separators (`/` `\`), path traversal (`..`), null bytes

Applied to `kg_add` and `kg_invalidate` in `mcp_server.py`.

## Test plan

- [x] Chinese characters accepted: `sanitize_kg_value("告警记录与投递分层")`
- [x] Commas accepted: `sanitize_kg_value("Record, Delivery split")`
- [x] Slashes still blocked: `sanitize_kg_value("a/b")` raises ValueError
- [x] Null bytes still blocked: `sanitize_kg_value("a\x00b")` raises ValueError
- [x] Path traversal still blocked: `sanitize_kg_value("a..b")` raises ValueError
- [x] Existing `sanitize_name()` for wing/room names unchanged