### PR TITLE
fix: hash full content in tool_add_drawer drawer ID

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -481,7 +481,9 @@ def tool_add_drawer(
     if not col:
         return _no_palace()
 
-    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content).encode()).hexdigest()[:24]}"
+    drawer_id = (
+        f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content).encode()).hexdigest()[:24]}"
+    )
 
     _wal_log(
         "add_drawer",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -481,7 +481,7 @@ def tool_add_drawer(
     if not col:
         return _no_palace()
 
-    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content[:100]).encode()).hexdigest()[:24]}"
+    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content).encode()).hexdigest()[:24]}"
 
     _wal_log(
         "add_drawer",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -409,7 +409,10 @@ class TestWriteTools:
         from mempalace.mcp_server import tool_add_drawer
 
         header = "# ACME Corp Knowledge Base\n**Project:** Alpha | **Team:** Backend | **Status:** Active\n\n"
-        doc1 = header + "Decision: Use PostgreSQL for primary storage. Rationale: ACID compliance required."
+        doc1 = (
+            header
+            + "Decision: Use PostgreSQL for primary storage. Rationale: ACID compliance required."
+        )
         doc2 = header + "Decision: Use Redis for session caching. Rationale: sub-ms latency needed."
 
         result1 = tool_add_drawer(wing="work", room="decisions", content=doc1)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -401,6 +401,26 @@ class TestWriteTools:
         assert result2["success"] is True
         assert result2["reason"] == "already_exists"
 
+    def test_add_drawer_shared_header_no_collision(self, monkeypatch, config, palace_path, kg):
+        """Documents sharing a >100-char header must get distinct IDs (full-content hash)."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        header = "# ACME Corp Knowledge Base\n**Project:** Alpha | **Team:** Backend | **Status:** Active\n\n"
+        doc1 = header + "Decision: Use PostgreSQL for primary storage. Rationale: ACID compliance required."
+        doc2 = header + "Decision: Use Redis for session caching. Rationale: sub-ms latency needed."
+
+        result1 = tool_add_drawer(wing="work", room="decisions", content=doc1)
+        result2 = tool_add_drawer(wing="work", room="decisions", content=doc2)
+
+        assert result1["success"] is True
+        assert result2["success"] is True
+        assert result1["drawer_id"] != result2["drawer_id"], (
+            "Documents with shared header but different content must have distinct drawer IDs"
+        )
+
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_delete_drawer

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -420,9 +420,9 @@ class TestWriteTools:
 
         assert result1["success"] is True
         assert result2["success"] is True
-        assert result1["drawer_id"] != result2["drawer_id"], (
-            "Documents with shared header but different content must have distinct drawer IDs"
-        )
+        assert (
+            result1["drawer_id"] != result2["drawer_id"]
+        ), "Documents with shared header but different content must have distinct drawer IDs"
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)


### PR DESCRIPTION
Fixes #715

## What does this PR do?

`tool_add_drawer` generated drawer IDs by hashing only the first 100 characters
of content (`content[:100]`). Two documents in the same wing and room whose first
100 characters are identical received the same ID — the second `upsert` silently
overwrote the first with no error or warning.

**Before:**
```python
drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content[:100]).encode()).hexdigest()[:24]}"
```

**After:**
```python
drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content).encode()).hexdigest()[:24]}"
```

A 97-character company template header (common in Notion exports, wiki pages,
meeting notes) is enough to trigger the collision. The fix hashes the full
content, matching the uniqueness guarantee users expect from `tool_add_drawer`.

**Note on backward compatibility:** Drawers filed before this fix will not be
deduplicated against new filings of identical content — the ID scheme changed.
No existing data is deleted or corrupted.

## How to test

```bash
# Run the targeted tests
python -m pytest tests/test_mcp_server.py -v

# Run the full suite
python -m pytest tests/ -v
```

A new regression test `test_add_drawer_shared_header_no_collision` in
`tests/test_mcp_server.py` verifies that two documents sharing a 97-character
header receive distinct drawer IDs.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
