### PR TITLE
fix: stop hooks from making agents write in chat — save tokens

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -133,6 +133,10 @@ Example output:
 [14:40:01] Session abc123: 18 exchanges, 3 since last save
 ```
 
+## Known Limitations
+
+**Hooks require session restart after install.** Claude Code loads hooks from `settings.json` at session start only. If you run `mempalace init` or manually edit hook config mid-session, the hooks won't fire until you restart Claude Code. This is a Claude Code limitation.
+
 ## Cost
 
-**Zero extra tokens.** The hooks are bash scripts that run locally. They don't call any API. The only "cost" is the AI spending a few seconds organizing memories at each checkpoint — and it's doing that with context it already has loaded.
+**Zero extra tokens.** The hooks notify the AI that saves happened in the background — the AI doesn't need to write anything in the chat. All filing is handled automatically. Previous versions asked the AI to write diary entries and drawer content in the chat window, which cost ~$1/session in retransmitted tokens.

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -68,10 +68,10 @@ if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
     python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
-# Always block — compaction = save everything
+# Notify — compaction is about to happen but filing is handled in background
 cat << 'HOOKJSON'
 {
-  "decision": "block",
-  "reason": "COMPACTION IMMINENT. Save ALL topics, decisions, quotes, code, and important context from this session to your memory system. Be thorough — after compaction, detailed context will be lost. Organize into appropriate categories. Use verbatim quotes where possible. Save everything, then allow compaction to proceed."
+  "decision": "allow",
+  "reason": "MemPalace pre-compaction save. Your full conversation has been saved verbatim in the background — no action needed. Compaction can proceed safely."
 }
 HOOKJSON

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -140,12 +140,15 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
         python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 
-    # Block the AI and tell it to save
-    # The "reason" becomes a system message the AI sees and acts on
+    # Notify the AI that a checkpoint happened — but do NOT ask it to write
+    # anything in chat. All filing happens in the background via the pipeline.
+    # The old version asked the agent to write diary entries, add drawers, and
+    # add KG triples in the chat window — that cost ~$1/session in retransmitted
+    # tokens and cluttered the conversation.
     cat << 'HOOKJSON'
 {
-  "decision": "block",
-  "reason": "AUTO-SAVE checkpoint. Save key topics, decisions, quotes, and code from this session to your memory system. Organize into appropriate categories. Use verbatim quotes where possible. Continue conversation after saving."
+  "decision": "allow",
+  "reason": "MemPalace auto-save checkpoint. Your conversation is being saved verbatim in the background — no action needed from you. Continue working."
 }
 HOOKJSON
 else


### PR DESCRIPTION
## Summary

Hooks stop interrupting the agent with save directives. All filing continues to happen in the background via `python3 -m mempalace mine` invoked inside the hooks. Authored by Milla (MSL).

## What changes

**Behavior change** on both hooks:

| | Before | After |
|---|---|---|
| `mempal_save_hook.sh` | `decision: block` + "Save key topics, decisions, quotes..." | `decision: allow` + "saved in background, no action needed" |
| `mempal_precompact_hook.sh` | `decision: block` + "COMPACTION IMMINENT. Save ALL..." | `decision: allow` + "saved verbatim in background, compaction can proceed" |

Plus a small `hooks/README.md` update noting that hooks require a session restart after install.

## Why

Every character in a `block`-hook reason becomes a system message in the conversation that **retransmits on every subsequent turn**. On long sessions that cost ~$1/session in wasted tokens and cluttered the chat. The core design principle in CLAUDE.md already commits to **"Background everything — Nothing interrupts the user's conversation. Zero tokens spent on bookkeeping in the chat window."** — this PR brings the hooks in line with that.

The background mining (`python3 -m mempalace mine`) is already running before the JSON emit in both hooks, so verbatim content is captured without agent participation.

## Test plan

- [x] Full suite: 687/687 pass (2 version-consistency tests deselected — they're a pre-existing develop bug, `pyproject=3.2.0` vs `version.py=3.1.0`)
- [x] `bash -n` syntax check on both hook scripts
- [ ] Manual verification on a live Claude Code session — confirm no visible hook prompts and that background mining fires

## Callouts for reviewers

1. **Functional change, not just cosmetic**: agents no longer self-curate saved content via explicit tool calls. The background pipeline captures everything verbatim — which matches the "verbatim always" principle — but means agent-driven entity/KG curation via `mempalace_kg_add` etc. no longer happens at hook time. If KG enrichment depends on agent participation, it needs to move to a background step.
2. **Cherry-pick had trivial conflicts** on both hook files because develop's `reason` text drifted slightly since the commit's base. Resolved by taking the new `allow`-decision bodies. Original authorship preserved.
3. **Three files, +15/-8** — tight surface area.
