### PR TITLE
fix: log warnings on silent metadata exceptions in navigation tools

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -150,8 +150,8 @@ def tool_status():
             r = m.get("room", "unknown")
             wings[w] = wings.get(w, 0) + 1
             rooms[r] = rooms.get(r, 0) + 1
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("tool_status: could not aggregate metadata: %s", e)
     return {
         "total_drawers": count,
         "wings": wings,
@@ -205,8 +205,8 @@ def tool_list_wings():
         for m in all_meta:
             w = m.get("wing", "unknown")
             wings[w] = wings.get(w, 0) + 1
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("tool_list_wings: could not aggregate metadata: %s", e)
     return {"wings": wings}
 
 
@@ -223,8 +223,8 @@ def tool_list_rooms(wing: str = None):
         for m in all_meta:
             r = m.get("room", "unknown")
             rooms[r] = rooms.get(r, 0) + 1
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("tool_list_rooms: could not aggregate metadata: %s", e)
     return {"wing": wing or "all", "rooms": rooms}
 
 
@@ -241,8 +241,8 @@ def tool_get_taxonomy():
             if w not in taxonomy:
                 taxonomy[w] = {}
             taxonomy[w][r] = taxonomy[w].get(r, 0) + 1
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("tool_get_taxonomy: could not aggregate metadata: %s", e)
     return {"taxonomy": taxonomy}
 
 


### PR DESCRIPTION
## What does this PR do?

Replaces four bare `except Exception: pass` blocks with `logger.warning()` calls in the metadata navigation tools.

**Affected functions:** `tool_status()`, `tool_list_wings()`, `tool_list_rooms()`, `tool_get_taxonomy()`

All four follow the same pattern:

```python
try:
    all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
    for m in all_meta:
        ...
except Exception:
    pass  # ← silent failure
```

When ChromaDB fails during metadata iteration (e.g. collection corruption, SQLite lock, out-of-memory) the tool returns empty dicts — wings `{}`, rooms `{}` — with no indication anything went wrong. The MCP client sees a valid but empty response and has no way to know the data is missing.

After this change the failure is recorded in the server log:
```
WARNING  mempalace.mcp_server: tool_list_wings: could not aggregate metadata: <exception>
```

The return contract is unchanged — the tool still returns a partial result rather than an error, which keeps existing clients working.

## How to test

```bash
python -m pytest tests/ -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)