### PR TITLE
fix: batch status fetches for large palaces

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -629,10 +629,19 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
+    # Count by wing and room (batch to avoid SQLite variable limit)
     total = col.count()
-    r = col.get(limit=total, include=["metadatas"]) if total else {"metadatas": []}
-    metas = r["metadatas"]
+    metas = []
+    if total:
+        batch_size = 5000
+        offset = 0
+        while offset < total:
+            r = col.get(limit=batch_size, offset=offset, include=["metadatas"])
+            batch = r["metadatas"]
+            if not batch:
+                break
+            metas.extend(batch)
+            offset += len(batch)
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -629,11 +629,11 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room (batch to avoid SQLite variable limit)
+    # Count by wing and room (batch to avoid SQLite variable limit ~32k vars)
     total = col.count()
     metas = []
     if total:
-        batch_size = 5000
+        batch_size = 5000  # matches cli.py / repair.py; keep under SQLite limit
         offset = 0
         while offset < total:
             r = col.get(limit=batch_size, offset=offset, include=["metadatas"])


### PR DESCRIPTION
## Summary
- `mempalace status` crashes with `chromadb.errors.InternalError: too many SQL variables` on palaces with >~40k drawers
- PR #707 removed the 10k cap and replaced `limit=10000` with `limit=total`, which correctly shows all drawers but hits SQLite's `SQLITE_MAX_VARIABLE_NUMBER` limit (default 32766) on large palaces
- Fix: fetch metadata in batches of 5,000 using ChromaDB's built-in `offset` parameter

## Reproducer
```
$ mempalace status
# Palace with 115,171 drawers → crashes:
# chromadb.errors.InternalError: Error executing plan: Internal error:
# error returned from database: (code: 1) too many SQL variables
```

## Test plan
- [x] Verified fix works on a palace with 115,171 drawers — `mempalace status` completes successfully and shows correct counts for all wings/rooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)