### PR TITLE
fix: prevent convo_miner from re-processing 0-chunk files on every run (#654)

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -31,6 +31,30 @@ MIN_CHUNK_SIZE = 30
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
 
 
+def _register_file(collection, source_file: str, wing: str, agent: str):
+    """Write a sentinel so file_already_mined() returns True for 0-chunk files.
+
+    Without this, files that normalize to nothing or produce zero chunks are
+    re-read and re-processed on every mine run because nothing was written to
+    ChromaDB on the first pass.
+    """
+    sentinel_id = f"_reg_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+    collection.upsert(
+        documents=[f"[registry] {source_file}"],
+        ids=[sentinel_id],
+        metadatas=[
+            {
+                "wing": wing,
+                "room": "_registry",
+                "source_file": source_file,
+                "added_by": agent,
+                "filed_at": datetime.now().isoformat(),
+                "ingest_mode": "registry",
+            }
+        ],
+    )
+
+
 # =============================================================================
 # CHUNKING — exchange pairs for conversations
 # =============================================================================
@@ -282,9 +306,13 @@ def mine_convos(
         try:
             content = normalize(str(filepath))
         except (OSError, ValueError):
+            if not dry_run:
+                _register_file(collection, source_file, wing, agent)
             continue
 
         if not content or len(content.strip()) < MIN_CHUNK_SIZE:
+            if not dry_run:
+                _register_file(collection, source_file, wing, agent)
             continue
 
         # Chunk — either exchange pairs or general extraction
@@ -297,6 +325,8 @@ def mine_convos(
             chunks = chunk_exchanges(content)
 
         if not chunks:
+            if not dry_run:
+                _register_file(collection, source_file, wing, agent)
             continue
 
         # Detect room from content (general mode uses memory_type instead)

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import shutil
+from pathlib import Path
 
 import chromadb
 
@@ -41,12 +42,13 @@ def test_mine_convos_does_not_reprocess_short_files(capsys):
 
         # First run -- file is processed (sentinel written)
         mine_convos(tmpdir, palace_path, wing="test")
-        out1 = capsys.readouterr().out
+        capsys.readouterr()  # drain output
 
-        # Verify sentinel was written
+        # Verify sentinel was written (resolve path -- macOS /var -> /private/var)
+        resolved_file = str(Path(tmpdir).resolve() / "tiny.txt")
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")
-        assert file_already_mined(col, os.path.join(tmpdir, "tiny.txt"))
+        assert file_already_mined(col, resolved_file)
 
         # Second run -- file should be skipped
         mine_convos(tmpdir, palace_path, wing="test")

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,8 +1,11 @@
 import os
 import tempfile
 import shutil
+
 import chromadb
+
 from mempalace.convo_miner import mine_convos
+from mempalace.palace import file_already_mined
 
 
 def test_convo_mining():
@@ -24,3 +27,49 @@ def test_convo_mining():
     assert len(results["documents"][0]) > 0
 
     shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_convos_does_not_reprocess_short_files(capsys):
+    """Files below MIN_CHUNK_SIZE get a sentinel so they are skipped on re-run."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # A file too short to produce any chunks
+        with open(os.path.join(tmpdir, "tiny.txt"), "w") as f:
+            f.write("hi")
+
+        palace_path = os.path.join(tmpdir, "palace")
+
+        # First run -- file is processed (sentinel written)
+        mine_convos(tmpdir, palace_path, wing="test")
+        out1 = capsys.readouterr().out
+
+        # Verify sentinel was written
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+        assert file_already_mined(col, os.path.join(tmpdir, "tiny.txt"))
+
+        # Second run -- file should be skipped
+        mine_convos(tmpdir, palace_path, wing="test")
+        out2 = capsys.readouterr().out
+        assert "Files skipped (already filed): 1" in out2
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_convos_does_not_reprocess_empty_chunk_files(capsys):
+    """Files that normalize but produce 0 exchange chunks get a sentinel."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # Content long enough to pass MIN_CHUNK_SIZE but with no exchange markers
+        # (no "> " lines), so chunk_exchanges returns []
+        with open(os.path.join(tmpdir, "no_exchanges.txt"), "w") as f:
+            f.write("This is a plain paragraph without any exchange markers. " * 5)
+
+        palace_path = os.path.join(tmpdir, "palace")
+
+        mine_convos(tmpdir, palace_path, wing="test")
+        mine_convos(tmpdir, palace_path, wing="test")
+        out2 = capsys.readouterr().out
+        assert "Files skipped (already filed): 1" in out2
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
Closes #654 (Bug 1 only).

`mine_convos()` has three early-exit paths (OSError during normalize, content below `MIN_CHUNK_SIZE`, zero chunks from `chunk_exchanges`) that `continue` without writing anything to ChromaDB. Since `file_already_mined()` checks for a document with a matching `source_file` metadata value, these files return `False` on every subsequent run and get re-read, re-normalized, and re-chunked -- forever.

With 50 such files in a directory, that is 50 wasted reads on every `mine` invocation.

**Fix (2 files, +79/-0):**

`mempalace/convo_miner.py`:
- Add `_register_file()` helper that upserts a lightweight sentinel document (`room="_registry"`, `ingest_mode="registry"`) so `file_already_mined()` returns True on future runs
- Call it at all three early-exit points, guarded by `if not dry_run`
- Uses `upsert()` (not `add()`) so repeated runs are idempotent

`tests/test_convo_miner.py`:
- `test_mine_convos_does_not_reprocess_short_files` -- verifies a too-short file gets a sentinel and is skipped on second run
- `test_mine_convos_does_not_reprocess_empty_chunk_files` -- verifies a file with no exchange markers gets a sentinel and is skipped

**Scope note:** Bug 2 from the issue (drawers_added counter always 0) was already resolved upstream via the switch from `collection.add()` to `collection.upsert()`. This PR only addresses Bug 1, as @DevOPsJourneyman suggested in the issue thread -- a small focused follow-up separate from the batching logic in #629.