### PR TITLE
feat: add MiniMax-M3 (and M2.7) provider support to benchmark tools

### DIFF
--- a/benchmarks/locomo_bench.py
+++ b/benchmarks/locomo_bench.py
@@ -393,8 +393,16 @@ PALACE_ROOMS = [
 _PALACE_ROOM_LIST = "\n".join(f"  - {r}" for r in PALACE_ROOMS)
 
 
+def _llm_base_url(model):
+    """Return the Anthropic-compatible API base URL for the given model."""
+    if model.startswith("MiniMax"):
+        return os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io/anthropic")
+    return "https://api.anthropic.com"
+
+
 def _llm_call(prompt, api_key, model="claude-haiku-4-5-20251001", max_tokens=32):
     """Minimal LLM call. Returns text response or empty string on failure."""
+    base_url = _llm_base_url(model)
     payload = json.dumps(
         {
             "model": model,
@@ -403,7 +411,7 @@ def _llm_call(prompt, api_key, model="claude-haiku-4-5-20251001", max_tokens=32)
         }
     ).encode("utf-8")
     req = urllib.request.Request(
-        "https://api.anthropic.com/v1/messages",
+        f"{base_url}/v1/messages",
         data=payload,
         headers={
             "x-api-key": api_key,
@@ -534,6 +542,7 @@ def llm_rerank_locomo(
         f"Reply with just the number (1-{len(candidates)}).\n\n" + "\n".join(lines)
     )
 
+    base_url = _llm_base_url(model)
     payload = json.dumps(
         {
             "model": model,
@@ -543,7 +552,7 @@ def llm_rerank_locomo(
     ).encode("utf-8")
 
     req = urllib.request.Request(
-        "https://api.anthropic.com/v1/messages",
+        f"{base_url}/v1/messages",
         data=payload,
         headers={
             "x-api-key": api_key,
@@ -579,10 +588,18 @@ def llm_rerank_locomo(
     return retrieved_ids
 
 
-def _load_api_key(key_arg):
-    """Load API key from --llm-key arg or ANTHROPIC_API_KEY env var."""
+def _load_api_key(key_arg, model=""):
+    """Load API key from --llm-key arg or environment variables.
+
+    For MiniMax models (starting with 'MiniMax'), checks MINIMAX_API_KEY first.
+    Falls back to ANTHROPIC_API_KEY for Anthropic/Claude models.
+    """
     if key_arg:
         return key_arg
+    if model.startswith("MiniMax"):
+        env_key = os.environ.get("MINIMAX_API_KEY", "")
+        if env_key:
+            return env_key
     env_key = os.environ.get("ANTHROPIC_API_KEY", "")
     if env_key:
         return env_key
@@ -618,9 +635,13 @@ def run_benchmark(
 
     api_key = ""
     if llm_rerank_enabled or mode == "palace":
-        api_key = _load_api_key(llm_key)
+        api_key = _load_api_key(llm_key, model=llm_model)
         if not api_key:
-            print(f"ERROR: --mode {mode} requires an API key (--llm-key or ANTHROPIC_API_KEY).")
+            env_hint = "MINIMAX_API_KEY" if llm_model.startswith("MiniMax") else "ANTHROPIC_API_KEY"
+            print(
+                f"ERROR: --mode {mode} requires an API key "
+                f"(--llm-key or {env_hint} env var)."
+            )
             sys.exit(1)
 
     # Palace mode: load or create room assignment cache
@@ -1010,9 +1031,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--llm-model",
         default="claude-sonnet-4-6",
-        help="Model for LLM rerank (default: claude-sonnet-4-6)",
+        help="Model for LLM rerank (default: claude-sonnet-4-6). "
+        "MiniMax models also supported: MiniMax-M2.7, MiniMax-M2.7-highspeed "
+        "(set MINIMAX_API_KEY env var or pass via --llm-key).",
     )
-    parser.add_argument("--llm-key", default="", help="API key (or set ANTHROPIC_API_KEY env var)")
+    parser.add_argument(
+        "--llm-key",
+        default="",
+        help="API key. For Anthropic models, falls back to ANTHROPIC_API_KEY env var. "
+        "For MiniMax models, falls back to MINIMAX_API_KEY env var.",
+    )
     parser.add_argument(
         "--hybrid-weight",
         type=float,

--- a/benchmarks/locomo_bench.py
+++ b/benchmarks/locomo_bench.py
@@ -1032,7 +1032,7 @@ if __name__ == "__main__":
         "--llm-model",
         default="claude-sonnet-4-6",
         help="Model for LLM rerank (default: claude-sonnet-4-6). "
-        "MiniMax models also supported: MiniMax-M2.7, MiniMax-M2.7-highspeed "
+        "MiniMax models also supported: MiniMax-M3 (recommended), MiniMax-M2.7 "
         "(set MINIMAX_API_KEY env var or pass via --llm-key).",
     )
     parser.add_argument(

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -2367,6 +2367,13 @@ def build_palace_and_retrieve_palace(
 # =============================================================================
 
 
+def _llm_base_url(model):
+    """Return the Anthropic-compatible API base URL for the given model."""
+    if model.startswith("MiniMax"):
+        return os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io/anthropic")
+    return "https://api.anthropic.com"
+
+
 def diary_ingest_session(session, sess_id, api_key, model="claude-haiku-4-5-20251001"):
     """
     Call an LLM to extract topics and a summary from one session.
@@ -2417,7 +2424,7 @@ def diary_ingest_session(session, sess_id, api_key, model="claude-haiku-4-5-2025
     ).encode("utf-8")
 
     req = _urllib_request.Request(
-        "https://api.anthropic.com/v1/messages",
+        f"{_llm_base_url(model)}/v1/messages",
         data=payload,
         headers={
             "x-api-key": api_key,
@@ -2822,7 +2829,7 @@ def llm_rerank(
     ).encode("utf-8")
 
     req = urllib.request.Request(
-        "https://api.anthropic.com/v1/messages",
+        f"{_llm_base_url(model)}/v1/messages",
         data=payload,
         headers={
             "x-api-key": api_key,
@@ -2860,10 +2867,18 @@ def llm_rerank(
     return rankings
 
 
-def _load_api_key(key_arg):
-    """Load API key from --llm-key arg or ANTHROPIC_API_KEY env var."""
+def _load_api_key(key_arg, model=""):
+    """Load API key from --llm-key arg or environment variables.
+
+    For MiniMax models (starting with 'MiniMax'), checks MINIMAX_API_KEY first.
+    Falls back to ANTHROPIC_API_KEY for Anthropic/Claude models.
+    """
     if key_arg:
         return key_arg
+    if model.startswith("MiniMax"):
+        env_key = os.environ.get("MINIMAX_API_KEY", "")
+        if env_key:
+            return env_key
     env_key = os.environ.get("ANTHROPIC_API_KEY", "")
     if env_key:
         return env_key
@@ -2946,11 +2961,12 @@ def run_benchmark(
 
     api_key = ""
     if llm_rerank_enabled or mode == "diary":
-        api_key = _load_api_key(llm_key)
+        api_key = _load_api_key(llm_key, model=llm_model)
         if not api_key:
+            env_hint = "MINIMAX_API_KEY" if llm_model.startswith("MiniMax") else "ANTHROPIC_API_KEY"
             print(
-                "ERROR: --llm-rerank / --mode diary requires an API key. "
-                "Set ANTHROPIC_API_KEY or use --llm-key."
+                f"ERROR: --llm-rerank / --mode diary requires an API key. "
+                f"Set {env_hint} or use --llm-key."
             )
             sys.exit(1)
 
@@ -3269,14 +3285,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--llm-key",
         default="",
-        help="Anthropic API key for LLM re-ranking. Falls back to ANTHROPIC_API_KEY env var.",
+        help="API key for LLM re-ranking/diary. For Anthropic models, falls back to "
+        "ANTHROPIC_API_KEY env var. For MiniMax models, falls back to MINIMAX_API_KEY env var.",
     )
     parser.add_argument(
         "--llm-model",
         default="claude-haiku-4-5-20251001",
         help="Model for LLM re-ranking and diary ingest "
         "(default: claude-haiku-4-5-20251001). "
-        "Use 'claude-sonnet-4-6' for Sonnet comparison.",
+        "MiniMax models also supported: MiniMax-M2.7, MiniMax-M2.7-highspeed "
+        "(set MINIMAX_API_KEY env var or pass via --llm-key).",
     )
     parser.add_argument(
         "--diary-cache",

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -3293,7 +3293,7 @@ if __name__ == "__main__":
         default="claude-haiku-4-5-20251001",
         help="Model for LLM re-ranking and diary ingest "
         "(default: claude-haiku-4-5-20251001). "
-        "MiniMax models also supported: MiniMax-M2.7, MiniMax-M2.7-highspeed "
+        "MiniMax models also supported: MiniMax-M3 (recommended), MiniMax-M2.7 "
         "(set MINIMAX_API_KEY env var or pass via --llm-key).",
     )
     parser.add_argument(

--- a/tests/test_benchmark_minimax.py
+++ b/tests/test_benchmark_minimax.py
@@ -1,0 +1,103 @@
+"""
+Tests for MiniMax provider routing in benchmark tools.
+
+Verifies that _llm_base_url and _load_api_key correctly route to MiniMax
+vs Anthropic endpoints based on model name, without making real API calls.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load benchmark modules directly since benchmarks/ has no __init__.py
+_ROOT = Path(__file__).parent.parent
+
+
+def _load_bench(filename):
+    spec = importlib.util.spec_from_file_location(filename, _ROOT / "benchmarks" / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_locomo = _load_bench("locomo_bench.py")
+_longmem = _load_bench("longmemeval_bench.py")
+
+
+# ── _llm_base_url ──────────────────────────────────────────────────────────────
+
+
+class TestLlmBaseUrl:
+    def test_claude_model_returns_anthropic(self):
+        assert _locomo._llm_base_url("claude-haiku-4-5-20251001") == "https://api.anthropic.com"
+
+    def test_claude_sonnet_returns_anthropic(self):
+        assert _locomo._llm_base_url("claude-sonnet-4-6") == "https://api.anthropic.com"
+
+    def test_minimax_m2_7_returns_minimax(self):
+        assert _locomo._llm_base_url("MiniMax-M2.7") == "https://api.minimax.io/anthropic"
+
+    def test_minimax_highspeed_returns_minimax(self):
+        assert _locomo._llm_base_url("MiniMax-M2.7-highspeed") == "https://api.minimax.io/anthropic"
+
+    def test_minimax_base_url_env_override(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_BASE_URL", "https://api.minimaxi.com/anthropic")
+        assert _locomo._llm_base_url("MiniMax-M2.7") == "https://api.minimaxi.com/anthropic"
+
+    def test_longmemeval_minimax_returns_minimax(self):
+        assert _longmem._llm_base_url("MiniMax-M2.7") == "https://api.minimax.io/anthropic"
+
+    def test_longmemeval_claude_returns_anthropic(self):
+        assert _longmem._llm_base_url("claude-haiku-4-5-20251001") == "https://api.anthropic.com"
+
+    def test_unknown_model_returns_anthropic(self):
+        assert _locomo._llm_base_url("gpt-4o") == "https://api.anthropic.com"
+
+
+# ── _load_api_key ─────────────────────────────────────────────────────────────
+
+
+class TestLoadApiKey:
+    def test_explicit_key_always_wins(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "env-anthropic")
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-minimax")
+        assert _locomo._load_api_key("explicit-key", model="MiniMax-M2.7") == "explicit-key"
+        assert _locomo._load_api_key("explicit-key", model="claude-sonnet-4-6") == "explicit-key"
+
+    def test_minimax_model_uses_minimax_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "minimax-secret")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert _locomo._load_api_key("", model="MiniMax-M2.7") == "minimax-secret"
+
+    def test_minimax_model_falls_back_to_anthropic_if_no_minimax_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        assert _locomo._load_api_key("", model="MiniMax-M2.7") == "anthropic-secret"
+
+    def test_anthropic_model_uses_anthropic_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        monkeypatch.setenv("MINIMAX_API_KEY", "minimax-secret")
+        assert _locomo._load_api_key("", model="claude-sonnet-4-6") == "anthropic-secret"
+
+    def test_no_env_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        assert _locomo._load_api_key("", model="MiniMax-M2.7") == ""
+
+    def test_longmemeval_minimax_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "minimax-secret")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert _longmem._load_api_key("", model="MiniMax-M2.7") == "minimax-secret"
+
+    def test_longmemeval_anthropic_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        assert _longmem._load_api_key("", model="claude-haiku-4-5-20251001") == "anthropic-secret"
+
+    def test_no_model_falls_back_to_anthropic(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        assert _locomo._load_api_key("") == "anthropic-secret"
+

--- a/tests/test_benchmark_minimax.py
+++ b/tests/test_benchmark_minimax.py
@@ -40,6 +40,9 @@ class TestLlmBaseUrl:
     def test_minimax_m2_7_returns_minimax(self):
         assert _locomo._llm_base_url("MiniMax-M2.7") == "https://api.minimax.io/anthropic"
 
+    def test_minimax_m3_returns_minimax(self):
+        assert _locomo._llm_base_url("MiniMax-M3") == "https://api.minimax.io/anthropic"
+
     def test_minimax_highspeed_returns_minimax(self):
         assert _locomo._llm_base_url("MiniMax-M2.7-highspeed") == "https://api.minimax.io/anthropic"
 
@@ -49,6 +52,9 @@ class TestLlmBaseUrl:
 
     def test_longmemeval_minimax_returns_minimax(self):
         assert _longmem._llm_base_url("MiniMax-M2.7") == "https://api.minimax.io/anthropic"
+
+    def test_longmemeval_minimax_m3_returns_minimax(self):
+        assert _longmem._llm_base_url("MiniMax-M3") == "https://api.minimax.io/anthropic"
 
     def test_longmemeval_claude_returns_anthropic(self):
         assert _longmem._llm_base_url("claude-haiku-4-5-20251001") == "https://api.anthropic.com"
@@ -71,6 +77,11 @@ class TestLoadApiKey:
         monkeypatch.setenv("MINIMAX_API_KEY", "minimax-secret")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         assert _locomo._load_api_key("", model="MiniMax-M2.7") == "minimax-secret"
+
+    def test_minimax_m3_uses_minimax_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "minimax-secret")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert _locomo._load_api_key("", model="MiniMax-M3") == "minimax-secret"
 
     def test_minimax_model_falls_back_to_anthropic_if_no_minimax_key(self, monkeypatch):
         monkeypatch.delenv("MINIMAX_API_KEY", raising=False)


### PR DESCRIPTION
## Summary

Adds MiniMax LLM provider support to the benchmark evaluation tools (`locomo_bench.py` and `longmemeval_bench.py`), enabling researchers to benchmark MemPalace memory retrieval using MiniMax models as the LLM scorer instead of being locked in to Anthropic.

The recommended default MiniMax model is **MiniMax-M3** (peak performance). The previous-generation **MiniMax-M2.7** remains supported for back-compat.

## Changes

- **`benchmarks/locomo_bench.py`**: Added `_llm_base_url()` helper that routes `MiniMax-*` model names to MiniMax's Anthropic-compatible endpoint (`https://api.minimax.io/anthropic`) and Claude models to `https://api.anthropic.com`. Updated `_llm_call()`, `llm_rerank_locomo()`, and `_load_api_key()` to use the correct endpoint and API key. `--llm-model` help text now lists `MiniMax-M3` (recommended) and `MiniMax-M2.7`.

- **`benchmarks/longmemeval_bench.py`**: Same changes applied to `diary_ingest_session()`, `llm_rerank()`, and `_load_api_key()`. `--llm-model` help text now lists `MiniMax-M3` (recommended) and `MiniMax-M2.7`.

- **`tests/test_benchmark_minimax.py`**: Unit tests covering URL routing and API key selection for both benchmark files, including explicit M3 coverage.

## Supported Models

| Model | Type |
|-------|------|
| `MiniMax-M3` | Recommended — Peak Performance |
| `MiniMax-M2.7` | Previous generation, kept for back-compat |

MiniMax uses an Anthropic-compatible API, so the same request format and `x-api-key` header are used — only the base URL changes. Both M3 and M2.7 share the same endpoint.

## Usage

```bash
# LoCoMo benchmark with MiniMax-M3 reranker (recommended)
MINIMAX_API_KEY=<key> python benchmarks/locomo_bench.py data.json \
  --mode hybrid --llm-rerank --llm-model MiniMax-M3

# LongMemEval diary mode with MiniMax-M3
MINIMAX_API_KEY=<key> python benchmarks/longmemeval_bench.py data.json \
  --mode diary --llm-model MiniMax-M3

# Previous-generation M2.7 still works
MINIMAX_API_KEY=<key> python benchmarks/locomo_bench.py data.json \
  --mode hybrid --llm-rerank --llm-model MiniMax-M2.7

# Domestic (China) endpoint override
MINIMAX_BASE_URL=https://api.minimaxi.com/anthropic ...
```

## API Reference

- Chat (Anthropic Compatible): https://platform.minimax.io/docs/api-reference/text-anthropic-api