### PR TITLE
fix: implement ping method in MCP server

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -868,6 +868,8 @@ def handle_request(request):
         }
     elif method == "notifications/initialized":
         return None
+    elif method == "ping":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {}}
     elif method == "tools/list":
         return {
             "jsonrpc": "2.0",


### PR DESCRIPTION
## What does this PR do?

Adds a `ping` handler to the MCP stdio dispatch loop.

MCP clients such as AnythingLLM v1.12.0 send a `ping` health-check immediately after connecting. Without a handler the server returns `{"code": -32601, "message": "Unknown method: ping"}`, which causes the client to kill and restart the server in an infinite loop.

The fix adds a single branch that responds with an empty result object, as specified by the [MCP protocol](https://spec.modelcontextprotocol.io/specification/basic/utilities/ping/):

```json
{"jsonrpc": "2.0", "id": <req_id>, "result": {}}
```

Fixes #584

## How to test

1. Connect AnythingLLM v1.12.0 (or any MCP client that sends `ping`) to the server
2. Confirm the server stays up instead of restarting in a loop

Or directly:
```bash
echo '{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}' | python -m mempalace mcp run
# Expected: {"jsonrpc": "2.0", "id": 1, "result": {}}
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)