### PR TITLE
fix(kg): prevent edge duplication with partial UNIQUE index and atomic upsert

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -204,12 +204,17 @@ class KnowledgeGraph:
                         source_file,
                     ),
                 )
-                # Fetch whichever row won (ours or a concurrent insert's)
-                row = conn.execute(
-                    "SELECT id FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
-                    (sub_id, pred, obj_id),
-                ).fetchone()
-        return row["id"] if row else triple_id
+                # For active triples, fetch whichever row won (ours or a concurrent
+                # insert's) — their IDs may differ if two threads raced here.
+                # Expired triples have no UNIQUE index constraint, so triple_id is
+                # always the inserted row.
+                if valid_to is None:
+                    winner = conn.execute(
+                        "SELECT id FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
+                        (sub_id, pred, obj_id),
+                    ).fetchone()
+                    triple_id = winner["id"] if winner else triple_id
+        return triple_id
 
     def invalidate(self, subject: str, predicate: str, obj: str, ended: str = None):
         """Mark a relationship as no longer valid (set valid_to date)."""

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -176,18 +176,19 @@ class KnowledgeGraph:
                     "INSERT OR IGNORE INTO entities (id, name) VALUES (?, ?)", (obj_id, obj)
                 )
 
-                # Deterministic ID for active triples so INSERT OR IGNORE
-                # deduplicates correctly with the partial UNIQUE index.
-                # Expired triples keep a timestamp component so re-adds after
-                # invalidation always produce a fresh row (different primary key).
-                if valid_to is None:
-                    id_seed = f"{sub_id}|{pred}|{obj_id}|active"
-                else:
-                    id_seed = f"{sub_id}|{pred}|{obj_id}|{valid_from}|{valid_to}|{datetime.now().isoformat()}"
-                triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.sha256(id_seed.encode()).hexdigest()[:12]}"
+                # Always use a timestamp-based ID so that a re-add after
+                # invalidation produces a genuinely new row with a different PK.
+                # The partial UNIQUE index on (subject, predicate, object)
+                # WHERE valid_to IS NULL is what closes the TOCTOU race for
+                # active triples — INSERT OR IGNORE on that index silently
+                # discards the loser when two threads race, regardless of
+                # whether their generated IDs differ.
+                triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.sha256(f'{valid_from}{datetime.now().isoformat()}'.encode()).hexdigest()[:12]}"
 
-                # INSERT OR IGNORE: if the UNIQUE index blocks insertion (concurrent
-                # duplicate), we silently discard the loser and return the winner.
+                # INSERT OR IGNORE: the partial UNIQUE index blocks a second active
+                # insert for the same (subject, predicate, object).  Expired rows
+                # (valid_to IS NOT NULL) are outside the index so re-adds after
+                # invalidation always succeed.
                 conn.execute(
                     """INSERT OR IGNORE INTO triples
                        (id, subject, predicate, object, valid_from, valid_to, confidence, source_closet, source_file)
@@ -204,10 +205,9 @@ class KnowledgeGraph:
                         source_file,
                     ),
                 )
-                # For active triples, fetch whichever row won (ours or a concurrent
-                # insert's) — their IDs may differ if two threads raced here.
-                # Expired triples have no UNIQUE index constraint, so triple_id is
-                # always the inserted row.
+                # For active triples, return the winner's ID — may differ from
+                # triple_id if a concurrent insert beat us and INSERT OR IGNORE
+                # silently discarded our row.
                 if valid_to is None:
                     winner = conn.execute(
                         "SELECT id FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -88,6 +88,27 @@ class KnowledgeGraph:
             CREATE INDEX IF NOT EXISTS idx_triples_predicate ON triples(predicate);
             CREATE INDEX IF NOT EXISTS idx_triples_valid ON triples(valid_from, valid_to);
         """)
+        # Dedup any existing active triples before adding the UNIQUE index so
+        # CREATE UNIQUE INDEX doesn't fail on pre-existing duplicates.
+        conn.execute("""
+            DELETE FROM triples
+            WHERE rowid NOT IN (
+                SELECT MIN(rowid)
+                FROM triples
+                WHERE valid_to IS NULL
+                GROUP BY subject, predicate, object
+            )
+            AND valid_to IS NULL
+        """)
+        # Partial UNIQUE index: only one active (non-invalidated) triple per
+        # (subject, predicate, object) is allowed at any time.  This is the
+        # database-level guard that prevents TOCTOU race duplicates regardless
+        # of how many threads or processes share the same SQLite file.
+        conn.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_triples_active
+                ON triples(subject, predicate, object)
+                WHERE valid_to IS NULL
+        """)
         conn.commit()
 
     def _conn(self):
@@ -155,19 +176,21 @@ class KnowledgeGraph:
                     "INSERT OR IGNORE INTO entities (id, name) VALUES (?, ?)", (obj_id, obj)
                 )
 
-                # Check for existing identical triple
-                existing = conn.execute(
-                    "SELECT id FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
-                    (sub_id, pred, obj_id),
-                ).fetchone()
+                # Deterministic ID for active triples so INSERT OR IGNORE
+                # deduplicates correctly with the partial UNIQUE index.
+                # Expired triples keep a timestamp component so re-adds after
+                # invalidation always produce a fresh row (different primary key).
+                if valid_to is None:
+                    id_seed = f"{sub_id}|{pred}|{obj_id}|active"
+                else:
+                    id_seed = f"{sub_id}|{pred}|{obj_id}|{valid_from}|{valid_to}|{datetime.now().isoformat()}"
+                triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.sha256(id_seed.encode()).hexdigest()[:12]}"
 
-                if existing:
-                    return existing["id"]  # Already exists and still valid
-
-                triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.sha256(f'{valid_from}{datetime.now().isoformat()}'.encode()).hexdigest()[:12]}"
-
+                # INSERT OR IGNORE: if the UNIQUE index blocks insertion (concurrent
+                # duplicate), we silently discard the loser and return the winner.
                 conn.execute(
-                    """INSERT INTO triples (id, subject, predicate, object, valid_from, valid_to, confidence, source_closet, source_file)
+                    """INSERT OR IGNORE INTO triples
+                       (id, subject, predicate, object, valid_from, valid_to, confidence, source_closet, source_file)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         triple_id,
@@ -181,7 +204,12 @@ class KnowledgeGraph:
                         source_file,
                     ),
                 )
-        return triple_id
+                # Fetch whichever row won (ours or a concurrent insert's)
+                row = conn.execute(
+                    "SELECT id FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
+                    (sub_id, pred, obj_id),
+                ).fetchone()
+        return row["id"] if row else triple_id
 
     def invalidate(self, subject: str, predicate: str, obj: str, ended: str = None):
         """Mark a relationship as no longer valid (set valid_to date)."""

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"


### PR DESCRIPTION
## Problem

`add_triple()` uses a SELECT-then-INSERT pattern with no database-level uniqueness guarantee — a classic TOCTOU race. Two concurrent callers can both execute the SELECT (both see no existing row), then both proceed to INSERT, producing duplicate active triples.

The existing `INSERT OR IGNORE` did not help because the `id` column is generated with `datetime.now().isoformat()` baked in — every call produces a unique primary key, so `INSERT OR IGNORE` never triggers.

There is also no `UNIQUE` constraint on `(subject, predicate, object) WHERE valid_to IS NULL`, so the database cannot enforce the invariant independently of Python logic.

Fixes #655.

## Solution

**1. Partial UNIQUE index** (`_init_db`):
```sql
CREATE UNIQUE INDEX IF NOT EXISTS uq_triples_active
    ON triples(subject, predicate, object)
    WHERE valid_to IS NULL;
```
This is the database-level enforcement layer — no concurrent caller can bypass it.

**2. Dedup migration** (also `_init_db`):
Before creating the index, remove any pre-existing duplicate active triples (keeping the oldest by `rowid`) so the `CREATE UNIQUE INDEX` does not fail on upgraded databases.

**3. Deterministic ID for active triples** (`add_triple`):
Active triples use `id_seed = f"{sub_id}|{pred}|{obj_id}|active"` so the computed `triple_id` is the same for both concurrent callers. `INSERT OR IGNORE` then discards the second insert atomically. Expired triples retain the `datetime.now()` component so re-adds after invalidation always generate a distinct row.

**4. Atomic upsert pattern**:
Replace SELECT-check + plain INSERT with INSERT OR IGNORE followed by a SELECT to return whichever row won (ours or a concurrent insert's).

## Test results

All existing `test_knowledge_graph.py` tests pass, including `test_duplicate_triple_returns_existing_id` and `test_invalidated_triple_allows_re_add`.