### PR TITLE
fix: file-level locking to prevent multi-agent duplicate drawers

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -272,6 +272,47 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
+def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+    """Acquire the per-file lock, double-check mined status, and upsert chunks.
+
+    Returns (drawers_added, room_counts_delta, skipped).
+    """
+    room_counts_delta: dict = defaultdict(int)
+    drawers_added = 0
+    with mine_lock(source_file):
+        # Re-check after lock — another agent may have just finished this file
+        if file_already_mined(collection, source_file):
+            return 0, room_counts_delta, True
+
+        for chunk in chunks:
+            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
+            if extract_mode == "general":
+                room_counts_delta[chunk_room] += 1
+            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+            try:
+                collection.upsert(
+                    documents=[chunk["content"]],
+                    ids=[drawer_id],
+                    metadatas=[
+                        {
+                            "wing": wing,
+                            "room": chunk_room,
+                            "source_file": source_file,
+                            "chunk_index": chunk["chunk_index"],
+                            "added_by": agent,
+                            "filed_at": datetime.now().isoformat(),
+                            "ingest_mode": "convos",
+                            "extract_mode": extract_mode,
+                        }
+                    ],
+                )
+                drawers_added += 1
+            except Exception as e:
+                if "already exists" not in str(e).lower():
+                    raise
+    return drawers_added, room_counts_delta, False
+
+
 def mine_convos(
     convo_dir: str,
     palace_path: str,
@@ -376,39 +417,14 @@ def mine_convos(
             room_counts[room] += 1
 
         # File each chunk — lock to prevent concurrent agents duplicating
-        drawers_added = 0
-        with mine_lock(source_file):
-            # Re-check after lock — another agent may have just finished this file
-            if file_already_mined(collection, source_file):
-                files_skipped += 1
-                continue
-
-            for chunk in chunks:
-                chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-                if extract_mode == "general":
-                    room_counts[chunk_room] += 1
-                drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
-                try:
-                    collection.upsert(
-                        documents=[chunk["content"]],
-                        ids=[drawer_id],
-                        metadatas=[
-                            {
-                                "wing": wing,
-                                "room": chunk_room,
-                                "source_file": source_file,
-                                "chunk_index": chunk["chunk_index"],
-                                "added_by": agent,
-                                "filed_at": datetime.now().isoformat(),
-                                "ingest_mode": "convos",
-                                "extract_mode": extract_mode,
-                            }
-                        ],
-                    )
-                    drawers_added += 1
-                except Exception as e:
-                    if "already exists" not in str(e).lower():
-                        raise
+        drawers_added, room_delta, skipped = _file_chunks_locked(
+            collection, source_file, chunks, wing, room, agent, extract_mode
+        )
+        if skipped:
+            files_skipped += 1
+            continue
+        for r, n in room_delta.items():
+            room_counts[r] += n
 
         total_drawers += drawers_added
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import SKIP_DIRS, get_collection, file_already_mined, mine_lock
 
 
 # File types that might contain conversations
@@ -375,34 +375,40 @@ def mine_convos(
         if extract_mode != "general":
             room_counts[room] += 1
 
-        # File each chunk
+        # File each chunk — lock to prevent concurrent agents duplicating
         drawers_added = 0
-        for chunk in chunks:
-            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-            if extract_mode == "general":
-                room_counts[chunk_room] += 1
-            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
-            try:
-                collection.upsert(
-                    documents=[chunk["content"]],
-                    ids=[drawer_id],
-                    metadatas=[
-                        {
-                            "wing": wing,
-                            "room": chunk_room,
-                            "source_file": source_file,
-                            "chunk_index": chunk["chunk_index"],
-                            "added_by": agent,
-                            "filed_at": datetime.now().isoformat(),
-                            "ingest_mode": "convos",
-                            "extract_mode": extract_mode,
-                        }
-                    ],
-                )
-                drawers_added += 1
-            except Exception as e:
-                if "already exists" not in str(e).lower():
-                    raise
+        with mine_lock(source_file):
+            # Re-check after lock — another agent may have just finished this file
+            if file_already_mined(collection, source_file):
+                files_skipped += 1
+                continue
+
+            for chunk in chunks:
+                chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
+                if extract_mode == "general":
+                    room_counts[chunk_room] += 1
+                drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+                try:
+                    collection.upsert(
+                        documents=[chunk["content"]],
+                        ids=[drawer_id],
+                        metadatas=[
+                            {
+                                "wing": wing,
+                                "room": chunk_room,
+                                "source_file": source_file,
+                                "chunk_index": chunk["chunk_index"],
+                                "added_by": agent,
+                                "filed_at": datetime.now().isoformat(),
+                                "ingest_mode": "convos",
+                                "extract_mode": extract_mode,
+                            }
+                        ],
+                    )
+                    drawers_added += 1
+                except Exception as e:
+                    if "already exists" not in str(e).lower():
+                        raise
 
         total_drawers += drawers_added
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import SKIP_DIRS, get_collection, file_already_mined, mine_lock
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -434,29 +434,37 @@ def process_file(
         print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
         return len(chunks), room
 
-    # Purge stale drawers for this file before re-inserting the fresh chunks.
-    # Converts modified-file re-mines from upsert-over-existing-IDs (which hits
-    # hnswlib's thread-unsafe updatePoint path and can segfault on macOS ARM
-    # with chromadb 0.6.3) into a clean delete+insert, bypassing the update
-    # path entirely.
-    try:
-        collection.delete(where={"source_file": source_file})
-    except Exception:
-        pass
+    # Lock this file so concurrent agents don't interleave delete+insert.
+    # Without the lock, two agents can both pass file_already_mined(),
+    # both delete, and both insert — creating duplicates or losing data.
+    with mine_lock(source_file):
+        # Re-check after acquiring lock — another agent may have just finished
+        if file_already_mined(collection, source_file, check_mtime=True):
+            return 0, room
 
-    drawers_added = 0
-    for chunk in chunks:
-        added = add_drawer(
-            collection=collection,
-            wing=wing,
-            room=room,
-            content=chunk["content"],
-            source_file=source_file,
-            chunk_index=chunk["chunk_index"],
-            agent=agent,
-        )
-        if added:
-            drawers_added += 1
+        # Purge stale drawers for this file before re-inserting the fresh chunks.
+        # Converts modified-file re-mines from upsert-over-existing-IDs (which hits
+        # hnswlib's thread-unsafe updatePoint path and can segfault on macOS ARM
+        # with chromadb 0.6.3) into a clean delete+insert, bypassing the update
+        # path entirely.
+        try:
+            collection.delete(where={"source_file": source_file})
+        except Exception:
+            pass
+
+        drawers_added = 0
+        for chunk in chunks:
+            added = add_drawer(
+                collection=collection,
+                wing=wing,
+                room=room,
+                content=chunk["content"],
+                source_file=source_file,
+                chunk_index=chunk["chunk_index"],
+                agent=agent,
+            )
+            if added:
+                drawers_added += 1
 
     return drawers_added, room
 

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -69,18 +69,22 @@ def mine_lock(source_file: str):
     try:
         if os.name == "nt":
             import msvcrt
+
             msvcrt.locking(lf.fileno(), msvcrt.LK_LOCK, 1)
         else:
             import fcntl
+
             fcntl.flock(lf, fcntl.LOCK_EX)
         yield
     finally:
         try:
             if os.name == "nt":
                 import msvcrt
+
                 msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
             else:
                 import fcntl
+
                 fcntl.flock(lf, fcntl.LOCK_UN)
         except Exception:
             pass

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -4,6 +4,8 @@ palace.py — Shared palace operations.
 Consolidates collection access patterns used by both miners and the MCP server.
 """
 
+import contextlib
+import hashlib
 import os
 
 from .backends.chroma import ChromaBackend
@@ -48,6 +50,41 @@ def get_collection(
         collection_name=collection_name,
         create=create,
     )
+
+
+@contextlib.contextmanager
+def mine_lock(source_file: str):
+    """Cross-platform file lock for mine operations.
+
+    Prevents multiple agents from mining the same file simultaneously,
+    which causes duplicate drawers when the delete+insert cycle interleaves.
+    """
+    lock_dir = os.path.join(os.path.expanduser("~"), ".mempalace", "locks")
+    os.makedirs(lock_dir, exist_ok=True)
+    lock_path = os.path.join(
+        lock_dir, hashlib.sha256(source_file.encode()).hexdigest()[:16] + ".lock"
+    )
+
+    lf = open(lock_path, "w")
+    try:
+        if os.name == "nt":
+            import msvcrt
+            msvcrt.locking(lf.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(lf, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(lf, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        lf.close()
 
 
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:


### PR DESCRIPTION
## Summary

Cherry-picked from Milla's branch — the file-level locking fix, in isolation.

**Authorship**: Milla (MSL) is the sole commit author — cherry-pick preserved the original `Author` header. This PR splits off one focused commit from a larger branch to keep reviews surgical.

## What this changes

- `mempalace/palace.py`: new `mine_lock(source_file)` context manager. Cross-platform (fcntl on Unix, msvcrt on Windows). Lock files at `~/.mempalace/locks/<sha256[:16]>.lock`.
- `mempalace/miner.py` and `mempalace/convo_miner.py`: both miners wrap their delete+insert critical section in `mine_lock`, with a **double-checked** `file_already_mined()` after acquiring the lock.

## Why

Two concurrent Stop-hook miners (e.g., two Claude Code sessions) can both pass `file_already_mined()`, both delete + insert the same source's drawers, wasting CPU/embeddings and potentially interleaving writes. The lock serializes the critical section per source file without blocking different files.

## Validation

Validated by running two concurrent `mempalace mine ... --mode convos` processes against the same source directory (62 Claude Code JSONL files):

| | Agent A | Agent B | Total |
|---|---|---|---|
| Files processed | 37 | 25 | **62** ✓ |
| Files skipped (double-check caught in-lock) | 25 | 37 | **62** ✓ |
| Drawers filed | 3,727 | 1,987 | 5,714 |
| Errors / tracebacks | 0 | 0 | 0 |

Clean partition, zero duplicates, zero `already exists` exceptions.

## Test plan

- [x] `pytest tests/test_miner.py tests/test_convo_miner.py tests/test_convo_miner_unit.py tests/test_palace*.py` — 54/54 pass
- [x] Full suite: 687/688 pass. The one failure (`test_package_version_matches_pyproject`) is a pre-existing develop bug unrelated to this PR (`pyproject.toml` says 3.2.0, `mempalace/version.py` says 3.1.0).
- [x] Concurrent mining stress test against real dataset (above)

## Notes for reviewers

- This is **PR 1 of ~9** splitting Milla's omnibus branch into reviewable chunks targeting v3.3.
- Lock files are never pruned — cosmetic concern, not a correctness issue. Consider a future `mempalace repair --prune-locks` if `~/.mempalace/locks/` grows unwieldy.