### PR TITLE
fix: correct typo in entity_detector interactive classification prompt

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -760,7 +760,7 @@ def confirm_entities(detected: dict, yes: bool = False) -> dict:
         if detected["uncertain"]:
             print("\n  Uncertain entities — classify each:")
             for e in detected["uncertain"]:
-                ans = input(f"    {e['name']} — (p)erson, (r)roject, or (s)kip? ").strip().lower()
+                ans = input(f"    {e['name']} — (p)erson, (r)project, or (s)kip? ").strip().lower()
                 if ans == "p":
                     confirmed_people.append(e["name"])
                 elif ans == "r":


### PR DESCRIPTION
Cherry-pick of arnoldwender's fix in #728 onto `develop`.

#728 targeted `main` (stale) and accumulated merge conflicts when retargeted. This branch re-applies the one-character fix cleanly on top of `develop`.

## What does this PR do?

Fixes a one-character typo in the interactive entity classification prompt in `mempalace/entity_detector.py` line 763:

- Before: `(p)erson, (r)roject, or (s)kip?`
- After: `(p)erson, (r)project, or (s)kip?`

Key binding `r` is unchanged — display-only fix.

## Credit

Original author: @arnoldwender (authorship preserved in the commit).
Original approval: @bensig on #728.

## Test plan

- [x] CI green on #728 (same commit contents)
- [x] Cherry-pick applied cleanly onto develop — no conflicts