### PR TITLE
fix: address i18n review issues from PR #718

### DIFF
--- a/mempalace/dialect.py
+++ b/mempalace/dialect.py
@@ -362,7 +362,7 @@ class Dialect:
         return cls(
             entities=config.get("entities", {}),
             skip_names=config.get("skip_names", []),
-            lang=config.get("lang"),
+            lang=config.get("lang", "en"),
         )
 
     def save_config(self, config_path: str):

--- a/mempalace/i18n/ko.json
+++ b/mempalace/i18n/ko.json
@@ -25,7 +25,7 @@
     "status_palace": "궁전: {path}",
     "status_wings": "날개 {count}개",
     "status_closets": "벽장 {count}개",
-    "status_drawers": "서랍 {drawers}개",
+    "status_drawers": "서랍 {count}개",
     "init_complete": "{path}에 궁전 초기화 완료",
     "init_exists": "{path}에 궁전이 이미 존재합니다",
     "repair_complete": "수리 완료. {fixed}개 문제 해결.",

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,11 +1,4 @@
-#!/usr/bin/env python3
-"""Quick smoke test for i18n dictionaries + Dialect integration."""
-
-import sys
-from pathlib import Path
-
-# Add parent to path so we can import mempalace
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+"""Smoke tests for i18n dictionaries + Dialect integration."""
 
 from mempalace.i18n import load_lang, t, available_languages
 from mempalace.dialect import Dialect
@@ -75,10 +68,19 @@ def test_dialect_compress_samples():
     print("  PASS: compression works for all sample languages")
 
 
-if __name__ == "__main__":
-    print("i18n smoke tests:")
-    test_all_languages_load()
-    test_interpolation()
-    test_dialect_loads_lang()
-    test_dialect_compress_samples()
-    print("\nAll tests passed.")
+def test_korean_status_drawers_uses_count():
+    """ko.json status_drawers must use {count}, not {drawers}."""
+    load_lang("ko")
+    result = t("cli.status_drawers", count=42)
+    assert "42" in result, f"Expected '42' in '{result}' -- count variable not interpolated"
+
+
+def test_from_config_defaults_to_english(tmp_path):
+    """Dialect.from_config without a lang key must not inherit module-level state."""
+    load_lang("ko")  # pollute module-level _current_lang
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"entities": {}}')
+
+    d = Dialect.from_config(str(config_path))
+    assert d.lang == "en", f"Expected 'en', got '{d.lang}' -- state leak from prior load_lang"


### PR DESCRIPTION
Addresses three issues bensig flagged on PR #718 before merge.

**1. ko.json variable name mismatch (line 28)**
`status_drawers` used `{drawers}` while all other 7 languages use `{count}`. The `t()` call passes `count=N`, so Korean showed the raw template string instead of the number. One-character fix.

**2. Test file shipped inside the installed package**
`mempalace/i18n/test_i18n.py` used a `sys.path.insert` hack to work around its wrong location. Moved to `tests/test_i18n.py` per AGENTS.md convention. Removed the sys.path hack and the `__name__` runner block.

**3. Dialect.from_config() state leak**
`from_config` passed `lang=config.get("lang")` which defaults to None. When no `"lang"` key is in the config, `__init__` fell through to `current_lang()` -- a module-level global set by whichever `load_lang()` call ran most recently. Now defaults to `"en"` explicitly so `from_config` is deterministic.

Bug 1 from bensig's review (compress() never uses self.aaak_instruction or self.lang_regex) is intentionally not addressed here -- bensig suggested deferring the regex wiring until alignment with #488/#507 on extraction approach.

**Changes (3 files, +19/-17):**
- `mempalace/i18n/ko.json` -- `{drawers}` -> `{count}`
- `mempalace/dialect.py` -- `config.get("lang")` -> `config.get("lang", "en")`
- `tests/test_i18n.py` -- moved from `mempalace/i18n/`, added 2 regression tests

**References:** bensig's review comments on PR #718 (2026-04-12T21:54Z and 22:01Z)