### PR TITLE
fix: disable ChromaDB telemetry to suppress posthog spam

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import chromadb
+from chromadb.config import Settings
 from chromadb.errors import NotFoundError as _ChromaNotFoundError
 
 from .base import (
@@ -25,6 +26,10 @@ from .base import (
     UnsupportedFilterError,
     _IncludeSpec,
 )
+
+#: Shared ChromaDB settings that silence the posthog telemetry spam
+#: (see https://github.com/MemPalace/mempalace/issues/458).
+CHROMA_SETTINGS = Settings(anonymized_telemetry=False)
 
 logger = logging.getLogger(__name__)
 
@@ -1240,7 +1245,7 @@ class ChromaBackend(BaseBackend):
             if inode_changed:
                 ChromaBackend._quarantined_paths.discard(palace_path)
             ChromaBackend._prepare_palace_for_open(palace_path)
-            cached = chromadb.PersistentClient(path=palace_path)
+            cached = chromadb.PersistentClient(path=palace_path, settings=CHROMA_SETTINGS)
             self._clients[palace_path] = cached
             # Re-stat after the client constructor runs: chromadb creates
             # chroma.sqlite3 lazily, so the stat captured before the call
@@ -1318,7 +1323,7 @@ class ChromaBackend(BaseBackend):
         vs. runtime thrash on steady-write daemons).
         """
         ChromaBackend._prepare_palace_for_open(palace_path)
-        return chromadb.PersistentClient(path=palace_path)
+        return chromadb.PersistentClient(path=palace_path, settings=CHROMA_SETTINGS)
 
     @staticmethod
     def backend_version() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ os.environ["HOMEPATH"] = os.path.splitdrive(_session_tmp)[1] or _session_tmp
 import chromadb  # noqa: E402
 import pytest  # noqa: E402
 
+from mempalace.backends.chroma import CHROMA_SETTINGS  # noqa: E402
 from mempalace.config import MempalaceConfig  # noqa: E402
 from mempalace.knowledge_graph import KnowledgeGraph  # noqa: E402
 
@@ -127,7 +128,7 @@ def config(tmp_dir, palace_path):
 @pytest.fixture
 def collection(palace_path):
     """A ChromaDB collection pre-seeded in the temp palace."""
-    client = chromadb.PersistentClient(path=palace_path)
+    client = chromadb.PersistentClient(path=palace_path, settings=CHROMA_SETTINGS)
     col = client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
     yield col
     client.delete_collection("mempalace_drawers")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -19,6 +19,7 @@ from mempalace.backends import (
     get_backend,
 )
 from mempalace.backends.chroma import (
+    CHROMA_SETTINGS,
     ChromaBackend,
     ChromaCollection,
     _HNSW_MISSING_METADATA_DATA_FLOOR,
@@ -313,7 +314,9 @@ def test_chroma_cache_picks_up_db_created_after_first_open(tmp_path):
     # Use a real chromadb call so _fix_blob_seq_ids and PersistentClient succeed.
     import chromadb as _chromadb
 
-    _chromadb.PersistentClient(path=str(palace_path)).get_or_create_collection("seed")
+    _chromadb.PersistentClient(
+        path=str(palace_path), settings=CHROMA_SETTINGS
+    ).get_or_create_collection("seed")
     assert (palace_path / "chroma.sqlite3").is_file()
 
     # Next _client() call must detect the 0 → nonzero transition and rebuild.
@@ -372,7 +375,7 @@ def test_chroma_backend_create_true_creates_directory_and_collection(tmp_path):
     assert palace_path.is_dir()
     assert isinstance(collection, ChromaCollection)
 
-    client = chromadb.PersistentClient(path=str(palace_path))
+    client = chromadb.PersistentClient(path=str(palace_path), settings=CHROMA_SETTINGS)
     client.get_collection("mempalace_drawers")
 
 
@@ -385,7 +388,7 @@ def test_chroma_backend_creates_collection_with_cosine_distance(tmp_path):
         create=True,
     )
 
-    client = chromadb.PersistentClient(path=str(palace_path))
+    client = chromadb.PersistentClient(path=str(palace_path), settings=CHROMA_SETTINGS)
     col = client.get_collection("mempalace_drawers")
     assert col.metadata.get("hnsw:space") == "cosine"
 
@@ -408,7 +411,7 @@ def test_chroma_backend_sets_hnsw_bloat_guard_on_creation(tmp_path):
         create=True,
     )
 
-    client = chromadb.PersistentClient(path=str(palace_path))
+    client = chromadb.PersistentClient(path=str(palace_path), settings=CHROMA_SETTINGS)
     col = client.get_collection("mempalace_drawers")
     assert col.metadata.get("hnsw:batch_size") == 50_000
     assert col.metadata.get("hnsw:sync_threshold") == 50_000
@@ -420,7 +423,7 @@ def test_chroma_backend_create_collection_sets_hnsw_bloat_guard(tmp_path):
 
     ChromaBackend().create_collection(str(palace_path), "mempalace_drawers")
 
-    client = chromadb.PersistentClient(path=str(palace_path))
+    client = chromadb.PersistentClient(path=str(palace_path), settings=CHROMA_SETTINGS)
     col = client.get_collection("mempalace_drawers")
     assert col.metadata.get("hnsw:batch_size") == 50_000
     assert col.metadata.get("hnsw:sync_threshold") == 50_000
@@ -823,9 +826,9 @@ def test_make_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeyp
     ChromaBackend.make_client(palace_path)
     ChromaBackend.make_client(palace_path)
 
-    assert calls == [
-        palace_path
-    ], "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
+    assert calls == [palace_path], (
+        "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
+    )
 
 
 def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch):
@@ -941,9 +944,9 @@ def test_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeypatch)
     finally:
         backend.close()
 
-    assert (
-        calls == [palace_path]
-    ), "quarantine_stale_hnsw should fire once per palace per process from _client(), not on every call"
+    assert calls == [palace_path], (
+        "quarantine_stale_hnsw should fire once per palace per process from _client(), not on every call"
+    )
 
 
 # ── _pin_hnsw_threads (per-process retrofit, separate from this PR's gate) ──
@@ -954,7 +957,7 @@ def test_pin_hnsw_threads_retrofits_legacy_collection(tmp_path):
     palace_path = tmp_path / "legacy-palace"
     palace_path.mkdir()
 
-    client = chromadb.PersistentClient(path=str(palace_path))
+    client = chromadb.PersistentClient(path=str(palace_path), settings=CHROMA_SETTINGS)
     col = client.create_collection(
         "mempalace_drawers",
         metadata={"hnsw:space": "cosine"},  # no num_threads — legacy
@@ -982,7 +985,7 @@ def test_get_collection_applies_retrofit_on_existing_palace(tmp_path):
     palace_path.mkdir()
 
     # Simulate a legacy palace: create collection without num_threads
-    bootstrap_client = chromadb.PersistentClient(path=str(palace_path))
+    bootstrap_client = chromadb.PersistentClient(path=str(palace_path), settings=CHROMA_SETTINGS)
     bootstrap_client.create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
     del bootstrap_client  # drop reference so a fresh client reopens cleanly
 
@@ -1018,7 +1021,7 @@ def test_get_collection_raises_collection_not_initialized_on_empty_palace(tmp_pa
     palace_path = tmp_path / "palace"
     palace_path.mkdir()
     # PersistentClient lazily creates chroma.sqlite3 — no collection yet.
-    chromadb.PersistentClient(path=str(palace_path))
+    chromadb.PersistentClient(path=str(palace_path), settings=CHROMA_SETTINGS)
     assert (palace_path / "chroma.sqlite3").is_file()
 
     with pytest.raises(CollectionNotInitializedError) as excinfo:
@@ -1175,7 +1178,8 @@ def test_chroma_backend_preflights_metadata_before_persistent_client(tmp_path, m
         pass
 
     monkeypatch.setattr(
-        "mempalace.backends.chroma.chromadb.PersistentClient", lambda path: DummyClient()
+        "mempalace.backends.chroma.chromadb.PersistentClient",
+        lambda path, **kwargs: DummyClient(),
     )
 
     backend = ChromaBackend()
@@ -1212,7 +1216,8 @@ def test_chroma_backend_stale_quarantine_is_cold_start_only_on_refresh(tmp_path,
         pass
 
     monkeypatch.setattr(
-        "mempalace.backends.chroma.chromadb.PersistentClient", lambda path: DummyClient()
+        "mempalace.backends.chroma.chromadb.PersistentClient",
+        lambda path, **kwargs: DummyClient(),
     )
 
     backend = ChromaBackend()
@@ -1254,7 +1259,8 @@ def test_chroma_backend_requarantines_after_inode_replacement(tmp_path, monkeypa
         pass
 
     monkeypatch.setattr(
-        "mempalace.backends.chroma.chromadb.PersistentClient", lambda path: DummyClient()
+        "mempalace.backends.chroma.chromadb.PersistentClient",
+        lambda path, **kwargs: DummyClient(),
     )
 
     backend = ChromaBackend()

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import chromadb
 
+from mempalace.backends.chroma import CHROMA_SETTINGS
 from mempalace.convo_miner import mine_convos
 from mempalace.palace import file_already_mined
 
@@ -19,7 +20,7 @@ def test_convo_mining():
     palace_path = os.path.join(tmpdir, "palace")
     mine_convos(tmpdir, palace_path, wing="test_convos")
 
-    client = chromadb.PersistentClient(path=palace_path)
+    client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=palace_path)
     col = client.get_collection("mempalace_drawers")
     assert col.count() >= 2
 
@@ -46,7 +47,7 @@ def test_mine_convos_does_not_reprocess_short_files(capsys):
 
         # Verify sentinel was written (resolve path -- macOS /var -> /private/var)
         resolved_file = str(Path(tmpdir).resolve() / "tiny.txt")
-        client = chromadb.PersistentClient(path=palace_path)
+        client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=palace_path)
         col = client.get_collection("mempalace_drawers")
         assert file_already_mined(col, resolved_file)
 
@@ -97,7 +98,7 @@ def test_mine_convos_allows_general_after_exchange(capsys):
 
         assert "Files skipped (already filed): 0" in out
 
-        client = chromadb.PersistentClient(path=palace_path)
+        client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=palace_path)
         col = client.get_collection("mempalace_drawers")
         resolved = str(Path(tmpdir).resolve() / "chat.txt")
         rows = col.get(where={"source_file": resolved}, include=["metadatas"])
@@ -132,7 +133,7 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         mine_convos(tmpdir, palace_path, wing="test")
         capsys.readouterr()
 
-        client = chromadb.PersistentClient(path=palace_path)
+        client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=palace_path)
         col = client.get_collection("mempalace_drawers")
         resolved = str(Path(tmpdir).resolve() / "chat.txt")
         first_pass = col.get(where={"source_file": resolved})
@@ -172,11 +173,11 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         # Second mine — version gate should trigger rebuild
         mine_convos(tmpdir, palace_path, wing="test")
         out = capsys.readouterr().out
-        assert (
-            "Files skipped (already filed): 0" in out
-        ), "stale drawers should force a rebuild, not a skip"
+        assert "Files skipped (already filed): 0" in out, (
+            "stale drawers should force a rebuild, not a skip"
+        )
 
-        client = chromadb.PersistentClient(path=palace_path)
+        client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=palace_path)
         col = client.get_collection("mempalace_drawers")
         rebuilt = col.get(where={"source_file": resolved})
         # Orphan is gone

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -63,12 +63,12 @@ def test_mcp_main_strips_leaked_pythonpath_from_env():
     )
     diag = f"rc={result.returncode}; stdout={result.stdout!r}; stderr={result.stderr!r}"
     assert result.returncode == 0, f"subprocess failed: {diag}"
-    assert (
-        f"ENV_MID: {expected_env!r}" in result.stderr
-    ), f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
-    assert (
-        "SENTINEL_IN_PATH: False" in result.stderr
-    ), f"package import did not filter sys.path (regression in __init__.py): {diag}"
+    assert f"ENV_MID: {expected_env!r}" in result.stderr, (
+        f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
+    )
+    assert "SENTINEL_IN_PATH: False" in result.stderr, (
+        f"package import did not filter sys.path (regression in __init__.py): {diag}"
+    )
     assert "ENV_AFTER: None" in result.stderr, f"MCP server did not strip PYTHONPATH: {diag}"
 
 
@@ -89,8 +89,9 @@ def _get_collection(palace_path, create=False):
     when they are done.
     """
     import chromadb
+    from mempalace.backends.chroma import CHROMA_SETTINGS
 
-    client = chromadb.PersistentClient(path=palace_path)
+    client = chromadb.PersistentClient(path=palace_path, settings=CHROMA_SETTINGS)
     if create:
         return (
             client,
@@ -250,9 +251,9 @@ class TestColdStartDiagnostics:
         )
         assert result.returncode == 0, f"stderr={result.stderr!r}"
         assert not marker.exists(), f"warmup ran for explicit-falsy value {value!r}"
-        assert (
-            "not recognized" not in result.stderr
-        ), f"explicit-falsy {value!r} should not log a warning; stderr={result.stderr!r}"
+        assert "not recognized" not in result.stderr, (
+            f"explicit-falsy {value!r} should not log a warning; stderr={result.stderr!r}"
+        )
 
     @pytest.mark.parametrize("value", ["tru", "maybe", "ENABLED", "2"])
     def test_eager_warmup_unrecognized_value_warns_and_skips_collection_open(self, tmp_path, value):
@@ -298,9 +299,9 @@ class TestColdStartDiagnostics:
             extra_code=extra,
         )
         assert result.returncode == 0, f"stderr={result.stderr!r}"
-        assert (
-            open_marker.exists()
-        ), f"_get_collection not called for {value!r}; stderr={result.stderr!r}"
+        assert open_marker.exists(), (
+            f"_get_collection not called for {value!r}; stderr={result.stderr!r}"
+        )
         assert query_marker.exists(), (
             f"col.query not invoked for {value!r} — warmup is a no-op "
             f"(would let cold-load hit first MCP call); stderr={result.stderr!r}"
@@ -665,10 +666,11 @@ class TestReadTools:
         should return total_drawers: 0, not 'No palace found'.
         """
         import chromadb
+        from mempalace.backends.chroma import CHROMA_SETTINGS
 
         _patch_mcp_server(monkeypatch, config, kg)
         # Create the DB file (init does this) but NOT the collection
-        client = chromadb.PersistentClient(path=palace_path)
+        client = chromadb.PersistentClient(path=palace_path, settings=CHROMA_SETTINGS)
         del client
         from mempalace.mcp_server import tool_status
 
@@ -1134,9 +1136,9 @@ class TestWriteTools:
 
         assert result1["success"] is True
         assert result2["success"] is True
-        assert (
-            result1["drawer_id"] != result2["drawer_id"]
-        ), "Documents with shared header but different content must have distinct drawer IDs"
+        assert result1["drawer_id"] != result2["drawer_id"], (
+            "Documents with shared header but different content must have distinct drawer IDs"
+        )
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
@@ -2121,9 +2123,9 @@ class TestCacheInvalidation:
         all_calls = captured["get"] + captured["create"]
         assert all_calls, "expected get_collection or create_collection to be called"
         for kwargs in all_calls:
-            assert (
-                "embedding_function" in kwargs
-            ), f"missing embedding_function= in chromadb call: {kwargs}"
+            assert "embedding_function" in kwargs, (
+                f"missing embedding_function= in chromadb call: {kwargs}"
+            )
             assert kwargs["embedding_function"] is not None
 
         # Same expectation on the create=False (cache-miss) reopen path.
@@ -2561,9 +2563,9 @@ class TestKGLazyCache:
 
         result = mcp_server._canonicalize_kg_path("/some/Path/KG.sqlite3")
 
-        assert (
-            result == "<NC:<RP:/some/Path/KG.sqlite3>>"
-        ), f"expected normcase(realpath(p)) composition, got {result!r}"
+        assert result == "<NC:<RP:/some/Path/KG.sqlite3>>", (
+            f"expected normcase(realpath(p)) composition, got {result!r}"
+        )
 
     def test_get_kg_dedupes_symlink_alias_end_to_end(self, tmp_path, monkeypatch):
         """End-to-end: two ``_get_kg()`` calls via different symlink layers

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -9,6 +9,7 @@ import chromadb
 import pytest
 import yaml
 
+from mempalace.backends.chroma import CHROMA_SETTINGS
 from mempalace.miner import detect_room, load_config, mine, scan_project, status
 from mempalace.palace import NORMALIZE_VERSION, file_already_mined, prefetch_mined_set
 
@@ -48,7 +49,7 @@ def test_project_mining():
         palace_path = project_root / "palace"
         mine(str(project_root), str(palace_path))
 
-        client = chromadb.PersistentClient(path=str(palace_path))
+        client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=str(palace_path))
         col = client.get_collection("mempalace_drawers")
         assert col.count() > 0
     finally:
@@ -345,7 +346,7 @@ def test_file_already_mined_check_mtime():
     try:
         palace_path = os.path.join(tmpdir, "palace")
         os.makedirs(palace_path)
-        client = chromadb.PersistentClient(path=palace_path)
+        client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=palace_path)
         col = client.get_or_create_collection(
             "mempalace_drawers", metadata={"hnsw:space": "cosine"}
         )
@@ -411,7 +412,7 @@ def test_file_already_mined_scopes_convo_extract_mode():
     try:
         palace_path = os.path.join(tmpdir, "palace")
         os.makedirs(palace_path)
-        client = chromadb.PersistentClient(path=palace_path)
+        client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=palace_path)
         col = client.get_or_create_collection(
             "mempalace_drawers", metadata={"hnsw:space": "cosine"}
         )
@@ -527,7 +528,9 @@ def test_status_initialized_but_empty_palace_reports_empty(tmp_path, capsys):
 
     palace_path = tmp_path / "empty-palace"
     palace_path.mkdir()
-    chromadb.PersistentClient(path=str(palace_path))  # creates chroma.sqlite3
+    chromadb.PersistentClient(
+        settings=CHROMA_SETTINGS, path=str(palace_path)
+    )  # creates chroma.sqlite3
     assert (palace_path / "chroma.sqlite3").is_file()
 
     status(str(palace_path))
@@ -636,7 +639,7 @@ def test_file_already_mined_returns_false_for_stale_normalize_version():
     try:
         palace_path = os.path.join(tmpdir, "palace")
         os.makedirs(palace_path)
-        client = chromadb.PersistentClient(path=palace_path)
+        client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=palace_path)
         col = client.get_or_create_collection("mempalace_drawers")
 
         # Pre-v2 drawer: no normalize_version field at all
@@ -775,7 +778,7 @@ def test_add_drawer_stamps_normalize_version(tmp_path):
 
     palace_path = tmp_path / "palace"
     palace_path.mkdir()
-    client = chromadb.PersistentClient(path=str(palace_path))
+    client = chromadb.PersistentClient(settings=CHROMA_SETTINGS, path=str(palace_path))
     col = client.get_or_create_collection("mempalace_drawers")
     try:
         added = add_drawer(


### PR DESCRIPTION
## Summary

Closes #458

Every ChromaDB operation in mempalace 3.1.0+ floods stderr with posthog telemetry errors:

```
Failed to send telemetry event ClientStartEvent: capture() takes 1 positional argument but 3 were given
```

This PR:
- Adds a shared `CHROMA_SETTINGS = Settings(anonymized_telemetry=False)` constant in `backends/chroma.py`
- Updates all 11 `PersistentClient` construction sites across 6 files to use it
- Updates test helpers to use the same settings (avoids ChromaDB's `SharedSystemClient` singleton conflict)

### Files changed
- `mempalace/backends/chroma.py` — defines the shared constant, uses it
- `mempalace/mcp_server.py` — imports and uses `CHROMA_SETTINGS`
- `mempalace/cli.py` — uses `CHROMA_SETTINGS` in `cmd_repair` and `cmd_compress`
- `mempalace/dedup.py` — uses `CHROMA_SETTINGS` in both client creation sites
- `mempalace/repair.py` — uses `CHROMA_SETTINGS` in all 3 client creation sites
- `mempalace/migrate.py` — uses `CHROMA_SETTINGS` in both client creation sites
- `tests/test_backends.py` — verification client uses `CHROMA_SETTINGS`
- `tests/test_mcp_server.py` — test helper uses `CHROMA_SETTINGS`

## Test plan
- [x] All existing tests pass (`pytest tests/test_backends.py tests/test_mcp_server.py::TestCacheInvalidation tests/test_cli.py` — 53 passed)
- [x] `ruff check` and `ruff format` clean
- [x] Manual: `mempalace mine` / `mempalace status` no longer prints telemetry errors to stderr