### PR TITLE
fix: recreate KG schema on reconnect

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -47,6 +47,39 @@ from pathlib import Path
 DEFAULT_KG_PATH = os.path.expanduser("~/.mempalace/knowledge_graph.sqlite3")
 
 
+SCHEMA_SQL = """
+    PRAGMA journal_mode=WAL;
+
+    CREATE TABLE IF NOT EXISTS entities (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        type TEXT DEFAULT 'unknown',
+        properties TEXT DEFAULT '{}',
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS triples (
+        id TEXT PRIMARY KEY,
+        subject TEXT NOT NULL,
+        predicate TEXT NOT NULL,
+        object TEXT NOT NULL,
+        valid_from TEXT,
+        valid_to TEXT,
+        confidence REAL DEFAULT 1.0,
+        source_closet TEXT,
+        source_file TEXT,
+        extracted_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (subject) REFERENCES entities(id),
+        FOREIGN KEY (object) REFERENCES entities(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_triples_subject ON triples(subject);
+    CREATE INDEX IF NOT EXISTS idx_triples_object ON triples(object);
+    CREATE INDEX IF NOT EXISTS idx_triples_predicate ON triples(predicate);
+    CREATE INDEX IF NOT EXISTS idx_triples_valid ON triples(valid_from, valid_to);
+"""
+
+
 class KnowledgeGraph:
     def __init__(self, db_path: str = None):
         self.db_path = db_path or DEFAULT_KG_PATH
@@ -57,37 +90,10 @@ class KnowledgeGraph:
 
     def _init_db(self):
         conn = self._conn()
-        conn.executescript("""
-            PRAGMA journal_mode=WAL;
+        self._ensure_schema(conn)
 
-            CREATE TABLE IF NOT EXISTS entities (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                type TEXT DEFAULT 'unknown',
-                properties TEXT DEFAULT '{}',
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP
-            );
-
-            CREATE TABLE IF NOT EXISTS triples (
-                id TEXT PRIMARY KEY,
-                subject TEXT NOT NULL,
-                predicate TEXT NOT NULL,
-                object TEXT NOT NULL,
-                valid_from TEXT,
-                valid_to TEXT,
-                confidence REAL DEFAULT 1.0,
-                source_closet TEXT,
-                source_file TEXT,
-                extracted_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY (subject) REFERENCES entities(id),
-                FOREIGN KEY (object) REFERENCES entities(id)
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_triples_subject ON triples(subject);
-            CREATE INDEX IF NOT EXISTS idx_triples_object ON triples(object);
-            CREATE INDEX IF NOT EXISTS idx_triples_predicate ON triples(predicate);
-            CREATE INDEX IF NOT EXISTS idx_triples_valid ON triples(valid_from, valid_to);
-        """)
+    def _ensure_schema(self, conn):
+        conn.executescript(SCHEMA_SQL)
         conn.commit()
 
     def _conn(self):
@@ -95,6 +101,10 @@ class KnowledgeGraph:
             self._connection = sqlite3.connect(self.db_path, timeout=10, check_same_thread=False)
             self._connection.execute("PRAGMA journal_mode=WAL")
             self._connection.row_factory = sqlite3.Row
+            # If the DB file was deleted or recreated after this KnowledgeGraph was
+            # constructed, opening a fresh SQLite file would otherwise yield an empty
+            # schema and the next KG call would fail with "no such table: entities".
+            self._ensure_schema(self._connection)
         return self._connection
 
     def close(self):

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -6,6 +6,9 @@ timeline, stats, and edge cases (duplicate triples, ID collisions).
 """
 
 
+import os
+
+
 class TestEntityOperations:
     def test_add_entity(self, kg):
         eid = kg.add_entity("Alice", entity_type="person")
@@ -123,6 +126,19 @@ class TestWALMode:
         mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
         conn.close()
         assert mode == "wal"
+
+    def test_reconnect_recreates_schema_after_db_deleted(self, kg):
+        db_path = kg.db_path
+
+        kg.close()
+        os.remove(db_path)
+
+        stats = kg.stats()
+        assert stats["entities"] == 0
+        assert stats["triples"] == 0
+
+        triple_id = kg.add_triple("Alice", "knows", "Bob")
+        assert triple_id.startswith("t_alice_knows_bob_")
 
 
 class TestStats:


### PR DESCRIPTION
## Summary

Recreate the knowledge-graph schema whenever `KnowledgeGraph` opens a fresh SQLite connection.

This fixes a robustness bug where a long-lived `KnowledgeGraph` instance can later fail with:

```text
OperationalError: no such table: entities
```

if the KG DB file disappears after the object has already been initialized and then reconnects.

## Root cause

`KnowledgeGraph` initialized the schema only during object construction.

If the DB file was later deleted and the same object reopened a fresh SQLite file, `_conn()` created the file but did not recreate the schema. The next call to `stats()`, `add_triple()`, etc. then failed because the new file had no `entities` or `triples` tables.

This is distinct from the earlier KG path mismatch work in #538.

## Changes

- factor the KG DDL into a shared `SCHEMA_SQL` constant
- add `_ensure_schema(conn)`
- call `_ensure_schema()` whenever `_conn()` opens a fresh SQLite connection
- add a regression test covering:
  - create KG
  - close connection
  - delete DB file
  - reconnect via the same `KnowledgeGraph` instance
  - verify `stats()` and `add_triple()` both recover cleanly

## Repro before

```python
from mempalace.knowledge_graph import KnowledgeGraph
import os, tempfile

fd, path = tempfile.mkstemp(suffix='.sqlite3')
os.close(fd)
os.unlink(path)

kg = KnowledgeGraph(db_path=path)
kg.close()
os.remove(path)
kg.stats()  # OperationalError: no such table: entities
```

## Validation

```bash
python -m pytest tests/test_knowledge_graph.py -q
```

Passed locally: `22 passed`