### PR TITLE
fix: resolve python path in hooks + document restart requirement

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -133,6 +133,10 @@ Example output:
 [14:40:01] Session abc123: 18 exchanges, 3 since last save
 ```
 
+## Known Limitations
+
+**Hooks require session restart after install.** Claude Code loads hooks from `settings.json` at session start only. If you run `mempalace init` or manually edit hook config mid-session, the hooks won't fire until you restart Claude Code. This is a Claude Code limitation.
+
 ## Cost
 
 **Zero extra tokens.** The hooks are bash scripts that run locally. They don't call any API. The only "cost" is the AI spending a few seconds organizing memories at each checkpoint — and it's doing that with context it already has loaded.

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -65,7 +65,8 @@ echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     REPO_DIR="$(dirname "$SCRIPT_DIR")"
-    python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
+    PYTHON="$(command -v python3)"
+    "$PYTHON" -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
 # Always block — compaction = save everything

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -137,7 +137,8 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         REPO_DIR="$(dirname "$SCRIPT_DIR")"
-        python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
+        PYTHON="$(command -v python3)"
+        "$PYTHON" -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 
     # Block the AI and tell it to save


### PR DESCRIPTION
## Summary

- Fix bare `python3` in background calls in both hook scripts — `nohup` strips PATH so `python3` can resolve to system python missing mempalace packages
- Document the known limitation that hooks require session restart after install

## What was happening

In long sessions, the `mempal_save_hook.sh` background ingest (`python3 -m mempalace mine`) would silently fail with `ModuleNotFoundError` because `nohup` resolved `python3` to a different install. Fix: resolve `$(command -v python3)` before the call.

## Files changed

- `hooks/mempal_save_hook.sh` — resolve python path before background mine
- `hooks/mempal_precompact_hook.sh` — same fix for sync mine call
- `hooks/README.md` — added "Known Limitations" section about session restart

## Test plan

- [x] `$(command -v python3)` resolves correctly and has packages
- [x] Existing hook logic unchanged — only the python invocation method changed
- [x] README documents the restart requirement

Thank you from Milla and Lu✨