### PR TITLE
fix: extract tool_use and tool_result blocks in Claude Code JSONL mining

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -100,6 +100,11 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
             text = _extract_content(message.get("content", ""))
             if text:
                 messages.append(("assistant", text))
+        elif msg_type == "tool":
+            # Tool result entries — content holds the output returned to the assistant
+            text = _extract_content(message.get("content", ""))
+            if text:
+                messages.append(("assistant", text))
     if len(messages) >= 2:
         return _messages_to_transcript(messages)
     return None
@@ -279,8 +284,23 @@ def _extract_content(content) -> str:
         for item in content:
             if isinstance(item, str):
                 parts.append(item)
-            elif isinstance(item, dict) and item.get("type") == "text":
-                parts.append(item.get("text", ""))
+            elif isinstance(item, dict):
+                block_type = item.get("type")
+                if block_type == "text":
+                    parts.append(item.get("text", ""))
+                elif block_type == "tool_use":
+                    # Record the tool invocation so the mining context is preserved
+                    parts.append(f"[Tool: {item.get('name', 'tool')}]")
+                elif block_type == "tool_result":
+                    # Inline tool output — may be a string or a list of text blocks
+                    result = item.get("content", "")
+                    if isinstance(result, list):
+                        result = " ".join(
+                            b.get("text", "") for b in result
+                            if isinstance(b, dict) and b.get("type") == "text"
+                        )
+                    if result:
+                        parts.append(str(result))
         return " ".join(parts).strip()
     if isinstance(content, dict):
         return content.get("text", "").strip()


### PR DESCRIPTION
## What does this PR do?

Fixes silent content loss when mining Claude Code `.jsonl` session files. Tool invocations and their outputs were being dropped because `_extract_content()` only handled `type=text` blocks.

For a typical Claude Code session (file reads, grep, code inspection), this caused ~49% content loss. Fixes #590.

## Root cause

`_extract_content()` in `normalize.py`:

```python
# Before — only text blocks extracted
elif isinstance(item, dict) and item.get("type") == "text":
    parts.append(item.get("text", ""))
# tool_use and tool_result blocks silently dropped ↑
```

Claude Code JSONL sessions contain assistant messages with mixed content like:
```json
[
  {"type": "text", "text": "Let me read that file."},
  {"type": "tool_use", "name": "Read", "input": {"file_path": "src/main.py"}},
  {"type": "tool_result", "content": "def main(): ..."}
]
```

The tool invocation and the file content were both dropped.

## Fix

**`_extract_content()`** — handles all three content block types:
- `tool_use` → appended as `[Tool: Read]` so context knows what was invoked
- `tool_result` → appended as plain text (may be a string or a list of text sub-blocks)

**`_try_claude_code_jsonl()`** — adds handling for top-level `type=tool` entries, the envelope Claude Code uses to carry tool results back to the assistant.

## How to test

Mine a Claude Code session that used tools (file read, grep, bash):
```bash
mempalace mine ~/.claude/projects/
mempalace search "any term from a file you read in that session"
```

Before: tool output missing from results. After: file content and tool context appear in search hits.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)