### PR TITLE
docs: update MCP tools reference for #667 additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Restart Claude Code, then type `/skills` to verify "mempalace" appears.
 claude mcp add mempalace -- python -m mempalace.mcp_server
 ```
 
-Now your AI has 19 tools available through MCP. Ask it anything:
+Now your AI has 24 tools available through MCP. Ask it anything:
 
 > *"What did we decide about auth last month?"*
 
@@ -470,7 +470,7 @@ claude plugin install --scope user mempalace
 claude mcp add mempalace -- python -m mempalace.mcp_server
 ```
 
-### 19 Tools
+### 24 Tools
 
 **Palace (read)**
 
@@ -490,6 +490,9 @@ claude mcp add mempalace -- python -m mempalace.mcp_server
 |------|------|
 | `mempalace_add_drawer` | File verbatim content |
 | `mempalace_delete_drawer` | Remove by ID |
+| `mempalace_get_drawer` | Fetch a drawer by ID |
+| `mempalace_list_drawers` | List drawers with pagination and filters |
+| `mempalace_update_drawer` | Update drawer content or metadata |
 
 **Knowledge Graph**
 
@@ -515,6 +518,13 @@ claude mcp add mempalace -- python -m mempalace.mcp_server
 |------|------|
 | `mempalace_diary_write` | Write AAAK diary entry |
 | `mempalace_diary_read` | Read recent diary entries |
+
+**Settings**
+
+| Tool | What |
+|------|------|
+| `mempalace_hook_settings` | Get or set hook behavior (silent save, desktop toast) |
+| `mempalace_memories_filed_away` | Check if a recent checkpoint was saved |
 
 The AI learns AAAK and the memory protocol automatically from the `mempalace_status` response. No manual configuration.
 
@@ -645,7 +655,7 @@ Plain text. Becomes Layer 0 — loaded every session.
 | `cli.py` | CLI entry point |
 | `config.py` | Configuration loading and defaults |
 | `normalize.py` | Converts 5 chat formats to standard transcript |
-| `mcp_server.py` | MCP server — 19 tools, AAAK auto-teach, memory protocol |
+| `mcp_server.py` | MCP server — 24 tools, AAAK auto-teach, memory protocol |
 | `miner.py` | Project file ingest |
 | `convo_miner.py` | Conversation ingest — chunks by exchange pair |
 | `searcher.py` | Semantic search via ChromaDB |
@@ -669,7 +679,7 @@ mempalace/
 ├── README.md                  ← you are here
 ├── mempalace/                 ← core package (README)
 │   ├── cli.py                 ← CLI entry point
-│   ├── mcp_server.py          ← MCP server (19 tools)
+│   ├── mcp_server.py          ← MCP server (24 tools)
 │   ├── knowledge_graph.py     ← temporal entity graph
 │   ├── palace_graph.py        ← room navigation graph
 │   ├── dialect.py             ← AAAK compression

--- a/website/guide/searching.md
+++ b/website/guide/searching.md
@@ -24,9 +24,10 @@ mempalace search "deploy process" --results 10
 ## How Search Works
 
 1. Your query is embedded using ChromaDB's default model (`all-MiniLM-L6-v2`)
-2. The embedding is compared against all drawers using cosine similarity
+2. The embedding is compared against all drawers using cosine distance
 3. Optional wing/room filters narrow the search scope
-4. Results are returned with similarity scores and source metadata
+4. Results beyond `max_distance` are filtered out (default: 1.5, lower = stricter)
+5. Results are returned with similarity scores, distances, and source metadata
 
 ### Why Structure Matters
 
@@ -54,6 +55,7 @@ results = search_memories(
     wing="myapp",
     room="auth",
     n_results=5,
+    max_distance=1.0,  # only close matches (0=identical, 2=opposite)
 )
 
 for hit in results["results"]:
@@ -74,9 +76,11 @@ The `search_memories()` function returns a dict:
             "room": "auth-migration",
             "source_file": "session_2026-01-15.md",
             "similarity": 0.892,
+            "distance": 0.108,
         },
         # ...
     ],
+    "total_before_filter": 5,
 }
 ```
 

--- a/website/index.md
+++ b/website/index.md
@@ -43,8 +43,8 @@ features:
   - icon:
       src: /icons/wrench.svg
       alt: 19 MCP Tools
-    title: 19 MCP Tools
-    details: MCP tools expose search, filing, knowledge graph, graph navigation, and diary operations to compatible clients.
+    title: 24 MCP Tools
+    details: MCP tools expose search, filing, knowledge graph, graph navigation, diary, and settings operations to compatible clients.
   - icon:
       src: /icons/shield-check.svg
       alt: Zero Cloud

--- a/website/index.md
+++ b/website/index.md
@@ -42,7 +42,7 @@ features:
     details: Temporal entity-relationship triples in SQLite. Facts can be added, queried, and invalidated over time.
   - icon:
       src: /icons/wrench.svg
-      alt: 19 MCP Tools
+      alt: 24 MCP Tools
     title: 24 MCP Tools
     details: MCP tools expose search, filing, knowledge graph, graph navigation, diary, and settings operations to compatible clients.
   - icon:

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -59,7 +59,9 @@ Semantic search. Returns verbatim drawer content with similarity scores.
 | `max_distance` | number | No | Max cosine distance threshold (0=identical, 2=opposite). Results further than this are dropped. Default 1.5. Set to 0 to disable. |
 | `context` | string | No | Background context for the search. Not used for embedding — only for future re-ranking. |
 
-**Returns:** `{ query, filters, results: [{ text, wing, room, source_file, similarity, distance }] }`
+**Returns:** `{ query, filters, keyword_fallback, total_before_filter, results: [{ text, wing, room, source_file, similarity, distance }] }`
+
+May also include `query_sanitized` and `sanitizer` if the query was cleaned, and `context_received` if context was provided.
 
 ---
 
@@ -124,7 +126,9 @@ Fetch a single drawer by ID — returns full content and metadata.
 |-----------|------|----------|-------------|
 | `drawer_id` | string | **Yes** | ID of the drawer to fetch |
 
-**Returns:** `{ drawer_id, content, wing, room, source_file, metadata }`
+**Returns:** `{ drawer_id, content, wing, room, metadata }`
+
+`source_file` is inside the `metadata` object, not a top-level field.
 
 ---
 
@@ -139,7 +143,7 @@ List drawers with pagination. Optional wing/room filter. Returns IDs, wings, roo
 | `limit` | integer | No | Max results per page (default: 20, max: 100) |
 | `offset` | integer | No | Offset for pagination (default: 0) |
 
-**Returns:** `{ drawers: [{ id, wing, room, preview }], total, offset, limit }`
+**Returns:** `{ drawers: [{ drawer_id, wing, room, content_preview }], count, offset, limit }`
 
 ---
 
@@ -154,7 +158,7 @@ Update an existing drawer's content and/or metadata (wing, room). Returns error 
 | `wing` | string | No | New wing (omit to keep existing) |
 | `room` | string | No | New room (omit to keep existing) |
 
-**Returns:** `{ success, drawer_id, updated_fields }`
+**Returns:** `{ success, drawer_id, wing, room }` — or `{ success, drawer_id, noop: true }` when called with no fields to update.
 
 ---
 
@@ -169,7 +173,7 @@ Get or set hook behavior. Call with no arguments to view current settings.
 | `silent_save` | boolean | No | True = silent direct save, False = legacy blocking MCP calls |
 | `desktop_toast` | boolean | No | True = show desktop notification via notify-send |
 
-**Returns:** `{ silent_save, desktop_toast }`
+**Returns:** `{ success, settings: { silent_save, desktop_toast } }` — includes `updated` array when settings were changed.
 
 ---
 
@@ -179,7 +183,7 @@ Check if a recent palace checkpoint was saved. Returns message count and timesta
 
 **Parameters:** None
 
-**Returns:** `{ last_save, message_count, timestamp }`
+**Returns:** `{ status, message, count, timestamp }`
 
 ---
 

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Detailed parameter schemas for all 19 MCP tools.
+Detailed parameter schemas for all 24 MCP tools.
 
 ## Palace — Read Tools
 
@@ -52,12 +52,14 @@ Semantic search. Returns verbatim drawer content with similarity scores.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `query` | string | **Yes** | What to search for |
-| `limit` | integer | No | Max results (default: 5) |
+| `query` | string | **Yes** | Short search query — keywords or a question. Max 200 chars recommended. |
+| `limit` | integer | No | Max results (default: 5, max: 100) |
 | `wing` | string | No | Filter by wing |
 | `room` | string | No | Filter by room |
+| `max_distance` | number | No | Max cosine distance threshold (0=identical, 2=opposite). Results further than this are dropped. Default 1.5. Set to 0 to disable. |
+| `context` | string | No | Background context for the search. Not used for embedding — only for future re-ranking. |
 
-**Returns:** `{ query, filters, results: [{ text, wing, room, source_file, similarity }] }`
+**Returns:** `{ query, filters, results: [{ text, wing, room, source_file, similarity, distance }] }`
 
 ---
 
@@ -111,6 +113,73 @@ Delete a drawer by ID. Irreversible.
 | `drawer_id` | string | **Yes** | ID of the drawer to delete |
 
 **Returns:** `{ success, drawer_id }`
+
+---
+
+### `mempalace_get_drawer`
+
+Fetch a single drawer by ID — returns full content and metadata.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `drawer_id` | string | **Yes** | ID of the drawer to fetch |
+
+**Returns:** `{ drawer_id, content, wing, room, source_file, metadata }`
+
+---
+
+### `mempalace_list_drawers`
+
+List drawers with pagination. Optional wing/room filter. Returns IDs, wings, rooms, and content previews.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `wing` | string | No | Filter by wing |
+| `room` | string | No | Filter by room |
+| `limit` | integer | No | Max results per page (default: 20, max: 100) |
+| `offset` | integer | No | Offset for pagination (default: 0) |
+
+**Returns:** `{ drawers: [{ id, wing, room, preview }], total, offset, limit }`
+
+---
+
+### `mempalace_update_drawer`
+
+Update an existing drawer's content and/or metadata (wing, room). Returns error if drawer not found.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `drawer_id` | string | **Yes** | ID of the drawer to update |
+| `content` | string | No | New content (omit to keep existing) |
+| `wing` | string | No | New wing (omit to keep existing) |
+| `room` | string | No | New room (omit to keep existing) |
+
+**Returns:** `{ success, drawer_id, updated_fields }`
+
+---
+
+## Settings Tools
+
+### `mempalace_hook_settings`
+
+Get or set hook behavior. Call with no arguments to view current settings.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `silent_save` | boolean | No | True = silent direct save, False = legacy blocking MCP calls |
+| `desktop_toast` | boolean | No | True = show desktop notification via notify-send |
+
+**Returns:** `{ silent_save, desktop_toast }`
+
+---
+
+### `mempalace_memories_filed_away`
+
+Check if a recent palace checkpoint was saved. Returns message count and timestamp.
+
+**Parameters:** None
+
+**Returns:** `{ last_save, message_count, timestamp }`
 
 ---
 

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -59,7 +59,7 @@ Semantic search. Returns verbatim drawer content with similarity scores.
 | `max_distance` | number | No | Max cosine distance threshold (0=identical, 2=opposite). Results further than this are dropped. Default 1.5. Set to 0 to disable. |
 | `context` | string | No | Background context for the search. Not used for embedding — only for future re-ranking. |
 
-**Returns:** `{ query, filters, keyword_fallback, total_before_filter, results: [{ text, wing, room, source_file, similarity, distance }] }`
+**Returns:** `{ query, filters, total_before_filter, results: [{ text, wing, room, source_file, similarity, distance }] }`
 
 May also include `query_sanitized` and `sanitizer` if the query was cleaned, and `context_received` if context was provided.
 


### PR DESCRIPTION
## Summary

- Add 5 tools shipped in #667 that are missing from the VitePress docs: `get_drawer`, `list_drawers`, `update_drawer`, `hook_settings`, `memories_filed_away`
- Add `max_distance` and `context` parameters to `mempalace_search` docs (also from #667)
- Add `distance` field to search response examples
- Update tool count from 19 to 24 in mcp-tools.md and index.md

## Test plan

- [ ] VitePress site builds without errors
- [ ] New tool entries render correctly with parameter tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)