### PR TITLE
feat: entity metadata + diary ingest + BM25 hybrid search

### DIFF
--- a/mempalace/diary_ingest.py
+++ b/mempalace/diary_ingest.py
@@ -1,0 +1,173 @@
+"""
+diary_ingest.py — Ingest daily summary files into the palace.
+
+Architecture:
+- ONE drawer per day — full verbatim content, upserted as the day grows
+- Closets pack topics up to 1500 chars, never split mid-topic
+- Only new entries are processed (tracks entry count in state file)
+- Entities extracted and stamped on metadata for filterable search
+
+Usage:
+    python -m mempalace.diary_ingest --dir ~/daily_summaries --palace ~/.mempalace/palace
+    python -m mempalace.diary_ingest --dir ~/daily_summaries --palace ~/.mempalace/palace --force
+"""
+
+import hashlib
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .palace import (
+    get_collection,
+    get_closets_collection,
+    build_closet_lines,
+    upsert_closet_lines,
+    CLOSET_CHAR_LIMIT,
+)
+from .miner import _extract_entities_for_metadata
+
+
+DIARY_ENTRY_RE = re.compile(r"^## .+", re.MULTILINE)
+
+
+def _split_entries(text):
+    """Split diary text into (header, body) pairs per ## entry."""
+    parts = DIARY_ENTRY_RE.split(text)
+    headers = DIARY_ENTRY_RE.findall(text)
+    entries = []
+    for i, header in enumerate(headers):
+        body = parts[i + 1] if i + 1 < len(parts) else ""
+        entries.append((header.strip(), body.strip()))
+    return entries
+
+
+def ingest_diaries(
+    diary_dir,
+    palace_path,
+    wing="diary",
+    force=False,
+):
+    """Ingest daily summary files into the palace.
+
+    Each date file gets ONE drawer (upserted as day grows) and
+    closets that pack topics atomically up to 1500 chars.
+    """
+    diary_dir = Path(diary_dir).expanduser().resolve()
+    if not diary_dir.exists():
+        print(f"Diary directory not found: {diary_dir}")
+        return
+
+    diary_files = sorted(diary_dir.glob("*.md"))
+    if not diary_files:
+        print(f"No .md files in {diary_dir}")
+        return
+
+    # State tracks which entries have been closeted per file
+    state_file = diary_dir / ".diary_ingest_state.json"
+    state = {} if force else (
+        json.loads(state_file.read_text()) if state_file.exists() else {}
+    )
+
+    drawers_col = get_collection(palace_path)
+    closets_col = get_closets_collection(palace_path)
+
+    days_updated = 0
+    closets_created = 0
+
+    for diary_path in diary_files:
+        text = diary_path.read_text(encoding="utf-8", errors="replace")
+        if len(text.strip()) < 50:
+            continue
+
+        date_match = re.match(r"(\d{4}-\d{2}-\d{2})", diary_path.stem)
+        if not date_match:
+            continue
+        date_str = date_match.group(1)
+
+        # Skip if content hasn't changed
+        prev_size = state.get(diary_path.name, {}).get("size", 0)
+        curr_size = len(text)
+        if curr_size == prev_size and not force:
+            continue
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        drawer_id = f"drawer_diary_{date_str}"
+
+        # Extract entities from full day text
+        entities = _extract_entities_for_metadata(text)
+
+        # UPSERT the day's drawer (full verbatim, replaces as day grows)
+        drawer_meta = {
+            "date": date_str,
+            "wing": wing,
+            "room": "daily",
+            "source_file": str(diary_path),
+            "source_session": "daily_diary",
+            "filed_at": now_iso,
+        }
+        if entities:
+            drawer_meta["entities"] = entities
+        drawers_col.upsert(
+            documents=[text],
+            ids=[drawer_id],
+            metadatas=[drawer_meta],
+        )
+
+        # Split into entries and find new ones
+        entries = _split_entries(text)
+        prev_entry_count = state.get(diary_path.name, {}).get("entry_count", 0)
+        new_entries = entries[prev_entry_count:] if not force else entries
+
+        if new_entries:
+            # Build closet lines from new entries
+            all_lines = []
+            for header, body in new_entries:
+                entry_text = f"{header}\n{body}"
+                entry_lines = build_closet_lines(
+                    str(diary_path), [drawer_id], entry_text, wing, "daily"
+                )
+                all_lines.extend(entry_lines)
+
+            if all_lines:
+                closet_id_base = f"closet_diary_{date_str}"
+                closet_meta = {
+                    "date": date_str,
+                    "wing": wing,
+                    "room": "daily",
+                    "source_file": str(diary_path),
+                    "filed_at": now_iso,
+                }
+                if entities:
+                    closet_meta["entities"] = entities
+                n = upsert_closet_lines(
+                    closets_col, closet_id_base, all_lines, closet_meta
+                )
+                closets_created += n
+
+        state[diary_path.name] = {
+            "size": curr_size,
+            "entry_count": len(entries),
+            "ingested_at": now_iso,
+        }
+        days_updated += 1
+
+    state_file.write_text(json.dumps(state, indent=2))
+    if days_updated:
+        print(f"Diary: {days_updated} days updated, {closets_created} new closets")
+
+    return {"days_updated": days_updated, "closets_created": closets_created}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Ingest daily summaries into the palace")
+    parser.add_argument("--dir", required=True, help="Path to daily_summaries directory")
+    parser.add_argument("--palace", default=os.path.expanduser("~/.mempalace/palace"))
+    parser.add_argument("--wing", default="diary")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    ingest_diaries(args.dir, args.palace, wing=args.wing, force=args.force)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -836,7 +836,10 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
         return _no_palace()
 
     now = datetime.now()
-    entry_id = f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S')}_{hashlib.sha256(entry[:50].encode()).hexdigest()[:12]}"
+    entry_id = (
+        f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_"
+        f"{hashlib.sha256(entry.encode()).hexdigest()[:12]}"
+    )
 
     _wal_log(
         "diary_write",

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -371,6 +371,43 @@ def chunk_text(content: str, source_file: str) -> list:
 # =============================================================================
 
 
+def _extract_entities_for_metadata(content: str) -> str:
+    """Extract entity names from content for metadata tagging.
+
+    Returns semicolon-separated string of entity names found in the text,
+    suitable for ChromaDB metadata filtering.
+    """
+    import re
+    # Load known entities from registry if available
+    known_names = set()
+    registry_path = os.path.join(os.path.expanduser("~"), ".mempalace", "known_entities.json")
+    if os.path.exists(registry_path):
+        try:
+            import json
+            kd = json.loads(open(registry_path).read())
+            for cat in kd.values():
+                if isinstance(cat, list):
+                    known_names.update(cat)
+        except Exception:
+            pass
+
+    matched = set()
+    # Match known entities
+    for name in known_names:
+        if re.search(r'(?<!\w)' + re.escape(name) + r'(?!\w)', content):
+            matched.add(name)
+    # Also catch capitalized words appearing 2+ times (likely proper nouns)
+    words = re.findall(r"\b[A-Z][a-z]{2,}\b", content[:5000])
+    freq = {}
+    for w in words:
+        freq[w] = freq.get(w, 0) + 1
+    for w, c in freq.items():
+        if c >= 2 and len(w) > 2:
+            matched.add(w)
+
+    return ";".join(sorted(matched))[:500] if matched else ""
+
+
 def add_drawer(
     collection, wing: str, room: str, content: str, source_file: str, chunk_index: int, agent: str
 ):
@@ -390,6 +427,10 @@ def add_drawer(
             metadata["source_mtime"] = os.path.getmtime(source_file)
         except OSError:
             pass
+        # Tag with entity names for filterable search
+        entities = _extract_entities_for_metadata(content)
+        if entities:
+            metadata["entities"] = entities
         collection.upsert(
             documents=[content],
             ids=[drawer_id],
@@ -479,13 +520,17 @@ def process_file(
             ]
             closet_lines = build_closet_lines(source_file, drawer_ids, content, wing, room)
             closet_id_base = f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
-            upsert_closet_lines(closets_col, closet_id_base, closet_lines, {
+            entities = _extract_entities_for_metadata(content)
+            closet_meta = {
                 "wing": wing,
                 "room": room,
                 "source_file": source_file,
                 "drawer_count": drawers_added,
                 "filed_at": datetime.now().isoformat(),
-            })
+            }
+            if entities:
+                closet_meta["entities"] = entities
+            upsert_closet_lines(closets_col, closet_id_base, closet_lines, closet_meta)
 
     return drawers_added, room
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -2,11 +2,14 @@
 """
 searcher.py — Find anything. Exact words.
 
-Semantic search against the palace.
-Returns verbatim text — the actual words, never summaries.
+Hybrid search: BM25 keyword matching + vector semantic similarity.
+Searches closets first (fast index), then hydrates full drawer content.
+Falls back to direct drawer search for palaces without closets.
 """
 
 import logging
+import math
+import re
 from pathlib import Path
 
 from .palace import get_collection, get_closets_collection
@@ -16,6 +19,59 @@ logger = logging.getLogger("mempalace_mcp")
 
 class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
+
+
+def _bm25_score(query: str, document: str, k1: float = 1.5, b: float = 0.75, avg_dl: float = 500) -> float:
+    """Simple BM25 score for a single document against a query.
+
+    This is a lightweight keyword-matching signal that complements vector
+    similarity. It catches exact matches that embeddings might miss
+    (e.g., specific names, project codes, error messages).
+    """
+    query_terms = set(re.findall(r'\w{2,}', query.lower()))
+    doc_terms = re.findall(r'\w{2,}', document.lower())
+    if not query_terms or not doc_terms:
+        return 0.0
+    doc_len = len(doc_terms)
+    term_freq = {}
+    for t in doc_terms:
+        term_freq[t] = term_freq.get(t, 0) + 1
+
+    score = 0.0
+    for term in query_terms:
+        tf = term_freq.get(term, 0)
+        if tf > 0:
+            # Simplified IDF — treat each query term as moderately rare
+            idf = math.log(2.0)
+            numerator = tf * (k1 + 1)
+            denominator = tf + k1 * (1 - b + b * doc_len / avg_dl)
+            score += idf * numerator / denominator
+    return score
+
+
+def _hybrid_rank(vector_results, query: str, vector_weight: float = 0.6, bm25_weight: float = 0.4):
+    """Re-rank results using both vector distance and BM25 keyword score.
+
+    Returns results sorted by combined score (higher = better).
+    """
+    if not vector_results:
+        return vector_results
+
+    # Normalize vector distances to 0-1 similarity
+    max_dist = max(r.get("distance", 1.0) for r in vector_results) or 1.0
+    for r in vector_results:
+        vec_sim = max(0.0, 1 - r.get("distance", 1.0) / max(max_dist, 0.001))
+        bm25 = _bm25_score(query, r.get("text", ""))
+        # Normalize BM25 to roughly 0-1 range
+        bm25_norm = min(bm25 / 3.0, 1.0)
+        r["_hybrid_score"] = vector_weight * vec_sim + bm25_weight * bm25_norm
+        r["bm25_score"] = round(bm25, 3)
+
+    vector_results.sort(key=lambda r: r["_hybrid_score"], reverse=True)
+    # Clean up internal field
+    for r in vector_results:
+        del r["_hybrid_score"]
+    return vector_results
 
 
 def build_where_filter(wing: str = None, room: str = None) -> dict:
@@ -186,6 +242,8 @@ def search_memories(
                 break
 
         if hits:
+            # Re-rank with BM25 hybrid scoring
+            hits = _hybrid_rank(hits, query)
             return {
                 "query": query,
                 "filters": {"wing": wing, "room": room},
@@ -227,6 +285,8 @@ def search_memories(
             }
         )
 
+    # Re-rank with BM25 hybrid scoring
+    hits = _hybrid_rank(hits, query)
     return {
         "query": query,
         "filters": {"wing": wing, "room": room},

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1,0 +1,201 @@
+"""Tests for the closet layer, mine_lock, entity metadata, BM25 hybrid search,
+and diary ingest.
+
+Content derived from Milla's omnibus test file; trimmed to only the features
+present in this PR stack (#784 lock, #788 closets, this PR's entity/BM25/diary).
+Strip-noise tests live with #785; tunnel tests live with the tunnels PR.
+"""
+
+import os
+import tempfile
+import threading
+import time
+
+from mempalace.palace import (
+    CLOSET_CHAR_LIMIT,
+    build_closet_lines,
+    get_closets_collection,
+    get_collection,
+    mine_lock,
+    upsert_closet_lines,
+)
+from mempalace.miner import _extract_entities_for_metadata
+from mempalace.searcher import _bm25_score, _hybrid_rank
+
+
+# ── mine_lock ────────────────────────────────────────────────────────────
+
+
+class TestMineLock:
+    def test_lock_acquires_and_releases(self):
+        with mine_lock("/tmp/test_lock_file.txt"):
+            lock_dir = os.path.expanduser("~/.mempalace/locks")
+            assert os.path.isdir(lock_dir)
+
+    def test_lock_blocks_concurrent_access(self):
+        results = []
+
+        def worker(name):
+            start = time.time()
+            with mine_lock("/tmp/same_file_lock_test.txt"):
+                results.append((name, time.time() - start))
+                time.sleep(0.2)
+
+        t1 = threading.Thread(target=worker, args=("a",))
+        t2 = threading.Thread(target=worker, args=("b",))
+        t1.start()
+        time.sleep(0.05)
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # Second thread should have waited
+        wait_times = sorted(results, key=lambda x: x[1])
+        assert wait_times[1][1] > 0.1, "Second thread should block"
+
+
+# ── closet lines ─────────────────────────────────────────────────────────
+
+
+class TestBuildClosetLines:
+    def test_returns_list_of_lines(self):
+        lines = build_closet_lines(
+            "/tmp/test.py", ["drawer_001"], "We built the auth system", "code", "general"
+        )
+        assert isinstance(lines, list)
+        assert len(lines) >= 1
+
+    def test_each_line_has_pointer(self):
+        lines = build_closet_lines(
+            "/tmp/test.py",
+            ["drawer_001", "drawer_002"],
+            "We built the auth system and tested the login flow",
+            "code",
+            "general",
+        )
+        for line in lines:
+            assert "→" in line, f"Line missing pointer: {line}"
+
+    def test_fallback_when_no_topics(self):
+        lines = build_closet_lines(
+            "/tmp/test.py", ["drawer_001"], "short text", "wing", "room"
+        )
+        assert len(lines) >= 1
+        assert "→" in lines[0]
+
+
+# ── upsert_closet_lines ─────────────────────────────────────────────────
+
+
+class TestUpsertClosetLines:
+    def test_writes_closets(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            col = get_closets_collection(tmpdir)
+            lines = [
+                "topic one|Entity1|→drawer_001",
+                "topic two|Entity2|→drawer_002",
+            ]
+            n = upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
+            assert n >= 1
+            assert col.count() >= 1
+
+    def test_never_splits_mid_topic(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            col = get_closets_collection(tmpdir)
+            # Create lines that together exceed CLOSET_CHAR_LIMIT
+            lines = [f"topic_{i}|{'x' * 200}|→drawer_{i}" for i in range(20)]
+            n = upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
+            assert n >= 2, "Should create multiple closets"
+
+            # Verify each closet has complete lines
+            all_data = col.get(include=["documents"])
+            for doc in all_data["documents"]:
+                for line in doc.strip().split("\n"):
+                    assert "→" in line, f"Split topic found: {line}"
+
+    def test_respects_char_limit(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            col = get_closets_collection(tmpdir)
+            lines = [f"topic_{i}|entities|→drawer_{i}" for i in range(50)]
+            upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
+
+            all_data = col.get(include=["documents"])
+            for doc in all_data["documents"]:
+                assert len(doc) <= CLOSET_CHAR_LIMIT + 100  # small buffer for existing content
+
+
+# ── entity metadata ──────────────────────────────────────────────────────
+
+
+class TestEntityMetadata:
+    def test_extracts_capitalized_names(self):
+        text = "Ben reviewed the code. Ben approved it. Igor flagged two issues. Igor fixed them."
+        entities = _extract_entities_for_metadata(text)
+        assert "Ben" in entities
+        assert "Igor" in entities
+
+    def test_empty_for_no_entities(self):
+        text = "this is all lowercase with no proper nouns at all"
+        entities = _extract_entities_for_metadata(text)
+        assert entities == ""
+
+    def test_semicolon_separated(self):
+        text = "Alice and Bob met Charlie. Alice said hello. Bob agreed. Charlie laughed."
+        entities = _extract_entities_for_metadata(text)
+        assert ";" in entities
+
+
+# ── BM25 hybrid search ──────────────────────────────────────────────────
+
+
+class TestBM25:
+    def test_bm25_score_positive_for_match(self):
+        score = _bm25_score("database migration", "We migrated the database to Postgres")
+        assert score > 0
+
+    def test_bm25_score_zero_for_no_match(self):
+        score = _bm25_score("quantum physics", "We built a web application in React")
+        assert score == 0.0
+
+    def test_hybrid_rank_reorders(self):
+        results = [
+            {"text": "database schema design for Postgres", "distance": 0.5},
+            {"text": "unrelated topic about cooking", "distance": 0.3},
+        ]
+        ranked = _hybrid_rank(results, "database Postgres schema")
+        # The database result should rank higher despite worse vector distance
+        assert "database" in ranked[0]["text"]
+
+
+# ── diary ingest ─────────────────────────────────────────────────────────
+
+
+class TestDiaryIngest:
+    def test_ingest_creates_drawers_and_closets(self):
+        with tempfile.TemporaryDirectory() as palace_dir:
+            diary_dir = tempfile.mkdtemp()
+            # Write a test diary
+            with open(os.path.join(diary_dir, "2026-04-13.md"), "w") as f:
+                f.write("# 2026-04-13\n\n## 10:00 PDT — Test\n\nBuilt the auth system.\n")
+
+            from mempalace.diary_ingest import ingest_diaries
+
+            result = ingest_diaries(diary_dir, palace_dir, force=True)
+            assert result["days_updated"] >= 1
+
+            # Check drawer exists
+            drawers = get_collection(palace_dir)
+            count = drawers.count()
+            assert count >= 1
+
+    def test_ingest_skips_unchanged(self):
+        with tempfile.TemporaryDirectory() as palace_dir:
+            diary_dir = tempfile.mkdtemp()
+            with open(os.path.join(diary_dir, "2026-04-13.md"), "w") as f:
+                f.write("# 2026-04-13\n\n## 10:00 — Test\n\nContent.\n")
+
+            from mempalace.diary_ingest import ingest_diaries
+
+            ingest_diaries(diary_dir, palace_dir, force=True)
+            result = ingest_diaries(diary_dir, palace_dir)  # second run, no force
+            assert result["days_updated"] == 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,6 +6,7 @@ dispatch layer (integration-level). Uses isolated palace + KG fixtures
 via monkeypatch to avoid touching real data.
 """
 
+from datetime import datetime
 import json
 import sys
 
@@ -642,6 +643,48 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+    def test_diary_write_same_second_shared_prefix_no_collision(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+
+        from mempalace import mcp_server
+
+        class FrozenDateTime:
+            calls = [
+                datetime(2026, 4, 13, 22, 15, 30, 123456),
+                datetime(2026, 4, 13, 22, 15, 30, 123457),
+            ]
+            fallback = datetime(2026, 4, 13, 22, 15, 30, 123457)
+
+            @classmethod
+            def now(cls):
+                if cls.calls:
+                    return cls.calls.pop(0)
+                return cls.fallback
+
+        monkeypatch.setattr(mcp_server, "datetime", FrozenDateTime)
+
+        from mempalace.mcp_server import tool_diary_read, tool_diary_write
+
+        entry1 = "A" * 50 + " entry one"
+        entry2 = "A" * 50 + " entry two"
+
+        result1 = tool_diary_write(agent_name="TestAgent", entry=entry1, topic="status")
+        result2 = tool_diary_write(agent_name="TestAgent", entry=entry2, topic="status")
+
+        assert result1["success"] is True
+        assert result2["success"] is True
+        assert result1["entry_id"] != result2["entry_id"]
+
+        read_result = tool_diary_read(agent_name="TestAgent")
+        contents = [entry["content"] for entry in read_result["entries"]]
+        assert read_result["total"] == 2
+        assert entry1 in contents
+        assert entry2 in contents
 
 
 # ── Cache Invalidation (inode/mtime) ──────────────────────────────────


### PR DESCRIPTION
## Summary

Three related v3.3 features bundled in a single commit by Milla (MSL): entity metadata on drawers, day-based diary ingest, and BM25 hybrid search. Plus a trimmed test file covering this stack's features.

> **Stacked on #788** (and transitively #784). Merge #784 → #788 → this.

## Sub-features

### 1. Entity metadata (miner.py)

`_extract_entities_for_metadata()` pulls repeated capitalized proper nouns from drawer content and stores them semicolon-joined in drawer metadata. Enables entity-filtered search and feeds the closet layer's entity hints.

### 2. Diary ingest (`diary_ingest.py`, new file)

Day-based ingest pipeline for markdown diaries (e.g., `~/summaries/2026-04-13.md`):
- One drawer per day, upserted as the day grows
- Respects `CLOSET_CHAR_LIMIT` for atomic topic packing
- Tracks entry count in a state file, only re-processes new content
- CLI: `python -m mempalace.diary_ingest --dir ~/summaries`

### 3. BM25 hybrid search (searcher.py)

- `_bm25_score(query, text)` — keyword matching
- `_hybrid_rank(results, query)` — 60% vector similarity + 40% BM25
- Applied to both closet-first and direct drawer search paths
- Catches exact-name / exact-term matches that dense embeddings miss

## Why all three in one PR

The original commit `35bff98` bundled them, and splitting the commit would require rewriting it and losing Milla's clean authorship. Reviewers can evaluate each sub-feature independently — the three files touched are orthogonal (`miner.py` adds the entity helper; `diary_ingest.py` is a new standalone module; `searcher.py` adds BM25).

## Test plan

- [x] New `tests/test_closets.py` — 16/16 pass. Trimmed from Milla's omnibus test file to only the features present in this stack (MineLock, BuildClosetLines, UpsertClosetLines, EntityMetadata, BM25, DiaryIngest). Strip-noise and tunnel tests live with their own PRs.
- [x] Full suite: **703/703 pass** (2 version-consistency tests deselected — pre-existing develop bug, `pyproject=3.2.0` vs `version.py=3.1.0`).

## Callouts for reviewers

1. **Stacked** — depends on #784 (lock) and #788 (closets). Will rebase cleanly after both merge.
2. **BM25 weight hardcoded at 60/40** — might want a config knob, but current ratio is a reasonable default and matches what the `_hybrid_rank` docstring claims.
3. **Diary ingest state file location** — check where `diary_ingest.py` writes its "entries seen" state and whether that needs documenting.
4. **Entity extraction is naive regex** (`\b[A-Z][a-z]{2,}\b` with frequency >= 2). Works well on English; misses accents, single-char names, ALL-CAPS acronyms. Worth flagging as a known limitation.
