### PR TITLE
feat: optional LLM-based closet regeneration — bring-your-own endpoint

### DIFF
--- a/docs/CLOSETS.md
+++ b/docs/CLOSETS.md
@@ -32,13 +32,11 @@ Topics are never split across closets. If adding a topic would exceed 1,500 char
 
 ### When do closets update?
 
-When a file is re-mined (content changed), its drawers are replaced and new closets are built from the fresh content. The old closet content is replaced via upsert.
+When a file is re-mined (content changed, or `NORMALIZE_VERSION` was bumped), the miner first deletes every closet for that source file (`purge_file_closets`) and then writes a fresh set. Stale topics from the prior mine are gone — closets are always a snapshot of the current content, never an accumulation across runs.
 
 ### What about stale topics?
 
-If a file's content changes and a topic no longer exists, the closet is rebuilt entirely from the new content — stale topics are gone. Closets are tied to source files, not to individual topics.
-
-If you add content to an existing file (e.g., a daily diary growing throughout the day), new topics are appended to the existing closet until the 1,500-char limit, then a new closet is created.
+There are no stale topics: each re-mine is a clean rebuild for that source file. If a file gets larger and produces fewer or more closets than last time, the leftover numbered closets from the larger run are still purged because the delete is done by `source_file`, not by ID.
 
 ### Do closets survive palace rebuilds?
 
@@ -49,31 +47,42 @@ Closets are stored in the `mempalace_closets` ChromaDB collection alongside `mem
 ```
 Query → search mempalace_closets (fast, small documents)
          ↓
-    top closet hits → extract drawer IDs from pointer lines
+    top closet hits → parse `→drawer_id_a,drawer_id_b` pointers
          ↓
-    fetch drawers from mempalace_drawers (full verbatim content)
+    fetch exactly those drawers from mempalace_drawers (verbatim content)
          ↓
-    BM25 hybrid re-rank (keyword match + vector similarity)
+    apply max_distance filter
          ↓
-    return results to user
+    return chunk-level results (same shape as direct search)
 ```
 
-If no closets exist (palace created before this feature), search falls back to direct drawer search. Closets are created on next mine.
+Hits carry `matched_via: "closet"` (or `"drawer"` for the fallback path) plus a `closet_preview` field showing the line that surfaced them.
+
+If no closets exist (palace created before this feature) — or all closet hits get filtered out by `max_distance` — search falls back to direct drawer search. Closets are created on next mine.
+
+> **BM25 hybrid re-rank** is on the roadmap (deferred to a follow-up PR alongside generic `LLM_*` env-var support); the current closet search ranks purely by ChromaDB cosine distance against the closet text.
 
 ## Limits
 
 | Setting | Value | Reason |
 |---------|-------|--------|
-| Max closet size | 1,500 chars | Leaves buffer under ChromaDB's working limit |
+| Max closet size | 1,500 chars (`CLOSET_CHAR_LIMIT`) | Leaves buffer under ChromaDB's working limit |
+| Source content scanned | 5,000 chars (`CLOSET_EXTRACT_WINDOW`) | Caps regex extraction cost on long files; back-of-file content is currently invisible to closet extraction (tracked for follow-up) |
 | Max topics per file | 12 | Keeps closets focused |
 | Max quotes per file | 3 | Most relevant only |
-| Max entities per pointer | 5 | Top names by frequency |
-| Max response chars | 10,000 | Prevents hydration blowup on large files |
+| Max entities per pointer | 5 | Top names by frequency, after stoplist filtering |
 
 ## For developers
 
 Closet functions live in `mempalace/palace.py`:
 - `get_closets_collection()` — get the closets ChromaDB collection
 - `build_closet_lines()` — extract topics/entities/quotes into pointer lines
-- `upsert_closet_lines()` — write lines to closets respecting the char limit
-- `CLOSET_CHAR_LIMIT` — the 1,500 char limit constant
+- `upsert_closet_lines()` — write lines to closets respecting the char limit (overwrites existing IDs; does not append — call `purge_file_closets` first when re-mining)
+- `purge_file_closets()` — delete every closet for a given source file before rebuild
+- `CLOSET_CHAR_LIMIT` / `CLOSET_EXTRACT_WINDOW` — size constants
+
+The closet-first search path lives in `mempalace/searcher.py`:
+- `_extract_drawer_ids_from_closet()` — parse `→drawer_a,drawer_b` pointers out of a closet document
+- `_closet_first_hits()` — query closets, parse pointers, hydrate matching drawers, return chunk-level hits or `None` to fall back
+
+Note: only the project miner (`miner.py::process_file`) builds closets today. Conversation-mined wings (Claude Code JSONL, ChatGPT export, etc.) will keep using direct drawer search via the searcher fallback until the convo-closet PR lands.

--- a/docs/CLOSETS.md
+++ b/docs/CLOSETS.md
@@ -1,0 +1,88 @@
+# Closets — The Searchable Index Layer
+
+## What closets are
+
+Drawers hold your verbatim content. Closets are the index — compact pointers that tell the searcher which drawers to open.
+
+```
+CLOSET: "built auth system|Ben;Igor|→drawer_api_auth_a1b2c3"
+         ↑ topic           ↑ entities  ↑ points to this drawer
+```
+
+An agent searching "who built the auth?" hits the closet first (fast scan of short text), then opens the referenced drawer to get the full verbatim content.
+
+## Lifecycle
+
+### When are closets created?
+
+Closets are created during `mempalace mine`. For each file mined:
+1. Content is chunked into drawers (verbatim, ~800 chars each)
+2. Topics, entities, and quotes are extracted from the content
+3. A closet is created with pointer lines to those drawers
+
+### What's inside a closet?
+
+Each line is one atomic topic pointer:
+```
+topic description|entity1;entity2|→drawer_id_1,drawer_id_2
+"verbatim quote from the content"|entity1|→drawer_id_3
+```
+
+Topics are never split across closets. If adding a topic would exceed 1,500 characters, a new closet is created.
+
+### When do closets update?
+
+When a file is re-mined (content changed, or `NORMALIZE_VERSION` was bumped), the miner first deletes every closet for that source file (`purge_file_closets`) and then writes a fresh set. Stale topics from the prior mine are gone — closets are always a snapshot of the current content, never an accumulation across runs.
+
+### What about stale topics?
+
+There are no stale topics: each re-mine is a clean rebuild for that source file. If a file gets larger and produces fewer or more closets than last time, the leftover numbered closets from the larger run are still purged because the delete is done by `source_file`, not by ID.
+
+### Do closets survive palace rebuilds?
+
+Closets are stored in the `mempalace_closets` ChromaDB collection alongside `mempalace_drawers`. If you delete and rebuild the palace, closets are recreated during the next `mempalace mine`.
+
+## How search uses closets
+
+```
+Query → search mempalace_closets (fast, small documents)
+         ↓
+    top closet hits → parse `→drawer_id_a,drawer_id_b` pointers
+         ↓
+    fetch exactly those drawers from mempalace_drawers (verbatim content)
+         ↓
+    apply max_distance filter
+         ↓
+    return chunk-level results (same shape as direct search)
+```
+
+Hits carry `matched_via: "closet"` (or `"drawer"` for the fallback path) plus a `closet_preview` field showing the line that surfaced them.
+
+If no closets exist (palace created before this feature) — or all closet hits get filtered out by `max_distance` — search falls back to direct drawer search. Closets are created on next mine.
+
+> **BM25 hybrid re-rank** is on the roadmap (deferred to a follow-up PR alongside generic `LLM_*` env-var support); the current closet search ranks purely by ChromaDB cosine distance against the closet text.
+
+## Limits
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| Max closet size | 1,500 chars (`CLOSET_CHAR_LIMIT`) | Leaves buffer under ChromaDB's working limit |
+| Source content scanned | 5,000 chars (`CLOSET_EXTRACT_WINDOW`) | Caps regex extraction cost on long files; back-of-file content is currently invisible to closet extraction (tracked for follow-up) |
+| Max topics per file | 12 | Keeps closets focused |
+| Max quotes per file | 3 | Most relevant only |
+| Max entities per pointer | 5 | Top names by frequency, after stoplist filtering |
+
+## For developers
+
+Closet functions live in `mempalace/palace.py`:
+- `get_closets_collection()` — get the closets ChromaDB collection
+- `build_closet_lines()` — extract topics/entities/quotes into pointer lines
+- `upsert_closet_lines()` — write lines to closets respecting the char limit (overwrites existing IDs; does not append — call `purge_file_closets` first when re-mining)
+- `purge_file_closets()` — delete every closet for a given source file before rebuild
+- `CLOSET_CHAR_LIMIT` / `CLOSET_EXTRACT_WINDOW` — size constants
+
+The closet-first search path lives in `mempalace/searcher.py`:
+- `_extract_drawer_ids_from_closet()` — parse `→drawer_a,drawer_b` pointers out of a closet document
+- `_closet_first_hits()` — query closets, parse pointers, hydrate matching drawers, return chunk-level hits or `None` to fall back
+
+Note: only the project miner (`miner.py::process_file`) builds closets today. Conversation-mined wings (Claude Code JSONL, ChatGPT export, etc.) will keep using direct drawer search via the searcher fallback until the convo-closet PR lands.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -133,6 +133,10 @@ Example output:
 [14:40:01] Session abc123: 18 exchanges, 3 since last save
 ```
 
+## Known Limitations
+
+**Hooks require session restart after install.** Claude Code loads hooks from `settings.json` at session start only. If you run `mempalace init` or manually edit hook config mid-session, the hooks won't fire until you restart Claude Code. This is a Claude Code limitation.
+
 ## Cost
 
-**Zero extra tokens.** The hooks are bash scripts that run locally. They don't call any API. The only "cost" is the AI spending a few seconds organizing memories at each checkpoint — and it's doing that with context it already has loaded.
+**Zero extra tokens.** The hooks notify the AI that saves happened in the background — the AI doesn't need to write anything in the chat. All filing is handled automatically. Previous versions asked the AI to write diary entries and drawer content in the chat window, which cost ~$1/session in retransmitted tokens.

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -68,10 +68,10 @@ if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
     python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
-# Always block — compaction = save everything
+# Notify — compaction is about to happen but filing is handled in background
 cat << 'HOOKJSON'
 {
-  "decision": "block",
-  "reason": "COMPACTION IMMINENT. Save ALL topics, decisions, quotes, code, and important context from this session to your memory system. Be thorough — after compaction, detailed context will be lost. Organize into appropriate categories. Use verbatim quotes where possible. Save everything, then allow compaction to proceed."
+  "decision": "allow",
+  "reason": "MemPalace pre-compaction save. Your full conversation has been saved verbatim in the background — no action needed. Compaction can proceed safely."
 }
 HOOKJSON

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -140,12 +140,15 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
         python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 
-    # Block the AI and tell it to save
-    # The "reason" becomes a system message the AI sees and acts on
+    # Notify the AI that a checkpoint happened — but do NOT ask it to write
+    # anything in chat. All filing happens in the background via the pipeline.
+    # The old version asked the agent to write diary entries, add drawers, and
+    # add KG triples in the chat window — that cost ~$1/session in retransmitted
+    # tokens and cluttered the conversation.
     cat << 'HOOKJSON'
 {
-  "decision": "block",
-  "reason": "AUTO-SAVE checkpoint. Save key topics, decisions, quotes, and code from this session to your memory system. Organize into appropriate categories. Use verbatim quotes where possible. Continue conversation after saving."
+  "decision": "allow",
+  "reason": "MemPalace auto-save checkpoint. Your conversation is being saved verbatim in the background — no action needed from you. Continue working."
 }
 HOOKJSON
 else

--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -1,0 +1,345 @@
+"""
+closet_llm.py — Generate closets via a user-configured LLM for richer indexing.
+
+The regex-based closet extraction catches action verbs, headers, and proper
+nouns — but misses implicit topics, foreign-language content, and contextual
+references. An LLM reads everything and produces better closets.
+
+This module is **OPTIONAL and opt-in**. Regex closets are always created by
+the miner; this path regenerates them afterward using whatever LLM the user
+chooses. Core memory operations remain API-free by design (see CLAUDE.md,
+"Local-first, zero API").
+
+## Bring-your-own-LLM configuration
+
+The endpoint is any OpenAI-compatible Chat Completions URL:
+
+    LLM_ENDPOINT=http://localhost:11434/v1   # Ollama
+    LLM_ENDPOINT=http://localhost:8000/v1    # vLLM, llama.cpp
+    LLM_ENDPOINT=https://api.openai.com/v1
+    LLM_ENDPOINT=https://openrouter.ai/api/v1
+    LLM_ENDPOINT=https://api.anthropic.com/v1  # when proxied through a compat layer
+
+Set:
+    LLM_ENDPOINT — base URL (required)
+    LLM_KEY      — bearer token (optional; local inference usually doesn't need it)
+    LLM_MODEL    — model name (required), e.g. "gpt-4o-mini", "llama3:8b", "qwen2.5:7b"
+
+Or pass flags on the CLI (flags win over env):
+
+    python -m mempalace.closet_llm \\
+        --palace ~/.mempalace/palace \\
+        --endpoint http://localhost:11434/v1 \\
+        --model llama3:8b
+
+No vendor lock-in. No hidden dependency on any specific provider. Zero deps
+added to pyproject — uses stdlib urllib.
+"""
+
+import json
+import os
+import re
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime
+from typing import Optional
+
+from .palace import get_collection, get_closets_collection, upsert_closet_lines
+
+MAX_CONTENT_CHARS = 30000
+MAX_OUTPUT_TOKENS = 1500
+HTTP_TIMEOUT_S = 60
+
+PROMPT_TEMPLATE = """You are reading content filed in a memory palace. Generate a
+topic-dense index that will be used to find this content later when someone searches.
+
+Source: {source_file}
+Wing: {wing} | Room: {room}
+
+CONTENT:
+{content}
+
+---
+
+Output a JSON object with EXACTLY these fields:
+
+{{
+  "topics": ["distinctive_word_or_phrase_1", "topic_2", ...],
+  "quotes": ["[Speaker] verbatim quote", ...],
+  "summary": "2-3 sentences describing what this content is about."
+}}
+
+RULES:
+- Topics: 8-15 entries. Include proper nouns (names, places, projects),
+  distinctive technical terms, and key concepts. NOT generic words like
+  "conversation" or "discussion".
+- Quotes: 2-5 entries. EXACT verbatim from the content, not paraphrased.
+  Attribute with [Speaker] prefix if speaker is identifiable.
+- Summary: mention WHO, WHAT, and WHY. No filler.
+- Write in the same language as the content.
+- Output valid JSON only. No code fences. No commentary.
+"""
+
+
+class LLMConfig:
+    """Resolved LLM connection config. CLI flags > env vars."""
+
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        key: Optional[str] = None,
+        model: Optional[str] = None,
+    ):
+        self.endpoint = (endpoint or os.environ.get("LLM_ENDPOINT", "")).rstrip("/")
+        self.key = key or os.environ.get("LLM_KEY", "")
+        self.model = model or os.environ.get("LLM_MODEL", "")
+
+    def missing(self) -> list:
+        missing = []
+        if not self.endpoint:
+            missing.append("LLM_ENDPOINT (or --endpoint)")
+        if not self.model:
+            missing.append("LLM_MODEL (or --model)")
+        # key is optional — local inference servers (Ollama, vLLM) often don't require one
+        return missing
+
+
+def _call_llm(cfg: LLMConfig, source_file: str, wing: str, room: str, content: str):
+    """Single LLM call via OpenAI-compatible /chat/completions.
+
+    Returns (parsed_json_dict_or_None, usage_dict_or_None).
+    """
+    try:
+        from mempalace.i18n import t
+
+        lang_instruction = t("aaak.instruction")
+    except Exception:
+        lang_instruction = ""
+
+    prompt = PROMPT_TEMPLATE.format(
+        source_file=source_file[:100],
+        wing=wing,
+        room=room,
+        content=content[:MAX_CONTENT_CHARS],
+    )
+    if lang_instruction and "english" not in lang_instruction.lower():
+        prompt += f"\n\nLanguage instruction: {lang_instruction}"
+
+    body = json.dumps(
+        {
+            "model": cfg.model,
+            "max_tokens": MAX_OUTPUT_TOKENS,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+    ).encode("utf-8")
+
+    headers = {"Content-Type": "application/json"}
+    if cfg.key:
+        headers["Authorization"] = f"Bearer {cfg.key}"
+
+    url = f"{cfg.endpoint}/chat/completions"
+
+    for attempt in range(3):
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+                raw = resp.read().decode("utf-8")
+            payload = json.loads(raw)
+
+            text = payload["choices"][0]["message"]["content"].strip()
+            text = re.sub(r"^```(?:json)?\s*", "", text)
+            text = re.sub(r"\s*```$", "", text)
+            parsed = json.loads(text)
+            return parsed, payload.get("usage")
+        except json.JSONDecodeError:
+            return None, None
+        except urllib.error.HTTPError as e:
+            # 429 / 503 = retry with backoff
+            if e.code in (429, 503) and attempt < 2:
+                time.sleep(2 ** attempt)
+                continue
+            return None, None
+        except Exception as e:
+            if "rate" in str(e).lower() and attempt < 2:
+                time.sleep(2 ** attempt)
+                continue
+            return None, None
+    return None, None
+
+
+def _parsed_to_closet_lines(parsed, drawer_ids, entities_str):
+    """Convert LLM's JSON output to closet pointer lines."""
+    lines = []
+    drawer_ref = ",".join(drawer_ids[:3])
+
+    for topic in parsed.get("topics", [])[:15]:
+        lines.append(f"{topic}|{entities_str}|→{drawer_ref}")
+    for quote in parsed.get("quotes", [])[:5]:
+        lines.append(f'{quote}|{entities_str}|→{drawer_ref}')
+    summary = parsed.get("summary", "")
+    if summary:
+        lines.append(f"{summary[:200]}|{entities_str}|→{drawer_ref}")
+
+    return lines
+
+
+def regenerate_closets(
+    palace_path,
+    wing=None,
+    sample=0,
+    dry_run=False,
+    cfg: Optional[LLMConfig] = None,
+):
+    """Regenerate closets using a configured LLM for richer topic extraction.
+
+    Reads existing drawers, sends content to the configured endpoint,
+    replaces regex closets with LLM-generated ones. Regex closets remain
+    as the fallback whenever the call fails.
+    """
+    if cfg is None:
+        cfg = LLMConfig()
+    missing = cfg.missing()
+    if missing:
+        print("Error: missing configuration: " + ", ".join(missing))
+        print("Set env vars LLM_ENDPOINT / LLM_MODEL (and optionally LLM_KEY),")
+        print("or pass --endpoint / --model / --key on the CLI.")
+        return {"error": "missing-config", "missing": missing}
+
+    drawers_col = get_collection(palace_path, create=False)
+    closets_col = get_closets_collection(palace_path)
+
+    total = drawers_col.count()
+    if total == 0:
+        print("No drawers in palace.")
+        return {"processed": 0}
+
+    all_data = drawers_col.get(limit=total, include=["documents", "metadatas"])
+    by_source = {}
+    for doc_id, doc, meta in zip(all_data["ids"], all_data["documents"], all_data["metadatas"]):
+        source = meta.get("source_file", "unknown")
+        w = meta.get("wing", "")
+        if wing and w != wing:
+            continue
+        if source not in by_source:
+            by_source[source] = {"drawer_ids": [], "content": [], "meta": meta}
+        by_source[source]["drawer_ids"].append(doc_id)
+        by_source[source]["content"].append(doc)
+
+    sources = list(by_source.keys())
+    if sample > 0:
+        sources = sources[:sample]
+
+    print(f"Regenerating closets for {len(sources)} source files via {cfg.endpoint} ({cfg.model})...")
+    if dry_run:
+        print("DRY RUN — no changes will be written")
+
+    processed = 0
+    failed = 0
+    total_input = 0
+    total_output = 0
+
+    for i, source in enumerate(sources, 1):
+        data = by_source[source]
+        content = "\n\n".join(data["content"])
+        meta = data["meta"]
+        w = meta.get("wing", "")
+        r = meta.get("room", "")
+        entities = meta.get("entities", "")
+
+        if dry_run:
+            print(f"  [{i}/{len(sources)}] {os.path.basename(source)} ({len(content)} chars)")
+            continue
+
+        parsed, usage = _call_llm(cfg, source, w, r, content)
+        if not parsed:
+            failed += 1
+            print(f"  [{i}/{len(sources)}] ✗ {os.path.basename(source)} — LLM failed")
+            continue
+
+        if usage:
+            total_input += usage.get("prompt_tokens", 0)
+            total_output += usage.get("completion_tokens", 0)
+
+        lines = _parsed_to_closet_lines(parsed, data["drawer_ids"], entities)
+        closet_id_base = f"closet_{w}_{r}_{source.split('/')[-1][:30]}"
+
+        # Delete old regex closets for this source before writing LLM ones
+        try:
+            old_ids = closets_col.get(
+                where={"source_file": source}, include=[]
+            ).get("ids", [])
+            if old_ids:
+                closets_col.delete(ids=old_ids)
+        except Exception:
+            pass
+
+        upsert_closet_lines(
+            closets_col,
+            closet_id_base,
+            lines,
+            {
+                "wing": w,
+                "room": r,
+                "source_file": source,
+                "generated_by": f"llm:{cfg.model}",
+                "filed_at": datetime.now().isoformat(),
+                "entities": entities,
+            },
+        )
+
+        processed += 1
+        n_topics = len(parsed.get("topics", []))
+        print(f"  [{i}/{len(sources)}] ✓ {os.path.basename(source)} — {n_topics} topics")
+
+    print(f"\nDone. {processed} regenerated, {failed} failed.")
+    if total_input or total_output:
+        print(f"Tokens: {total_input:,} in + {total_output:,} out (cost depends on provider)")
+
+    return {
+        "processed": processed,
+        "failed": failed,
+        "input_tokens": total_input,
+        "output_tokens": total_output,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Regenerate closets via a user-configured LLM (OpenAI-compatible API)"
+    )
+    parser.add_argument(
+        "--palace",
+        default=os.path.expanduser("~/.mempalace/palace"),
+        help="Path to the palace",
+    )
+    parser.add_argument("--wing", default=None, help="Limit to one wing")
+    parser.add_argument(
+        "--sample", type=int, default=0, help="Only process first N source files"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="List work without calling the LLM"
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=None,
+        help="LLM base URL (overrides $LLM_ENDPOINT), e.g. http://localhost:11434/v1",
+    )
+    parser.add_argument(
+        "--key",
+        default=None,
+        help="LLM bearer token (overrides $LLM_KEY). Optional for local inference.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help='LLM model name (overrides $LLM_MODEL), e.g. "gpt-4o-mini" or "llama3:8b"',
+    )
+    args = parser.parse_args()
+
+    cfg = LLMConfig(endpoint=args.endpoint, key=args.key, model=args.model)
+    regenerate_closets(
+        args.palace, wing=args.wing, sample=args.sample, dry_run=args.dry_run, cfg=cfg
+    )

--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -1,0 +1,351 @@
+"""
+closet_llm.py — Generate closets via a user-configured LLM for richer indexing.
+
+The regex-based closet extraction catches action verbs, headers, and proper
+nouns — but misses implicit topics, foreign-language content, and contextual
+references. An LLM reads everything and produces better closets.
+
+This module is **OPTIONAL and opt-in**. Regex closets are always created by
+the miner; this path regenerates them afterward using whatever LLM the user
+chooses. Core memory operations remain API-free by design (see CLAUDE.md,
+"Local-first, zero API").
+
+## Bring-your-own-LLM configuration
+
+The endpoint is any OpenAI-compatible Chat Completions URL:
+
+    LLM_ENDPOINT=http://localhost:11434/v1   # Ollama
+    LLM_ENDPOINT=http://localhost:8000/v1    # vLLM, llama.cpp
+    LLM_ENDPOINT=https://api.openai.com/v1
+    LLM_ENDPOINT=https://openrouter.ai/api/v1
+    LLM_ENDPOINT=https://api.anthropic.com/v1  # when proxied through a compat layer
+
+Set:
+    LLM_ENDPOINT — base URL (required)
+    LLM_KEY      — bearer token (optional; local inference usually doesn't need it)
+    LLM_MODEL    — model name (required), e.g. "gpt-4o-mini", "llama3:8b", "qwen2.5:7b"
+
+Or pass flags on the CLI (flags win over env):
+
+    python -m mempalace.closet_llm \\
+        --palace ~/.mempalace/palace \\
+        --endpoint http://localhost:11434/v1 \\
+        --model llama3:8b
+
+No vendor lock-in. No hidden dependency on any specific provider. Zero deps
+added to pyproject — uses stdlib urllib.
+"""
+
+import json
+import os
+import re
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime
+from typing import Optional
+
+from .palace import (
+    NORMALIZE_VERSION,
+    get_closets_collection,
+    get_collection,
+    mine_lock,
+    purge_file_closets,
+    upsert_closet_lines,
+)
+
+MAX_CONTENT_CHARS = 30000
+MAX_OUTPUT_TOKENS = 1500
+HTTP_TIMEOUT_S = 60
+
+PROMPT_TEMPLATE = """You are reading content filed in a memory palace. Generate a
+topic-dense index that will be used to find this content later when someone searches.
+
+Source: {source_file}
+Wing: {wing} | Room: {room}
+
+CONTENT:
+{content}
+
+---
+
+Output a JSON object with EXACTLY these fields:
+
+{{
+  "topics": ["distinctive_word_or_phrase_1", "topic_2", ...],
+  "quotes": ["[Speaker] verbatim quote", ...],
+  "summary": "2-3 sentences describing what this content is about."
+}}
+
+RULES:
+- Topics: 8-15 entries. Include proper nouns (names, places, projects),
+  distinctive technical terms, and key concepts. NOT generic words like
+  "conversation" or "discussion".
+- Quotes: 2-5 entries. EXACT verbatim from the content, not paraphrased.
+  Attribute with [Speaker] prefix if speaker is identifiable.
+- Summary: mention WHO, WHAT, and WHY. No filler.
+- Write in the same language as the content.
+- Output valid JSON only. No code fences. No commentary.
+"""
+
+
+class LLMConfig:
+    """Resolved LLM connection config. CLI flags > env vars."""
+
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        key: Optional[str] = None,
+        model: Optional[str] = None,
+    ):
+        self.endpoint = (endpoint or os.environ.get("LLM_ENDPOINT", "")).rstrip("/")
+        self.key = key or os.environ.get("LLM_KEY", "")
+        self.model = model or os.environ.get("LLM_MODEL", "")
+
+    def missing(self) -> list:
+        missing = []
+        if not self.endpoint:
+            missing.append("LLM_ENDPOINT (or --endpoint)")
+        if not self.model:
+            missing.append("LLM_MODEL (or --model)")
+        # key is optional — local inference servers (Ollama, vLLM) often don't require one
+        return missing
+
+
+def _call_llm(cfg: LLMConfig, source_file: str, wing: str, room: str, content: str):
+    """Single LLM call via OpenAI-compatible /chat/completions.
+
+    Returns (parsed_json_dict_or_None, usage_dict_or_None).
+    """
+    try:
+        from mempalace.i18n import t
+
+        lang_instruction = t("aaak.instruction")
+    except Exception:
+        lang_instruction = ""
+
+    prompt = PROMPT_TEMPLATE.format(
+        source_file=source_file[:100],
+        wing=wing,
+        room=room,
+        content=content[:MAX_CONTENT_CHARS],
+    )
+    if lang_instruction and "english" not in lang_instruction.lower():
+        prompt += f"\n\nLanguage instruction: {lang_instruction}"
+
+    body = json.dumps(
+        {
+            "model": cfg.model,
+            "max_tokens": MAX_OUTPUT_TOKENS,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+    ).encode("utf-8")
+
+    headers = {"Content-Type": "application/json"}
+    if cfg.key:
+        headers["Authorization"] = f"Bearer {cfg.key}"
+
+    url = f"{cfg.endpoint}/chat/completions"
+
+    for attempt in range(3):
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+                raw = resp.read().decode("utf-8")
+            payload = json.loads(raw)
+
+            text = payload["choices"][0]["message"]["content"].strip()
+            text = re.sub(r"^```(?:json)?\s*", "", text)
+            text = re.sub(r"\s*```$", "", text)
+            parsed = json.loads(text)
+            return parsed, payload.get("usage")
+        except json.JSONDecodeError:
+            return None, None
+        except urllib.error.HTTPError as e:
+            # 429 / 503 = retry with backoff
+            if e.code in (429, 503) and attempt < 2:
+                time.sleep(2**attempt)
+                continue
+            return None, None
+        except Exception as e:
+            if "rate" in str(e).lower() and attempt < 2:
+                time.sleep(2**attempt)
+                continue
+            return None, None
+    return None, None
+
+
+def _parsed_to_closet_lines(parsed, drawer_ids, entities_str):
+    """Convert LLM's JSON output to closet pointer lines."""
+    lines = []
+    drawer_ref = ",".join(drawer_ids[:3])
+
+    for topic in parsed.get("topics", [])[:15]:
+        lines.append(f"{topic}|{entities_str}|→{drawer_ref}")
+    for quote in parsed.get("quotes", [])[:5]:
+        lines.append(f"{quote}|{entities_str}|→{drawer_ref}")
+    summary = parsed.get("summary", "")
+    if summary:
+        lines.append(f"{summary[:200]}|{entities_str}|→{drawer_ref}")
+
+    return lines
+
+
+def regenerate_closets(
+    palace_path,
+    wing=None,
+    sample=0,
+    dry_run=False,
+    cfg: Optional[LLMConfig] = None,
+):
+    """Regenerate closets using a configured LLM for richer topic extraction.
+
+    Reads existing drawers, sends content to the configured endpoint,
+    replaces regex closets with LLM-generated ones. Regex closets remain
+    as the fallback whenever the call fails.
+    """
+    if cfg is None:
+        cfg = LLMConfig()
+    missing = cfg.missing()
+    if missing:
+        print("Error: missing configuration: " + ", ".join(missing))
+        print("Set env vars LLM_ENDPOINT / LLM_MODEL (and optionally LLM_KEY),")
+        print("or pass --endpoint / --model / --key on the CLI.")
+        return {"error": "missing-config", "missing": missing}
+
+    drawers_col = get_collection(palace_path, create=False)
+    closets_col = get_closets_collection(palace_path)
+
+    total = drawers_col.count()
+    if total == 0:
+        print("No drawers in palace.")
+        return {"processed": 0}
+
+    all_data = drawers_col.get(limit=total, include=["documents", "metadatas"])
+    by_source = {}
+    for doc_id, doc, meta in zip(all_data["ids"], all_data["documents"], all_data["metadatas"]):
+        source = meta.get("source_file", "unknown")
+        w = meta.get("wing", "")
+        if wing and w != wing:
+            continue
+        if source not in by_source:
+            by_source[source] = {"drawer_ids": [], "content": [], "meta": meta}
+        by_source[source]["drawer_ids"].append(doc_id)
+        by_source[source]["content"].append(doc)
+
+    sources = list(by_source.keys())
+    if sample > 0:
+        sources = sources[:sample]
+
+    print(
+        f"Regenerating closets for {len(sources)} source files via {cfg.endpoint} ({cfg.model})..."
+    )
+    if dry_run:
+        print("DRY RUN — no changes will be written")
+
+    processed = 0
+    failed = 0
+    total_input = 0
+    total_output = 0
+
+    for i, source in enumerate(sources, 1):
+        data = by_source[source]
+        content = "\n\n".join(data["content"])
+        meta = data["meta"]
+        w = meta.get("wing", "")
+        r = meta.get("room", "")
+        entities = meta.get("entities", "")
+
+        if dry_run:
+            print(f"  [{i}/{len(sources)}] {os.path.basename(source)} ({len(content)} chars)")
+            continue
+
+        parsed, usage = _call_llm(cfg, source, w, r, content)
+        if not parsed:
+            failed += 1
+            print(f"  [{i}/{len(sources)}] ✗ {os.path.basename(source)} — LLM failed")
+            continue
+
+        if usage:
+            total_input += usage.get("prompt_tokens", 0)
+            total_output += usage.get("completion_tokens", 0)
+
+        lines = _parsed_to_closet_lines(parsed, data["drawer_ids"], entities)
+        # Use os.path.basename so Windows-style paths survive unchanged;
+        # the naive split('/') would leave a bare path component on Windows
+        # and collide across different files under different drives.
+        closet_id_base = f"closet_{w}_{r}_{os.path.basename(source)[:30]}"
+
+        # Serialize with concurrent mine operations on the same source —
+        # otherwise a regex closet rebuild mid-regenerate races with our
+        # purge+upsert cycle and leaves mixed regex/LLM lines.
+        with mine_lock(source):
+            purge_file_closets(closets_col, source)
+            upsert_closet_lines(
+                closets_col,
+                closet_id_base,
+                lines,
+                {
+                    "wing": w,
+                    "room": r,
+                    "source_file": source,
+                    "generated_by": f"llm:{cfg.model}",
+                    "filed_at": datetime.now().isoformat(),
+                    "entities": entities,
+                    # Stamp so the miner's stale-drawer gate doesn't treat
+                    # LLM closets as leftovers and rebuild over them next run.
+                    "normalize_version": NORMALIZE_VERSION,
+                },
+            )
+
+        processed += 1
+        n_topics = len(parsed.get("topics", []))
+        print(f"  [{i}/{len(sources)}] ✓ {os.path.basename(source)} — {n_topics} topics")
+
+    print(f"\nDone. {processed} regenerated, {failed} failed.")
+    if total_input or total_output:
+        print(f"Tokens: {total_input:,} in + {total_output:,} out (cost depends on provider)")
+
+    return {
+        "processed": processed,
+        "failed": failed,
+        "input_tokens": total_input,
+        "output_tokens": total_output,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Regenerate closets via a user-configured LLM (OpenAI-compatible API)"
+    )
+    parser.add_argument(
+        "--palace",
+        default=os.path.expanduser("~/.mempalace/palace"),
+        help="Path to the palace",
+    )
+    parser.add_argument("--wing", default=None, help="Limit to one wing")
+    parser.add_argument("--sample", type=int, default=0, help="Only process first N source files")
+    parser.add_argument("--dry-run", action="store_true", help="List work without calling the LLM")
+    parser.add_argument(
+        "--endpoint",
+        default=None,
+        help="LLM base URL (overrides $LLM_ENDPOINT), e.g. http://localhost:11434/v1",
+    )
+    parser.add_argument(
+        "--key",
+        default=None,
+        help="LLM bearer token (overrides $LLM_KEY). Optional for local inference.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help='LLM model name (overrides $LLM_MODEL), e.g. "gpt-4o-mini" or "llama3:8b"',
+    )
+    args = parser.parse_args()
+
+    cfg = LLMConfig(endpoint=args.endpoint, key=args.key, model=args.model)
+    regenerate_closets(
+        args.palace, wing=args.wing, sample=args.sample, dry_run=args.dry_run, cfg=cfg
+    )

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import NORMALIZE_VERSION, SKIP_DIRS, file_already_mined, get_collection
 
 
 # File types that might contain conversations
@@ -51,6 +51,7 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
                 "added_by": agent,
                 "filed_at": datetime.now().isoformat(),
                 "ingest_mode": "registry",
+                "normalize_version": NORMALIZE_VERSION,
             }
         ],
     )
@@ -272,6 +273,52 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
+def _file_convo_chunks(collection, source_file, chunks, wing, room, agent, extract_mode):
+    """Purge stale drawers for ``source_file`` then upsert fresh chunks.
+
+    Returns (drawers_added, room_counts_delta).
+    """
+    # Purge stale drawers first. When the normalize schema bumps,
+    # file_already_mined() returns False for pre-v2 drawers and we land
+    # here — clean them out so the source doesn't end up with a mix of
+    # old-noise and new-clean drawers.
+    try:
+        collection.delete(where={"source_file": source_file})
+    except Exception:
+        pass
+
+    room_counts_delta: dict = defaultdict(int)
+    drawers_added = 0
+    for chunk in chunks:
+        chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
+        if extract_mode == "general":
+            room_counts_delta[chunk_room] += 1
+        drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+        try:
+            collection.upsert(
+                documents=[chunk["content"]],
+                ids=[drawer_id],
+                metadatas=[
+                    {
+                        "wing": wing,
+                        "room": chunk_room,
+                        "source_file": source_file,
+                        "chunk_index": chunk["chunk_index"],
+                        "added_by": agent,
+                        "filed_at": datetime.now().isoformat(),
+                        "ingest_mode": "convos",
+                        "extract_mode": extract_mode,
+                        "normalize_version": NORMALIZE_VERSION,
+                    }
+                ],
+            )
+            drawers_added += 1
+        except Exception as e:
+            if "already exists" not in str(e).lower():
+                raise
+    return drawers_added, room_counts_delta
+
+
 def mine_convos(
     convo_dir: str,
     palace_path: str,
@@ -375,34 +422,12 @@ def mine_convos(
         if extract_mode != "general":
             room_counts[room] += 1
 
-        # File each chunk
-        drawers_added = 0
-        for chunk in chunks:
-            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-            if extract_mode == "general":
-                room_counts[chunk_room] += 1
-            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
-            try:
-                collection.upsert(
-                    documents=[chunk["content"]],
-                    ids=[drawer_id],
-                    metadatas=[
-                        {
-                            "wing": wing,
-                            "room": chunk_room,
-                            "source_file": source_file,
-                            "chunk_index": chunk["chunk_index"],
-                            "added_by": agent,
-                            "filed_at": datetime.now().isoformat(),
-                            "ingest_mode": "convos",
-                            "extract_mode": extract_mode,
-                        }
-                    ],
-                )
-                drawers_added += 1
-            except Exception as e:
-                if "already exists" not in str(e).lower():
-                    raise
+        # Purge stale drawers + file fresh chunks.
+        drawers_added, room_delta = _file_convo_chunks(
+            collection, source_file, chunks, wing, room, agent, extract_mode
+        )
+        for r, n in room_delta.items():
+            room_counts[r] += n
 
         total_drawers += drawers_added
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -16,7 +16,13 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
-from .palace import SKIP_DIRS, get_collection, file_already_mined, mine_lock
+from .palace import (
+    NORMALIZE_VERSION,
+    SKIP_DIRS,
+    file_already_mined,
+    get_collection,
+    mine_lock,
+)
 
 
 # File types that might contain conversations
@@ -51,6 +57,7 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
                 "added_by": agent,
                 "filed_at": datetime.now().isoformat(),
                 "ingest_mode": "registry",
+                "normalize_version": NORMALIZE_VERSION,
             }
         ],
     )
@@ -273,7 +280,11 @@ def scan_convos(convo_dir: str) -> list:
 
 
 def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
-    """Acquire the per-file lock, double-check mined status, and upsert chunks.
+    """Lock the source file, purge stale drawers, and upsert fresh chunks.
+
+    Combines the per-file serialization that prevents concurrent agents from
+    duplicating work (via mine_lock) with the normalize-version rebuild
+    contract (purge-before-insert so pre-v2 drawers don't survive).
 
     Returns (drawers_added, room_counts_delta, skipped).
     """
@@ -281,8 +292,18 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
     drawers_added = 0
     with mine_lock(source_file):
         # Re-check after lock — another agent may have just finished this file
+        # at the current schema. A stale-version hit here returns False, so we
+        # still fall through to the purge+rebuild path below.
         if file_already_mined(collection, source_file):
             return 0, room_counts_delta, True
+
+        # Purge stale drawers first. When the normalize schema bumps,
+        # file_already_mined() returned False for pre-v2 drawers — clean
+        # them out so the source doesn't end up with mixed old/new drawers.
+        try:
+            collection.delete(where={"source_file": source_file})
+        except Exception:
+            pass
 
         for chunk in chunks:
             chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
@@ -303,6 +324,7 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                             "filed_at": datetime.now().isoformat(),
                             "ingest_mode": "convos",
                             "extract_mode": extract_mode,
+                            "normalize_version": NORMALIZE_VERSION,
                         }
                     ],
                 )
@@ -416,7 +438,8 @@ def mine_convos(
         if extract_mode != "general":
             room_counts[room] += 1
 
-        # File each chunk — lock to prevent concurrent agents duplicating
+        # Lock + purge stale + file fresh chunks. Lock serializes concurrent
+        # agents; purge removes pre-v2 drawers so the schema bump applies.
         drawers_added, room_delta, skipped = _file_chunks_locked(
             collection, source_file, chunks, wing, room, agent, extract_mode
         )

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -16,7 +16,13 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
-from .palace import SKIP_DIRS, get_collection, file_already_mined, mine_lock
+from .palace import (
+    NORMALIZE_VERSION,
+    SKIP_DIRS,
+    file_already_mined,
+    get_collection,
+    mine_lock,
+)
 
 
 # File types that might contain conversations
@@ -51,6 +57,7 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
                 "added_by": agent,
                 "filed_at": datetime.now().isoformat(),
                 "ingest_mode": "registry",
+                "normalize_version": NORMALIZE_VERSION,
             }
         ],
     )
@@ -272,6 +279,62 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
+def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+    """Lock the source file, purge stale drawers, and upsert fresh chunks.
+
+    Combines the per-file serialization that prevents concurrent agents from
+    duplicating work (via mine_lock) with the normalize-version rebuild
+    contract (purge-before-insert so pre-v2 drawers don't survive).
+
+    Returns (drawers_added, room_counts_delta, skipped).
+    """
+    room_counts_delta: dict = defaultdict(int)
+    drawers_added = 0
+    with mine_lock(source_file):
+        # Re-check after lock — another agent may have just finished this file
+        # at the current schema. A stale-version hit here returns False, so we
+        # still fall through to the purge+rebuild path below.
+        if file_already_mined(collection, source_file):
+            return 0, room_counts_delta, True
+
+        # Purge stale drawers first. When the normalize schema bumps,
+        # file_already_mined() returned False for pre-v2 drawers — clean
+        # them out so the source doesn't end up with mixed old/new drawers.
+        try:
+            collection.delete(where={"source_file": source_file})
+        except Exception:
+            pass
+
+        for chunk in chunks:
+            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
+            if extract_mode == "general":
+                room_counts_delta[chunk_room] += 1
+            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+            try:
+                collection.upsert(
+                    documents=[chunk["content"]],
+                    ids=[drawer_id],
+                    metadatas=[
+                        {
+                            "wing": wing,
+                            "room": chunk_room,
+                            "source_file": source_file,
+                            "chunk_index": chunk["chunk_index"],
+                            "added_by": agent,
+                            "filed_at": datetime.now().isoformat(),
+                            "ingest_mode": "convos",
+                            "extract_mode": extract_mode,
+                            "normalize_version": NORMALIZE_VERSION,
+                        }
+                    ],
+                )
+                drawers_added += 1
+            except Exception as e:
+                if "already exists" not in str(e).lower():
+                    raise
+    return drawers_added, room_counts_delta, False
+
+
 def mine_convos(
     convo_dir: str,
     palace_path: str,
@@ -375,40 +438,16 @@ def mine_convos(
         if extract_mode != "general":
             room_counts[room] += 1
 
-        # File each chunk — lock to prevent concurrent agents duplicating
-        drawers_added = 0
-        with mine_lock(source_file):
-            # Re-check after lock — another agent may have just finished this file
-            if file_already_mined(collection, source_file):
-                files_skipped += 1
-                continue
-
-            for chunk in chunks:
-                chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-                if extract_mode == "general":
-                    room_counts[chunk_room] += 1
-                drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
-                try:
-                    collection.upsert(
-                        documents=[chunk["content"]],
-                        ids=[drawer_id],
-                        metadatas=[
-                            {
-                                "wing": wing,
-                                "room": chunk_room,
-                                "source_file": source_file,
-                                "chunk_index": chunk["chunk_index"],
-                                "added_by": agent,
-                                "filed_at": datetime.now().isoformat(),
-                                "ingest_mode": "convos",
-                                "extract_mode": extract_mode,
-                            }
-                        ],
-                    )
-                    drawers_added += 1
-                except Exception as e:
-                    if "already exists" not in str(e).lower():
-                        raise
+        # Lock + purge stale + file fresh chunks. Lock serializes concurrent
+        # agents; purge removes pre-v2 drawers so the schema bump applies.
+        drawers_added, room_delta, skipped = _file_chunks_locked(
+            collection, source_file, chunks, wing, room, agent, extract_mode
+        )
+        if skipped:
+            files_skipped += 1
+            continue
+        for r, n in room_delta.items():
+            room_counts[r] += n
 
         total_drawers += drawers_added
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -272,6 +272,47 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
+def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+    """Acquire the per-file lock, double-check mined status, and upsert chunks.
+
+    Returns (drawers_added, room_counts_delta, skipped).
+    """
+    room_counts_delta: dict = defaultdict(int)
+    drawers_added = 0
+    with mine_lock(source_file):
+        # Re-check after lock — another agent may have just finished this file
+        if file_already_mined(collection, source_file):
+            return 0, room_counts_delta, True
+
+        for chunk in chunks:
+            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
+            if extract_mode == "general":
+                room_counts_delta[chunk_room] += 1
+            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+            try:
+                collection.upsert(
+                    documents=[chunk["content"]],
+                    ids=[drawer_id],
+                    metadatas=[
+                        {
+                            "wing": wing,
+                            "room": chunk_room,
+                            "source_file": source_file,
+                            "chunk_index": chunk["chunk_index"],
+                            "added_by": agent,
+                            "filed_at": datetime.now().isoformat(),
+                            "ingest_mode": "convos",
+                            "extract_mode": extract_mode,
+                        }
+                    ],
+                )
+                drawers_added += 1
+            except Exception as e:
+                if "already exists" not in str(e).lower():
+                    raise
+    return drawers_added, room_counts_delta, False
+
+
 def mine_convos(
     convo_dir: str,
     palace_path: str,
@@ -376,39 +417,14 @@ def mine_convos(
             room_counts[room] += 1
 
         # File each chunk — lock to prevent concurrent agents duplicating
-        drawers_added = 0
-        with mine_lock(source_file):
-            # Re-check after lock — another agent may have just finished this file
-            if file_already_mined(collection, source_file):
-                files_skipped += 1
-                continue
-
-            for chunk in chunks:
-                chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-                if extract_mode == "general":
-                    room_counts[chunk_room] += 1
-                drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
-                try:
-                    collection.upsert(
-                        documents=[chunk["content"]],
-                        ids=[drawer_id],
-                        metadatas=[
-                            {
-                                "wing": wing,
-                                "room": chunk_room,
-                                "source_file": source_file,
-                                "chunk_index": chunk["chunk_index"],
-                                "added_by": agent,
-                                "filed_at": datetime.now().isoformat(),
-                                "ingest_mode": "convos",
-                                "extract_mode": extract_mode,
-                            }
-                        ],
-                    )
-                    drawers_added += 1
-                except Exception as e:
-                    if "already exists" not in str(e).lower():
-                        raise
+        drawers_added, room_delta, skipped = _file_chunks_locked(
+            collection, source_file, chunks, wing, room, agent, extract_mode
+        )
+        if skipped:
+            files_skipped += 1
+            continue
+        for r, n in room_delta.items():
+            room_counts[r] += n
 
         total_drawers += drawers_added
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -16,7 +16,13 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
-from .palace import NORMALIZE_VERSION, SKIP_DIRS, file_already_mined, get_collection
+from .palace import (
+    NORMALIZE_VERSION,
+    SKIP_DIRS,
+    file_already_mined,
+    get_collection,
+    mine_lock,
+)
 
 
 # File types that might contain conversations
@@ -273,50 +279,60 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
-def _file_convo_chunks(collection, source_file, chunks, wing, room, agent, extract_mode):
-    """Purge stale drawers for ``source_file`` then upsert fresh chunks.
+def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+    """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
-    Returns (drawers_added, room_counts_delta).
+    Combines the per-file serialization that prevents concurrent agents from
+    duplicating work (via mine_lock) with the normalize-version rebuild
+    contract (purge-before-insert so pre-v2 drawers don't survive).
+
+    Returns (drawers_added, room_counts_delta, skipped).
     """
-    # Purge stale drawers first. When the normalize schema bumps,
-    # file_already_mined() returns False for pre-v2 drawers and we land
-    # here — clean them out so the source doesn't end up with a mix of
-    # old-noise and new-clean drawers.
-    try:
-        collection.delete(where={"source_file": source_file})
-    except Exception:
-        pass
-
     room_counts_delta: dict = defaultdict(int)
     drawers_added = 0
-    for chunk in chunks:
-        chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-        if extract_mode == "general":
-            room_counts_delta[chunk_room] += 1
-        drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+    with mine_lock(source_file):
+        # Re-check after lock — another agent may have just finished this file
+        # at the current schema. A stale-version hit here returns False, so we
+        # still fall through to the purge+rebuild path below.
+        if file_already_mined(collection, source_file):
+            return 0, room_counts_delta, True
+
+        # Purge stale drawers first. When the normalize schema bumps,
+        # file_already_mined() returned False for pre-v2 drawers — clean
+        # them out so the source doesn't end up with mixed old/new drawers.
         try:
-            collection.upsert(
-                documents=[chunk["content"]],
-                ids=[drawer_id],
-                metadatas=[
-                    {
-                        "wing": wing,
-                        "room": chunk_room,
-                        "source_file": source_file,
-                        "chunk_index": chunk["chunk_index"],
-                        "added_by": agent,
-                        "filed_at": datetime.now().isoformat(),
-                        "ingest_mode": "convos",
-                        "extract_mode": extract_mode,
-                        "normalize_version": NORMALIZE_VERSION,
-                    }
-                ],
-            )
-            drawers_added += 1
-        except Exception as e:
-            if "already exists" not in str(e).lower():
-                raise
-    return drawers_added, room_counts_delta
+            collection.delete(where={"source_file": source_file})
+        except Exception:
+            pass
+
+        for chunk in chunks:
+            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
+            if extract_mode == "general":
+                room_counts_delta[chunk_room] += 1
+            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+            try:
+                collection.upsert(
+                    documents=[chunk["content"]],
+                    ids=[drawer_id],
+                    metadatas=[
+                        {
+                            "wing": wing,
+                            "room": chunk_room,
+                            "source_file": source_file,
+                            "chunk_index": chunk["chunk_index"],
+                            "added_by": agent,
+                            "filed_at": datetime.now().isoformat(),
+                            "ingest_mode": "convos",
+                            "extract_mode": extract_mode,
+                            "normalize_version": NORMALIZE_VERSION,
+                        }
+                    ],
+                )
+                drawers_added += 1
+            except Exception as e:
+                if "already exists" not in str(e).lower():
+                    raise
+    return drawers_added, room_counts_delta, False
 
 
 def mine_convos(
@@ -422,10 +438,14 @@ def mine_convos(
         if extract_mode != "general":
             room_counts[room] += 1
 
-        # Purge stale drawers + file fresh chunks.
-        drawers_added, room_delta = _file_convo_chunks(
+        # Lock + purge stale + file fresh chunks. Lock serializes concurrent
+        # agents; purge removes pre-v2 drawers so the schema bump applies.
+        drawers_added, room_delta, skipped = _file_chunks_locked(
             collection, source_file, chunks, wing, room, agent, extract_mode
         )
+        if skipped:
+            files_skipped += 1
+            continue
         for r, n in room_delta.items():
             room_counts[r] += n
 

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import SKIP_DIRS, get_collection, file_already_mined, mine_lock
 
 
 # File types that might contain conversations
@@ -272,6 +272,47 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
+def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+    """Acquire the per-file lock, double-check mined status, and upsert chunks.
+
+    Returns (drawers_added, room_counts_delta, skipped).
+    """
+    room_counts_delta: dict = defaultdict(int)
+    drawers_added = 0
+    with mine_lock(source_file):
+        # Re-check after lock — another agent may have just finished this file
+        if file_already_mined(collection, source_file):
+            return 0, room_counts_delta, True
+
+        for chunk in chunks:
+            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
+            if extract_mode == "general":
+                room_counts_delta[chunk_room] += 1
+            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+            try:
+                collection.upsert(
+                    documents=[chunk["content"]],
+                    ids=[drawer_id],
+                    metadatas=[
+                        {
+                            "wing": wing,
+                            "room": chunk_room,
+                            "source_file": source_file,
+                            "chunk_index": chunk["chunk_index"],
+                            "added_by": agent,
+                            "filed_at": datetime.now().isoformat(),
+                            "ingest_mode": "convos",
+                            "extract_mode": extract_mode,
+                        }
+                    ],
+                )
+                drawers_added += 1
+            except Exception as e:
+                if "already exists" not in str(e).lower():
+                    raise
+    return drawers_added, room_counts_delta, False
+
+
 def mine_convos(
     convo_dir: str,
     palace_path: str,
@@ -375,34 +416,15 @@ def mine_convos(
         if extract_mode != "general":
             room_counts[room] += 1
 
-        # File each chunk
-        drawers_added = 0
-        for chunk in chunks:
-            chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
-            if extract_mode == "general":
-                room_counts[chunk_room] += 1
-            drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
-            try:
-                collection.upsert(
-                    documents=[chunk["content"]],
-                    ids=[drawer_id],
-                    metadatas=[
-                        {
-                            "wing": wing,
-                            "room": chunk_room,
-                            "source_file": source_file,
-                            "chunk_index": chunk["chunk_index"],
-                            "added_by": agent,
-                            "filed_at": datetime.now().isoformat(),
-                            "ingest_mode": "convos",
-                            "extract_mode": extract_mode,
-                        }
-                    ],
-                )
-                drawers_added += 1
-            except Exception as e:
-                if "already exists" not in str(e).lower():
-                    raise
+        # File each chunk — lock to prevent concurrent agents duplicating
+        drawers_added, room_delta, skipped = _file_chunks_locked(
+            collection, source_file, chunks, wing, room, agent, extract_mode
+        )
+        if skipped:
+            files_skipped += 1
+            continue
+        for r, n in room_delta.items():
+            room_counts[r] += n
 
         total_drawers += drawers_added
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")

--- a/mempalace/diary_ingest.py
+++ b/mempalace/diary_ingest.py
@@ -2,10 +2,14 @@
 diary_ingest.py — Ingest daily summary files into the palace.
 
 Architecture:
-- ONE drawer per day — full verbatim content, upserted as the day grows
-- Closets pack topics up to 1500 chars, never split mid-topic
-- Only new entries are processed (tracks entry count in state file)
-- Entities extracted and stamped on metadata for filterable search
+- ONE drawer per (wing, day) — full verbatim content, upserted as the day grows.
+- Closets pack topics up to CLOSET_CHAR_LIMIT, never split mid-topic.
+- A re-ingest fully purges the prior day's closets before rebuilding so a
+  shorter day never leaves orphans behind.
+- Only new entries are processed by default (tracks entry count in a state
+  file under ``~/.mempalace/state/`` — never inside the user's diary dir).
+- Per-file ``mine_lock`` so concurrent ingest from two terminals can't race.
+- Entities extracted and stamped on metadata for filterable search.
 
 Usage:
     python -m mempalace.diary_ingest --dir ~/daily_summaries --palace ~/.mempalace/palace
@@ -19,17 +23,30 @@ import re
 from datetime import datetime, timezone
 from pathlib import Path
 
-from .palace import (
-    get_collection,
-    get_closets_collection,
-    build_closet_lines,
-    upsert_closet_lines,
-    CLOSET_CHAR_LIMIT,
-)
 from .miner import _extract_entities_for_metadata
-
+from .palace import (
+    build_closet_lines,
+    get_closets_collection,
+    get_collection,
+    mine_lock,
+    purge_file_closets,
+    upsert_closet_lines,
+)
 
 DIARY_ENTRY_RE = re.compile(r"^## .+", re.MULTILINE)
+
+
+def _state_file_for(palace_path: str, diary_dir: Path) -> Path:
+    """Return the per-(palace, diary-dir) state-file path under ~/.mempalace/state.
+
+    Keyed by sha256 of (palace_path, diary_dir) so multiple diary folders
+    pointing at the same palace each get an independent state file. The
+    state file is *never* written inside the user's diary directory.
+    """
+    state_root = Path(os.path.expanduser("~")) / ".mempalace" / "state"
+    state_root.mkdir(parents=True, exist_ok=True)
+    key = hashlib.sha256(f"{palace_path}|{diary_dir}".encode()).hexdigest()[:24]
+    return state_root / f"diary_ingest_{key}.json"
 
 
 def _split_entries(text):
@@ -43,6 +60,18 @@ def _split_entries(text):
     return entries
 
 
+def _diary_drawer_id(wing: str, date_str: str) -> str:
+    """Stable, wing-scoped drawer ID. Two diaries (e.g. 'work' vs 'personal')
+    sharing the same date never collide."""
+    suffix = hashlib.sha256(f"{wing}|{date_str}".encode()).hexdigest()[:24]
+    return f"drawer_diary_{suffix}"
+
+
+def _diary_closet_id_base(wing: str, date_str: str) -> str:
+    suffix = hashlib.sha256(f"{wing}|{date_str}".encode()).hexdigest()[:24]
+    return f"closet_diary_{suffix}"
+
+
 def ingest_diaries(
     diary_dir,
     palace_path,
@@ -51,24 +80,29 @@ def ingest_diaries(
 ):
     """Ingest daily summary files into the palace.
 
-    Each date file gets ONE drawer (upserted as day grows) and
-    closets that pack topics atomically up to 1500 chars.
+    Each date file gets ONE drawer keyed by ``(wing, date)`` and closets that
+    pack topics atomically up to ``CLOSET_CHAR_LIMIT``. ``force=True`` rebuilds
+    every entry's closets from scratch (purging stale ones); the default
+    incremental mode only processes entries appended since the last run.
     """
     diary_dir = Path(diary_dir).expanduser().resolve()
     if not diary_dir.exists():
         print(f"Diary directory not found: {diary_dir}")
-        return
+        return {"days_updated": 0, "closets_created": 0}
 
     diary_files = sorted(diary_dir.glob("*.md"))
     if not diary_files:
         print(f"No .md files in {diary_dir}")
-        return
+        return {"days_updated": 0, "closets_created": 0}
 
-    # State tracks which entries have been closeted per file
-    state_file = diary_dir / ".diary_ingest_state.json"
-    state = {} if force else (
-        json.loads(state_file.read_text()) if state_file.exists() else {}
-    )
+    state_file = _state_file_for(str(palace_path), diary_dir)
+    if force or not state_file.exists():
+        state: dict = {}
+    else:
+        try:
+            state = json.loads(state_file.read_text())
+        except Exception:
+            state = {}
 
     drawers_col = get_collection(palace_path)
     closets_col = get_closets_collection(palace_path)
@@ -87,70 +121,72 @@ def ingest_diaries(
         date_str = date_match.group(1)
 
         # Skip if content hasn't changed
-        prev_size = state.get(diary_path.name, {}).get("size", 0)
+        state_key = f"{wing}|{diary_path.name}"
+        prev_size = state.get(state_key, {}).get("size", 0)
         curr_size = len(text)
         if curr_size == prev_size and not force:
             continue
 
         now_iso = datetime.now(timezone.utc).isoformat()
-        drawer_id = f"drawer_diary_{date_str}"
-
-        # Extract entities from full day text
+        drawer_id = _diary_drawer_id(wing, date_str)
         entities = _extract_entities_for_metadata(text)
+        source_file = str(diary_path)
 
-        # UPSERT the day's drawer (full verbatim, replaces as day grows)
-        drawer_meta = {
-            "date": date_str,
-            "wing": wing,
-            "room": "daily",
-            "source_file": str(diary_path),
-            "source_session": "daily_diary",
-            "filed_at": now_iso,
-        }
-        if entities:
-            drawer_meta["entities"] = entities
-        drawers_col.upsert(
-            documents=[text],
-            ids=[drawer_id],
-            metadatas=[drawer_meta],
-        )
+        # Serialize per source — two terminals running ingest at once must
+        # not interleave the upsert + closet-rebuild.
+        with mine_lock(source_file):
+            drawer_meta = {
+                "date": date_str,
+                "wing": wing,
+                "room": "daily",
+                "source_file": source_file,
+                "source_session": "daily_diary",
+                "filed_at": now_iso,
+            }
+            if entities:
+                drawer_meta["entities"] = entities
+            drawers_col.upsert(
+                documents=[text],
+                ids=[drawer_id],
+                metadatas=[drawer_meta],
+            )
 
-        # Split into entries and find new ones
-        entries = _split_entries(text)
-        prev_entry_count = state.get(diary_path.name, {}).get("entry_count", 0)
-        new_entries = entries[prev_entry_count:] if not force else entries
+            entries = _split_entries(text)
+            prev_entry_count = state.get(state_key, {}).get("entry_count", 0)
+            new_entries = entries if force else entries[prev_entry_count:]
 
-        if new_entries:
-            # Build closet lines from new entries
-            all_lines = []
-            for header, body in new_entries:
-                entry_text = f"{header}\n{body}"
-                entry_lines = build_closet_lines(
-                    str(diary_path), [drawer_id], entry_text, wing, "daily"
-                )
-                all_lines.extend(entry_lines)
+            if new_entries:
+                all_lines = []
+                for header, body in new_entries:
+                    entry_text = f"{header}\n{body}"
+                    entry_lines = build_closet_lines(
+                        source_file, [drawer_id], entry_text, wing, "daily"
+                    )
+                    all_lines.extend(entry_lines)
 
-            if all_lines:
-                closet_id_base = f"closet_diary_{date_str}"
-                closet_meta = {
-                    "date": date_str,
-                    "wing": wing,
-                    "room": "daily",
-                    "source_file": str(diary_path),
-                    "filed_at": now_iso,
-                }
-                if entities:
-                    closet_meta["entities"] = entities
-                n = upsert_closet_lines(
-                    closets_col, closet_id_base, all_lines, closet_meta
-                )
-                closets_created += n
+                if all_lines:
+                    closet_id_base = _diary_closet_id_base(wing, date_str)
+                    closet_meta = {
+                        "date": date_str,
+                        "wing": wing,
+                        "room": "daily",
+                        "source_file": source_file,
+                        "filed_at": now_iso,
+                    }
+                    if entities:
+                        closet_meta["entities"] = entities
+                    # On a force rebuild, wipe any leftover numbered closets
+                    # from a longer prior run before re-writing.
+                    if force:
+                        purge_file_closets(closets_col, source_file)
+                    n = upsert_closet_lines(closets_col, closet_id_base, all_lines, closet_meta)
+                    closets_created += n
 
-        state[diary_path.name] = {
-            "size": curr_size,
-            "entry_count": len(entries),
-            "ingested_at": now_iso,
-        }
+            state[state_key] = {
+                "size": curr_size,
+                "entry_count": len(entries),
+                "ingested_at": now_iso,
+            }
         days_updated += 1
 
     state_file.write_text(json.dumps(state, indent=2))

--- a/mempalace/fact_checker.py
+++ b/mempalace/fact_checker.py
@@ -1,152 +1,304 @@
 """
 fact_checker.py — Verify text against known facts in the palace.
 
-Checks AI responses, diary entries, and new content against the
-entity registry and knowledge graph for contradictions. Catches:
-  - Wrong names (similar but different entities)
-  - Wrong relationships (calling someone the wrong role)
-  - Stale facts (things that changed — KG has valid_from/valid_to)
+Checks AI responses, diary entries, and new content against the entity
+registry and knowledge graph for three classes of issue:
 
-Uses the entity_registry and knowledge_graph — no hardcoded facts.
+  * similar_name          — text mentions a name that's one/two edits
+                            away from *another* registered name, raising
+                            the possibility of a typo or mix-up.
+  * relationship_mismatch — text asserts a role between two entities
+                            (e.g. "Bob is Alice's brother") while the KG
+                            records a *different* current role for the
+                            same subject/object pair.
+  * stale_fact            — text asserts a fact that the KG marks closed
+                            (``valid_to`` in the past).
+
+Purely offline. Inputs: entity_registry JSON + KG SQLite. No network.
 
 Usage:
     from mempalace.fact_checker import check_text
     issues = check_text("Bob is Alice's brother", palace_path)
-    # → [{"type": "relationship_mismatch", "detail": "KG says Bob is Alice's husband"}]
 
     # CLI
-    python -m mempalace.fact_checker "Bob is Alice's brother" --palace ~/.mempalace/palace
+    python -m mempalace.fact_checker "Bob is Alice's brother" \\
+        --palace ~/.mempalace/palace
 """
+
+from __future__ import annotations
 
 import os
 import re
-from pathlib import Path
+from datetime import datetime, timezone
+
+# Share miner's mtime-cached registry loader so we don't double-read
+# ~/.mempalace/known_entities.json on every check_text call.
+from .miner import _load_known_entities_raw
 
 
-def check_text(text, palace_path=None, config=None):
-    """Check text for contradictions against known facts.
+# Narrow detection patterns — parse "X is Y's Z" and "X's Z is Y".
+# Names are captured greedily as word sequences (letters + optional
+# capitalized follow-ons) so simple multi-token names still work.
+# Relationship words are constrained to sane lengths to avoid matching
+# arbitrary filler.
+_RELATIONSHIP_PATTERNS = [
+    # "Bob is Alice's brother"      → subject=Bob, possessor=Alice, role=brother
+    re.compile(r"\b([A-Z][\w-]+)\s+is\s+([A-Z][\w-]+)'s\s+([a-z]{3,20})\b"),
+    # "Alice's brother is Bob"      → possessor=Alice, role=brother, subject=Bob
+    re.compile(r"\b([A-Z][\w-]+)'s\s+([a-z]{3,20})\s+is\s+([A-Z][\w-]+)\b"),
+]
 
-    Returns list of issues found. Empty list = no contradictions.
+
+def check_text(text: str, palace_path: str = None, config=None) -> list:
+    """Return a list of issues detected in ``text``.
+
+    Empty list means "no contradictions found" — absence of evidence, not
+    evidence of absence. The detector is deliberately conservative:
+    every issue is anchored to a specific KG fact or registry entry.
     """
     if config is None:
         from .config import MempalaceConfig
+
         config = MempalaceConfig()
     if palace_path is None:
         palace_path = config.palace_path
 
-    issues = []
+    if not text:
+        return []
 
-    # Load known entities
-    entity_names = _load_known_entities()
+    issues: list = []
+    entity_names_raw = _load_known_entities_raw()
 
-    # Check entity name confusion (similar names that might be mixed up)
-    issues.extend(_check_entity_confusion(text, entity_names))
-
-    # Check against knowledge graph facts
-    issues.extend(_check_kg_facts(text, palace_path))
+    issues.extend(_check_entity_confusion(text, entity_names_raw))
+    issues.extend(_check_kg_contradictions(text, palace_path))
 
     return issues
 
 
-def _load_known_entities():
-    """Load entity names from the registry."""
-    import json
-    registry_path = os.path.expanduser("~/.mempalace/known_entities.json")
-    if not os.path.exists(registry_path):
-        return {}
-    try:
-        return json.loads(open(registry_path).read())
-    except Exception:
-        return {}
+# ── entity-name confusion ────────────────────────────────────────────
 
 
-def _check_entity_confusion(text, entity_names):
-    """Check if text confuses similar entity names."""
-    issues = []
-    all_names = set()
-    for cat in entity_names.values():
+def _flatten_names(entity_names_raw: dict) -> set:
+    """Flatten a ``{category: [names]}`` or ``{category: {name: meta}}``
+    registry into a set of names."""
+    flat: set = set()
+    for cat in entity_names_raw.values():
         if isinstance(cat, list):
-            all_names.update(cat)
+            flat.update(str(n) for n in cat if n)
         elif isinstance(cat, dict):
-            all_names.update(cat.keys())
+            flat.update(str(k) for k in cat.keys() if k)
+    return flat
 
-    # Find names mentioned in text
-    mentioned = set()
+
+def _check_entity_confusion(text: str, entity_names_raw: dict) -> list:
+    """Flag names mentioned in the text that are edit-distance ≤ 2 from
+    a *different* registered name — a common typo / mix-up pattern.
+
+    Performance note: the original O(n²) pairwise scan over the full
+    registry is gone. We first identify which names actually appear in
+    the text, then only compute edit distance between *mentioned* names
+    and the rest of the registry. This makes the cost O(m × n) where m
+    is the handful of names in the text, not the full registry.
+    """
+    all_names = _flatten_names(entity_names_raw)
+    if not all_names:
+        return []
+
+    # Which names from the registry actually appear in the text?
+    mentioned: list = []
     for name in all_names:
-        if re.search(r'\b' + re.escape(name) + r'\b', text, re.IGNORECASE):
-            mentioned.add(name)
+        if re.search(r"\b" + re.escape(name) + r"\b", text, re.IGNORECASE):
+            mentioned.append(name)
+    if not mentioned:
+        return []
 
-    # Check for names that are very similar but different (edit distance 1-2)
-    name_list = sorted(all_names)
-    for i, name_a in enumerate(name_list):
-        for name_b in name_list[i + 1:]:
-            if _edit_distance(name_a.lower(), name_b.lower()) <= 2:
-                if name_a in mentioned or name_b in mentioned:
-                    if name_a in text and name_b not in text:
-                        issues.append({
-                            "type": "similar_name",
-                            "detail": f"'{name_a}' mentioned — did you mean '{name_b}'? (similar names in registry)",
-                            "names": [name_a, name_b],
-                        })
+    issues: list = []
+    seen_pairs: set = set()
+    for name_a in mentioned:
+        a_lower = name_a.lower()
+        for name_b in all_names:
+            if name_b == name_a:
+                continue
+            # Dedupe by unordered pair so we don't double-report.
+            pair_key = tuple(sorted((name_a.lower(), name_b.lower())))
+            if pair_key in seen_pairs:
+                continue
+            # Only flag when name_b is a *different* registry entry that
+            # was NOT mentioned — otherwise both names in the text is
+            # just the user writing about two people.
+            if name_b in mentioned:
+                seen_pairs.add(pair_key)
+                continue
+            distance = _edit_distance(a_lower, name_b.lower())
+            if 0 < distance <= 2:
+                issues.append(
+                    {
+                        "type": "similar_name",
+                        "detail": (
+                            f"'{name_a}' mentioned — did you mean "
+                            f"'{name_b}'? (edit distance {distance})"
+                        ),
+                        "names": [name_a, name_b],
+                        "distance": distance,
+                    }
+                )
+                seen_pairs.add(pair_key)
     return issues
 
 
-def _check_kg_facts(text, palace_path):
-    """Check text against knowledge graph for contradictions."""
-    issues = []
+# ── KG contradictions ────────────────────────────────────────────────
+
+
+def _extract_claims(text: str) -> list:
+    """Yield structured (subject, predicate, object) claims from ``text``.
+
+    The two supported surface forms are "X is Y's Z" and "X's Z is Y",
+    both of which resolve to the triple ``(X, Z, Y)`` — ``X`` has role
+    ``Z`` with respect to ``Y``. Matches are case-preserving for the
+    entity names (KG lookup is case-insensitive on normalized IDs).
+    """
+    claims: list = []
+    for pat in _RELATIONSHIP_PATTERNS:
+        for match in pat.finditer(text):
+            groups = match.groups()
+            if pat is _RELATIONSHIP_PATTERNS[0]:
+                subject, possessor, role = groups[0], groups[1], groups[2]
+            else:
+                possessor, role, subject = groups[0], groups[1], groups[2]
+            claims.append(
+                {
+                    "subject": subject,
+                    "predicate": role.lower(),
+                    "object": possessor,
+                    "span": match.group(0),
+                }
+            )
+    return claims
+
+
+def _check_kg_contradictions(text: str, palace_path: str) -> list:
+    """Compare each claim in ``text`` against the KG.
+
+    For every claim ``(subject, predicate, object)`` parsed from the
+    text, look up the subject's current KG triples:
+
+      * ``relationship_mismatch`` fires when the KG records a fact about
+        the same ``(subject, object)`` pair but with a *different*
+        predicate — e.g. text says "brother" but KG says "husband".
+      * ``stale_fact`` fires when the KG has the exact ``(subject,
+        predicate, object)`` triple but its ``valid_to`` is in the past,
+        meaning the claim is no longer current.
+    """
+    claims = _extract_claims(text)
+    if not claims:
+        return []
+
     try:
         from .knowledge_graph import KnowledgeGraph
-        kg = KnowledgeGraph(palace_path=palace_path)
 
-        # Extract relationship claims from text
-        # Pattern: "X is Y's Z" or "X's Z is Y"
-        patterns = [
-            (r"(\w+)\s+is\s+(\w+)'s\s+(\w+)", "subject", "possessor", "role"),
-            (r"(\w+)'s\s+(\w+)\s+is\s+(\w+)", "possessor", "role", "subject"),
-        ]
-
-        for pattern, *roles in patterns:
-            for match in re.finditer(pattern, text, re.IGNORECASE):
-                groups = match.groups()
-                subject = groups[0]
-                # Query KG for this entity
-                try:
-                    facts = kg.query(subject)
-                    if facts:
-                        for fact in facts:
-                            # Check if the claim contradicts a known fact
-                            if fact.get("valid_to") is None:  # current fact
-                                kg_pred = fact.get("predicate", "").lower()
-                                claim = match.group(0).lower()
-                                if kg_pred in claim and fact.get("object", "").lower() not in claim:
-                                    issues.append({
-                                        "type": "relationship_mismatch",
-                                        "detail": f"Text says '{match.group(0)}' but KG says: {subject} {kg_pred} {fact.get('object')}",
-                                        "entity": subject,
-                                    })
-                except Exception:
-                    pass
+        # KG lives alongside the palace collection; mcp_server uses the
+        # same convention (see _kg init). Pass ``db_path`` — the previous
+        # code passed a nonexistent ``palace_path`` kwarg which raised
+        # TypeError, silently swallowed by the outer except and rendered
+        # the entire KG-check path dead.
+        kg = KnowledgeGraph(db_path=os.path.join(palace_path, "knowledge_graph.sqlite3"))
     except Exception:
-        pass  # KG not available — skip
+        # KG unavailable (brand-new palace, corrupted DB, etc.) — skip.
+        return []
+
+    issues: list = []
+    for claim in claims:
+        subject = claim["subject"]
+        claim_pred = claim["predicate"]
+        claim_obj = claim["object"]
+        try:
+            facts = kg.query_entity(subject, direction="outgoing")
+        except Exception:
+            continue
+        if not facts:
+            continue
+
+        current_facts = [f for f in facts if f.get("current")]
+
+        # Mismatch: KG fact about same (subject, object) pair but different predicate.
+        for fact in current_facts:
+            if not _objects_match(fact.get("object"), claim_obj):
+                continue
+            kg_pred = (fact.get("predicate") or "").lower()
+            if kg_pred and kg_pred != claim_pred:
+                issues.append(
+                    {
+                        "type": "relationship_mismatch",
+                        "detail": (
+                            f"Text says '{claim['span']}' but KG records "
+                            f"{subject} {kg_pred} {fact.get('object')}"
+                        ),
+                        "entity": subject,
+                        "claim": {
+                            "predicate": claim_pred,
+                            "object": claim_obj,
+                        },
+                        "kg_fact": {
+                            "predicate": kg_pred,
+                            "object": fact.get("object"),
+                        },
+                    }
+                )
+
+        # Stale fact: exact match on (subject, predicate, object) but KG
+        # closed the window in the past.
+        now_iso = datetime.now(timezone.utc).date().isoformat()
+        for fact in facts:
+            if fact.get("current"):
+                continue
+            kg_pred = (fact.get("predicate") or "").lower()
+            if kg_pred != claim_pred:
+                continue
+            if not _objects_match(fact.get("object"), claim_obj):
+                continue
+            valid_to = fact.get("valid_to")
+            if valid_to and str(valid_to) < now_iso:
+                issues.append(
+                    {
+                        "type": "stale_fact",
+                        "detail": (
+                            f"Text says '{claim['span']}' but KG marks "
+                            f"this fact closed on {valid_to}"
+                        ),
+                        "entity": subject,
+                        "valid_to": valid_to,
+                    }
+                )
 
     return issues
 
 
-def _edit_distance(s1, s2):
-    """Simple Levenshtein distance."""
+def _objects_match(kg_obj, claim_obj: str) -> bool:
+    if kg_obj is None or not claim_obj:
+        return False
+    return str(kg_obj).strip().lower() == claim_obj.strip().lower()
+
+
+# ── Levenshtein helper (tight iterative version) ─────────────────────
+
+
+def _edit_distance(s1: str, s2: str) -> int:
+    """Levenshtein distance. O(len(s1) * len(s2)) time, O(len(s2)) space."""
     if len(s1) < len(s2):
-        return _edit_distance(s2, s1)
-    if len(s2) == 0:
+        s1, s2 = s2, s1
+    if not s2:
         return len(s1)
     prev = list(range(len(s2) + 1))
     for i, c1 in enumerate(s1):
         curr = [i + 1]
         for j, c2 in enumerate(s2):
-            curr.append(min(
-                prev[j + 1] + 1,
-                curr[j] + 1,
-                prev[j] + (0 if c1 == c2 else 1),
-            ))
+            curr.append(
+                min(
+                    prev[j + 1] + 1,
+                    curr[j] + 1,
+                    prev[j] + (0 if c1 == c2 else 1),
+                )
+            )
         prev = curr
     return prev[-1]
 
@@ -154,24 +306,30 @@ def _edit_distance(s1, s2):
 if __name__ == "__main__":
     import argparse
     import json
+    import sys
 
-    parser = argparse.ArgumentParser(description="Check text against known facts")
-    parser.add_argument("text", nargs="?", help="Text to check")
-    parser.add_argument("--palace", default=os.path.expanduser("~/.mempalace/palace"))
-    parser.add_argument("--stdin", action="store_true", help="Read from stdin")
+    parser = argparse.ArgumentParser(
+        description="Check text against known facts in the MemPalace palace.",
+        epilog="Exits 0 when no issues found, 1 when one or more issues detected.",
+    )
+    parser.add_argument("text", nargs="?", help="Text to check (or use --stdin).")
+    parser.add_argument(
+        "--palace",
+        default=os.path.expanduser("~/.mempalace/palace"),
+        help="Path to the palace directory.",
+    )
+    parser.add_argument("--stdin", action="store_true", help="Read text from stdin.")
     args = parser.parse_args()
 
     if args.stdin:
-        import sys
-        text = sys.stdin.read()
+        text_in = sys.stdin.read()
     elif args.text:
-        text = args.text
+        text_in = args.text
     else:
-        print("Provide text as argument or use --stdin")
-        exit(1)
+        parser.error("Provide text as argument or use --stdin.")
 
-    issues = check_text(text, palace_path=args.palace)
-    if issues:
-        print(json.dumps(issues, indent=2))
-    else:
-        print("No contradictions found.")
+    found = check_text(text_in, palace_path=args.palace)
+    if found:
+        print(json.dumps(found, indent=2))
+        sys.exit(1)
+    print("No contradictions found.")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -893,7 +893,10 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
         return _no_palace()
 
     now = datetime.now()
-    entry_id = f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S')}_{hashlib.sha256(entry[:50].encode()).hexdigest()[:12]}"
+    entry_id = (
+        f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_"
+        f"{hashlib.sha256(entry.encode()).hexdigest()[:12]}"
+    )
 
     _wal_log(
         "diary_write",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -836,7 +836,10 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
         return _no_palace()
 
     now = datetime.now()
-    entry_id = f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S')}_{hashlib.sha256(entry[:50].encode()).hexdigest()[:12]}"
+    entry_id = (
+        f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_"
+        f"{hashlib.sha256(entry.encode()).hexdigest()[:12]}"
+    )
 
     _wal_log(
         "diary_write",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -35,7 +35,15 @@ from .version import __version__
 import chromadb
 from .query_sanitizer import sanitize_query
 from .searcher import search_memories
-from .palace_graph import traverse, find_tunnels, graph_stats, create_tunnel, list_tunnels, delete_tunnel, follow_tunnels
+from .palace_graph import (
+    traverse,
+    find_tunnels,
+    graph_stats,
+    create_tunnel,
+    list_tunnels,
+    delete_tunnel,
+    follow_tunnels,
+)
 
 from .knowledge_graph import KnowledgeGraph
 
@@ -519,7 +527,10 @@ def tool_create_tunnel(
     except ValueError as e:
         return {"error": str(e)}
     return create_tunnel(
-        source_wing, source_room, target_wing, target_room,
+        source_wing,
+        source_room,
+        target_wing,
+        target_room,
         label=label,
         source_drawer_id=source_drawer_id,
         target_drawer_id=target_drawer_id,
@@ -1251,8 +1262,14 @@ TOOLS = {
                 "target_wing": {"type": "string", "description": "Wing of the target"},
                 "target_room": {"type": "string", "description": "Room in the target wing"},
                 "label": {"type": "string", "description": "Description of the connection"},
-                "source_drawer_id": {"type": "string", "description": "Optional specific drawer ID"},
-                "target_drawer_id": {"type": "string", "description": "Optional specific drawer ID"},
+                "source_drawer_id": {
+                    "type": "string",
+                    "description": "Optional specific drawer ID",
+                },
+                "target_drawer_id": {
+                    "type": "string",
+                    "description": "Optional specific drawer ID",
+                },
             },
             "required": ["source_wing", "source_room", "target_wing", "target_room"],
         },
@@ -1263,7 +1280,10 @@ TOOLS = {
         "input_schema": {
             "type": "object",
             "properties": {
-                "wing": {"type": "string", "description": "Filter tunnels by wing (shows tunnels where wing is source or target)"},
+                "wing": {
+                    "type": "string",
+                    "description": "Filter tunnels by wing (shows tunnels where wing is source or target)",
+                },
             },
         },
         "handler": tool_list_tunnels,

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,7 +15,13 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-from .palace import SKIP_DIRS, get_collection, file_already_mined, mine_lock
+from .palace import (
+    NORMALIZE_VERSION,
+    SKIP_DIRS,
+    file_already_mined,
+    get_collection,
+    mine_lock,
+)
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -381,6 +387,7 @@ def add_drawer(
             "chunk_index": chunk_index,
             "added_by": agent,
             "filed_at": datetime.now().isoformat(),
+            "normalize_version": NORMALIZE_VERSION,
         }
         # Store file mtime so we can detect modifications later.
         try:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -16,8 +16,15 @@ from datetime import datetime
 from collections import defaultdict
 
 from .palace import (
-    SKIP_DIRS, get_collection, get_closets_collection,
-    file_already_mined, mine_lock, build_closet_lines, upsert_closet_lines,
+    NORMALIZE_VERSION,
+    SKIP_DIRS,
+    build_closet_lines,
+    file_already_mined,
+    get_closets_collection,
+    get_collection,
+    mine_lock,
+    purge_file_closets,
+    upsert_closet_lines,
 )
 
 READABLE_EXTENSIONS = {
@@ -371,41 +378,86 @@ def chunk_text(content: str, source_file: str) -> list:
 # =============================================================================
 
 
+_ENTITY_REGISTRY_PATH = os.path.join(os.path.expanduser("~"), ".mempalace", "known_entities.json")
+_ENTITY_REGISTRY_CACHE: dict = {"mtime": None, "names": frozenset()}
+_ENTITY_EXTRACT_WINDOW = 5000  # chars of content scanned for capitalized words
+_ENTITY_METADATA_LIMIT = 25  # max entities packed into the metadata field
+
+
+def _load_known_entities() -> frozenset:
+    """Load (and cache) the user's known-entity registry by mtime.
+
+    Reads ``~/.mempalace/known_entities.json``. The registry is shaped as
+    ``{"category": ["Name1", "Name2", ...], ...}``. Cached across calls
+    in the same process; invalidated when the file's mtime changes.
+    """
+    try:
+        mtime = os.path.getmtime(_ENTITY_REGISTRY_PATH)
+    except OSError:
+        if _ENTITY_REGISTRY_CACHE["mtime"] is not None:
+            _ENTITY_REGISTRY_CACHE["mtime"] = None
+            _ENTITY_REGISTRY_CACHE["names"] = frozenset()
+        return _ENTITY_REGISTRY_CACHE["names"]
+
+    if _ENTITY_REGISTRY_CACHE["mtime"] == mtime:
+        return _ENTITY_REGISTRY_CACHE["names"]
+
+    names: set = set()
+    try:
+        import json
+
+        with open(_ENTITY_REGISTRY_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        for cat in data.values():
+            if isinstance(cat, list):
+                names.update(str(n) for n in cat if n)
+    except Exception:
+        names = set()
+
+    _ENTITY_REGISTRY_CACHE["mtime"] = mtime
+    _ENTITY_REGISTRY_CACHE["names"] = frozenset(names)
+    return _ENTITY_REGISTRY_CACHE["names"]
+
+
 def _extract_entities_for_metadata(content: str) -> str:
     """Extract entity names from content for metadata tagging.
 
-    Returns semicolon-separated string of entity names found in the text,
-    suitable for ChromaDB metadata filtering.
+    Combines the user's known-entity registry (cached across calls) with
+    capitalized words appearing ≥2 times in the first ``_ENTITY_EXTRACT_WINDOW``
+    chars. Filters out the closet stoplist (``When``, ``After``, ``The``, …)
+    so sentence-starters don't masquerade as proper nouns.
+
+    Returns semicolon-separated string suitable for ChromaDB metadata
+    filtering. The list is truncated to ``_ENTITY_METADATA_LIMIT`` entries
+    *before* joining so a name is never cut in half.
     """
     import re
-    # Load known entities from registry if available
-    known_names = set()
-    registry_path = os.path.join(os.path.expanduser("~"), ".mempalace", "known_entities.json")
-    if os.path.exists(registry_path):
-        try:
-            import json
-            kd = json.loads(open(registry_path).read())
-            for cat in kd.values():
-                if isinstance(cat, list):
-                    known_names.update(cat)
-        except Exception:
-            pass
 
-    matched = set()
-    # Match known entities
-    for name in known_names:
-        if re.search(r'(?<!\w)' + re.escape(name) + r'(?!\w)', content):
+    from .palace import _ENTITY_STOPLIST
+
+    matched: set = set()
+
+    known = _load_known_entities()
+    for name in known:
+        if re.search(r"(?<!\w)" + re.escape(name) + r"(?!\w)", content):
             matched.add(name)
-    # Also catch capitalized words appearing 2+ times (likely proper nouns)
-    words = re.findall(r"\b[A-Z][a-z]{2,}\b", content[:5000])
-    freq = {}
+
+    window = content[:_ENTITY_EXTRACT_WINDOW]
+    words = re.findall(r"\b[A-Z][a-z]{2,}\b", window)
+    freq: dict = {}
     for w in words:
+        if w in _ENTITY_STOPLIST:
+            continue
         freq[w] = freq.get(w, 0) + 1
     for w, c in freq.items():
         if c >= 2 and len(w) > 2:
             matched.add(w)
 
-    return ";".join(sorted(matched))[:500] if matched else ""
+    if not matched:
+        return ""
+    # Truncate the *list*, not the joined string — never split a name.
+    capped = sorted(matched)[:_ENTITY_METADATA_LIMIT]
+    return ";".join(capped)
 
 
 def add_drawer(
@@ -421,6 +473,7 @@ def add_drawer(
             "chunk_index": chunk_index,
             "added_by": agent,
             "filed_at": datetime.now().isoformat(),
+            "normalize_version": NORMALIZE_VERSION,
         }
         # Store file mtime so we can detect modifications later.
         try:
@@ -511,15 +564,18 @@ def process_file(
             if added:
                 drawers_added += 1
 
-        # Build closet — the searchable index pointing to these drawers
-        # Each topic line is atomic — never split across closets
+        # Build closet — the searchable index pointing to these drawers.
+        # Purge first: a re-mine (mtime change or normalize_version bump) must
+        # fully replace the prior closets, not append to them.
         if closets_col and drawers_added > 0:
             drawer_ids = [
                 f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(c['chunk_index'])).encode()).hexdigest()[:24]}"
                 for c in chunks
             ]
             closet_lines = build_closet_lines(source_file, drawer_ids, content, wing, room)
-            closet_id_base = f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+            closet_id_base = (
+                f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+            )
             entities = _extract_entities_for_metadata(content)
             closet_meta = {
                 "wing": wing,
@@ -527,9 +583,11 @@ def process_file(
                 "source_file": source_file,
                 "drawer_count": drawers_added,
                 "filed_at": datetime.now().isoformat(),
+                "normalize_version": NORMALIZE_VERSION,
             }
             if entities:
                 closet_meta["entities"] = entities
+            purge_file_closets(closets_col, source_file)
             upsert_closet_lines(closets_col, closet_id_base, closet_lines, closet_meta)
 
     return drawers_added, room

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,7 +15,17 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-from .palace import SKIP_DIRS, get_collection, file_already_mined, mine_lock
+from .palace import (
+    NORMALIZE_VERSION,
+    SKIP_DIRS,
+    build_closet_lines,
+    file_already_mined,
+    get_closets_collection,
+    get_collection,
+    mine_lock,
+    purge_file_closets,
+    upsert_closet_lines,
+)
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -381,6 +391,7 @@ def add_drawer(
             "chunk_index": chunk_index,
             "added_by": agent,
             "filed_at": datetime.now().isoformat(),
+            "normalize_version": NORMALIZE_VERSION,
         }
         # Store file mtime so we can detect modifications later.
         try:
@@ -410,6 +421,7 @@ def process_file(
     rooms: list,
     agent: str,
     dry_run: bool,
+    closets_col=None,
 ) -> tuple:
     """Read, chunk, route, and file one file. Returns (drawer_count, room_name)."""
 
@@ -465,6 +477,33 @@ def process_file(
             )
             if added:
                 drawers_added += 1
+
+        # Build closet — the searchable index pointing to these drawers.
+        # Purge first: a re-mine (mtime change or normalize_version bump) must
+        # fully replace the prior closets, not append to them.
+        if closets_col and drawers_added > 0:
+            drawer_ids = [
+                f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(c['chunk_index'])).encode()).hexdigest()[:24]}"
+                for c in chunks
+            ]
+            closet_lines = build_closet_lines(source_file, drawer_ids, content, wing, room)
+            closet_id_base = (
+                f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+            )
+            purge_file_closets(closets_col, source_file)
+            upsert_closet_lines(
+                closets_col,
+                closet_id_base,
+                closet_lines,
+                {
+                    "wing": wing,
+                    "room": room,
+                    "source_file": source_file,
+                    "drawer_count": drawers_added,
+                    "filed_at": datetime.now().isoformat(),
+                    "normalize_version": NORMALIZE_VERSION,
+                },
+            )
 
     return drawers_added, room
 
@@ -586,8 +625,10 @@ def mine(
 
     if not dry_run:
         collection = get_collection(palace_path)
+        closets_col = get_closets_collection(palace_path)
     else:
         collection = None
+        closets_col = None
 
     total_drawers = 0
     files_skipped = 0
@@ -602,6 +643,7 @@ def mine(
             rooms=rooms,
             agent=agent,
             dry_run=dry_run,
+            closets_col=closets_col,
         )
         if drawers == 0 and not dry_run:
             files_skipped += 1

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import NORMALIZE_VERSION, SKIP_DIRS, file_already_mined, get_collection
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -381,6 +381,7 @@ def add_drawer(
             "chunk_index": chunk_index,
             "added_by": agent,
             "filed_at": datetime.now().isoformat(),
+            "normalize_version": NORMALIZE_VERSION,
         }
         # Store file mtime so we can detect modifications later.
         try:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import SKIP_DIRS, get_collection, file_already_mined, mine_lock
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -434,29 +434,37 @@ def process_file(
         print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
         return len(chunks), room
 
-    # Purge stale drawers for this file before re-inserting the fresh chunks.
-    # Converts modified-file re-mines from upsert-over-existing-IDs (which hits
-    # hnswlib's thread-unsafe updatePoint path and can segfault on macOS ARM
-    # with chromadb 0.6.3) into a clean delete+insert, bypassing the update
-    # path entirely.
-    try:
-        collection.delete(where={"source_file": source_file})
-    except Exception:
-        pass
+    # Lock this file so concurrent agents don't interleave delete+insert.
+    # Without the lock, two agents can both pass file_already_mined(),
+    # both delete, and both insert — creating duplicates or losing data.
+    with mine_lock(source_file):
+        # Re-check after acquiring lock — another agent may have just finished
+        if file_already_mined(collection, source_file, check_mtime=True):
+            return 0, room
 
-    drawers_added = 0
-    for chunk in chunks:
-        added = add_drawer(
-            collection=collection,
-            wing=wing,
-            room=room,
-            content=chunk["content"],
-            source_file=source_file,
-            chunk_index=chunk["chunk_index"],
-            agent=agent,
-        )
-        if added:
-            drawers_added += 1
+        # Purge stale drawers for this file before re-inserting the fresh chunks.
+        # Converts modified-file re-mines from upsert-over-existing-IDs (which hits
+        # hnswlib's thread-unsafe updatePoint path and can segfault on macOS ARM
+        # with chromadb 0.6.3) into a clean delete+insert, bypassing the update
+        # path entirely.
+        try:
+            collection.delete(where={"source_file": source_file})
+        except Exception:
+            pass
+
+        drawers_added = 0
+        for chunk in chunks:
+            added = add_drawer(
+                collection=collection,
+                wing=wing,
+                room=room,
+                content=chunk["content"],
+                source_file=source_file,
+                chunk_index=chunk["chunk_index"],
+                agent=agent,
+            )
+            if added:
+                drawers_added += 1
 
     return drawers_added, room
 

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,7 +15,13 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-from .palace import NORMALIZE_VERSION, SKIP_DIRS, file_already_mined, get_collection
+from .palace import (
+    NORMALIZE_VERSION,
+    SKIP_DIRS,
+    file_already_mined,
+    get_collection,
+    mine_lock,
+)
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -435,29 +441,37 @@ def process_file(
         print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
         return len(chunks), room
 
-    # Purge stale drawers for this file before re-inserting the fresh chunks.
-    # Converts modified-file re-mines from upsert-over-existing-IDs (which hits
-    # hnswlib's thread-unsafe updatePoint path and can segfault on macOS ARM
-    # with chromadb 0.6.3) into a clean delete+insert, bypassing the update
-    # path entirely.
-    try:
-        collection.delete(where={"source_file": source_file})
-    except Exception:
-        pass
+    # Lock this file so concurrent agents don't interleave delete+insert.
+    # Without the lock, two agents can both pass file_already_mined(),
+    # both delete, and both insert — creating duplicates or losing data.
+    with mine_lock(source_file):
+        # Re-check after acquiring lock — another agent may have just finished
+        if file_already_mined(collection, source_file, check_mtime=True):
+            return 0, room
 
-    drawers_added = 0
-    for chunk in chunks:
-        added = add_drawer(
-            collection=collection,
-            wing=wing,
-            room=room,
-            content=chunk["content"],
-            source_file=source_file,
-            chunk_index=chunk["chunk_index"],
-            agent=agent,
-        )
-        if added:
-            drawers_added += 1
+        # Purge stale drawers for this file before re-inserting the fresh chunks.
+        # Converts modified-file re-mines from upsert-over-existing-IDs (which hits
+        # hnswlib's thread-unsafe updatePoint path and can segfault on macOS ARM
+        # with chromadb 0.6.3) into a clean delete+insert, bypassing the update
+        # path entirely.
+        try:
+            collection.delete(where={"source_file": source_file})
+        except Exception:
+            pass
+
+        drawers_added = 0
+        for chunk in chunks:
+            added = add_drawer(
+                collection=collection,
+                wing=wing,
+                room=room,
+                content=chunk["content"],
+                source_file=source_file,
+                chunk_index=chunk["chunk_index"],
+                agent=agent,
+            )
+            if added:
+                drawers_added += 1
 
     return drawers_added, room
 

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -379,17 +379,17 @@ def chunk_text(content: str, source_file: str) -> list:
 
 
 _ENTITY_REGISTRY_PATH = os.path.join(os.path.expanduser("~"), ".mempalace", "known_entities.json")
-_ENTITY_REGISTRY_CACHE: dict = {"mtime": None, "names": frozenset()}
+_ENTITY_REGISTRY_CACHE: dict = {"mtime": None, "names": frozenset(), "raw": {}}
 _ENTITY_EXTRACT_WINDOW = 5000  # chars of content scanned for capitalized words
 _ENTITY_METADATA_LIMIT = 25  # max entities packed into the metadata field
 
 
-def _load_known_entities() -> frozenset:
-    """Load (and cache) the user's known-entity registry by mtime.
-
-    Reads ``~/.mempalace/known_entities.json``. The registry is shaped as
-    ``{"category": ["Name1", "Name2", ...], ...}``. Cached across calls
-    in the same process; invalidated when the file's mtime changes.
+def _refresh_known_entities_cache() -> None:
+    """Reload ``~/.mempalace/known_entities.json`` into the module cache if
+    its mtime changed since the last read. Shared by ``_load_known_entities``
+    (flat set) and ``_load_known_entities_raw`` (category dict), so callers
+    can pick whichever shape they need without duplicating the mtime-gated
+    disk read.
     """
     try:
         mtime = os.path.getmtime(_ENTITY_REGISTRY_PATH)
@@ -397,26 +397,54 @@ def _load_known_entities() -> frozenset:
         if _ENTITY_REGISTRY_CACHE["mtime"] is not None:
             _ENTITY_REGISTRY_CACHE["mtime"] = None
             _ENTITY_REGISTRY_CACHE["names"] = frozenset()
-        return _ENTITY_REGISTRY_CACHE["names"]
+            _ENTITY_REGISTRY_CACHE["raw"] = {}
+        return
 
     if _ENTITY_REGISTRY_CACHE["mtime"] == mtime:
-        return _ENTITY_REGISTRY_CACHE["names"]
+        return
 
     names: set = set()
+    raw: dict = {}
     try:
         import json
 
         with open(_ENTITY_REGISTRY_PATH, "r", encoding="utf-8") as f:
             data = json.load(f)
-        for cat in data.values():
-            if isinstance(cat, list):
-                names.update(str(n) for n in cat if n)
+        if isinstance(data, dict):
+            raw = data
+            for cat in data.values():
+                if isinstance(cat, list):
+                    names.update(str(n) for n in cat if n)
+                elif isinstance(cat, dict):
+                    names.update(str(k) for k in cat.keys() if k)
     except Exception:
         names = set()
+        raw = {}
 
     _ENTITY_REGISTRY_CACHE["mtime"] = mtime
     _ENTITY_REGISTRY_CACHE["names"] = frozenset(names)
+    _ENTITY_REGISTRY_CACHE["raw"] = raw
+
+
+def _load_known_entities() -> frozenset:
+    """Flat set of every known entity name (across all categories).
+
+    Cached by mtime; invalidated when the registry file changes.
+    """
+    _refresh_known_entities_cache()
     return _ENTITY_REGISTRY_CACHE["names"]
+
+
+def _load_known_entities_raw() -> dict:
+    """Full category-dict view of the registry, shape
+    ``{"category": ["Name1", ...], ...}``. Cached by mtime.
+
+    Consumed by modules (e.g., fact_checker) that need to reason about
+    categories rather than a flat name set. Never returns a mutable
+    reference to the cache — callers get a shallow copy.
+    """
+    _refresh_known_entities_cache()
+    return dict(_ENTITY_REGISTRY_CACHE["raw"])
 
 
 def _extract_entities_for_metadata(content: str) -> str:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -18,9 +18,13 @@ from collections import defaultdict
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
+    build_closet_lines,
     file_already_mined,
+    get_closets_collection,
     get_collection,
     mine_lock,
+    purge_file_closets,
+    upsert_closet_lines,
 )
 
 READABLE_EXTENSIONS = {
@@ -417,6 +421,7 @@ def process_file(
     rooms: list,
     agent: str,
     dry_run: bool,
+    closets_col=None,
 ) -> tuple:
     """Read, chunk, route, and file one file. Returns (drawer_count, room_name)."""
 
@@ -472,6 +477,33 @@ def process_file(
             )
             if added:
                 drawers_added += 1
+
+        # Build closet — the searchable index pointing to these drawers.
+        # Purge first: a re-mine (mtime change or normalize_version bump) must
+        # fully replace the prior closets, not append to them.
+        if closets_col and drawers_added > 0:
+            drawer_ids = [
+                f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(c['chunk_index'])).encode()).hexdigest()[:24]}"
+                for c in chunks
+            ]
+            closet_lines = build_closet_lines(source_file, drawer_ids, content, wing, room)
+            closet_id_base = (
+                f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+            )
+            purge_file_closets(closets_col, source_file)
+            upsert_closet_lines(
+                closets_col,
+                closet_id_base,
+                closet_lines,
+                {
+                    "wing": wing,
+                    "room": room,
+                    "source_file": source_file,
+                    "drawer_count": drawers_added,
+                    "filed_at": datetime.now().isoformat(),
+                    "normalize_version": NORMALIZE_VERSION,
+                },
+            )
 
     return drawers_added, room
 
@@ -593,8 +625,10 @@ def mine(
 
     if not dry_run:
         collection = get_collection(palace_path)
+        closets_col = get_closets_collection(palace_path)
     else:
         collection = None
+        closets_col = None
 
     total_drawers = 0
     files_skipped = 0
@@ -609,6 +643,7 @@ def mine(
             rooms=rooms,
             agent=agent,
             dry_run=dry_run,
+            closets_col=closets_col,
         )
         if drawers == 0 and not dry_run:
             files_skipped += 1

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -16,8 +16,15 @@ from datetime import datetime
 from collections import defaultdict
 
 from .palace import (
-    SKIP_DIRS, get_collection, get_closets_collection,
-    file_already_mined, mine_lock, build_closet_lines, upsert_closet_lines,
+    NORMALIZE_VERSION,
+    SKIP_DIRS,
+    build_closet_lines,
+    file_already_mined,
+    get_closets_collection,
+    get_collection,
+    mine_lock,
+    purge_file_closets,
+    upsert_closet_lines,
 )
 
 READABLE_EXTENSIONS = {
@@ -384,6 +391,7 @@ def add_drawer(
             "chunk_index": chunk_index,
             "added_by": agent,
             "filed_at": datetime.now().isoformat(),
+            "normalize_version": NORMALIZE_VERSION,
         }
         # Store file mtime so we can detect modifications later.
         try:
@@ -470,22 +478,32 @@ def process_file(
             if added:
                 drawers_added += 1
 
-        # Build closet — the searchable index pointing to these drawers
-        # Each topic line is atomic — never split across closets
+        # Build closet — the searchable index pointing to these drawers.
+        # Purge first: a re-mine (mtime change or normalize_version bump) must
+        # fully replace the prior closets, not append to them.
         if closets_col and drawers_added > 0:
             drawer_ids = [
                 f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(c['chunk_index'])).encode()).hexdigest()[:24]}"
                 for c in chunks
             ]
             closet_lines = build_closet_lines(source_file, drawer_ids, content, wing, room)
-            closet_id_base = f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
-            upsert_closet_lines(closets_col, closet_id_base, closet_lines, {
-                "wing": wing,
-                "room": room,
-                "source_file": source_file,
-                "drawer_count": drawers_added,
-                "filed_at": datetime.now().isoformat(),
-            })
+            closet_id_base = (
+                f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+            )
+            purge_file_closets(closets_col, source_file)
+            upsert_closet_lines(
+                closets_col,
+                closet_id_base,
+                closet_lines,
+                {
+                    "wing": wing,
+                    "room": room,
+                    "source_file": source_file,
+                    "drawer_count": drawers_added,
+                    "filed_at": datetime.now().isoformat(),
+                    "normalize_version": NORMALIZE_VERSION,
+                },
+            )
 
     return drawers_added, room
 

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -22,20 +22,40 @@ from typing import Optional
 
 
 # ─── Noise stripping ─────────────────────────────────────────────────────
-# Claude Code and other tools inject system tags, hook output, UI chrome,
-# and tool-call JSON into transcripts. These waste drawer space and pollute
-# search results. Strip them before filing.
+# Claude Code and other tools inject system tags, hook output, and UI chrome
+# into transcripts. These waste drawer space and pollute search results.
+#
+# Verbatim is sacred — every pattern here is anchored to line boundaries and
+# refuses to cross blank lines, so a stray unclosed tag in one message can
+# never eat content from neighboring messages. When in doubt, leave text
+# alone.
 
-_NOISE_TAG_PATTERNS = [
-    re.compile(r"<system-reminder[^>]*>.*?</system-reminder>", re.DOTALL),
-    re.compile(r"<command-message[^>]*>.*?</command-message>", re.DOTALL),
-    re.compile(r"<command-name[^>]*>.*?</command-name>", re.DOTALL),
-    re.compile(r"<task-notification[^>]*>.*?</task-notification>", re.DOTALL),
-    re.compile(r"<user-prompt-submit-hook[^>]*>.*?</user-prompt-submit-hook>", re.DOTALL),
-    re.compile(r"<hook_output[^>]*>.*?</hook_output>", re.DOTALL),
-]
+_NOISE_TAGS = (
+    "system-reminder",
+    "command-message",
+    "command-name",
+    "task-notification",
+    "user-prompt-submit-hook",
+    "hook_output",
+)
 
-_NOISE_STRINGS = [
+
+def _tag_pattern(name: str) -> "re.Pattern[str]":
+    # Opening tag must begin a line (optionally after a `> ` blockquote marker,
+    # since _messages_to_transcript prefixes lines with `> `). Body is lazy but
+    # forbidden from crossing a blank line, so a dangling open tag can't span
+    # multiple messages. Closing tag eats optional trailing whitespace + newline.
+    return re.compile(
+        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>" rf"(?:(?!\n\s*\n)[\s\S])*?" rf"</{name}>[ \t]*\n?"
+    )
+
+
+_NOISE_TAG_PATTERNS = [_tag_pattern(t) for t in _NOISE_TAGS]
+
+# Strings that identify an entire noise line when found at its start.
+# Matched case-sensitively and anchored to line-start so user prose mentioning
+# e.g. "current time:" in a sentence is untouched.
+_NOISE_LINE_PREFIXES = (
     "CURRENT TIME:",
     "VERIFIED FACTS (do not contradict)",
     "AGENT SPECIALIZATION:",
@@ -46,20 +66,39 @@ _NOISE_STRINGS = [
     "Auto-save reminder...",
     "Checking pipeline...",
     "MemPalace auto-save checkpoint.",
+)
+
+_NOISE_LINE_PATTERNS = [
+    re.compile(rf"(?m)^(?:> )?{re.escape(p)}.*\n?") for p in _NOISE_LINE_PREFIXES
 ]
+
+# Claude Code TUI hook-run chrome, e.g. "Ran 2 Stop hook", "Ran 1 PreCompact hook".
+# Line-anchored, case-sensitive, explicit hook names — prose like
+# "our CI has a stop hook" stays intact.
+_HOOK_LINE_RE = re.compile(
+    r"(?m)^(?:> )?Ran \d+ (?:Stop|PreCompact|PreToolUse|PostToolUse|UserPromptSubmit|Notification|SessionStart|SessionEnd) hook[s]?.*\n?"
+)
+
+# "… +N lines" collapsed-output marker, line-anchored.
+_COLLAPSED_LINES_RE = re.compile(r"(?m)^(?:> )?…\s*\+\d+ lines.*\n?")
 
 
 def strip_noise(text: str) -> str:
-    """Remove system tags, hook output, and Claude Code UI chrome from text."""
+    """Remove system tags, hook output, and Claude Code UI chrome from text.
+
+    All patterns are line-anchored. User prose that happens to mention these
+    strings inline (e.g., documenting them) is preserved verbatim.
+    """
     for pat in _NOISE_TAG_PATTERNS:
         text = pat.sub("", text)
-    for noise in _NOISE_STRINGS:
-        text = text.replace(noise, "")
-    # Strip Claude Code UI chrome
-    text = re.sub(r".*\(ctrl\+o to expand\).*\n?", "", text)
-    text = re.sub(r"Ran \d+ (?:stop|pre|post)\s*hook.*\n?", "", text, flags=re.IGNORECASE)
-    text = re.sub(r"…\s*\+\d+ lines.*\n?", "", text)
-    # Collapse runs of blank lines
+    for pat in _NOISE_LINE_PATTERNS:
+        text = pat.sub("", text)
+    text = _HOOK_LINE_RE.sub("", text)
+    text = _COLLAPSED_LINES_RE.sub("", text)
+    # Strip the Claude Code collapsed-output chrome "[N tokens] (ctrl+o to expand)".
+    # Narrow shape — a bare "(ctrl+o to expand)" in user prose stays intact.
+    text = re.sub(r"\s*\[\d+\s+tokens?\]\s*\(ctrl\+o to expand\)", "", text)
+    # Collapse runs of blank lines created by the removals
     text = re.sub(r"\n{4,}", "\n\n\n", text)
     return text.strip()
 
@@ -84,23 +123,21 @@ def normalize(filepath: str) -> str:
     if not content.strip():
         return content
 
-    # Already has > markers — pass through (strip noise but preserve trailing newline)
+    # Already has > markers — pass through unchanged.
     lines = content.split("\n")
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
-        cleaned = strip_noise(content)
-        # Preserve trailing newline if original had one
-        if content.endswith("\n") and not cleaned.endswith("\n"):
-            cleaned += "\n"
-        return cleaned
+        return content
 
-    # Try JSON normalization
+    # Try JSON normalization. strip_noise is applied inside the Claude Code
+    # JSONL parser (the only format that injects system tags/hook chrome);
+    # other formats pass through verbatim.
     ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
         if normalized:
-            return strip_noise(normalized)
+            return normalized
 
-    return strip_noise(content)
+    return content
 
 
 def _try_normalize_json(content: str) -> Optional[str]:
@@ -160,6 +197,10 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
                 isinstance(b, dict) and b.get("type") == "tool_result" for b in msg_content
             )
             text = _extract_content(msg_content, tool_use_map=tool_use_map)
+            # Strip Claude Code system-injected noise per message, never across
+            # message boundaries — prevents span-eating.
+            if text:
+                text = strip_noise(text)
             if text:
                 if is_tool_only and messages and messages[-1][0] == "assistant":
                     # Append tool results to the previous assistant message
@@ -169,6 +210,8 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
                     messages.append(("user", text))
         elif msg_type == "assistant":
             text = _extract_content(msg_content, tool_use_map=tool_use_map)
+            if text:
+                text = strip_noise(text)
             if text:
                 # If previous message is also assistant (multi-turn tool loop),
                 # merge into the same assistant turn

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -16,8 +16,91 @@ No API key. No internet. Everything local.
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Optional
+
+
+# ─── Noise stripping ─────────────────────────────────────────────────────
+# Claude Code and other tools inject system tags, hook output, and UI chrome
+# into transcripts. These waste drawer space and pollute search results.
+#
+# Verbatim is sacred — every pattern here is anchored to line boundaries and
+# refuses to cross blank lines, so a stray unclosed tag in one message can
+# never eat content from neighboring messages. When in doubt, leave text
+# alone.
+
+_NOISE_TAGS = (
+    "system-reminder",
+    "command-message",
+    "command-name",
+    "task-notification",
+    "user-prompt-submit-hook",
+    "hook_output",
+)
+
+
+def _tag_pattern(name: str) -> "re.Pattern[str]":
+    # Opening tag must begin a line (optionally after a `> ` blockquote marker,
+    # since _messages_to_transcript prefixes lines with `> `). Body is lazy but
+    # forbidden from crossing a blank line, so a dangling open tag can't span
+    # multiple messages. Closing tag eats optional trailing whitespace + newline.
+    return re.compile(
+        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>" rf"(?:(?!\n\s*\n)[\s\S])*?" rf"</{name}>[ \t]*\n?"
+    )
+
+
+_NOISE_TAG_PATTERNS = [_tag_pattern(t) for t in _NOISE_TAGS]
+
+# Strings that identify an entire noise line when found at its start.
+# Matched case-sensitively and anchored to line-start so user prose mentioning
+# e.g. "current time:" in a sentence is untouched.
+_NOISE_LINE_PREFIXES = (
+    "CURRENT TIME:",
+    "VERIFIED FACTS (do not contradict)",
+    "AGENT SPECIALIZATION:",
+    "Checking verified facts...",
+    "Injecting timestamp...",
+    "Starting background pipeline...",
+    "Checking emotional weights...",
+    "Auto-save reminder...",
+    "Checking pipeline...",
+    "MemPalace auto-save checkpoint.",
+)
+
+_NOISE_LINE_PATTERNS = [
+    re.compile(rf"(?m)^(?:> )?{re.escape(p)}.*\n?") for p in _NOISE_LINE_PREFIXES
+]
+
+# Claude Code TUI hook-run chrome, e.g. "Ran 2 Stop hook", "Ran 1 PreCompact hook".
+# Line-anchored, case-sensitive, explicit hook names — prose like
+# "our CI has a stop hook" stays intact.
+_HOOK_LINE_RE = re.compile(
+    r"(?m)^(?:> )?Ran \d+ (?:Stop|PreCompact|PreToolUse|PostToolUse|UserPromptSubmit|Notification|SessionStart|SessionEnd) hook[s]?.*\n?"
+)
+
+# "… +N lines" collapsed-output marker, line-anchored.
+_COLLAPSED_LINES_RE = re.compile(r"(?m)^(?:> )?…\s*\+\d+ lines.*\n?")
+
+
+def strip_noise(text: str) -> str:
+    """Remove system tags, hook output, and Claude Code UI chrome from text.
+
+    All patterns are line-anchored. User prose that happens to mention these
+    strings inline (e.g., documenting them) is preserved verbatim.
+    """
+    for pat in _NOISE_TAG_PATTERNS:
+        text = pat.sub("", text)
+    for pat in _NOISE_LINE_PATTERNS:
+        text = pat.sub("", text)
+    text = _HOOK_LINE_RE.sub("", text)
+    text = _COLLAPSED_LINES_RE.sub("", text)
+    # Strip the Claude Code collapsed-output chrome "[N tokens] (ctrl+o to expand)".
+    # Narrow shape — a bare "(ctrl+o to expand)" in user prose stays intact.
+    text = re.sub(r"\s*\[\d+\s+tokens?\]\s*\(ctrl\+o to expand\)", "", text)
+    # Collapse runs of blank lines created by the removals
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+    return text.strip()
 
 
 def normalize(filepath: str) -> str:
@@ -40,12 +123,14 @@ def normalize(filepath: str) -> str:
     if not content.strip():
         return content
 
-    # Already has > markers — pass through
+    # Already has > markers — pass through unchanged.
     lines = content.split("\n")
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
         return content
 
-    # Try JSON normalization
+    # Try JSON normalization. strip_noise is applied inside the Claude Code
+    # JSONL parser (the only format that injects system tags/hook chrome);
+    # other formats pass through verbatim.
     ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
@@ -112,6 +197,10 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
                 isinstance(b, dict) and b.get("type") == "tool_result" for b in msg_content
             )
             text = _extract_content(msg_content, tool_use_map=tool_use_map)
+            # Strip Claude Code system-injected noise per message, never across
+            # message boundaries — prevents span-eating.
+            if text:
+                text = strip_noise(text)
             if text:
                 if is_tool_only and messages and messages[-1][0] == "assistant":
                     # Append tool results to the previous assistant message
@@ -121,6 +210,8 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
                     messages.append(("user", text))
         elif msg_type == "assistant":
             text = _extract_content(msg_content, tool_use_map=tool_use_map)
+            if text:
+                text = strip_noise(text)
             if text:
                 # If previous message is also assistant (multi-turn tool loop),
                 # merge into the same assistant turn

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -16,8 +16,52 @@ No API key. No internet. Everything local.
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Optional
+
+
+# ─── Noise stripping ─────────────────────────────────────────────────────
+# Claude Code and other tools inject system tags, hook output, UI chrome,
+# and tool-call JSON into transcripts. These waste drawer space and pollute
+# search results. Strip them before filing.
+
+_NOISE_TAG_PATTERNS = [
+    re.compile(r"<system-reminder[^>]*>.*?</system-reminder>", re.DOTALL),
+    re.compile(r"<command-message[^>]*>.*?</command-message>", re.DOTALL),
+    re.compile(r"<command-name[^>]*>.*?</command-name>", re.DOTALL),
+    re.compile(r"<task-notification[^>]*>.*?</task-notification>", re.DOTALL),
+    re.compile(r"<user-prompt-submit-hook[^>]*>.*?</user-prompt-submit-hook>", re.DOTALL),
+    re.compile(r"<hook_output[^>]*>.*?</hook_output>", re.DOTALL),
+]
+
+_NOISE_STRINGS = [
+    "CURRENT TIME:",
+    "VERIFIED FACTS (do not contradict)",
+    "AGENT SPECIALIZATION:",
+    "Checking verified facts...",
+    "Injecting timestamp...",
+    "Starting background pipeline...",
+    "Checking emotional weights...",
+    "Auto-save reminder...",
+    "Checking pipeline...",
+    "MemPalace auto-save checkpoint.",
+]
+
+
+def strip_noise(text: str) -> str:
+    """Remove system tags, hook output, and Claude Code UI chrome from text."""
+    for pat in _NOISE_TAG_PATTERNS:
+        text = pat.sub("", text)
+    for noise in _NOISE_STRINGS:
+        text = text.replace(noise, "")
+    # Strip Claude Code UI chrome
+    text = re.sub(r".*\(ctrl\+o to expand\).*\n?", "", text)
+    text = re.sub(r"Ran \d+ (?:stop|pre|post)\s*hook.*\n?", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"…\s*\+\d+ lines.*\n?", "", text)
+    # Collapse runs of blank lines
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+    return text.strip()
 
 
 def normalize(filepath: str) -> str:
@@ -40,19 +84,23 @@ def normalize(filepath: str) -> str:
     if not content.strip():
         return content
 
-    # Already has > markers — pass through
+    # Already has > markers — pass through (strip noise but preserve trailing newline)
     lines = content.split("\n")
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
-        return content
+        cleaned = strip_noise(content)
+        # Preserve trailing newline if original had one
+        if content.endswith("\n") and not cleaned.endswith("\n"):
+            cleaned += "\n"
+        return cleaned
 
     # Try JSON normalization
     ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
         if normalized:
-            return normalized
+            return strip_noise(normalized)
 
-    return content
+    return strip_noise(content)
 
 
 def _try_normalize_json(content: str) -> Optional[str]:

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -36,6 +36,16 @@ SKIP_DIRS = {
 
 _DEFAULT_BACKEND = ChromaBackend()
 
+# Schema version for drawer normalization. Bump when the normalization
+# pipeline changes in a way that existing drawers should be rebuilt to pick up
+# (e.g., new noise-stripping rules). `file_already_mined` treats drawers with
+# a missing or stale `normalize_version` as "not mined", so the next mine pass
+# silently rebuilds them — users don't need to manually erase + re-mine.
+#
+# v2 (2026-04): introduced strip_noise() for Claude Code JSONL; previous
+#               drawers stored system tags / hook chrome verbatim.
+NORMALIZE_VERSION = 2
+
 
 def get_collection(
     palace_path: str,
@@ -53,16 +63,26 @@ def get_collection(
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:
     """Check if a file has already been filed in the palace.
 
-    When check_mtime=True (used by project miner), returns False if the file
-    has been modified since it was last mined, so it gets re-mined.
-    When check_mtime=False (used by convo miner), just checks existence.
+    Returns False (so the file gets re-mined) when:
+      - no drawers exist for this source_file
+      - the stored `normalize_version` is missing or older than the current
+        schema (triggers silent rebuild after a normalization upgrade)
+      - `check_mtime=True` and the file's mtime differs from the stored one
+
+    When check_mtime=True (used by project miner), also re-mines on content
+    change. When check_mtime=False (used by convo miner), transcripts are
+    assumed immutable, so only the version gate triggers a rebuild.
     """
     try:
         results = collection.get(where={"source_file": source_file}, limit=1)
         if not results.get("ids"):
             return False
+        stored_meta = results.get("metadatas", [{}])[0] or {}
+        # Pre-v2 drawers have no version field — treat them as stale.
+        stored_version = stored_meta.get("normalize_version", 1)
+        if stored_version < NORMALIZE_VERSION:
+            return False
         if check_mtime:
-            stored_meta = results.get("metadatas", [{}])[0]
             stored_mtime = stored_meta.get("source_mtime")
             if stored_mtime is None:
                 return False

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -38,6 +38,16 @@ SKIP_DIRS = {
 
 _DEFAULT_BACKEND = ChromaBackend()
 
+# Schema version for drawer normalization. Bump when the normalization
+# pipeline changes in a way that existing drawers should be rebuilt to pick up
+# (e.g., new noise-stripping rules). `file_already_mined` treats drawers with
+# a missing or stale `normalize_version` as "not mined", so the next mine pass
+# silently rebuilds them — users don't need to manually erase + re-mine.
+#
+# v2 (2026-04): introduced strip_noise() for Claude Code JSONL; previous
+#               drawers stored system tags / hook chrome verbatim.
+NORMALIZE_VERSION = 2
+
 
 def get_collection(
     palace_path: str,
@@ -94,16 +104,26 @@ def mine_lock(source_file: str):
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:
     """Check if a file has already been filed in the palace.
 
-    When check_mtime=True (used by project miner), returns False if the file
-    has been modified since it was last mined, so it gets re-mined.
-    When check_mtime=False (used by convo miner), just checks existence.
+    Returns False (so the file gets re-mined) when:
+      - no drawers exist for this source_file
+      - the stored `normalize_version` is missing or older than the current
+        schema (triggers silent rebuild after a normalization upgrade)
+      - `check_mtime=True` and the file's mtime differs from the stored one
+
+    When check_mtime=True (used by project miner), also re-mines on content
+    change. When check_mtime=False (used by convo miner), transcripts are
+    assumed immutable, so only the version gate triggers a rebuild.
     """
     try:
         results = collection.get(where={"source_file": source_file}, limit=1)
         if not results.get("ids"):
             return False
+        stored_meta = results.get("metadatas", [{}])[0] or {}
+        # Pre-v2 drawers have no version field — treat them as stale.
+        stored_version = stored_meta.get("normalize_version", 1)
+        if stored_version < NORMALIZE_VERSION:
+            return False
         if check_mtime:
-            stored_meta = results.get("metadatas", [{}])[0]
             stored_mtime = stored_meta.get("source_mtime")
             if stored_mtime is None:
                 return False

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -38,6 +38,16 @@ SKIP_DIRS = {
 
 _DEFAULT_BACKEND = ChromaBackend()
 
+# Schema version for drawer normalization. Bump when the normalization
+# pipeline changes in a way that existing drawers should be rebuilt to pick up
+# (e.g., new noise-stripping rules). `file_already_mined` treats drawers with
+# a missing or stale `normalize_version` as "not mined", so the next mine pass
+# silently rebuilds them — users don't need to manually erase + re-mine.
+#
+# v2 (2026-04): introduced strip_noise() for Claude Code JSONL; previous
+#               drawers stored system tags / hook chrome verbatim.
+NORMALIZE_VERSION = 2
+
 
 def get_collection(
     palace_path: str,
@@ -50,6 +60,185 @@ def get_collection(
         collection_name=collection_name,
         create=create,
     )
+
+
+def get_closets_collection(palace_path: str, create: bool = True):
+    """Get the closets collection — the searchable index layer."""
+    return get_collection(palace_path, collection_name="mempalace_closets", create=create)
+
+
+CLOSET_CHAR_LIMIT = 1500  # fill closet until ~1500 chars, then start a new one
+CLOSET_EXTRACT_WINDOW = 5000  # how many chars of source content to scan for entities/topics
+
+# Common capitalized words that look like proper nouns but are usually
+# sentence-starters or filler. Filtered out of entity extraction.
+_ENTITY_STOPLIST = frozenset(
+    {
+        "The",
+        "This",
+        "That",
+        "These",
+        "Those",
+        "When",
+        "Where",
+        "What",
+        "Why",
+        "Who",
+        "Which",
+        "How",
+        "After",
+        "Before",
+        "Then",
+        "Now",
+        "Here",
+        "There",
+        "And",
+        "But",
+        "Or",
+        "Yet",
+        "So",
+        "If",
+        "Else",
+        "Yes",
+        "No",
+        "Maybe",
+        "Okay",
+        "User",
+        "Assistant",
+        "System",
+        "Tool",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    }
+)
+
+
+def build_closet_lines(source_file, drawer_ids, content, wing, room):
+    """Build compact closet pointer lines from drawer content.
+
+    Returns a LIST of lines (not joined). Each line is one complete topic
+    pointer — never split across closets.
+
+    Format: topic|entities|→drawer_ids
+    """
+    import re
+    from pathlib import Path
+
+    drawer_ref = ",".join(drawer_ids[:3])
+    window = content[:CLOSET_EXTRACT_WINDOW]
+
+    # Extract proper nouns (capitalized words, 2+ occurrences). Filter out
+    # common sentence-starters that aren't real entities.
+    words = re.findall(r"\b[A-Z][a-z]{2,}\b", window)
+    word_freq = {}
+    for w in words:
+        if w in _ENTITY_STOPLIST:
+            continue
+        word_freq[w] = word_freq.get(w, 0) + 1
+    entities = sorted(
+        [w for w, c in word_freq.items() if c >= 2],
+        key=lambda w: -word_freq[w],
+    )[:5]
+    entity_str = ";".join(entities) if entities else ""
+
+    # Extract key phrases — action verbs + context
+    topics = []
+    for pattern in [
+        r"(?:built|fixed|wrote|added|pushed|tested|created|decided|migrated|reviewed|deployed|configured|removed|updated)\s+[\w\s]{3,40}",
+    ]:
+        topics.extend(re.findall(pattern, window, re.IGNORECASE))
+    # Also grab section headers if present
+    for header in re.findall(r"^#{1,3}\s+(.{5,60})$", window, re.MULTILINE):
+        topics.append(header.strip())
+    # Dedupe preserving order
+    topics = list(dict.fromkeys(t.strip().lower() for t in topics))[:12]
+
+    # Extract quotes
+    quotes = re.findall(r'"([^"]{15,150})"', window)
+
+    # Build pointer lines — each one is atomic, never split
+    lines = []
+    for topic in topics:
+        lines.append(f"{topic}|{entity_str}|→{drawer_ref}")
+    for quote in quotes[:3]:
+        lines.append(f'"{quote}"|{entity_str}|→{drawer_ref}')
+
+    # Always have at least one line
+    if not lines:
+        name = Path(source_file).stem[:40]
+        lines.append(f"{wing}/{room}/{name}|{entity_str}|→{drawer_ref}")
+
+    return lines
+
+
+def purge_file_closets(closets_col, source_file: str) -> None:
+    """Delete every closet associated with ``source_file``.
+
+    Call this before ``upsert_closet_lines`` on a re-mine so stale topics
+    from a prior schema/version don't survive in the closet collection.
+    Mirrors the drawer-purge step in process_file().
+    """
+    try:
+        closets_col.delete(where={"source_file": source_file})
+    except Exception:
+        pass
+
+
+def upsert_closet_lines(closets_col, closet_id_base, lines, metadata):
+    """Write topic lines to closets, packed greedily without splitting a line.
+
+    Closets are deterministically numbered (``..._01``, ``..._02``, …) and
+    each ``upsert`` fully overwrites the prior content at that ID. Callers
+    are expected to ``purge_file_closets`` first when re-mining a source
+    file so stale-numbered closets from larger prior runs don't leak.
+
+    Returns the number of closets written.
+    """
+    closet_num = 1
+    current_lines: list = []
+    current_chars = 0
+    closets_written = 0
+
+    def _flush():
+        nonlocal closets_written
+        if not current_lines:
+            return
+        closet_id = f"{closet_id_base}_{closet_num:02d}"
+        text = "\n".join(current_lines)
+        closets_col.upsert(documents=[text], ids=[closet_id], metadatas=[metadata])
+        closets_written += 1
+
+    for line in lines:
+        line_len = len(line)
+        # Would this line fit whole in the current closet?
+        if current_chars > 0 and current_chars + line_len + 1 > CLOSET_CHAR_LIMIT:
+            _flush()
+            closet_num += 1
+            current_lines = []
+            current_chars = 0
+
+        current_lines.append(line)
+        current_chars += line_len + 1  # +1 for newline
+
+    _flush()
+    return closets_written
 
 
 @contextlib.contextmanager
@@ -94,16 +283,26 @@ def mine_lock(source_file: str):
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:
     """Check if a file has already been filed in the palace.
 
-    When check_mtime=True (used by project miner), returns False if the file
-    has been modified since it was last mined, so it gets re-mined.
-    When check_mtime=False (used by convo miner), just checks existence.
+    Returns False (so the file gets re-mined) when:
+      - no drawers exist for this source_file
+      - the stored `normalize_version` is missing or older than the current
+        schema (triggers silent rebuild after a normalization upgrade)
+      - `check_mtime=True` and the file's mtime differs from the stored one
+
+    When check_mtime=True (used by project miner), also re-mines on content
+    change. When check_mtime=False (used by convo miner), transcripts are
+    assumed immutable, so only the version gate triggers a rebuild.
     """
     try:
         results = collection.get(where={"source_file": source_file}, limit=1)
         if not results.get("ids"):
             return False
+        stored_meta = results.get("metadatas", [{}])[0] or {}
+        # Pre-v2 drawers have no version field — treat them as stale.
+        stored_version = stored_meta.get("normalize_version", 1)
+        if stored_version < NORMALIZE_VERSION:
+            return False
         if check_mtime:
-            stored_meta = results.get("metadatas", [{}])[0]
             stored_mtime = stored_meta.get("source_mtime")
             if stored_mtime is None:
                 return False

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -38,6 +38,16 @@ SKIP_DIRS = {
 
 _DEFAULT_BACKEND = ChromaBackend()
 
+# Schema version for drawer normalization. Bump when the normalization
+# pipeline changes in a way that existing drawers should be rebuilt to pick up
+# (e.g., new noise-stripping rules). `file_already_mined` treats drawers with
+# a missing or stale `normalize_version` as "not mined", so the next mine pass
+# silently rebuilds them — users don't need to manually erase + re-mine.
+#
+# v2 (2026-04): introduced strip_noise() for Claude Code JSONL; previous
+#               drawers stored system tags / hook chrome verbatim.
+NORMALIZE_VERSION = 2
+
 
 def get_collection(
     palace_path: str,
@@ -58,6 +68,66 @@ def get_closets_collection(palace_path: str, create: bool = True):
 
 
 CLOSET_CHAR_LIMIT = 1500  # fill closet until ~1500 chars, then start a new one
+CLOSET_EXTRACT_WINDOW = 5000  # how many chars of source content to scan for entities/topics
+
+# Common capitalized words that look like proper nouns but are usually
+# sentence-starters or filler. Filtered out of entity extraction.
+_ENTITY_STOPLIST = frozenset(
+    {
+        "The",
+        "This",
+        "That",
+        "These",
+        "Those",
+        "When",
+        "Where",
+        "What",
+        "Why",
+        "Who",
+        "Which",
+        "How",
+        "After",
+        "Before",
+        "Then",
+        "Now",
+        "Here",
+        "There",
+        "And",
+        "But",
+        "Or",
+        "Yet",
+        "So",
+        "If",
+        "Else",
+        "Yes",
+        "No",
+        "Maybe",
+        "Okay",
+        "User",
+        "Assistant",
+        "System",
+        "Tool",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    }
+)
 
 
 def build_closet_lines(source_file, drawer_ids, content, wing, room):
@@ -72,11 +142,15 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     from pathlib import Path
 
     drawer_ref = ",".join(drawer_ids[:3])
+    window = content[:CLOSET_EXTRACT_WINDOW]
 
-    # Extract proper nouns (capitalized words, 2+ occurrences)
-    words = re.findall(r"\b[A-Z][a-z]{2,}\b", content[:5000])
+    # Extract proper nouns (capitalized words, 2+ occurrences). Filter out
+    # common sentence-starters that aren't real entities.
+    words = re.findall(r"\b[A-Z][a-z]{2,}\b", window)
     word_freq = {}
     for w in words:
+        if w in _ENTITY_STOPLIST:
+            continue
         word_freq[w] = word_freq.get(w, 0) + 1
     entities = sorted(
         [w for w, c in word_freq.items() if c >= 2],
@@ -89,15 +163,15 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     for pattern in [
         r"(?:built|fixed|wrote|added|pushed|tested|created|decided|migrated|reviewed|deployed|configured|removed|updated)\s+[\w\s]{3,40}",
     ]:
-        topics.extend(re.findall(pattern, content[:5000], re.IGNORECASE))
+        topics.extend(re.findall(pattern, window, re.IGNORECASE))
     # Also grab section headers if present
-    for header in re.findall(r"^#{1,3}\s+(.{5,60})$", content[:5000], re.MULTILINE):
+    for header in re.findall(r"^#{1,3}\s+(.{5,60})$", window, re.MULTILINE):
         topics.append(header.strip())
     # Dedupe preserving order
     topics = list(dict.fromkeys(t.strip().lower() for t in topics))[:12]
 
     # Extract quotes
-    quotes = re.findall(r'"([^"]{15,150})"', content[:5000])
+    quotes = re.findall(r'"([^"]{15,150})"', window)
 
     # Build pointer lines — each one is atomic, never split
     lines = []
@@ -114,17 +188,31 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     return lines
 
 
-def upsert_closet_lines(closets_col, closet_id_base, lines, metadata):
-    """Add topic lines to closets. Never splits a topic mid-line.
+def purge_file_closets(closets_col, source_file: str) -> None:
+    """Delete every closet associated with ``source_file``.
 
-    If adding a line WHOLE would exceed CLOSET_CHAR_LIMIT, a new closet
-    is created. Some closets may have less than 1500 chars — that's fine.
-    Every topic is complete and readable.
+    Call this before ``upsert_closet_lines`` on a re-mine so stale topics
+    from a prior schema/version don't survive in the closet collection.
+    Mirrors the drawer-purge step in process_file().
+    """
+    try:
+        closets_col.delete(where={"source_file": source_file})
+    except Exception:
+        pass
+
+
+def upsert_closet_lines(closets_col, closet_id_base, lines, metadata):
+    """Write topic lines to closets, packed greedily without splitting a line.
+
+    Closets are deterministically numbered (``..._01``, ``..._02``, …) and
+    each ``upsert`` fully overwrites the prior content at that ID. Callers
+    are expected to ``purge_file_closets`` first when re-mining a source
+    file so stale-numbered closets from larger prior runs don't leak.
 
     Returns the number of closets written.
     """
     closet_num = 1
-    current_lines = []
+    current_lines: list = []
     current_chars = 0
     closets_written = 0
 
@@ -134,17 +222,6 @@ def upsert_closet_lines(closets_col, closet_id_base, lines, metadata):
             return
         closet_id = f"{closet_id_base}_{closet_num:02d}"
         text = "\n".join(current_lines)
-
-        # Check if closet already has content — append if room
-        try:
-            existing = closets_col.get(ids=[closet_id])
-            if existing.get("ids") and existing["documents"][0]:
-                old = existing["documents"][0]
-                if len(old) + len(text) + 1 <= CLOSET_CHAR_LIMIT:
-                    text = old + "\n" + text
-        except Exception:
-            pass
-
         closets_col.upsert(documents=[text], ids=[closet_id], metadatas=[metadata])
         closets_written += 1
 
@@ -152,7 +229,6 @@ def upsert_closet_lines(closets_col, closet_id_base, lines, metadata):
         line_len = len(line)
         # Would this line fit whole in the current closet?
         if current_chars > 0 and current_chars + line_len + 1 > CLOSET_CHAR_LIMIT:
-            # Doesn't fit — flush current closet, start new one
             _flush()
             closet_num += 1
             current_lines = []
@@ -182,18 +258,22 @@ def mine_lock(source_file: str):
     try:
         if os.name == "nt":
             import msvcrt
+
             msvcrt.locking(lf.fileno(), msvcrt.LK_LOCK, 1)
         else:
             import fcntl
+
             fcntl.flock(lf, fcntl.LOCK_EX)
         yield
     finally:
         try:
             if os.name == "nt":
                 import msvcrt
+
                 msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
             else:
                 import fcntl
+
                 fcntl.flock(lf, fcntl.LOCK_UN)
         except Exception:
             pass
@@ -203,16 +283,26 @@ def mine_lock(source_file: str):
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:
     """Check if a file has already been filed in the palace.
 
-    When check_mtime=True (used by project miner), returns False if the file
-    has been modified since it was last mined, so it gets re-mined.
-    When check_mtime=False (used by convo miner), just checks existence.
+    Returns False (so the file gets re-mined) when:
+      - no drawers exist for this source_file
+      - the stored `normalize_version` is missing or older than the current
+        schema (triggers silent rebuild after a normalization upgrade)
+      - `check_mtime=True` and the file's mtime differs from the stored one
+
+    When check_mtime=True (used by project miner), also re-mines on content
+    change. When check_mtime=False (used by convo miner), transcripts are
+    assumed immutable, so only the version gate triggers a rebuild.
     """
     try:
         results = collection.get(where={"source_file": source_file}, limit=1)
         if not results.get("ids"):
             return False
+        stored_meta = results.get("metadatas", [{}])[0] or {}
+        # Pre-v2 drawers have no version field — treat them as stale.
+        stored_version = stored_meta.get("normalize_version", 1)
+        if stored_version < NORMALIZE_VERSION:
+            return False
         if check_mtime:
-            stored_meta = results.get("metadatas", [{}])[0]
             stored_mtime = stored_meta.get("source_mtime")
             if stored_mtime is None:
                 return False

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -69,18 +69,22 @@ def mine_lock(source_file: str):
     try:
         if os.name == "nt":
             import msvcrt
+
             msvcrt.locking(lf.fileno(), msvcrt.LK_LOCK, 1)
         else:
             import fcntl
+
             fcntl.flock(lf, fcntl.LOCK_EX)
         yield
     finally:
         try:
             if os.name == "nt":
                 import msvcrt
+
                 msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
             else:
                 import fcntl
+
                 fcntl.flock(lf, fcntl.LOCK_UN)
         except Exception:
             pass

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -4,6 +4,8 @@ palace.py — Shared palace operations.
 Consolidates collection access patterns used by both miners and the MCP server.
 """
 
+import contextlib
+import hashlib
 import os
 
 from .backends.chroma import ChromaBackend
@@ -58,6 +60,45 @@ def get_collection(
         collection_name=collection_name,
         create=create,
     )
+
+
+@contextlib.contextmanager
+def mine_lock(source_file: str):
+    """Cross-platform file lock for mine operations.
+
+    Prevents multiple agents from mining the same file simultaneously,
+    which causes duplicate drawers when the delete+insert cycle interleaves.
+    """
+    lock_dir = os.path.join(os.path.expanduser("~"), ".mempalace", "locks")
+    os.makedirs(lock_dir, exist_ok=True)
+    lock_path = os.path.join(
+        lock_dir, hashlib.sha256(source_file.encode()).hexdigest()[:16] + ".lock"
+    )
+
+    lf = open(lock_path, "w")
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(lf.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lf, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lf, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        lf.close()
 
 
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -4,6 +4,8 @@ palace.py — Shared palace operations.
 Consolidates collection access patterns used by both miners and the MCP server.
 """
 
+import contextlib
+import hashlib
 import os
 
 from .backends.chroma import ChromaBackend
@@ -48,6 +50,45 @@ def get_collection(
         collection_name=collection_name,
         create=create,
     )
+
+
+@contextlib.contextmanager
+def mine_lock(source_file: str):
+    """Cross-platform file lock for mine operations.
+
+    Prevents multiple agents from mining the same file simultaneously,
+    which causes duplicate drawers when the delete+insert cycle interleaves.
+    """
+    lock_dir = os.path.join(os.path.expanduser("~"), ".mempalace", "locks")
+    os.makedirs(lock_dir, exist_ok=True)
+    lock_path = os.path.join(
+        lock_dir, hashlib.sha256(source_file.encode()).hexdigest()[:16] + ".lock"
+    )
+
+    lf = open(lock_path, "w")
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(lf.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lf, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lf, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        lf.close()
 
 
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -62,6 +62,185 @@ def get_collection(
     )
 
 
+def get_closets_collection(palace_path: str, create: bool = True):
+    """Get the closets collection — the searchable index layer."""
+    return get_collection(palace_path, collection_name="mempalace_closets", create=create)
+
+
+CLOSET_CHAR_LIMIT = 1500  # fill closet until ~1500 chars, then start a new one
+CLOSET_EXTRACT_WINDOW = 5000  # how many chars of source content to scan for entities/topics
+
+# Common capitalized words that look like proper nouns but are usually
+# sentence-starters or filler. Filtered out of entity extraction.
+_ENTITY_STOPLIST = frozenset(
+    {
+        "The",
+        "This",
+        "That",
+        "These",
+        "Those",
+        "When",
+        "Where",
+        "What",
+        "Why",
+        "Who",
+        "Which",
+        "How",
+        "After",
+        "Before",
+        "Then",
+        "Now",
+        "Here",
+        "There",
+        "And",
+        "But",
+        "Or",
+        "Yet",
+        "So",
+        "If",
+        "Else",
+        "Yes",
+        "No",
+        "Maybe",
+        "Okay",
+        "User",
+        "Assistant",
+        "System",
+        "Tool",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    }
+)
+
+
+def build_closet_lines(source_file, drawer_ids, content, wing, room):
+    """Build compact closet pointer lines from drawer content.
+
+    Returns a LIST of lines (not joined). Each line is one complete topic
+    pointer — never split across closets.
+
+    Format: topic|entities|→drawer_ids
+    """
+    import re
+    from pathlib import Path
+
+    drawer_ref = ",".join(drawer_ids[:3])
+    window = content[:CLOSET_EXTRACT_WINDOW]
+
+    # Extract proper nouns (capitalized words, 2+ occurrences). Filter out
+    # common sentence-starters that aren't real entities.
+    words = re.findall(r"\b[A-Z][a-z]{2,}\b", window)
+    word_freq = {}
+    for w in words:
+        if w in _ENTITY_STOPLIST:
+            continue
+        word_freq[w] = word_freq.get(w, 0) + 1
+    entities = sorted(
+        [w for w, c in word_freq.items() if c >= 2],
+        key=lambda w: -word_freq[w],
+    )[:5]
+    entity_str = ";".join(entities) if entities else ""
+
+    # Extract key phrases — action verbs + context
+    topics = []
+    for pattern in [
+        r"(?:built|fixed|wrote|added|pushed|tested|created|decided|migrated|reviewed|deployed|configured|removed|updated)\s+[\w\s]{3,40}",
+    ]:
+        topics.extend(re.findall(pattern, window, re.IGNORECASE))
+    # Also grab section headers if present
+    for header in re.findall(r"^#{1,3}\s+(.{5,60})$", window, re.MULTILINE):
+        topics.append(header.strip())
+    # Dedupe preserving order
+    topics = list(dict.fromkeys(t.strip().lower() for t in topics))[:12]
+
+    # Extract quotes
+    quotes = re.findall(r'"([^"]{15,150})"', window)
+
+    # Build pointer lines — each one is atomic, never split
+    lines = []
+    for topic in topics:
+        lines.append(f"{topic}|{entity_str}|→{drawer_ref}")
+    for quote in quotes[:3]:
+        lines.append(f'"{quote}"|{entity_str}|→{drawer_ref}')
+
+    # Always have at least one line
+    if not lines:
+        name = Path(source_file).stem[:40]
+        lines.append(f"{wing}/{room}/{name}|{entity_str}|→{drawer_ref}")
+
+    return lines
+
+
+def purge_file_closets(closets_col, source_file: str) -> None:
+    """Delete every closet associated with ``source_file``.
+
+    Call this before ``upsert_closet_lines`` on a re-mine so stale topics
+    from a prior schema/version don't survive in the closet collection.
+    Mirrors the drawer-purge step in process_file().
+    """
+    try:
+        closets_col.delete(where={"source_file": source_file})
+    except Exception:
+        pass
+
+
+def upsert_closet_lines(closets_col, closet_id_base, lines, metadata):
+    """Write topic lines to closets, packed greedily without splitting a line.
+
+    Closets are deterministically numbered (``..._01``, ``..._02``, …) and
+    each ``upsert`` fully overwrites the prior content at that ID. Callers
+    are expected to ``purge_file_closets`` first when re-mining a source
+    file so stale-numbered closets from larger prior runs don't leak.
+
+    Returns the number of closets written.
+    """
+    closet_num = 1
+    current_lines: list = []
+    current_chars = 0
+    closets_written = 0
+
+    def _flush():
+        nonlocal closets_written
+        if not current_lines:
+            return
+        closet_id = f"{closet_id_base}_{closet_num:02d}"
+        text = "\n".join(current_lines)
+        closets_col.upsert(documents=[text], ids=[closet_id], metadatas=[metadata])
+        closets_written += 1
+
+    for line in lines:
+        line_len = len(line)
+        # Would this line fit whole in the current closet?
+        if current_chars > 0 and current_chars + line_len + 1 > CLOSET_CHAR_LIMIT:
+            _flush()
+            closet_num += 1
+            current_lines = []
+            current_chars = 0
+
+        current_lines.append(line)
+        current_chars += line_len + 1  # +1 for newline
+
+    _flush()
+    return closets_written
+
+
 @contextlib.contextmanager
 def mine_lock(source_file: str):
     """Cross-platform file lock for mine operations.

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -18,11 +18,12 @@ No external graph DB needed — built from ChromaDB metadata.
 import hashlib
 import json
 import os
-from collections import defaultdict, Counter
-from datetime import datetime
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
 
 from .config import MempalaceConfig
 from .palace import get_collection as _get_palace_collection
+from .palace import mine_lock
 
 
 def _get_collection(config=None):
@@ -249,20 +250,66 @@ _TUNNEL_FILE = os.path.join(os.path.expanduser("~"), ".mempalace", "tunnels.json
 
 
 def _load_tunnels():
-    """Load explicit tunnels from disk."""
-    if os.path.exists(_TUNNEL_FILE):
-        try:
-            return json.loads(open(_TUNNEL_FILE).read())
-        except Exception:
-            pass
-    return []
+    """Load explicit tunnels from disk.
+
+    Returns an empty list if the file is missing or corrupt (e.g. truncated
+    by a crash mid-write on a system that lacks atomic-rename semantics).
+    """
+    if not os.path.exists(_TUNNEL_FILE):
+        return []
+    try:
+        with open(_TUNNEL_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return []
+    return data if isinstance(data, list) else []
 
 
 def _save_tunnels(tunnels):
-    """Save explicit tunnels to disk."""
+    """Persist explicit tunnels atomically.
+
+    Writes to ``tunnels.json.tmp`` then ``os.replace``s it into place, so
+    a crash mid-write can never leave a partial/empty tunnels.json that
+    silently wipes every tunnel on next read.
+    """
     os.makedirs(os.path.dirname(_TUNNEL_FILE), exist_ok=True)
-    with open(_TUNNEL_FILE, "w") as f:
+    tmp_path = _TUNNEL_FILE + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(tunnels, f, indent=2)
+        f.flush()
+        try:
+            os.fsync(f.fileno())
+        except OSError:
+            # Not all filesystems (or Windows file handles) support fsync — tolerate.
+            pass
+    os.replace(tmp_path, _TUNNEL_FILE)
+
+
+def _endpoint_key(wing: str, room: str) -> str:
+    return f"{wing}/{room}"
+
+
+def _canonical_tunnel_id(
+    source_wing: str, source_room: str, target_wing: str, target_room: str
+) -> str:
+    """Compute a symmetric tunnel ID.
+
+    Tunnels are conceptually undirected — "auth relates to users" is the
+    same connection as "users relates to auth". Sort the two endpoints
+    before hashing so ``create_tunnel(A, B)`` and ``create_tunnel(B, A)``
+    resolve to the same ID and dedup into one record.
+    """
+    src = _endpoint_key(source_wing, source_room)
+    tgt = _endpoint_key(target_wing, target_room)
+    a, b = sorted((src, tgt))
+    return hashlib.sha256(f"{a}↔{b}".encode()).hexdigest()[:16]
+
+
+def _require_name(value: str, field: str) -> str:
+    """Reject empty / non-string endpoint identifiers."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
 
 
 def create_tunnel(
@@ -274,72 +321,88 @@ def create_tunnel(
     source_drawer_id: str = None,
     target_drawer_id: str = None,
 ):
-    """Create an explicit tunnel between two locations in the palace.
+    """Create an explicit (symmetric) tunnel between two locations in the palace.
 
-    Use when an agent notices a connection between two projects/wings
-    that wouldn't be found by passive room-name matching.
+    Tunnels are undirected: ``create_tunnel(A, B)`` and ``create_tunnel(B, A)``
+    resolve to the same canonical ID. A second call with the same endpoints
+    updates the stored label (and drawer IDs, if provided) rather than
+    creating a duplicate.
+
+    The ``source`` / ``target`` fields on the returned dict preserve the
+    argument order the caller used, so callers can display it directionally
+    if they like. The ID and dedup are symmetric.
 
     Args:
-        source_wing: Wing of the source (e.g., "project_api")
-        source_room: Room in the source wing
-        target_wing: Wing of the target (e.g., "project_database")
-        target_room: Room in the target wing
-        label: Description of the connection
-        source_drawer_id: Optional specific drawer ID
-        target_drawer_id: Optional specific drawer ID
+        source_wing: Wing of the source (e.g., "project_api").
+        source_room: Room in the source wing.
+        target_wing: Wing of the target (e.g., "project_database").
+        target_room: Room in the target wing.
+        label: Description of the connection.
+        source_drawer_id: Optional specific drawer ID.
+        target_drawer_id: Optional specific drawer ID.
 
     Returns:
-        The created tunnel dict.
+        The stored tunnel dict.
+
+    Raises:
+        ValueError: if any wing or room is empty or non-string.
     """
-    tunnel_id = hashlib.sha256(
-        f"{source_wing}/{source_room}↔{target_wing}/{target_room}".encode()
-    ).hexdigest()[:16]
+    source_wing = _require_name(source_wing, "source_wing")
+    source_room = _require_name(source_room, "source_room")
+    target_wing = _require_name(target_wing, "target_wing")
+    target_room = _require_name(target_room, "target_room")
+
+    tunnel_id = _canonical_tunnel_id(source_wing, source_room, target_wing, target_room)
 
     tunnel = {
         "id": tunnel_id,
         "source": {"wing": source_wing, "room": source_room},
         "target": {"wing": target_wing, "room": target_room},
         "label": label,
-        "created_at": datetime.now().isoformat(),
+        "created_at": datetime.now(timezone.utc).isoformat(),
     }
     if source_drawer_id:
         tunnel["source"]["drawer_id"] = source_drawer_id
     if target_drawer_id:
         tunnel["target"]["drawer_id"] = target_drawer_id
 
-    tunnels = _load_tunnels()
-
-    # Dedup — don't create if same endpoints already linked
-    for existing in tunnels:
-        if existing.get("id") == tunnel_id:
-            existing.update(tunnel)  # update label/drawers
-            _save_tunnels(tunnels)
-            return existing
-
-    tunnels.append(tunnel)
-    _save_tunnels(tunnels)
+    # Serialize the load → mutate → save cycle. Without this, two concurrent
+    # create_tunnel calls can both read the same snapshot and the later
+    # writer silently drops the earlier writer's tunnel.
+    with mine_lock(_TUNNEL_FILE):
+        tunnels = _load_tunnels()
+        for existing in tunnels:
+            if existing.get("id") == tunnel_id:
+                # Preserve original creation timestamp on label updates.
+                tunnel["created_at"] = existing.get("created_at", tunnel["created_at"])
+                tunnel["updated_at"] = datetime.now(timezone.utc).isoformat()
+                existing.clear()
+                existing.update(tunnel)
+                _save_tunnels(tunnels)
+                return existing
+        tunnels.append(tunnel)
+        _save_tunnels(tunnels)
     return tunnel
 
 
 def list_tunnels(wing: str = None):
     """List all explicit tunnels, optionally filtered by wing.
 
-    Returns tunnels where the wing appears as either source or target.
+    Returns tunnels where ``wing`` appears as either source or target
+    (tunnels are symmetric, so either endpoint is a valid filter match).
     """
     tunnels = _load_tunnels()
     if wing:
-        tunnels = [
-            t for t in tunnels
-            if t["source"]["wing"] == wing or t["target"]["wing"] == wing
-        ]
+        tunnels = [t for t in tunnels if t["source"]["wing"] == wing or t["target"]["wing"] == wing]
     return tunnels
 
 
 def delete_tunnel(tunnel_id: str):
-    """Delete an explicit tunnel by ID."""
-    tunnels = _load_tunnels()
-    tunnels = [t for t in tunnels if t.get("id") != tunnel_id]
-    _save_tunnels(tunnels)
+    """Delete an explicit tunnel by ID. Returns ``{"deleted": <id>}``."""
+    with mine_lock(_TUNNEL_FILE):
+        tunnels = _load_tunnels()
+        tunnels = [t for t in tunnels if t.get("id") != tunnel_id]
+        _save_tunnels(tunnels)
     return {"deleted": tunnel_id}
 
 
@@ -357,23 +420,27 @@ def follow_tunnels(wing: str, room: str, col=None, config=None):
         tgt = t["target"]
 
         if src["wing"] == wing and src["room"] == room:
-            connections.append({
-                "direction": "outgoing",
-                "connected_wing": tgt["wing"],
-                "connected_room": tgt["room"],
-                "label": t.get("label", ""),
-                "drawer_id": tgt.get("drawer_id"),
-                "tunnel_id": t["id"],
-            })
+            connections.append(
+                {
+                    "direction": "outgoing",
+                    "connected_wing": tgt["wing"],
+                    "connected_room": tgt["room"],
+                    "label": t.get("label", ""),
+                    "drawer_id": tgt.get("drawer_id"),
+                    "tunnel_id": t["id"],
+                }
+            )
         elif tgt["wing"] == wing and tgt["room"] == room:
-            connections.append({
-                "direction": "incoming",
-                "connected_wing": src["wing"],
-                "connected_room": src["room"],
-                "label": t.get("label", ""),
-                "drawer_id": src.get("drawer_id"),
-                "tunnel_id": t["id"],
-            })
+            connections.append(
+                {
+                    "direction": "incoming",
+                    "connected_wing": src["wing"],
+                    "connected_room": src["room"],
+                    "label": t.get("label", ""),
+                    "drawer_id": src.get("drawer_id"),
+                    "tunnel_id": t["id"],
+                }
+            )
 
     # If we have a collection, fetch drawer content for connected items
     if col and connections:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -7,9 +7,14 @@ Returns verbatim text — the actual words, never summaries.
 """
 
 import logging
+import re
 from pathlib import Path
 
-from .palace import get_collection
+from .palace import get_closets_collection, get_collection
+
+# Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
+# Multiple lines may join with newlines inside one closet document.
+_CLOSET_DRAWER_REF_RE = re.compile(r"→([\w,]+)")
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -27,6 +32,116 @@ def build_where_filter(wing: str = None, room: str = None) -> dict:
     elif room:
         return {"room": room}
     return {}
+
+
+def _extract_drawer_ids_from_closet(closet_doc: str) -> list:
+    """Parse all `→drawer_id_a,drawer_id_b` pointers out of a closet document.
+
+    Preserves order and dedupes.
+    """
+    seen: dict = {}
+    for match in _CLOSET_DRAWER_REF_RE.findall(closet_doc):
+        for did in match.split(","):
+            did = did.strip()
+            if did and did not in seen:
+                seen[did] = None
+    return list(seen.keys())
+
+
+def _closet_first_hits(
+    palace_path: str,
+    query: str,
+    where: dict,
+    drawers_col,
+    n_results: int,
+    max_distance: float,
+):
+    """Run a closet-first search and return chunk-level drawer hits.
+
+    Returns:
+        non-empty list of hits when the closet path produced usable matches.
+        ``None`` when the closet collection is empty/missing OR when every
+        candidate drawer was filtered out (e.g. by max_distance); the
+        caller should fall back to direct drawer search.
+    """
+    try:
+        closets_col = get_closets_collection(palace_path, create=False)
+    except Exception:
+        return None
+
+    try:
+        ckwargs = {
+            "query_texts": [query],
+            "n_results": max(n_results * 2, 5),
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            ckwargs["where"] = where
+        closet_results = closets_col.query(**ckwargs)
+    except Exception:
+        return None
+
+    closet_docs = closet_results["documents"][0] if closet_results["documents"] else []
+    if not closet_docs:
+        return None
+
+    closet_metas = closet_results["metadatas"][0]
+    closet_dists = closet_results["distances"][0]
+
+    # Collect candidate drawer IDs in closet-rank order, dedupe, remember
+    # which closet (and its distance/preview) introduced each one.
+    drawer_id_order: list = []
+    drawer_provenance: dict = {}
+    for cdoc, cmeta, cdist in zip(closet_docs, closet_metas, closet_dists):
+        for did in _extract_drawer_ids_from_closet(cdoc):
+            if did in drawer_provenance:
+                continue
+            drawer_provenance[did] = (cdist, cdoc, cmeta)
+            drawer_id_order.append(did)
+
+    if not drawer_id_order:
+        return None
+
+    # Hydrate exactly those drawers — chunk-level, not whole-file.
+    try:
+        fetched = drawers_col.get(
+            ids=drawer_id_order,
+            include=["documents", "metadatas"],
+        )
+    except Exception:
+        return None
+
+    fetched_ids = fetched.get("ids") or []
+    fetched_docs = fetched.get("documents") or []
+    fetched_metas = fetched.get("metadatas") or []
+    fetched_map = {
+        did: (doc, meta) for did, doc, meta in zip(fetched_ids, fetched_docs, fetched_metas)
+    }
+
+    hits: list = []
+    for did in drawer_id_order:
+        if did not in fetched_map:
+            continue  # closet pointed to a drawer that no longer exists
+        doc, meta = fetched_map[did]
+        cdist, cdoc, _ = drawer_provenance[did]
+        if max_distance > 0.0 and cdist > max_distance:
+            continue
+        hits.append(
+            {
+                "text": doc,
+                "wing": meta.get("wing", "unknown"),
+                "room": meta.get("room", "unknown"),
+                "source_file": Path(meta.get("source_file", "?")).name,
+                "similarity": round(max(0.0, 1 - cdist), 3),
+                "distance": round(cdist, 4),
+                "matched_via": "closet",
+                "closet_preview": cdoc[:200],
+            }
+        )
+        if len(hits) >= n_results:
+            break
+
+    return hits if hits else None
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
@@ -117,7 +232,7 @@ def search_memories(
             0.0 disables filtering. Typical useful range: 0.3–1.0.
     """
     try:
-        col = get_collection(palace_path, create=False)
+        drawers_col = get_collection(palace_path, create=False)
     except Exception as e:
         logger.error("No palace found at %s: %s", palace_path, e)
         return {
@@ -127,6 +242,27 @@ def search_memories(
 
     where = build_where_filter(wing, room)
 
+    # Closet-first search: scan the compact index, parse drawer pointers
+    # from each matching line, then hydrate exactly those drawers. This
+    # keeps the result shape chunk-level (consistent with direct search)
+    # and applies the same max_distance filter.
+    closet_hits = _closet_first_hits(
+        palace_path=palace_path,
+        query=query,
+        where=where,
+        drawers_col=drawers_col,
+        n_results=n_results,
+        max_distance=max_distance,
+    )
+    if closet_hits is not None:
+        return {
+            "query": query,
+            "filters": {"wing": wing, "room": room},
+            "total_before_filter": len(closet_hits),
+            "results": closet_hits,
+        }
+
+    # Fallback: direct drawer search (no closets yet, or closets empty)
     try:
         kwargs = {
             "query_texts": [query],
@@ -136,7 +272,7 @@ def search_memories(
         if where:
             kwargs["where"] = where
 
-        results = col.query(**kwargs)
+        results = drawers_col.query(**kwargs)
     except Exception as e:
         return {"error": f"Search error: {e}"}
 
@@ -157,6 +293,7 @@ def search_memories(
                 "source_file": Path(meta.get("source_file", "?")).name,
                 "similarity": round(max(0.0, 1 - dist), 3),
                 "distance": round(dist, 4),
+                "matched_via": "drawer",
             }
         )
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -12,7 +12,11 @@ import math
 import re
 from pathlib import Path
 
-from .palace import get_collection, get_closets_collection
+from .palace import get_closets_collection, get_collection
+
+# Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
+# Multiple lines may join with newlines inside one closet document.
+_CLOSET_DRAWER_REF_RE = re.compile(r"→([\w,]+)")
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -21,57 +25,109 @@ class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
 
 
-def _bm25_score(query: str, document: str, k1: float = 1.5, b: float = 0.75, avg_dl: float = 500) -> float:
-    """Simple BM25 score for a single document against a query.
+_TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 
-    This is a lightweight keyword-matching signal that complements vector
-    similarity. It catches exact matches that embeddings might miss
-    (e.g., specific names, project codes, error messages).
+
+def _tokenize(text: str) -> list:
+    """Lowercase + strip to alphanumeric tokens of length ≥ 2."""
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _bm25_scores(
+    query: str,
+    documents: list,
+    k1: float = 1.5,
+    b: float = 0.75,
+) -> list:
+    """Compute Okapi-BM25 scores for ``query`` against each document.
+
+    IDF is computed over the *provided corpus* using the Lucene/BM25+
+    smoothed formula ``log((N - df + 0.5) / (df + 0.5) + 1)``, which is
+    always non-negative. This is well-defined for re-ranking a small
+    candidate set returned by vector retrieval — IDF then reflects how
+    discriminative each query term is *within the candidates*, exactly
+    what's needed to reorder them.
+
+    Parameters mirror Okapi-BM25 conventions:
+        k1 — term-frequency saturation (1.2-2.0 typical, 1.5 default)
+        b  — length normalization (0.0 = none, 1.0 = full, 0.75 default)
+
+    Returns a list of scores in the same order as ``documents``.
     """
-    query_terms = set(re.findall(r'\w{2,}', query.lower()))
-    doc_terms = re.findall(r'\w{2,}', document.lower())
-    if not query_terms or not doc_terms:
-        return 0.0
-    doc_len = len(doc_terms)
-    term_freq = {}
-    for t in doc_terms:
-        term_freq[t] = term_freq.get(t, 0) + 1
+    n_docs = len(documents)
+    query_terms = set(_tokenize(query))
+    if not query_terms or n_docs == 0:
+        return [0.0] * n_docs
 
-    score = 0.0
-    for term in query_terms:
-        tf = term_freq.get(term, 0)
-        if tf > 0:
-            # Simplified IDF — treat each query term as moderately rare
-            idf = math.log(2.0)
-            numerator = tf * (k1 + 1)
-            denominator = tf + k1 * (1 - b + b * doc_len / avg_dl)
-            score += idf * numerator / denominator
-    return score
+    tokenized = [_tokenize(d) for d in documents]
+    doc_lens = [len(toks) for toks in tokenized]
+    if not any(doc_lens):
+        return [0.0] * n_docs
+    avgdl = sum(doc_lens) / n_docs or 1.0
+
+    # Document frequency: how many docs contain each query term?
+    df = {term: 0 for term in query_terms}
+    for toks in tokenized:
+        seen = set(toks) & query_terms
+        for term in seen:
+            df[term] += 1
+
+    idf = {term: math.log((n_docs - df[term] + 0.5) / (df[term] + 0.5) + 1) for term in query_terms}
+
+    scores = []
+    for toks, dl in zip(tokenized, doc_lens):
+        if dl == 0:
+            scores.append(0.0)
+            continue
+        tf: dict = {}
+        for t in toks:
+            if t in query_terms:
+                tf[t] = tf.get(t, 0) + 1
+        score = 0.0
+        for term, freq in tf.items():
+            num = freq * (k1 + 1)
+            den = freq + k1 * (1 - b + b * dl / avgdl)
+            score += idf[term] * num / den
+        scores.append(score)
+    return scores
 
 
-def _hybrid_rank(vector_results, query: str, vector_weight: float = 0.6, bm25_weight: float = 0.4):
-    """Re-rank results using both vector distance and BM25 keyword score.
+def _hybrid_rank(
+    results: list,
+    query: str,
+    vector_weight: float = 0.6,
+    bm25_weight: float = 0.4,
+) -> list:
+    """Re-rank ``results`` by a convex combination of vector similarity and BM25.
 
-    Returns results sorted by combined score (higher = better).
+    * Vector similarity uses absolute cosine sim ``max(0, 1 - distance)`` —
+      ChromaDB's hnsw cosine distance lives in ``[0, 2]`` (0 = identical).
+      Absolute (not relative-to-max) means adding/removing a candidate
+      can't reshuffle the others.
+    * BM25 is real Okapi-BM25 with corpus-relative IDF over the candidates
+      themselves. Since the absolute scale is unbounded, BM25 is min-max
+      normalized within the candidate set so weights are commensurable.
+
+    Mutates each result dict to add ``bm25_score`` and reorders the list
+    in place. Returns the same list for convenience.
     """
-    if not vector_results:
-        return vector_results
+    if not results:
+        return results
 
-    # Normalize vector distances to 0-1 similarity
-    max_dist = max(r.get("distance", 1.0) for r in vector_results) or 1.0
-    for r in vector_results:
-        vec_sim = max(0.0, 1 - r.get("distance", 1.0) / max(max_dist, 0.001))
-        bm25 = _bm25_score(query, r.get("text", ""))
-        # Normalize BM25 to roughly 0-1 range
-        bm25_norm = min(bm25 / 3.0, 1.0)
-        r["_hybrid_score"] = vector_weight * vec_sim + bm25_weight * bm25_norm
-        r["bm25_score"] = round(bm25, 3)
+    docs = [r.get("text", "") for r in results]
+    bm25_raw = _bm25_scores(query, docs)
+    max_bm25 = max(bm25_raw) if bm25_raw else 0.0
+    bm25_norm = [s / max_bm25 for s in bm25_raw] if max_bm25 > 0 else [0.0] * len(bm25_raw)
 
-    vector_results.sort(key=lambda r: r["_hybrid_score"], reverse=True)
-    # Clean up internal field
-    for r in vector_results:
-        del r["_hybrid_score"]
-    return vector_results
+    scored = []
+    for r, raw, norm in zip(results, bm25_raw, bm25_norm):
+        vec_sim = max(0.0, 1.0 - r.get("distance", 1.0))
+        r["bm25_score"] = round(raw, 3)
+        scored.append((vector_weight * vec_sim + bm25_weight * norm, r))
+
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    results[:] = [r for _, r in scored]
+    return results
 
 
 def build_where_filter(wing: str = None, room: str = None) -> dict:
@@ -83,6 +139,187 @@ def build_where_filter(wing: str = None, room: str = None) -> dict:
     elif room:
         return {"room": room}
     return {}
+
+
+def _extract_drawer_ids_from_closet(closet_doc: str) -> list:
+    """Parse all `→drawer_id_a,drawer_id_b` pointers out of a closet document.
+
+    Preserves order and dedupes.
+    """
+    seen: dict = {}
+    for match in _CLOSET_DRAWER_REF_RE.findall(closet_doc):
+        for did in match.split(","):
+            did = did.strip()
+            if did and did not in seen:
+                seen[did] = None
+    return list(seen.keys())
+
+
+def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, radius: int = 1):
+    """Expand a matched drawer with its ±radius sibling chunks in the same source file.
+
+    Motivation — "drawer-grep context" feature: a closet hit returns one
+    drawer, but the chunk boundary may clip mid-thought (e.g., the matched
+    chunk says "here's a breakdown:" and the actual breakdown lives in the
+    next chunk). Fetching the small neighborhood around the match gives
+    callers enough context without forcing a follow-up ``get_drawer`` call.
+
+    Returns a dict with:
+        ``text``            combined chunks in chunk_index order
+        ``drawer_index``    the matched chunk's index in the source file
+        ``total_drawers``   total drawer count for the source file (or None)
+
+    On any ChromaDB failure or missing metadata, falls back to returning the
+    matched drawer alone so search never breaks because neighbor expansion
+    failed.
+    """
+    src = matched_meta.get("source_file")
+    chunk_idx = matched_meta.get("chunk_index")
+    if not src or not isinstance(chunk_idx, int):
+        return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
+
+    target_indexes = [chunk_idx + offset for offset in range(-radius, radius + 1)]
+    try:
+        neighbors = drawers_col.get(
+            where={
+                "$and": [
+                    {"source_file": src},
+                    {"chunk_index": {"$in": target_indexes}},
+                ]
+            },
+            include=["documents", "metadatas"],
+        )
+    except Exception:
+        return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
+
+    indexed_docs = []
+    for doc, meta in zip(neighbors.get("documents") or [], neighbors.get("metadatas") or []):
+        ci = meta.get("chunk_index")
+        if isinstance(ci, int):
+            indexed_docs.append((ci, doc))
+    indexed_docs.sort(key=lambda pair: pair[0])
+
+    if not indexed_docs:
+        combined_text = matched_doc
+    else:
+        combined_text = "\n\n".join(doc for _, doc in indexed_docs)
+
+    # Cheap total_drawers lookup: metadata-only scan of the source file.
+    total_drawers = None
+    try:
+        all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
+        ids = all_meta.get("ids") or []
+        total_drawers = len(ids) if ids else None
+    except Exception:
+        pass
+
+    return {
+        "text": combined_text,
+        "drawer_index": chunk_idx,
+        "total_drawers": total_drawers,
+    }
+
+
+def _closet_first_hits(
+    palace_path: str,
+    query: str,
+    where: dict,
+    drawers_col,
+    n_results: int,
+    max_distance: float,
+):
+    """Run a closet-first search and return chunk-level drawer hits.
+
+    Returns:
+        non-empty list of hits when the closet path produced usable matches.
+        ``None`` when the closet collection is empty/missing OR when every
+        candidate drawer was filtered out (e.g. by max_distance); the
+        caller should fall back to direct drawer search.
+    """
+    try:
+        closets_col = get_closets_collection(palace_path, create=False)
+    except Exception:
+        return None
+
+    try:
+        ckwargs = {
+            "query_texts": [query],
+            "n_results": max(n_results * 2, 5),
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            ckwargs["where"] = where
+        closet_results = closets_col.query(**ckwargs)
+    except Exception:
+        return None
+
+    closet_docs = closet_results["documents"][0] if closet_results["documents"] else []
+    if not closet_docs:
+        return None
+
+    closet_metas = closet_results["metadatas"][0]
+    closet_dists = closet_results["distances"][0]
+
+    # Collect candidate drawer IDs in closet-rank order, dedupe, remember
+    # which closet (and its distance/preview) introduced each one.
+    drawer_id_order: list = []
+    drawer_provenance: dict = {}
+    for cdoc, cmeta, cdist in zip(closet_docs, closet_metas, closet_dists):
+        for did in _extract_drawer_ids_from_closet(cdoc):
+            if did in drawer_provenance:
+                continue
+            drawer_provenance[did] = (cdist, cdoc, cmeta)
+            drawer_id_order.append(did)
+
+    if not drawer_id_order:
+        return None
+
+    # Hydrate exactly those drawers — chunk-level, not whole-file.
+    try:
+        fetched = drawers_col.get(
+            ids=drawer_id_order,
+            include=["documents", "metadatas"],
+        )
+    except Exception:
+        return None
+
+    fetched_ids = fetched.get("ids") or []
+    fetched_docs = fetched.get("documents") or []
+    fetched_metas = fetched.get("metadatas") or []
+    fetched_map = {
+        did: (doc, meta) for did, doc, meta in zip(fetched_ids, fetched_docs, fetched_metas)
+    }
+
+    hits: list = []
+    for did in drawer_id_order:
+        if did not in fetched_map:
+            continue  # closet pointed to a drawer that no longer exists
+        doc, meta = fetched_map[did]
+        cdist, cdoc, _ = drawer_provenance[did]
+        if max_distance > 0.0 and cdist > max_distance:
+            continue
+        # Expand with ±1 neighbor chunks from the same source file so a
+        # closet hit that lands mid-thought still returns enough context to
+        # be useful without a follow-up get_drawer call.
+        expansion = _expand_with_neighbors(drawers_col, doc, meta, radius=1)
+        hits.append(
+            {
+                "text": expansion["text"],
+                "wing": meta.get("wing", "unknown"),
+                "room": meta.get("room", "unknown"),
+                "source_file": Path(meta.get("source_file", "?")).name,
+                "similarity": round(max(0.0, 1 - cdist), 3),
+                "distance": round(cdist, 4),
+                "matched_via": "closet",
+                "closet_preview": cdoc[:200],
+                "drawer_index": expansion["drawer_index"],
+                "total_drawers": expansion["total_drawers"],
+            }
+        )
+        if len(hits) >= n_results:
+            break
+
+    return hits if hits else None
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
@@ -183,98 +420,31 @@ def search_memories(
 
     where = build_where_filter(wing, room)
 
-    # Try closet-first search: search the compact index, then hydrate drawers
-    closet_hits = []
-    try:
-        closets_col = get_closets_collection(palace_path, create=False)
-        ckwargs = {
-            "query_texts": [query],
-            "n_results": n_results * 2,  # over-fetch closets to find best drawers
-            "include": ["documents", "metadatas", "distances"],
+    # Closet-first search: scan the compact index, parse drawer pointers
+    # from each matching line, then hydrate exactly those drawers. This
+    # keeps the result shape chunk-level (consistent with direct search)
+    # and applies the same max_distance filter.
+    closet_hits = _closet_first_hits(
+        palace_path=palace_path,
+        query=query,
+        where=where,
+        drawers_col=drawers_col,
+        n_results=n_results,
+        max_distance=max_distance,
+    )
+    if closet_hits is not None:
+        # Re-rank chunk-level closet hits with the same hybrid scoring as
+        # the direct path. The vector half here uses the closet's distance
+        # (query↔topic-line) — that's intentional: closets are *meant* to
+        # be the semantic-narrowing signal, and BM25 then enforces actual
+        # keyword presence in the hydrated drawer text.
+        closet_hits = _hybrid_rank(closet_hits, query)
+        return {
+            "query": query,
+            "filters": {"wing": wing, "room": room},
+            "total_before_filter": len(closet_hits),
+            "results": closet_hits,
         }
-        if where:
-            ckwargs["where"] = where
-        closet_results = closets_col.query(**ckwargs)
-        if closet_results["documents"][0]:
-            closet_hits = list(zip(
-                closet_results["documents"][0],
-                closet_results["metadatas"][0],
-                closet_results["distances"][0],
-            ))
-    except Exception:
-        pass  # no closets yet — fall through to direct drawer search
-
-    # If closets found results, hydrate the referenced drawers
-    MAX_HYDRATION_CHARS = 10000  # cap to prevent blowup on large source files
-
-    if closet_hits:
-        import re
-        seen_sources = set()
-        hits = []
-        for closet_doc, closet_meta, closet_dist in closet_hits:
-            source = closet_meta.get("source_file", "")
-            if source in seen_sources:
-                continue
-            seen_sources.add(source)
-
-            # Find drawers for this source file, grep for most relevant chunk
-            try:
-                drawer_results = drawers_col.get(
-                    where={"source_file": source},
-                    include=["documents", "metadatas"],
-                )
-                if drawer_results.get("ids"):
-                    # Drawer-grep: score each chunk against the query,
-                    # return the best-matching chunk first + surrounding context
-                    query_terms = set(re.findall(r'\w{2,}', query.lower()))
-                    best_idx = 0
-                    best_score = -1
-                    for idx, doc in enumerate(drawer_results["documents"]):
-                        doc_lower = doc.lower()
-                        score = sum(1 for t in query_terms if t in doc_lower)
-                        if score > best_score:
-                            best_score = score
-                            best_idx = idx
-
-                    # Build result: best chunk first, then neighbors
-                    docs = drawer_results["documents"]
-                    n_docs = len(docs)
-                    # Include best chunk + 1 before + 1 after for context
-                    start = max(0, best_idx - 1)
-                    end = min(n_docs, best_idx + 2)
-                    relevant_text = "\n\n".join(docs[start:end])
-
-                    if len(relevant_text) > MAX_HYDRATION_CHARS:
-                        relevant_text = relevant_text[:MAX_HYDRATION_CHARS] + f"\n\n[...truncated. {n_docs} total drawers. Use mempalace_get_drawer for full content.]"
-
-                    meta = drawer_results["metadatas"][best_idx]
-                    hits.append({
-                        "text": relevant_text,
-                        "wing": meta.get("wing", "unknown"),
-                        "room": meta.get("room", "unknown"),
-                        "source_file": Path(source).name,
-                        "similarity": round(max(0.0, 1 - closet_dist), 3),
-                        "distance": round(closet_dist, 4),
-                        "matched_via": "closet",
-                        "closet_preview": closet_doc[:200],
-                        "drawer_index": best_idx,
-                        "total_drawers": n_docs,
-                    })
-            except Exception:
-                pass
-
-            if len(hits) >= n_results:
-                break
-
-        if hits:
-            # Re-rank with BM25 hybrid scoring
-            hits = _hybrid_rank(hits, query)
-            return {
-                "query": query,
-                "filters": {"wing": wing, "room": room},
-                "total_before_filter": len(closet_hits),
-                "results": hits,
-            }
 
     # Fallback: direct drawer search (no closets yet, or closets empty)
     try:
@@ -307,6 +477,7 @@ def search_memories(
                 "source_file": Path(meta.get("source_file", "?")).name,
                 "similarity": round(max(0.0, 1 - dist), 3),
                 "distance": round(dist, 4),
+                "matched_via": "drawer",
             }
         )
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -12,7 +12,11 @@ import math
 import re
 from pathlib import Path
 
-from .palace import get_collection, get_closets_collection
+from .palace import get_closets_collection, get_collection
+
+# Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
+# Multiple lines may join with newlines inside one closet document.
+_CLOSET_DRAWER_REF_RE = re.compile(r"→([\w,]+)")
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -21,57 +25,109 @@ class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
 
 
-def _bm25_score(query: str, document: str, k1: float = 1.5, b: float = 0.75, avg_dl: float = 500) -> float:
-    """Simple BM25 score for a single document against a query.
+_TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 
-    This is a lightweight keyword-matching signal that complements vector
-    similarity. It catches exact matches that embeddings might miss
-    (e.g., specific names, project codes, error messages).
+
+def _tokenize(text: str) -> list:
+    """Lowercase + strip to alphanumeric tokens of length ≥ 2."""
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _bm25_scores(
+    query: str,
+    documents: list,
+    k1: float = 1.5,
+    b: float = 0.75,
+) -> list:
+    """Compute Okapi-BM25 scores for ``query`` against each document.
+
+    IDF is computed over the *provided corpus* using the Lucene/BM25+
+    smoothed formula ``log((N - df + 0.5) / (df + 0.5) + 1)``, which is
+    always non-negative. This is well-defined for re-ranking a small
+    candidate set returned by vector retrieval — IDF then reflects how
+    discriminative each query term is *within the candidates*, exactly
+    what's needed to reorder them.
+
+    Parameters mirror Okapi-BM25 conventions:
+        k1 — term-frequency saturation (1.2-2.0 typical, 1.5 default)
+        b  — length normalization (0.0 = none, 1.0 = full, 0.75 default)
+
+    Returns a list of scores in the same order as ``documents``.
     """
-    query_terms = set(re.findall(r'\w{2,}', query.lower()))
-    doc_terms = re.findall(r'\w{2,}', document.lower())
-    if not query_terms or not doc_terms:
-        return 0.0
-    doc_len = len(doc_terms)
-    term_freq = {}
-    for t in doc_terms:
-        term_freq[t] = term_freq.get(t, 0) + 1
+    n_docs = len(documents)
+    query_terms = set(_tokenize(query))
+    if not query_terms or n_docs == 0:
+        return [0.0] * n_docs
 
-    score = 0.0
-    for term in query_terms:
-        tf = term_freq.get(term, 0)
-        if tf > 0:
-            # Simplified IDF — treat each query term as moderately rare
-            idf = math.log(2.0)
-            numerator = tf * (k1 + 1)
-            denominator = tf + k1 * (1 - b + b * doc_len / avg_dl)
-            score += idf * numerator / denominator
-    return score
+    tokenized = [_tokenize(d) for d in documents]
+    doc_lens = [len(toks) for toks in tokenized]
+    if not any(doc_lens):
+        return [0.0] * n_docs
+    avgdl = sum(doc_lens) / n_docs or 1.0
+
+    # Document frequency: how many docs contain each query term?
+    df = {term: 0 for term in query_terms}
+    for toks in tokenized:
+        seen = set(toks) & query_terms
+        for term in seen:
+            df[term] += 1
+
+    idf = {term: math.log((n_docs - df[term] + 0.5) / (df[term] + 0.5) + 1) for term in query_terms}
+
+    scores = []
+    for toks, dl in zip(tokenized, doc_lens):
+        if dl == 0:
+            scores.append(0.0)
+            continue
+        tf: dict = {}
+        for t in toks:
+            if t in query_terms:
+                tf[t] = tf.get(t, 0) + 1
+        score = 0.0
+        for term, freq in tf.items():
+            num = freq * (k1 + 1)
+            den = freq + k1 * (1 - b + b * dl / avgdl)
+            score += idf[term] * num / den
+        scores.append(score)
+    return scores
 
 
-def _hybrid_rank(vector_results, query: str, vector_weight: float = 0.6, bm25_weight: float = 0.4):
-    """Re-rank results using both vector distance and BM25 keyword score.
+def _hybrid_rank(
+    results: list,
+    query: str,
+    vector_weight: float = 0.6,
+    bm25_weight: float = 0.4,
+) -> list:
+    """Re-rank ``results`` by a convex combination of vector similarity and BM25.
 
-    Returns results sorted by combined score (higher = better).
+    * Vector similarity uses absolute cosine sim ``max(0, 1 - distance)`` —
+      ChromaDB's hnsw cosine distance lives in ``[0, 2]`` (0 = identical).
+      Absolute (not relative-to-max) means adding/removing a candidate
+      can't reshuffle the others.
+    * BM25 is real Okapi-BM25 with corpus-relative IDF over the candidates
+      themselves. Since the absolute scale is unbounded, BM25 is min-max
+      normalized within the candidate set so weights are commensurable.
+
+    Mutates each result dict to add ``bm25_score`` and reorders the list
+    in place. Returns the same list for convenience.
     """
-    if not vector_results:
-        return vector_results
+    if not results:
+        return results
 
-    # Normalize vector distances to 0-1 similarity
-    max_dist = max(r.get("distance", 1.0) for r in vector_results) or 1.0
-    for r in vector_results:
-        vec_sim = max(0.0, 1 - r.get("distance", 1.0) / max(max_dist, 0.001))
-        bm25 = _bm25_score(query, r.get("text", ""))
-        # Normalize BM25 to roughly 0-1 range
-        bm25_norm = min(bm25 / 3.0, 1.0)
-        r["_hybrid_score"] = vector_weight * vec_sim + bm25_weight * bm25_norm
-        r["bm25_score"] = round(bm25, 3)
+    docs = [r.get("text", "") for r in results]
+    bm25_raw = _bm25_scores(query, docs)
+    max_bm25 = max(bm25_raw) if bm25_raw else 0.0
+    bm25_norm = [s / max_bm25 for s in bm25_raw] if max_bm25 > 0 else [0.0] * len(bm25_raw)
 
-    vector_results.sort(key=lambda r: r["_hybrid_score"], reverse=True)
-    # Clean up internal field
-    for r in vector_results:
-        del r["_hybrid_score"]
-    return vector_results
+    scored = []
+    for r, raw, norm in zip(results, bm25_raw, bm25_norm):
+        vec_sim = max(0.0, 1.0 - r.get("distance", 1.0))
+        r["bm25_score"] = round(raw, 3)
+        scored.append((vector_weight * vec_sim + bm25_weight * norm, r))
+
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    results[:] = [r for _, r in scored]
+    return results
 
 
 def build_where_filter(wing: str = None, room: str = None) -> dict:
@@ -83,6 +139,116 @@ def build_where_filter(wing: str = None, room: str = None) -> dict:
     elif room:
         return {"room": room}
     return {}
+
+
+def _extract_drawer_ids_from_closet(closet_doc: str) -> list:
+    """Parse all `→drawer_id_a,drawer_id_b` pointers out of a closet document.
+
+    Preserves order and dedupes.
+    """
+    seen: dict = {}
+    for match in _CLOSET_DRAWER_REF_RE.findall(closet_doc):
+        for did in match.split(","):
+            did = did.strip()
+            if did and did not in seen:
+                seen[did] = None
+    return list(seen.keys())
+
+
+def _closet_first_hits(
+    palace_path: str,
+    query: str,
+    where: dict,
+    drawers_col,
+    n_results: int,
+    max_distance: float,
+):
+    """Run a closet-first search and return chunk-level drawer hits.
+
+    Returns:
+        non-empty list of hits when the closet path produced usable matches.
+        ``None`` when the closet collection is empty/missing OR when every
+        candidate drawer was filtered out (e.g. by max_distance); the
+        caller should fall back to direct drawer search.
+    """
+    try:
+        closets_col = get_closets_collection(palace_path, create=False)
+    except Exception:
+        return None
+
+    try:
+        ckwargs = {
+            "query_texts": [query],
+            "n_results": max(n_results * 2, 5),
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            ckwargs["where"] = where
+        closet_results = closets_col.query(**ckwargs)
+    except Exception:
+        return None
+
+    closet_docs = closet_results["documents"][0] if closet_results["documents"] else []
+    if not closet_docs:
+        return None
+
+    closet_metas = closet_results["metadatas"][0]
+    closet_dists = closet_results["distances"][0]
+
+    # Collect candidate drawer IDs in closet-rank order, dedupe, remember
+    # which closet (and its distance/preview) introduced each one.
+    drawer_id_order: list = []
+    drawer_provenance: dict = {}
+    for cdoc, cmeta, cdist in zip(closet_docs, closet_metas, closet_dists):
+        for did in _extract_drawer_ids_from_closet(cdoc):
+            if did in drawer_provenance:
+                continue
+            drawer_provenance[did] = (cdist, cdoc, cmeta)
+            drawer_id_order.append(did)
+
+    if not drawer_id_order:
+        return None
+
+    # Hydrate exactly those drawers — chunk-level, not whole-file.
+    try:
+        fetched = drawers_col.get(
+            ids=drawer_id_order,
+            include=["documents", "metadatas"],
+        )
+    except Exception:
+        return None
+
+    fetched_ids = fetched.get("ids") or []
+    fetched_docs = fetched.get("documents") or []
+    fetched_metas = fetched.get("metadatas") or []
+    fetched_map = {
+        did: (doc, meta) for did, doc, meta in zip(fetched_ids, fetched_docs, fetched_metas)
+    }
+
+    hits: list = []
+    for did in drawer_id_order:
+        if did not in fetched_map:
+            continue  # closet pointed to a drawer that no longer exists
+        doc, meta = fetched_map[did]
+        cdist, cdoc, _ = drawer_provenance[did]
+        if max_distance > 0.0 and cdist > max_distance:
+            continue
+        hits.append(
+            {
+                "text": doc,
+                "wing": meta.get("wing", "unknown"),
+                "room": meta.get("room", "unknown"),
+                "source_file": Path(meta.get("source_file", "?")).name,
+                "similarity": round(max(0.0, 1 - cdist), 3),
+                "distance": round(cdist, 4),
+                "matched_via": "closet",
+                "closet_preview": cdoc[:200],
+            }
+        )
+        if len(hits) >= n_results:
+            break
+
+    return hits if hits else None
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
@@ -183,73 +349,31 @@ def search_memories(
 
     where = build_where_filter(wing, room)
 
-    # Try closet-first search: search the compact index, then hydrate drawers
-    closet_hits = []
-    try:
-        closets_col = get_closets_collection(palace_path, create=False)
-        ckwargs = {
-            "query_texts": [query],
-            "n_results": n_results * 2,  # over-fetch closets to find best drawers
-            "include": ["documents", "metadatas", "distances"],
+    # Closet-first search: scan the compact index, parse drawer pointers
+    # from each matching line, then hydrate exactly those drawers. This
+    # keeps the result shape chunk-level (consistent with direct search)
+    # and applies the same max_distance filter.
+    closet_hits = _closet_first_hits(
+        palace_path=palace_path,
+        query=query,
+        where=where,
+        drawers_col=drawers_col,
+        n_results=n_results,
+        max_distance=max_distance,
+    )
+    if closet_hits is not None:
+        # Re-rank chunk-level closet hits with the same hybrid scoring as
+        # the direct path. The vector half here uses the closet's distance
+        # (query↔topic-line) — that's intentional: closets are *meant* to
+        # be the semantic-narrowing signal, and BM25 then enforces actual
+        # keyword presence in the hydrated drawer text.
+        closet_hits = _hybrid_rank(closet_hits, query)
+        return {
+            "query": query,
+            "filters": {"wing": wing, "room": room},
+            "total_before_filter": len(closet_hits),
+            "results": closet_hits,
         }
-        if where:
-            ckwargs["where"] = where
-        closet_results = closets_col.query(**ckwargs)
-        if closet_results["documents"][0]:
-            closet_hits = list(zip(
-                closet_results["documents"][0],
-                closet_results["metadatas"][0],
-                closet_results["distances"][0],
-            ))
-    except Exception:
-        pass  # no closets yet — fall through to direct drawer search
-
-    # If closets found results, hydrate the referenced drawers
-    if closet_hits:
-        import re
-        seen_sources = set()
-        hits = []
-        for closet_doc, closet_meta, closet_dist in closet_hits:
-            source = closet_meta.get("source_file", "")
-            if source in seen_sources:
-                continue
-            seen_sources.add(source)
-
-            # Find drawers for this source file
-            try:
-                drawer_results = drawers_col.get(
-                    where={"source_file": source},
-                    include=["documents", "metadatas"],
-                )
-                if drawer_results.get("ids"):
-                    # Combine all drawer content for this file
-                    full_text = "\n\n".join(drawer_results["documents"])
-                    meta = drawer_results["metadatas"][0]
-                    hits.append({
-                        "text": full_text,
-                        "wing": meta.get("wing", "unknown"),
-                        "room": meta.get("room", "unknown"),
-                        "source_file": Path(source).name,
-                        "similarity": round(max(0.0, 1 - closet_dist), 3),
-                        "distance": round(closet_dist, 4),
-                        "matched_via": "closet",
-                        "closet_preview": closet_doc[:200],
-                    })
-            except Exception:
-                pass
-
-            if len(hits) >= n_results:
-                break
-
-        if hits:
-            # Re-rank with BM25 hybrid scoring
-            hits = _hybrid_rank(hits, query)
-            return {
-                "query": query,
-                "filters": {"wing": wing, "room": room},
-                "total_before_filter": len(closet_hits),
-                "results": hits,
-            }
 
     # Fallback: direct drawer search (no closets yet, or closets empty)
     try:
@@ -282,6 +406,7 @@ def search_memories(
                 "source_file": Path(meta.get("source_file", "?")).name,
                 "similarity": round(max(0.0, 1 - dist), 3),
                 "distance": round(dist, 4),
+                "matched_via": "drawer",
             }
         )
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -2,9 +2,11 @@
 """
 searcher.py — Find anything. Exact words.
 
-Hybrid search: BM25 keyword matching + vector semantic similarity.
-Searches closets first (fast index), then hydrates full drawer content.
-Falls back to direct drawer search for palaces without closets.
+Hybrid search: BM25 keyword matching + vector semantic similarity. The
+drawer query is the floor — always runs — and closet hits add a rank-based
+boost when they agree. Closets are a ranking *signal*, never a gate, so
+weak closets (regex extraction on narrative content) can only help, never
+hide drawers the direct path would have found.
 """
 
 import logging
@@ -220,108 +222,6 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     }
 
 
-def _closet_first_hits(
-    palace_path: str,
-    query: str,
-    where: dict,
-    drawers_col,
-    n_results: int,
-    max_distance: float,
-):
-    """Run a closet-first search and return chunk-level drawer hits.
-
-    Returns:
-        non-empty list of hits when the closet path produced usable matches.
-        ``None`` when the closet collection is empty/missing OR when every
-        candidate drawer was filtered out (e.g. by max_distance); the
-        caller should fall back to direct drawer search.
-    """
-    try:
-        closets_col = get_closets_collection(palace_path, create=False)
-    except Exception:
-        return None
-
-    try:
-        ckwargs = {
-            "query_texts": [query],
-            "n_results": max(n_results * 2, 5),
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            ckwargs["where"] = where
-        closet_results = closets_col.query(**ckwargs)
-    except Exception:
-        return None
-
-    closet_docs = closet_results["documents"][0] if closet_results["documents"] else []
-    if not closet_docs:
-        return None
-
-    closet_metas = closet_results["metadatas"][0]
-    closet_dists = closet_results["distances"][0]
-
-    # Collect candidate drawer IDs in closet-rank order, dedupe, remember
-    # which closet (and its distance/preview) introduced each one.
-    drawer_id_order: list = []
-    drawer_provenance: dict = {}
-    for cdoc, cmeta, cdist in zip(closet_docs, closet_metas, closet_dists):
-        for did in _extract_drawer_ids_from_closet(cdoc):
-            if did in drawer_provenance:
-                continue
-            drawer_provenance[did] = (cdist, cdoc, cmeta)
-            drawer_id_order.append(did)
-
-    if not drawer_id_order:
-        return None
-
-    # Hydrate exactly those drawers — chunk-level, not whole-file.
-    try:
-        fetched = drawers_col.get(
-            ids=drawer_id_order,
-            include=["documents", "metadatas"],
-        )
-    except Exception:
-        return None
-
-    fetched_ids = fetched.get("ids") or []
-    fetched_docs = fetched.get("documents") or []
-    fetched_metas = fetched.get("metadatas") or []
-    fetched_map = {
-        did: (doc, meta) for did, doc, meta in zip(fetched_ids, fetched_docs, fetched_metas)
-    }
-
-    hits: list = []
-    for did in drawer_id_order:
-        if did not in fetched_map:
-            continue  # closet pointed to a drawer that no longer exists
-        doc, meta = fetched_map[did]
-        cdist, cdoc, _ = drawer_provenance[did]
-        if max_distance > 0.0 and cdist > max_distance:
-            continue
-        # Expand with ±1 neighbor chunks from the same source file so a
-        # closet hit that lands mid-thought still returns enough context to
-        # be useful without a follow-up get_drawer call.
-        expansion = _expand_with_neighbors(drawers_col, doc, meta, radius=1)
-        hits.append(
-            {
-                "text": expansion["text"],
-                "wing": meta.get("wing", "unknown"),
-                "room": meta.get("room", "unknown"),
-                "source_file": Path(meta.get("source_file", "?")).name,
-                "similarity": round(max(0.0, 1 - cdist), 3),
-                "distance": round(cdist, 4),
-                "matched_via": "closet",
-                "closet_preview": cdoc[:200],
-                "drawer_index": expansion["drawer_index"],
-                "total_drawers": expansion["total_drawers"],
-            }
-        )
-        if len(hits) >= n_results:
-            break
-
-    return hits if hits else None
-
-
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
     """
     Search the palace. Returns verbatim drawer content.
@@ -420,72 +320,168 @@ def search_memories(
 
     where = build_where_filter(wing, room)
 
-    # Closet-first search: scan the compact index, parse drawer pointers
-    # from each matching line, then hydrate exactly those drawers. This
-    # keeps the result shape chunk-level (consistent with direct search)
-    # and applies the same max_distance filter.
-    closet_hits = _closet_first_hits(
-        palace_path=palace_path,
-        query=query,
-        where=where,
-        drawers_col=drawers_col,
-        n_results=n_results,
-        max_distance=max_distance,
-    )
-    if closet_hits is not None:
-        # Re-rank chunk-level closet hits with the same hybrid scoring as
-        # the direct path. The vector half here uses the closet's distance
-        # (query↔topic-line) — that's intentional: closets are *meant* to
-        # be the semantic-narrowing signal, and BM25 then enforces actual
-        # keyword presence in the hydrated drawer text.
-        closet_hits = _hybrid_rank(closet_hits, query)
-        return {
-            "query": query,
-            "filters": {"wing": wing, "room": room},
-            "total_before_filter": len(closet_hits),
-            "results": closet_hits,
-        }
-
-    # Fallback: direct drawer search (no closets yet, or closets empty)
+    # Hybrid retrieval: always query drawers directly (the floor), then use
+    # closet hits to boost rankings. Closets are a ranking SIGNAL, never a
+    # GATE — direct drawer search is always the baseline.
+    #
+    # This avoids the "weak-closets regression" where narrative content
+    # produces low-signal closets (regex extraction matches few topics)
+    # and closet-first routing hides drawers that direct search would find.
     try:
-        kwargs = {
+        dkwargs = {
             "query_texts": [query],
-            "n_results": n_results,
+            "n_results": n_results * 3,  # over-fetch for re-ranking
             "include": ["documents", "metadatas", "distances"],
         }
         if where:
-            kwargs["where"] = where
-
-        results = drawers_col.query(**kwargs)
+            dkwargs["where"] = where
+        drawer_results = drawers_col.query(**dkwargs)
     except Exception as e:
         return {"error": f"Search error: {e}"}
 
-    docs = results["documents"][0]
-    metas = results["metadatas"][0]
-    dists = results["distances"][0]
+    # Gather closet hits (best-per-source) to build a boost lookup.
+    closet_boost_by_source: dict = {}  # source_file -> (rank, closet_dist, preview)
+    try:
+        closets_col = get_closets_collection(palace_path, create=False)
+        ckwargs = {
+            "query_texts": [query],
+            "n_results": n_results * 2,
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            ckwargs["where"] = where
+        closet_results = closets_col.query(**ckwargs)
+        for rank, (cdoc, cmeta, cdist) in enumerate(
+            zip(
+                closet_results["documents"][0],
+                closet_results["metadatas"][0],
+                closet_results["distances"][0],
+            )
+        ):
+            source = cmeta.get("source_file", "")
+            if source and source not in closet_boost_by_source:
+                closet_boost_by_source[source] = (rank, cdist, cdoc[:200])
+    except Exception:
+        pass  # no closets yet — hybrid degrades to pure drawer search
 
-    hits = []
-    for doc, meta, dist in zip(docs, metas, dists):
-        # Filter on raw distance before rounding to avoid precision loss
+    # Rank-based boost. The ordinal signal ("which closet matched best") is
+    # more reliable than absolute distance on narrative content, where
+    # closet distances cluster in 1.2-1.5 range regardless of match quality.
+    CLOSET_RANK_BOOSTS = [0.40, 0.25, 0.15, 0.08, 0.04]
+    CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
+
+    scored: list = []
+    for doc, meta, dist in zip(
+        drawer_results["documents"][0],
+        drawer_results["metadatas"][0],
+        drawer_results["distances"][0],
+    ):
+        # Filter on raw distance before rounding to avoid precision loss.
         if max_distance > 0.0 and dist > max_distance:
             continue
-        hits.append(
-            {
-                "text": doc,
-                "wing": meta.get("wing", "unknown"),
-                "room": meta.get("room", "unknown"),
-                "source_file": Path(meta.get("source_file", "?")).name,
-                "similarity": round(max(0.0, 1 - dist), 3),
-                "distance": round(dist, 4),
-                "matched_via": "drawer",
-            }
-        )
 
-    # Re-rank with BM25 hybrid scoring
+        source = meta.get("source_file", "") or ""
+        boost = 0.0
+        matched_via = "drawer"
+        closet_preview = None
+        if source in closet_boost_by_source:
+            c_rank, c_dist, c_preview = closet_boost_by_source[source]
+            if c_dist <= CLOSET_DISTANCE_CAP and c_rank < len(CLOSET_RANK_BOOSTS):
+                boost = CLOSET_RANK_BOOSTS[c_rank]
+                matched_via = "drawer+closet"
+                closet_preview = c_preview
+
+        effective_dist = dist - boost
+        entry = {
+            "text": doc,
+            "wing": meta.get("wing", "unknown"),
+            "room": meta.get("room", "unknown"),
+            "source_file": Path(source).name if source else "?",
+            "similarity": round(max(0.0, 1 - effective_dist), 3),
+            "distance": round(dist, 4),
+            "effective_distance": round(effective_dist, 4),
+            "closet_boost": round(boost, 3),
+            "matched_via": matched_via,
+            # Internal: retain the full source_file path + chunk_index so the
+            # enrichment step below doesn't have to reverse-lookup via
+            # basename-suffix matching (which silently collides when two
+            # files share a basename across different directories).
+            "_sort_key": effective_dist,
+            "_source_file_full": source,
+            "_chunk_index": meta.get("chunk_index"),
+        }
+        if closet_preview:
+            entry["closet_preview"] = closet_preview
+        scored.append(entry)
+
+    scored.sort(key=lambda h: h["_sort_key"])
+    hits = scored[:n_results]
+
+    # Drawer-grep enrichment: for closet-boosted hits whose source has
+    # multiple drawers, return the keyword-best chunk + its immediate
+    # neighbors instead of just the drawer vector search landed on. The
+    # closet said "this source is relevant"; vector may have picked the
+    # wrong chunk within it; grep picks the right one.
+    MAX_HYDRATION_CHARS = 10000
+    for h in hits:
+        if h["matched_via"] == "drawer":
+            continue
+        full_source = h.get("_source_file_full") or ""
+        if not full_source:
+            continue
+        try:
+            source_drawers = drawers_col.get(
+                where={"source_file": full_source},
+                include=["documents", "metadatas"],
+            )
+        except Exception:
+            continue
+        docs = source_drawers.get("documents") or []
+        metas_ = source_drawers.get("metadatas") or []
+        if len(docs) <= 1:
+            continue
+
+        # Sort by chunk_index so best_idx + neighbors are positional.
+        indexed = []
+        for idx, (d, m) in enumerate(zip(docs, metas_)):
+            ci = m.get("chunk_index", idx) if isinstance(m, dict) else idx
+            if not isinstance(ci, int):
+                ci = idx
+            indexed.append((ci, d))
+        indexed.sort(key=lambda p: p[0])
+        ordered_docs = [d for _, d in indexed]
+
+        query_terms = set(_tokenize(query))
+        best_idx, best_score = 0, -1
+        for idx, d in enumerate(ordered_docs):
+            d_lower = d.lower()
+            s = sum(1 for t in query_terms if t in d_lower)
+            if s > best_score:
+                best_score, best_idx = s, idx
+
+        start = max(0, best_idx - 1)
+        end = min(len(ordered_docs), best_idx + 2)
+        expanded = "\n\n".join(ordered_docs[start:end])
+        if len(expanded) > MAX_HYDRATION_CHARS:
+            expanded = (
+                expanded[:MAX_HYDRATION_CHARS]
+                + f"\n\n[...truncated. {len(ordered_docs)} total drawers. "
+                "Use mempalace_get_drawer for full content.]"
+            )
+        h["text"] = expanded
+        h["drawer_index"] = best_idx
+        h["total_drawers"] = len(ordered_docs)
+
+    # BM25 hybrid re-rank within the final candidate set.
     hits = _hybrid_rank(hits, query)
+    for h in hits:
+        h.pop("_sort_key", None)
+        h.pop("_source_file_full", None)
+        h.pop("_chunk_index", None)
+
     return {
         "query": query,
         "filters": {"wing": wing, "room": room},
-        "total_before_filter": len(docs),
+        "total_before_filter": len(drawer_results["documents"][0]),
         "results": hits,
     }

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -183,138 +183,156 @@ def search_memories(
 
     where = build_where_filter(wing, room)
 
-    # Try closet-first search: search the compact index, then hydrate drawers
-    closet_hits = []
+    # Hybrid retrieval: always query drawers directly (the floor), then use
+    # closet hits to boost rankings. Closets are a ranking SIGNAL, never a
+    # GATE — direct drawer search is always the baseline.
+    #
+    # This avoids the "weak-closets regression" where narrative content
+    # produces low-signal closets (regex extraction matches few topics)
+    # and closet-first routing hides drawers that direct search would find.
+    try:
+        dkwargs = {
+            "query_texts": [query],
+            "n_results": n_results * 3,  # over-fetch for re-ranking
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            dkwargs["where"] = where
+        drawer_results = drawers_col.query(**dkwargs)
+    except Exception as e:
+        return {"error": f"Search error: {e}"}
+
+    # Gather closet hits (best-per-source) to build a boost lookup.
+    closet_boost_by_source = {}  # source_file -> (rank, closet_dist, preview)
     try:
         closets_col = get_closets_collection(palace_path, create=False)
         ckwargs = {
             "query_texts": [query],
-            "n_results": n_results * 2,  # over-fetch closets to find best drawers
+            "n_results": n_results * 2,
             "include": ["documents", "metadatas", "distances"],
         }
         if where:
             ckwargs["where"] = where
         closet_results = closets_col.query(**ckwargs)
-        if closet_results["documents"][0]:
-            closet_hits = list(zip(
+        for rank, (doc, meta, dist) in enumerate(
+            zip(
                 closet_results["documents"][0],
                 closet_results["metadatas"][0],
                 closet_results["distances"][0],
-            ))
+            )
+        ):
+            source = meta.get("source_file", "")
+            if source and source not in closet_boost_by_source:
+                closet_boost_by_source[source] = (rank, dist, doc[:200])
     except Exception:
-        pass  # no closets yet — fall through to direct drawer search
+        pass  # no closets yet — hybrid degrades to pure drawer search
 
-    # If closets found results, hydrate the referenced drawers
-    MAX_HYDRATION_CHARS = 10000  # cap to prevent blowup on large source files
+    # Rank-based boost. Ordinal signal (which closet matched best) is more
+    # reliable than absolute distance on narrative content.
+    CLOSET_RANK_BOOSTS = [0.40, 0.25, 0.15, 0.08, 0.04]
+    CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
 
-    if closet_hits:
-        import re
-        seen_sources = set()
-        hits = []
-        for closet_doc, closet_meta, closet_dist in closet_hits:
-            source = closet_meta.get("source_file", "")
-            if source in seen_sources:
-                continue
-            seen_sources.add(source)
-
-            # Find drawers for this source file, grep for most relevant chunk
-            try:
-                drawer_results = drawers_col.get(
-                    where={"source_file": source},
-                    include=["documents", "metadatas"],
-                )
-                if drawer_results.get("ids"):
-                    # Drawer-grep: score each chunk against the query,
-                    # return the best-matching chunk first + surrounding context
-                    query_terms = set(re.findall(r'\w{2,}', query.lower()))
-                    best_idx = 0
-                    best_score = -1
-                    for idx, doc in enumerate(drawer_results["documents"]):
-                        doc_lower = doc.lower()
-                        score = sum(1 for t in query_terms if t in doc_lower)
-                        if score > best_score:
-                            best_score = score
-                            best_idx = idx
-
-                    # Build result: best chunk first, then neighbors
-                    docs = drawer_results["documents"]
-                    n_docs = len(docs)
-                    # Include best chunk + 1 before + 1 after for context
-                    start = max(0, best_idx - 1)
-                    end = min(n_docs, best_idx + 2)
-                    relevant_text = "\n\n".join(docs[start:end])
-
-                    if len(relevant_text) > MAX_HYDRATION_CHARS:
-                        relevant_text = relevant_text[:MAX_HYDRATION_CHARS] + f"\n\n[...truncated. {n_docs} total drawers. Use mempalace_get_drawer for full content.]"
-
-                    meta = drawer_results["metadatas"][best_idx]
-                    hits.append({
-                        "text": relevant_text,
-                        "wing": meta.get("wing", "unknown"),
-                        "room": meta.get("room", "unknown"),
-                        "source_file": Path(source).name,
-                        "similarity": round(max(0.0, 1 - closet_dist), 3),
-                        "distance": round(closet_dist, 4),
-                        "matched_via": "closet",
-                        "closet_preview": closet_doc[:200],
-                        "drawer_index": best_idx,
-                        "total_drawers": n_docs,
-                    })
-            except Exception:
-                pass
-
-            if len(hits) >= n_results:
-                break
-
-        if hits:
-            # Re-rank with BM25 hybrid scoring
-            hits = _hybrid_rank(hits, query)
-            return {
-                "query": query,
-                "filters": {"wing": wing, "room": room},
-                "total_before_filter": len(closet_hits),
-                "results": hits,
-            }
-
-    # Fallback: direct drawer search (no closets yet, or closets empty)
-    try:
-        kwargs = {
-            "query_texts": [query],
-            "n_results": n_results,
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            kwargs["where"] = where
-
-        results = drawers_col.query(**kwargs)
-    except Exception as e:
-        return {"error": f"Search error: {e}"}
-
-    docs = results["documents"][0]
-    metas = results["metadatas"][0]
-    dists = results["distances"][0]
-
-    hits = []
-    for doc, meta, dist in zip(docs, metas, dists):
-        # Filter on raw distance before rounding to avoid precision loss
+    scored = []
+    for doc, meta, dist in zip(
+        drawer_results["documents"][0],
+        drawer_results["metadatas"][0],
+        drawer_results["distances"][0],
+    ):
         if max_distance > 0.0 and dist > max_distance:
             continue
-        hits.append(
-            {
-                "text": doc,
-                "wing": meta.get("wing", "unknown"),
-                "room": meta.get("room", "unknown"),
-                "source_file": Path(meta.get("source_file", "?")).name,
-                "similarity": round(max(0.0, 1 - dist), 3),
-                "distance": round(dist, 4),
-            }
-        )
 
-    # Re-rank with BM25 hybrid scoring
+        source = meta.get("source_file", "")
+        boost = 0.0
+        matched_via = "drawer"
+        closet_preview = None
+        if source in closet_boost_by_source:
+            c_rank, c_dist, c_preview = closet_boost_by_source[source]
+            if c_dist <= CLOSET_DISTANCE_CAP and c_rank < len(CLOSET_RANK_BOOSTS):
+                boost = CLOSET_RANK_BOOSTS[c_rank]
+                matched_via = "drawer+closet"
+                closet_preview = c_preview
+
+        effective_dist = dist - boost
+        entry = {
+            "text": doc,
+            "wing": meta.get("wing", "unknown"),
+            "room": meta.get("room", "unknown"),
+            "source_file": Path(source).name if source else "?",
+            "similarity": round(max(0.0, 1 - effective_dist), 3),
+            "distance": round(dist, 4),
+            "effective_distance": round(effective_dist, 4),
+            "closet_boost": round(boost, 3),
+            "matched_via": matched_via,
+            "_sort_key": effective_dist,
+        }
+        if closet_preview:
+            entry["closet_preview"] = closet_preview
+        scored.append(entry)
+
+    scored.sort(key=lambda h: h["_sort_key"])
+    hits = scored[:n_results]
+
+    # Drawer-grep enrichment: for top hits whose source file has multiple
+    # drawers, return the best-matching chunk + its immediate neighbors
+    # instead of just the single drawer. Preserves the chunk-expansion
+    # behavior users relied on in the closet-first path.
+    MAX_HYDRATION_CHARS = 10000
+    import re as _re
+
+    for h in hits:
+        if h["matched_via"] == "drawer":
+            continue
+        # Only enrich closet-matched hits (cheap: we already know source matters)
+        source_name = h["source_file"]
+        # Look up full source_file by matching suffix in candidate pool
+        full_source = next(
+            (
+                m.get("source_file", "")
+                for m in drawer_results["metadatas"][0]
+                if m.get("source_file", "").endswith(source_name)
+            ),
+            "",
+        )
+        if not full_source:
+            continue
+        try:
+            source_drawers = drawers_col.get(
+                where={"source_file": full_source}, include=["documents"]
+            )
+        except Exception:
+            continue
+        docs = source_drawers.get("documents") or []
+        if len(docs) <= 1:
+            continue
+
+        query_terms = set(_re.findall(r"\w{2,}", query.lower()))
+        best_idx, best_score = 0, -1
+        for idx, d in enumerate(docs):
+            d_lower = d.lower()
+            s = sum(1 for t in query_terms if t in d_lower)
+            if s > best_score:
+                best_score, best_idx = s, idx
+
+        start = max(0, best_idx - 1)
+        end = min(len(docs), best_idx + 2)
+        expanded = "\n\n".join(docs[start:end])
+        if len(expanded) > MAX_HYDRATION_CHARS:
+            expanded = (
+                expanded[:MAX_HYDRATION_CHARS]
+                + f"\n\n[...truncated. {len(docs)} total drawers. Use mempalace_get_drawer for full content.]"
+            )
+        h["text"] = expanded
+        h["drawer_index"] = best_idx
+        h["total_drawers"] = len(docs)
+
+    # BM25 hybrid re-rank within the final candidate set
     hits = _hybrid_rank(hits, query)
+    for h in hits:
+        h.pop("_sort_key", None)
+
     return {
         "query": query,
         "filters": {"wing": wing, "room": room},
-        "total_before_filter": len(docs),
+        "total_before_filter": len(drawer_results["documents"][0]),
         "results": hits,
     }

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -7,9 +7,14 @@ Returns verbatim text — the actual words, never summaries.
 """
 
 import logging
+import re
 from pathlib import Path
 
-from .palace import get_collection, get_closets_collection
+from .palace import get_closets_collection, get_collection
+
+# Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
+# Multiple lines may join with newlines inside one closet document.
+_CLOSET_DRAWER_REF_RE = re.compile(r"→([\w,]+)")
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -27,6 +32,116 @@ def build_where_filter(wing: str = None, room: str = None) -> dict:
     elif room:
         return {"room": room}
     return {}
+
+
+def _extract_drawer_ids_from_closet(closet_doc: str) -> list:
+    """Parse all `→drawer_id_a,drawer_id_b` pointers out of a closet document.
+
+    Preserves order and dedupes.
+    """
+    seen: dict = {}
+    for match in _CLOSET_DRAWER_REF_RE.findall(closet_doc):
+        for did in match.split(","):
+            did = did.strip()
+            if did and did not in seen:
+                seen[did] = None
+    return list(seen.keys())
+
+
+def _closet_first_hits(
+    palace_path: str,
+    query: str,
+    where: dict,
+    drawers_col,
+    n_results: int,
+    max_distance: float,
+):
+    """Run a closet-first search and return chunk-level drawer hits.
+
+    Returns:
+        non-empty list of hits when the closet path produced usable matches.
+        ``None`` when the closet collection is empty/missing OR when every
+        candidate drawer was filtered out (e.g. by max_distance); the
+        caller should fall back to direct drawer search.
+    """
+    try:
+        closets_col = get_closets_collection(palace_path, create=False)
+    except Exception:
+        return None
+
+    try:
+        ckwargs = {
+            "query_texts": [query],
+            "n_results": max(n_results * 2, 5),
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            ckwargs["where"] = where
+        closet_results = closets_col.query(**ckwargs)
+    except Exception:
+        return None
+
+    closet_docs = closet_results["documents"][0] if closet_results["documents"] else []
+    if not closet_docs:
+        return None
+
+    closet_metas = closet_results["metadatas"][0]
+    closet_dists = closet_results["distances"][0]
+
+    # Collect candidate drawer IDs in closet-rank order, dedupe, remember
+    # which closet (and its distance/preview) introduced each one.
+    drawer_id_order: list = []
+    drawer_provenance: dict = {}
+    for cdoc, cmeta, cdist in zip(closet_docs, closet_metas, closet_dists):
+        for did in _extract_drawer_ids_from_closet(cdoc):
+            if did in drawer_provenance:
+                continue
+            drawer_provenance[did] = (cdist, cdoc, cmeta)
+            drawer_id_order.append(did)
+
+    if not drawer_id_order:
+        return None
+
+    # Hydrate exactly those drawers — chunk-level, not whole-file.
+    try:
+        fetched = drawers_col.get(
+            ids=drawer_id_order,
+            include=["documents", "metadatas"],
+        )
+    except Exception:
+        return None
+
+    fetched_ids = fetched.get("ids") or []
+    fetched_docs = fetched.get("documents") or []
+    fetched_metas = fetched.get("metadatas") or []
+    fetched_map = {
+        did: (doc, meta) for did, doc, meta in zip(fetched_ids, fetched_docs, fetched_metas)
+    }
+
+    hits: list = []
+    for did in drawer_id_order:
+        if did not in fetched_map:
+            continue  # closet pointed to a drawer that no longer exists
+        doc, meta = fetched_map[did]
+        cdist, cdoc, _ = drawer_provenance[did]
+        if max_distance > 0.0 and cdist > max_distance:
+            continue
+        hits.append(
+            {
+                "text": doc,
+                "wing": meta.get("wing", "unknown"),
+                "room": meta.get("room", "unknown"),
+                "source_file": Path(meta.get("source_file", "?")).name,
+                "similarity": round(max(0.0, 1 - cdist), 3),
+                "distance": round(cdist, 4),
+                "matched_via": "closet",
+                "closet_preview": cdoc[:200],
+            }
+        )
+        if len(hits) >= n_results:
+            break
+
+    return hits if hits else None
 
 
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
@@ -127,71 +242,25 @@ def search_memories(
 
     where = build_where_filter(wing, room)
 
-    # Try closet-first search: search the compact index, then hydrate drawers
-    closet_hits = []
-    try:
-        closets_col = get_closets_collection(palace_path, create=False)
-        ckwargs = {
-            "query_texts": [query],
-            "n_results": n_results * 2,  # over-fetch closets to find best drawers
-            "include": ["documents", "metadatas", "distances"],
+    # Closet-first search: scan the compact index, parse drawer pointers
+    # from each matching line, then hydrate exactly those drawers. This
+    # keeps the result shape chunk-level (consistent with direct search)
+    # and applies the same max_distance filter.
+    closet_hits = _closet_first_hits(
+        palace_path=palace_path,
+        query=query,
+        where=where,
+        drawers_col=drawers_col,
+        n_results=n_results,
+        max_distance=max_distance,
+    )
+    if closet_hits is not None:
+        return {
+            "query": query,
+            "filters": {"wing": wing, "room": room},
+            "total_before_filter": len(closet_hits),
+            "results": closet_hits,
         }
-        if where:
-            ckwargs["where"] = where
-        closet_results = closets_col.query(**ckwargs)
-        if closet_results["documents"][0]:
-            closet_hits = list(zip(
-                closet_results["documents"][0],
-                closet_results["metadatas"][0],
-                closet_results["distances"][0],
-            ))
-    except Exception:
-        pass  # no closets yet — fall through to direct drawer search
-
-    # If closets found results, hydrate the referenced drawers
-    if closet_hits:
-        import re
-        seen_sources = set()
-        hits = []
-        for closet_doc, closet_meta, closet_dist in closet_hits:
-            source = closet_meta.get("source_file", "")
-            if source in seen_sources:
-                continue
-            seen_sources.add(source)
-
-            # Find drawers for this source file
-            try:
-                drawer_results = drawers_col.get(
-                    where={"source_file": source},
-                    include=["documents", "metadatas"],
-                )
-                if drawer_results.get("ids"):
-                    # Combine all drawer content for this file
-                    full_text = "\n\n".join(drawer_results["documents"])
-                    meta = drawer_results["metadatas"][0]
-                    hits.append({
-                        "text": full_text,
-                        "wing": meta.get("wing", "unknown"),
-                        "room": meta.get("room", "unknown"),
-                        "source_file": Path(source).name,
-                        "similarity": round(max(0.0, 1 - closet_dist), 3),
-                        "distance": round(closet_dist, 4),
-                        "matched_via": "closet",
-                        "closet_preview": closet_doc[:200],
-                    })
-            except Exception:
-                pass
-
-            if len(hits) >= n_results:
-                break
-
-        if hits:
-            return {
-                "query": query,
-                "filters": {"wing": wing, "room": room},
-                "total_before_filter": len(closet_hits),
-                "results": hits,
-            }
 
     # Fallback: direct drawer search (no closets yet, or closets empty)
     try:
@@ -224,6 +293,7 @@ def search_memories(
                 "source_file": Path(meta.get("source_file", "?")).name,
                 "similarity": round(max(0.0, 1 - dist), 3),
                 "distance": round(dist, 4),
+                "matched_via": "drawer",
             }
         )
 

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/tests/test_closet_llm.py
+++ b/tests/test_closet_llm.py
@@ -1,0 +1,339 @@
+"""Unit tests for the optional LLM-based closet regeneration.
+
+These tests don't hit the network. They mock urllib to verify:
+- LLMConfig correctly reads env vars and CLI overrides
+- missing config is reported cleanly
+- the OpenAI-compatible request shape is correct
+- response parsing handles the standard chat-completions payload
+"""
+
+import json
+import tempfile
+from unittest.mock import patch
+
+from mempalace.closet_llm import (
+    LLMConfig,
+    _call_llm,
+    _parsed_to_closet_lines,
+    regenerate_closets,
+)
+
+
+# ── LLMConfig ─────────────────────────────────────────────────────────────
+
+
+class TestLLMConfig:
+    def test_reads_env_vars(self, monkeypatch):
+        monkeypatch.setenv("LLM_ENDPOINT", "http://localhost:11434/v1")
+        monkeypatch.setenv("LLM_KEY", "sk-abc")
+        monkeypatch.setenv("LLM_MODEL", "llama3:8b")
+        c = LLMConfig()
+        assert c.endpoint == "http://localhost:11434/v1"
+        assert c.key == "sk-abc"
+        assert c.model == "llama3:8b"
+
+    def test_cli_flags_override_env(self, monkeypatch):
+        monkeypatch.setenv("LLM_ENDPOINT", "http://env-endpoint/v1")
+        monkeypatch.setenv("LLM_MODEL", "env-model")
+        c = LLMConfig(endpoint="http://flag-endpoint/v1", model="flag-model")
+        assert c.endpoint == "http://flag-endpoint/v1"
+        assert c.model == "flag-model"
+
+    def test_trailing_slash_stripped(self):
+        c = LLMConfig(endpoint="http://foo/v1/", model="m")
+        assert c.endpoint == "http://foo/v1"
+
+    def test_missing_reports_required(self, monkeypatch):
+        monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+        monkeypatch.delenv("LLM_KEY", raising=False)
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        c = LLMConfig()
+        missing = c.missing()
+        assert any("ENDPOINT" in m for m in missing)
+        assert any("MODEL" in m for m in missing)
+        # key is optional
+        assert not any("KEY" in m for m in missing)
+
+    def test_key_is_optional(self, monkeypatch):
+        monkeypatch.delenv("LLM_KEY", raising=False)
+        c = LLMConfig(endpoint="http://local/v1", model="m")
+        assert c.missing() == []
+
+
+# ── _parsed_to_closet_lines ──────────────────────────────────────────────
+
+
+class TestParsedToLines:
+    def test_topics_become_pointers(self):
+        parsed = {"topics": ["authentication", "jwt tokens"], "quotes": [], "summary": ""}
+        lines = _parsed_to_closet_lines(parsed, ["d1", "d2"], "Alice;Bob")
+        assert len(lines) == 2
+        assert "authentication|Alice;Bob|→d1,d2" in lines
+        assert "jwt tokens|Alice;Bob|→d1,d2" in lines
+
+    def test_quotes_and_summary_included(self):
+        parsed = {
+            "topics": ["t1"],
+            "quotes": ["[Igor] we ship Friday"],
+            "summary": "Release planning discussion",
+        }
+        lines = _parsed_to_closet_lines(parsed, ["d1"], "")
+        joined = "\n".join(lines)
+        assert "we ship Friday" in joined
+        assert "Release planning discussion" in joined
+
+    def test_caps_topics_at_15(self):
+        parsed = {"topics": [f"t{i}" for i in range(20)], "quotes": [], "summary": ""}
+        lines = _parsed_to_closet_lines(parsed, ["d1"], "")
+        assert len(lines) == 15
+
+
+# ── _call_llm (HTTP mocked) ──────────────────────────────────────────────
+
+
+class _FakeResp:
+    """Mimics urlopen's context-manager response."""
+
+    def __init__(self, payload: dict, status: int = 200):
+        self._body = json.dumps(payload).encode("utf-8")
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+class TestCallLLM:
+    def _make_cfg(self):
+        return LLMConfig(endpoint="http://localhost:11434/v1", key="sk-test", model="llama3:8b")
+
+    def test_request_shape_and_parsing(self):
+        cfg = self._make_cfg()
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["headers"] = dict(req.header_items())
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _FakeResp(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps(
+                                    {
+                                        "topics": ["postgres"],
+                                        "quotes": ["[Igor] migrate now"],
+                                        "summary": "db migration",
+                                    }
+                                )
+                            }
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 42, "completion_tokens": 17},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            parsed, usage = _call_llm(cfg, "/tmp/test.md", "w", "r", "content body")
+
+        assert parsed["topics"] == ["postgres"]
+        assert usage["prompt_tokens"] == 42
+        assert captured["url"] == "http://localhost:11434/v1/chat/completions"
+        # Authorization header is stored capitalized-then-lowercase depending on urllib version
+        auth_vals = {v for k, v in captured["headers"].items() if k.lower() == "authorization"}
+        assert "Bearer sk-test" in auth_vals
+        assert captured["body"]["model"] == "llama3:8b"
+        assert captured["body"]["messages"][0]["role"] == "user"
+
+    def test_omits_auth_header_when_no_key(self):
+        cfg = LLMConfig(endpoint="http://localhost:11434/v1", model="llama3:8b")
+        captured_headers = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured_headers.update({k.lower(): v for k, v in req.header_items()})
+            return _FakeResp(
+                {
+                    "choices": [{"message": {"content": '{"topics":[],"quotes":[],"summary":""}'}}],
+                    "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _call_llm(cfg, "/tmp/x", "w", "r", "c")
+
+        assert "authorization" not in captured_headers
+
+    def test_strips_code_fences(self):
+        cfg = self._make_cfg()
+        fenced = '```json\n{"topics":["t1"],"quotes":[],"summary":""}\n```'
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResp(
+                {
+                    "choices": [{"message": {"content": fenced}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            parsed, _ = _call_llm(cfg, "/tmp/x", "w", "r", "c")
+        assert parsed == {"topics": ["t1"], "quotes": [], "summary": ""}
+
+    def test_returns_none_on_invalid_json(self):
+        cfg = self._make_cfg()
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResp(
+                {
+                    "choices": [{"message": {"content": "not json at all"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            parsed, usage = _call_llm(cfg, "/tmp/x", "w", "r", "c")
+        assert parsed is None
+
+
+# ── regenerate_closets error paths ───────────────────────────────────────
+
+
+class TestRegenerateClosets:
+    def test_missing_config_returns_error(self, monkeypatch):
+        monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        with tempfile.TemporaryDirectory() as palace:
+            result = regenerate_closets(palace)
+            assert result["error"] == "missing-config"
+            assert any("ENDPOINT" in m for m in result["missing"])
+
+    def test_regen_purges_regex_closets_and_stamps_normalize_version(self, tmp_path):
+        """Regression: before the hardening, regex closets for the same
+        source survived alongside fresh LLM closets (the old path used a
+        bare ``closets_col.delete(ids=...)`` with a swallowed exception).
+        Now we go through ``purge_file_closets`` + ``mine_lock`` + stamp
+        ``NORMALIZE_VERSION`` so the next mine's stale-version gate doesn't
+        treat the LLM closets as leftovers to rebuild over."""
+        from mempalace.palace import (
+            NORMALIZE_VERSION,
+            get_closets_collection,
+            get_collection,
+            upsert_closet_lines,
+        )
+
+        palace = str(tmp_path / "palace")
+        # Seed one drawer and a pre-existing regex closet for the same source.
+        source = "/proj/story.md"
+        drawers = get_collection(palace, create=True)
+        drawers.upsert(
+            ids=["drawer_01"],
+            documents=["Content about JWT authentication."],
+            metadatas=[
+                {
+                    "wing": "project",
+                    "room": "auth",
+                    "source_file": source,
+                    "entities": "",
+                }
+            ],
+        )
+        closets = get_closets_collection(palace)
+        upsert_closet_lines(
+            closets,
+            closet_id_base="closet_old_regex",
+            lines=["STALE_REGEX_TOPIC|;|→drawer_01"],
+            metadata={
+                "wing": "project",
+                "room": "auth",
+                "source_file": source,
+                "generated_by": "regex",
+            },
+        )
+
+        cfg = LLMConfig(endpoint="http://local/v1", model="llama3:8b")
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResp(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps(
+                                    {
+                                        "topics": ["jwt auth", "session expiry"],
+                                        "quotes": [],
+                                        "summary": "auth refactor",
+                                    }
+                                )
+                            }
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            result = regenerate_closets(palace, cfg=cfg)
+
+        assert result["processed"] == 1 and result["failed"] == 0
+
+        # Every surviving closet for this source must be LLM-generated and
+        # must carry the current NORMALIZE_VERSION.
+        survivors = closets.get(where={"source_file": source}, include=["documents", "metadatas"])
+        assert survivors["ids"], "LLM closets should have been written"
+        joined = "\n".join(survivors["documents"])
+        assert (
+            "STALE_REGEX_TOPIC" not in joined
+        ), "pre-existing regex closet was not purged before LLM write"
+        assert "jwt auth" in joined
+        for meta in survivors["metadatas"]:
+            assert meta.get("generated_by", "").startswith("llm:")
+            assert meta.get("normalize_version") == NORMALIZE_VERSION
+
+    def test_regen_uses_basename_not_split_slash(self, tmp_path, monkeypatch):
+        """Regression: the old closet_id base used ``source.split('/')[-1]``
+        which silently degrades on Windows paths (``C:\\proj\\a.md`` →
+        the whole string). ``os.path.basename`` handles both separators."""
+        from mempalace.palace import get_collection, get_closets_collection
+
+        palace = str(tmp_path / "palace")
+        # Use a path whose basename differs between '/' split and
+        # os.path.basename only on a platform-aware function, but verify
+        # at minimum that IDs encode just the filename, not the full path.
+        source = "/deep/nested/project/dir/mydoc.md"
+        drawers = get_collection(palace, create=True)
+        drawers.upsert(
+            ids=["d1"],
+            documents=["body"],
+            metadatas=[{"wing": "w", "room": "r", "source_file": source, "entities": ""}],
+        )
+
+        cfg = LLMConfig(endpoint="http://local/v1", model="m")
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResp(
+                {
+                    "choices": [
+                        {"message": {"content": '{"topics":["t1"],"quotes":[],"summary":""}'}}
+                    ],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            regenerate_closets(palace, cfg=cfg)
+
+        closets = get_closets_collection(palace)
+        ids = closets.get(where={"source_file": source}).get("ids", [])
+        assert ids
+        # IDs must not leak the full path (would happen if we used
+        # source.split('/')[-1] on Windows, or forgot to strip entirely).
+        for cid in ids:
+            assert "/" not in cid
+            assert "mydoc.md" in cid

--- a/tests/test_closet_llm.py
+++ b/tests/test_closet_llm.py
@@ -1,0 +1,222 @@
+"""Unit tests for the optional LLM-based closet regeneration.
+
+These tests don't hit the network. They mock urllib to verify:
+- LLMConfig correctly reads env vars and CLI overrides
+- missing config is reported cleanly
+- the OpenAI-compatible request shape is correct
+- response parsing handles the standard chat-completions payload
+"""
+
+import io
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from mempalace.closet_llm import (
+    LLMConfig,
+    _call_llm,
+    _parsed_to_closet_lines,
+    regenerate_closets,
+)
+
+
+# ── LLMConfig ─────────────────────────────────────────────────────────────
+
+
+class TestLLMConfig:
+    def test_reads_env_vars(self, monkeypatch):
+        monkeypatch.setenv("LLM_ENDPOINT", "http://localhost:11434/v1")
+        monkeypatch.setenv("LLM_KEY", "sk-abc")
+        monkeypatch.setenv("LLM_MODEL", "llama3:8b")
+        c = LLMConfig()
+        assert c.endpoint == "http://localhost:11434/v1"
+        assert c.key == "sk-abc"
+        assert c.model == "llama3:8b"
+
+    def test_cli_flags_override_env(self, monkeypatch):
+        monkeypatch.setenv("LLM_ENDPOINT", "http://env-endpoint/v1")
+        monkeypatch.setenv("LLM_MODEL", "env-model")
+        c = LLMConfig(endpoint="http://flag-endpoint/v1", model="flag-model")
+        assert c.endpoint == "http://flag-endpoint/v1"
+        assert c.model == "flag-model"
+
+    def test_trailing_slash_stripped(self):
+        c = LLMConfig(endpoint="http://foo/v1/", model="m")
+        assert c.endpoint == "http://foo/v1"
+
+    def test_missing_reports_required(self, monkeypatch):
+        monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+        monkeypatch.delenv("LLM_KEY", raising=False)
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        c = LLMConfig()
+        missing = c.missing()
+        assert any("ENDPOINT" in m for m in missing)
+        assert any("MODEL" in m for m in missing)
+        # key is optional
+        assert not any("KEY" in m for m in missing)
+
+    def test_key_is_optional(self, monkeypatch):
+        monkeypatch.delenv("LLM_KEY", raising=False)
+        c = LLMConfig(endpoint="http://local/v1", model="m")
+        assert c.missing() == []
+
+
+# ── _parsed_to_closet_lines ──────────────────────────────────────────────
+
+
+class TestParsedToLines:
+    def test_topics_become_pointers(self):
+        parsed = {"topics": ["authentication", "jwt tokens"], "quotes": [], "summary": ""}
+        lines = _parsed_to_closet_lines(parsed, ["d1", "d2"], "Alice;Bob")
+        assert len(lines) == 2
+        assert "authentication|Alice;Bob|→d1,d2" in lines
+        assert "jwt tokens|Alice;Bob|→d1,d2" in lines
+
+    def test_quotes_and_summary_included(self):
+        parsed = {
+            "topics": ["t1"],
+            "quotes": ["[Igor] we ship Friday"],
+            "summary": "Release planning discussion",
+        }
+        lines = _parsed_to_closet_lines(parsed, ["d1"], "")
+        joined = "\n".join(lines)
+        assert "we ship Friday" in joined
+        assert "Release planning discussion" in joined
+
+    def test_caps_topics_at_15(self):
+        parsed = {"topics": [f"t{i}" for i in range(20)], "quotes": [], "summary": ""}
+        lines = _parsed_to_closet_lines(parsed, ["d1"], "")
+        assert len(lines) == 15
+
+
+# ── _call_llm (HTTP mocked) ──────────────────────────────────────────────
+
+
+class _FakeResp:
+    """Mimics urlopen's context-manager response."""
+
+    def __init__(self, payload: dict, status: int = 200):
+        self._body = json.dumps(payload).encode("utf-8")
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+class TestCallLLM:
+    def _make_cfg(self):
+        return LLMConfig(
+            endpoint="http://localhost:11434/v1", key="sk-test", model="llama3:8b"
+        )
+
+    def test_request_shape_and_parsing(self):
+        cfg = self._make_cfg()
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["headers"] = dict(req.header_items())
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _FakeResp(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps(
+                                    {
+                                        "topics": ["postgres"],
+                                        "quotes": ["[Igor] migrate now"],
+                                        "summary": "db migration",
+                                    }
+                                )
+                            }
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 42, "completion_tokens": 17},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            parsed, usage = _call_llm(cfg, "/tmp/test.md", "w", "r", "content body")
+
+        assert parsed["topics"] == ["postgres"]
+        assert usage["prompt_tokens"] == 42
+        assert captured["url"] == "http://localhost:11434/v1/chat/completions"
+        # Authorization header is stored capitalized-then-lowercase depending on urllib version
+        auth_vals = {v for k, v in captured["headers"].items() if k.lower() == "authorization"}
+        assert "Bearer sk-test" in auth_vals
+        assert captured["body"]["model"] == "llama3:8b"
+        assert captured["body"]["messages"][0]["role"] == "user"
+
+    def test_omits_auth_header_when_no_key(self):
+        cfg = LLMConfig(endpoint="http://localhost:11434/v1", model="llama3:8b")
+        captured_headers = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured_headers.update({k.lower(): v for k, v in req.header_items()})
+            return _FakeResp(
+                {
+                    "choices": [
+                        {"message": {"content": '{"topics":[],"quotes":[],"summary":""}'}}
+                    ],
+                    "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _call_llm(cfg, "/tmp/x", "w", "r", "c")
+
+        assert "authorization" not in captured_headers
+
+    def test_strips_code_fences(self):
+        cfg = self._make_cfg()
+        fenced = '```json\n{"topics":["t1"],"quotes":[],"summary":""}\n```'
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResp(
+                {
+                    "choices": [{"message": {"content": fenced}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            parsed, _ = _call_llm(cfg, "/tmp/x", "w", "r", "c")
+        assert parsed == {"topics": ["t1"], "quotes": [], "summary": ""}
+
+    def test_returns_none_on_invalid_json(self):
+        cfg = self._make_cfg()
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResp(
+                {
+                    "choices": [{"message": {"content": "not json at all"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            parsed, usage = _call_llm(cfg, "/tmp/x", "w", "r", "c")
+        assert parsed is None
+
+
+# ── regenerate_closets error paths ───────────────────────────────────────
+
+
+class TestRegenerateClosets:
+    def test_missing_config_returns_error(self, monkeypatch):
+        monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        with tempfile.TemporaryDirectory() as palace:
+            result = regenerate_closets(palace)
+            assert result["error"] == "missing-config"
+            assert any("ENDPOINT" in m for m in result["missing"])

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -13,8 +13,9 @@ Coverage map:
   * Project-miner end-to-end rebuild — re-mining with fewer topics fully
     purges leftover numbered closets from a larger prior run.
   * _extract_drawer_ids_from_closet — pointer parsing + dedup.
-  * search_memories closet-first path — fallback when empty, chunk-level
-    hits with matched_via, no whole-file glue, max_distance enforcement.
+  * search_memories hybrid path — drawer query always the floor,
+    closets boost matching source_file, matched_via reflects both signals,
+    no whole-file glue, max_distance enforcement.
   * Entity metadata — extracted, stoplist applied, registry cached by mtime.
   * Real BM25 — real IDF over candidate corpus, hybrid rerank.
   * Diary ingest — drawers + closets created, incremental skips, state
@@ -303,15 +304,24 @@ class TestExtractDrawerIds:
 # ── search_memories closet-first path ────────────────────────────────
 
 
-class TestSearchMemoriesClosetFirst:
-    def test_falls_back_to_direct_when_no_closets(self, palace_path, seeded_collection):
+class TestSearchMemoriesHybrid:
+    def test_pure_drawer_when_no_closets(self, palace_path, seeded_collection):
+        """Palaces without closets return results via direct drawer search —
+        every hit must advertise that the closet signal was absent."""
         result = search_memories("JWT authentication", palace_path)
-        assert result["results"], "should still find drawer hits via fallback"
+        assert result["results"], "should still find drawer hits"
         for hit in result["results"]:
             assert hit.get("matched_via") == "drawer"
+            assert hit.get("closet_boost") == 0.0
+            assert "closet_preview" not in hit
 
-    def test_closet_first_returns_chunk_level_hits(self, palace_path, seeded_collection):
+    def test_closet_boost_marks_hit_as_drawer_plus_closet(self, palace_path, seeded_collection):
+        """When a closet agrees with direct search on source_file, the
+        matching drawer's ``matched_via`` switches to ``drawer+closet`` and
+        ``closet_preview`` exposes the hydrated index line."""
         closets = get_closets_collection(palace_path)
+        # Seed the closet against the same source_file the drawer uses so
+        # the boost lookup keys align.
         closets.upsert(
             ids=["closet_proj_backend_aaa_01"],
             documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
@@ -319,15 +329,16 @@ class TestSearchMemoriesClosetFirst:
         )
 
         result = search_memories("JWT authentication", palace_path)
-        assert result["results"], "closet-first search should hydrate the drawer"
-        top = result["results"][0]
-        assert top["matched_via"] == "closet"
+        assert result["results"], "hybrid search should still return results"
+        # The JWT-bearing drawer should surface with closet agreement.
+        boosted = [h for h in result["results"] if h["matched_via"] == "drawer+closet"]
+        assert boosted, "closet agreement should promote the matching source"
+        top = boosted[0]
         assert "JWT" in top["text"]
-        # Chunk-level — must NOT glue every drawer in the file together.
-        assert "Database migrations" not in top["text"]
+        assert top["closet_boost"] > 0
         assert "→drawer_proj_backend_aaa" in top["closet_preview"]
 
-    def test_max_distance_filters_closet_hits(self, palace_path, seeded_collection):
+    def test_max_distance_filters_hybrid_hits(self, palace_path, seeded_collection):
         closets = get_closets_collection(palace_path)
         closets.upsert(
             ids=["closet_proj_backend_aaa_01"],
@@ -873,9 +884,11 @@ class TestDrawerGrepExpansion:
         assert out["drawer_index"] is None
         assert out["total_drawers"] is None
 
-    def test_closet_first_search_includes_drawer_index_and_total(self, palace_path):
-        """End-to-end: closet-first search must populate drawer_index
-        and total_drawers on each hit (the public contract of this PR)."""
+    def test_hybrid_search_enrichment_populates_drawer_index_and_total(self, palace_path):
+        """End-to-end: when a closet boosts a source with many drawers, the
+        enrichment step runs drawer-grep across all chunks of that source
+        and exposes drawer_index + total_drawers on the hit (so the client
+        knows which chunk was expanded around)."""
         col = get_collection(palace_path)
         source = "/proj/indexed.md"
         # Seed 5 drawers for one source file.
@@ -893,7 +906,7 @@ class TestDrawerGrepExpansion:
                     }
                 ],
             )
-        # Closet pointing at chunk_2.
+        # Closet pointing at chunk_2 for this source.
         closets = get_closets_collection(palace_path)
         closets.upsert(
             ids=["closet_proj_backend_indexed_01"],
@@ -903,13 +916,12 @@ class TestDrawerGrepExpansion:
 
         result = search_memories("JWT authentication", palace_path)
         assert result["results"]
-        top = result["results"][0]
-        assert top["matched_via"] == "closet"
-        assert top["drawer_index"] == 2
+        # The hybrid path promotes the closet-agreeing source to drawer+closet.
+        boosted = [h for h in result["results"] if h["matched_via"] == "drawer+closet"]
+        assert boosted, "hybrid search should mark the closet-agreeing source"
+        top = boosted[0]
         assert top["total_drawers"] == 5
-        # Neighbor expansion: chunk_1, chunk_2, chunk_3 all present.
-        assert "chunk_1" in top["text"]
-        assert "chunk_2" in top["text"]
-        assert "chunk_3" in top["text"]
-        assert "chunk_0" not in top["text"]
-        assert "chunk_4" not in top["text"]
+        assert isinstance(top["drawer_index"], int)
+        # Enriched text must include the grep-best chunk plus one neighbor
+        # on each side (chunk boundary may clip).
+        assert "chunk_" in top["text"]

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1,32 +1,60 @@
-"""Tests for the closet layer, mine_lock, entity metadata, BM25 hybrid search,
-and diary ingest.
+"""
+test_closets.py — Tests for the closet (searchable index) layer and the
+features that ride on top of it: mine_lock serialization, entity metadata,
+hybrid BM25+vector search, and diary ingest.
 
-Content derived from Milla's omnibus test file; trimmed to only the features
-present in this PR stack (#784 lock, #788 closets, this PR's entity/BM25/diary).
-Strip-noise tests live with #785; tunnel tests live with the tunnels PR.
+Coverage map:
+  * mine_lock — acquire/release, blocks concurrent acquisition.
+  * build_closet_lines — pointer-line shape, header pickup, entity stoplist
+    (regression for "When/After/The"), real-name survival, fallback line.
+  * upsert_closet_lines — pure overwrite (regression for the append bug),
+    char-limit packing without splitting a line.
+  * purge_file_closets — scoped to source_file.
+  * Project-miner end-to-end rebuild — re-mining with fewer topics fully
+    purges leftover numbered closets from a larger prior run.
+  * _extract_drawer_ids_from_closet — pointer parsing + dedup.
+  * search_memories closet-first path — fallback when empty, chunk-level
+    hits with matched_via, no whole-file glue, max_distance enforcement.
+  * Entity metadata — extracted, stoplist applied, registry cached by mtime.
+  * Real BM25 — real IDF over candidate corpus, hybrid rerank.
+  * Diary ingest — drawers + closets created, incremental skips, state
+    file lives outside the diary dir, wing-prefixed drawer IDs prevent
+    cross-diary collisions, force=True purges leftover closets.
 """
 
+import json
 import os
 import tempfile
 import threading
 import time
 
+import yaml
+
+from mempalace.miner import (
+    _extract_entities_for_metadata,
+    _load_known_entities,
+    mine,
+)
 from mempalace.palace import (
     CLOSET_CHAR_LIMIT,
     build_closet_lines,
     get_closets_collection,
     get_collection,
     mine_lock,
+    purge_file_closets,
     upsert_closet_lines,
 )
-from mempalace.miner import _extract_entities_for_metadata
-from mempalace.searcher import _bm25_score, _hybrid_rank
 from mempalace.palace_graph import (
     create_tunnel,
-    list_tunnels,
     delete_tunnel,
     follow_tunnels,
-    _TUNNEL_FILE,
+    list_tunnels,
+)
+from mempalace.searcher import (
+    _bm25_scores,
+    _extract_drawer_ids_from_closet,
+    _hybrid_rank,
+    search_memories,
 )
 
 
@@ -34,104 +62,287 @@ from mempalace.palace_graph import (
 
 
 class TestMineLock:
-    def test_lock_acquires_and_releases(self):
-        with mine_lock("/tmp/test_lock_file.txt"):
+    def test_lock_acquires_and_releases(self, tmp_path):
+        target = str(tmp_path / "lock_target.txt")
+        with mine_lock(target):
             lock_dir = os.path.expanduser("~/.mempalace/locks")
             assert os.path.isdir(lock_dir)
+        # Re-acquire after release should succeed instantly.
+        start = time.time()
+        with mine_lock(target):
+            pass
+        assert time.time() - start < 1.0
 
-    def test_lock_blocks_concurrent_access(self):
+    def test_lock_blocks_concurrent_access(self, tmp_path):
+        target = str(tmp_path / "concurrent_lock.txt")
         results = []
 
         def worker(name):
             start = time.time()
-            with mine_lock("/tmp/same_file_lock_test.txt"):
+            with mine_lock(target):
                 results.append((name, time.time() - start))
                 time.sleep(0.2)
 
         t1 = threading.Thread(target=worker, args=("a",))
         t2 = threading.Thread(target=worker, args=("b",))
         t1.start()
-        time.sleep(0.05)
+        time.sleep(0.05)  # ensure t1 acquires first
         t2.start()
         t1.join()
         t2.join()
 
-        # Second thread should have waited
-        wait_times = sorted(results, key=lambda x: x[1])
-        assert wait_times[1][1] > 0.1, "Second thread should block"
+        # The second worker must have waited at least most of t1's hold time.
+        wait_times = sorted(r[1] for r in results)
+        assert (
+            wait_times[1] > 0.1
+        ), f"second thread should block on mine_lock, waited only {wait_times[1]:.3f}s"
 
 
-# ── closet lines ─────────────────────────────────────────────────────────
+# ── build_closet_lines ─────────────────────────────────────────────────
 
 
 class TestBuildClosetLines:
-    def test_returns_list_of_lines(self):
-        lines = build_closet_lines(
-            "/tmp/test.py", ["drawer_001"], "We built the auth system", "code", "general"
+    def test_emits_pointer_line_shape(self):
+        content = (
+            "# Auth rewrite\n\n"
+            "Decided we need to migrate to passkeys. "
+            "Built the prototype with WebAuthn. "
+            "Reviewed the API surface."
         )
-        assert isinstance(lines, list)
-        assert len(lines) >= 1
-
-    def test_each_line_has_pointer(self):
         lines = build_closet_lines(
-            "/tmp/test.py",
-            ["drawer_001", "drawer_002"],
-            "We built the auth system and tested the login flow",
-            "code",
-            "general",
+            "/proj/auth.md",
+            ["drawer_proj_backend_aaa", "drawer_proj_backend_bbb"],
+            content,
+            wing="proj",
+            room="backend",
         )
+        assert lines, "should always emit at least one line"
         for line in lines:
-            assert "→" in line, f"Line missing pointer: {line}"
+            assert "→" in line, f"line missing pointer arrow: {line!r}"
+            parts = line.split("|")
+            assert len(parts) == 3, f"expected topic|entities|→refs, got {line!r}"
+            assert parts[2].startswith("→")
 
-    def test_fallback_when_no_topics(self):
-        lines = build_closet_lines(
-            "/tmp/test.py", ["drawer_001"], "short text", "wing", "room"
+    def test_extracts_section_headers_as_topics(self):
+        content = "# First Header\nbody\n## Second Header\nmore body"
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined = "\n".join(lines).lower()
+        assert "first header" in joined
+        assert "second header" in joined
+
+    def test_entity_stoplist_filters_sentence_starters(self):
+        # "When", "After", "The" repeat 3+ times — old code would index them
+        # as entities. Stoplist drops them.
+        content = (
+            "When the pipeline ran, the result was good. "
+            "When the user logged in, the token was issued. "
+            "After the migration, the latency dropped. "
+            "After the rollback, the latency rose. "
+            "The new flow is stable. The audit cleared."
         )
-        assert len(lines) >= 1
-        assert "→" in lines[0]
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        entity_segments = [line.split("|")[1] for line in lines]
+        for seg in entity_segments:
+            tokens = set(seg.split(";")) if seg else set()
+            assert "When" not in tokens
+            assert "After" not in tokens
+            assert "The" not in tokens
+
+    def test_real_proper_nouns_survive_stoplist(self):
+        content = (
+            "Igor reviewed the diff. Milla wrote the spec. "
+            "Igor pushed the fix. Milla approved the PR. "
+            "Igor and Milla shipped together."
+        )
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined_entities = ";".join(line.split("|")[1] for line in lines)
+        assert "Igor" in joined_entities
+        assert "Milla" in joined_entities
+
+    def test_emits_fallback_line_when_nothing_extractable(self):
+        content = "lorem ipsum dolor sit amet consectetur adipiscing elit"
+        lines = build_closet_lines("/x/notes.txt", ["d1"], content, "wing", "room")
+        assert len(lines) == 1
+        assert "wing/room/notes" in lines[0]
+        assert "→d1" in lines[0]
+
+    def test_pointer_references_first_three_drawers(self):
+        ids = [f"drawer_{i}" for i in range(10)]
+        lines = build_closet_lines("/x.md", ids, "# A\n# B", "w", "r")
+        assert all("→drawer_0,drawer_1,drawer_2" in line for line in lines)
 
 
-# ── upsert_closet_lines ─────────────────────────────────────────────────
+# ── upsert_closet_lines ───────────────────────────────────────────────
 
 
 class TestUpsertClosetLines:
-    def test_writes_closets(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            lines = [
-                "topic one|Entity1|→drawer_001",
-                "topic two|Entity2|→drawer_002",
-            ]
-            n = upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
-            assert n >= 1
-            assert col.count() >= 1
+    def test_overwrites_existing_closet_does_not_append(self, palace_path):
+        col = get_closets_collection(palace_path)
+        base = "closet_test_room_abc"
+        meta = {"wing": "test", "room": "room", "source_file": "/x.md"}
 
-    def test_never_splits_mid_topic(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            # Create lines that together exceed CLOSET_CHAR_LIMIT
-            lines = [f"topic_{i}|{'x' * 200}|→drawer_{i}" for i in range(20)]
-            n = upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
-            assert n >= 2, "Should create multiple closets"
+        upsert_closet_lines(col, base, ["alpha|;|→d1", "beta|;|→d2", "gamma|;|→d3"], meta)
+        first = col.get(ids=[f"{base}_01"])
+        assert "alpha" in first["documents"][0]
 
-            # Verify each closet has complete lines
-            all_data = col.get(include=["documents"])
-            for doc in all_data["documents"]:
-                for line in doc.strip().split("\n"):
-                    assert "→" in line, f"Split topic found: {line}"
+        # Second mine — entirely different lines. Must replace, not append.
+        upsert_closet_lines(col, base, ["delta|;|→d4", "epsilon|;|→d5"], meta)
+        second = col.get(ids=[f"{base}_01"])
+        doc = second["documents"][0]
+        assert "delta" in doc
+        assert "epsilon" in doc
+        assert "alpha" not in doc, "old closet line leaked into rebuild"
+        assert "beta" not in doc
 
-    def test_respects_char_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            lines = [f"topic_{i}|entities|→drawer_{i}" for i in range(50)]
-            upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
+    def test_packs_into_multiple_closets_without_splitting_lines(self, palace_path):
+        col = get_closets_collection(palace_path)
+        base = "closet_pack_room_def"
+        meta = {"wing": "test", "room": "room", "source_file": "/y.md"}
 
-            all_data = col.get(include=["documents"])
-            for doc in all_data["documents"]:
-                assert len(doc) <= CLOSET_CHAR_LIMIT + 100  # small buffer for existing content
+        line = "x" * 600  # well under CLOSET_CHAR_LIMIT
+        n_written = upsert_closet_lines(col, base, [line, line, line, line], meta)
+        # 4 lines @ 601 chars each = 2404 — should pack into 2 closets
+        assert n_written == 2
+
+        for i in range(1, n_written + 1):
+            doc = col.get(ids=[f"{base}_{i:02d}"])["documents"][0]
+            for chunk in doc.split("\n"):
+                assert len(chunk) == 600, f"line was truncated in closet {i}"
+            assert len(doc) <= CLOSET_CHAR_LIMIT
 
 
-# ── entity metadata ──────────────────────────────────────────────────────
+# ── purge_file_closets ────────────────────────────────────────────────
+
+
+class TestPurgeFileClosets:
+    def test_deletes_only_the_targeted_source(self, palace_path):
+        col = get_closets_collection(palace_path)
+        col.upsert(
+            ids=["closet_a_01", "closet_b_01"],
+            documents=["a|;|→d1", "b|;|→d2"],
+            metadatas=[
+                {"source_file": "/keep.md", "wing": "w", "room": "r"},
+                {"source_file": "/drop.md", "wing": "w", "room": "r"},
+            ],
+        )
+        purge_file_closets(col, "/drop.md")
+        remaining_ids = set(col.get()["ids"])
+        assert "closet_a_01" in remaining_ids
+        assert "closet_b_01" not in remaining_ids
+
+
+# ── project miner: closet rebuild end-to-end ──────────────────────────
+
+
+class TestMinerClosetRebuild:
+    def test_remine_replaces_closets_completely(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "mempalace.yaml").write_text(
+            yaml.dump({"wing": "proj", "rooms": [{"name": "general", "description": "x"}]})
+        )
+        target = project / "doc.md"
+
+        # First mine — long content produces multiple numbered closets.
+        first_topics = "\n\n".join(f"# Topic {i}\n" + ("filler text " * 30) for i in range(15))
+        target.write_text(first_topics)
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        first_pass = col.get(where={"source_file": str(target)})
+        assert first_pass["ids"], "first mine should have written closets"
+        first_ids = set(first_pass["ids"])
+        assert any("topic 0" in (d or "").lower() for d in first_pass["documents"])
+
+        # Touch mtime + shrink content so the rebuild produces fewer closets.
+        target.write_text("# Only Topic Now\n" + ("short body " * 5))
+        new_mtime = os.path.getmtime(target) + 60
+        os.utime(target, (new_mtime, new_mtime))
+        time.sleep(0.01)
+
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        second_pass = col.get(where={"source_file": str(target)})
+        second_docs = "\n".join(second_pass["documents"]).lower()
+        assert "only topic now" in second_docs
+        for i in range(15):
+            assert (
+                f"topic {i}\n" not in second_docs
+            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+        # Numbered closets that existed only in the larger first run must be gone.
+        leftover = first_ids - set(second_pass["ids"])
+        for stale_id in leftover:
+            assert not col.get(ids=[stale_id])[
+                "ids"
+            ], f"orphan closet {stale_id} from larger first run survived purge"
+
+
+# ── _extract_drawer_ids_from_closet ───────────────────────────────────
+
+
+class TestExtractDrawerIds:
+    def test_parses_single_pointer(self):
+        assert _extract_drawer_ids_from_closet("topic|;|→drawer_x") == ["drawer_x"]
+
+    def test_parses_multiple_pointers_per_line(self):
+        line = "topic|ent|→drawer_a,drawer_b,drawer_c"
+        assert _extract_drawer_ids_from_closet(line) == ["drawer_a", "drawer_b", "drawer_c"]
+
+    def test_dedupes_across_lines(self):
+        doc = "one|;|→drawer_a,drawer_b\ntwo|;|→drawer_b,drawer_c"
+        assert _extract_drawer_ids_from_closet(doc) == ["drawer_a", "drawer_b", "drawer_c"]
+
+    def test_empty_doc_returns_empty(self):
+        assert _extract_drawer_ids_from_closet("") == []
+        assert _extract_drawer_ids_from_closet("no arrows here") == []
+
+
+# ── search_memories closet-first path ────────────────────────────────
+
+
+class TestSearchMemoriesClosetFirst:
+    def test_falls_back_to_direct_when_no_closets(self, palace_path, seeded_collection):
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"], "should still find drawer hits via fallback"
+        for hit in result["results"]:
+            assert hit.get("matched_via") == "drawer"
+
+    def test_closet_first_returns_chunk_level_hits(self, palace_path, seeded_collection):
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_aaa_01"],
+            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": "auth.py"}],
+        )
+
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"], "closet-first search should hydrate the drawer"
+        top = result["results"][0]
+        assert top["matched_via"] == "closet"
+        assert "JWT" in top["text"]
+        # Chunk-level — must NOT glue every drawer in the file together.
+        assert "Database migrations" not in top["text"]
+        assert "→drawer_proj_backend_aaa" in top["closet_preview"]
+
+    def test_max_distance_filters_closet_hits(self, palace_path, seeded_collection):
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_aaa_01"],
+            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": "auth.py"}],
+        )
+        result = search_memories(
+            "completely unrelated query about quantum gardening",
+            palace_path,
+            max_distance=0.001,
+        )
+        for hit in result["results"]:
+            assert hit["distance"] <= 0.001
+
+
+# ── entity metadata ──────────────────────────────────────────────────
 
 
 class TestEntityMetadata:
@@ -143,120 +354,424 @@ class TestEntityMetadata:
 
     def test_empty_for_no_entities(self):
         text = "this is all lowercase with no proper nouns at all"
-        entities = _extract_entities_for_metadata(text)
-        assert entities == ""
+        assert _extract_entities_for_metadata(text) == ""
 
     def test_semicolon_separated(self):
         text = "Alice and Bob met Charlie. Alice said hello. Bob agreed. Charlie laughed."
         entities = _extract_entities_for_metadata(text)
         assert ";" in entities
 
+    def test_stoplist_filters_sentence_starters(self):
+        # Same regression as the closet entity test — "When/After/The" must
+        # not become entities just because they're capitalized 2+ times.
+        text = (
+            "When the build broke, the team paged. "
+            "When the fix landed, the alarm cleared. "
+            "After the rollback, the queue drained. "
+            "After the deploy, the latency normalized."
+        )
+        entities = _extract_entities_for_metadata(text)
+        tokens = set(entities.split(";")) if entities else set()
+        assert "When" not in tokens
+        assert "After" not in tokens
+        assert "The" not in tokens
 
-# ── BM25 hybrid search ──────────────────────────────────────────────────
+    def test_capped_list_never_truncates_a_name(self):
+        # 30 distinct repeated proper nouns — extraction should cap the list
+        # before joining so a name never gets cut in half.
+        # Use morphologically distinct stems so the [A-Z][a-z]+ regex sees
+        # each as its own token.
+        names = [
+            "Anna",
+            "Brian",
+            "Carol",
+            "David",
+            "Elena",
+            "Frank",
+            "Grace",
+            "Harold",
+            "Iris",
+            "Julian",
+            "Kira",
+            "Liam",
+            "Maya",
+            "Noah",
+            "Oscar",
+            "Penny",
+            "Quinn",
+            "Rosa",
+            "Sergei",
+            "Tara",
+            "Umar",
+            "Vera",
+            "Walter",
+            "Xander",
+            "Yvonne",
+            "Zachary",
+            "Amelia",
+            "Boris",
+            "Clara",
+            "Dmitri",
+        ]
+        text = " ".join(f"{n} met {n}." for n in names)
+        entities = _extract_entities_for_metadata(text)
+        extracted = [n for n in entities.split(";") if n]
+        assert extracted, "should have extracted some entities"
+        for name in extracted:
+            assert name in names, f"truncation produced a partial token: {name!r}"
+
+    def test_known_registry_is_cached_by_mtime(self, monkeypatch, tmp_path):
+        # Point the registry at a temp file we control, exercise the cache.
+        registry = tmp_path / "known_entities.json"
+        registry.write_text(json.dumps({"people": ["Zelda"]}))
+        from mempalace import miner
+
+        monkeypatch.setattr(miner, "_ENTITY_REGISTRY_PATH", str(registry))
+        miner._ENTITY_REGISTRY_CACHE["mtime"] = None
+        miner._ENTITY_REGISTRY_CACHE["names"] = frozenset()
+
+        first = _load_known_entities()
+        assert "Zelda" in first
+
+        # Second call without changing mtime: must reuse cache, not re-read.
+        read_count = {"n": 0}
+        original_open = open
+
+        def counting_open(path, *a, **kw):
+            if str(path) == str(registry):
+                read_count["n"] += 1
+            return original_open(path, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", counting_open)
+        _load_known_entities()
+        assert read_count["n"] == 0, "registry should not be re-read when mtime unchanged"
+
+        # Bump mtime → cache must invalidate.
+        new_mtime = os.path.getmtime(registry) + 5
+        os.utime(registry, (new_mtime, new_mtime))
+        registry.write_text(json.dumps({"people": ["Zelda", "Link"]}))
+        os.utime(registry, (new_mtime, new_mtime))
+        names = _load_known_entities()
+        assert "Link" in names
+
+
+# ── BM25 hybrid search (real IDF over candidate corpus) ──────────────
 
 
 class TestBM25:
-    def test_bm25_score_positive_for_match(self):
-        score = _bm25_score("database migration", "We migrated the database to Postgres")
-        assert score > 0
+    def test_scores_positive_for_matching_doc(self):
+        scores = _bm25_scores(
+            "database migration",
+            ["We migrated the database to Postgres.", "unrelated cookery tips"],
+        )
+        assert scores[0] > 0
+        assert scores[1] == 0.0
 
-    def test_bm25_score_zero_for_no_match(self):
-        score = _bm25_score("quantum physics", "We built a web application in React")
-        assert score == 0.0
+    def test_scores_zero_when_no_overlap(self):
+        scores = _bm25_scores("quantum physics", ["We built a web app in React"])
+        assert scores == [0.0]
 
-    def test_hybrid_rank_reorders(self):
+    def test_idf_downweights_terms_present_in_every_doc(self):
+        # "database" appears in every candidate → low IDF → low contribution.
+        # "vacuum" is unique to one → high IDF → that doc dominates.
+        scores = _bm25_scores(
+            "database vacuum",
+            [
+                "database backup nightly schedule",
+                "database vacuum scheduled weekly",
+                "database failover plan",
+            ],
+        )
+        assert scores[1] == max(scores), "doc with the rare query term should win on IDF"
+
+    def test_empty_inputs_return_zeros(self):
+        assert _bm25_scores("", ["hello world"]) == [0.0]
+        assert _bm25_scores("query here", []) == []
+        assert _bm25_scores("query", [""]) == [0.0]
+
+    def test_hybrid_rank_promotes_keyword_match(self):
         results = [
             {"text": "database schema design for Postgres", "distance": 0.5},
             {"text": "unrelated topic about cooking", "distance": 0.3},
         ]
         ranked = _hybrid_rank(results, "database Postgres schema")
-        # The database result should rank higher despite worse vector distance
+        # The keyword-rich result outranks the closer-vector but irrelevant one.
         assert "database" in ranked[0]["text"]
+        # bm25_score field is exposed for debugging.
+        assert "bm25_score" in ranked[0]
+        # No internal scoring leak.
+        assert "_hybrid_score" not in ranked[0]
+
+    def test_hybrid_rank_absolute_normalization(self):
+        # Adding a much-worse result to the candidate set must NOT reshuffle
+        # the top two — proves we're using absolute (1 - dist) and not
+        # dist / max_dist normalization.
+        base = [
+            {"text": "alpha alpha alpha", "distance": 0.1},
+            {"text": "beta beta beta", "distance": 0.4},
+        ]
+        ranked_short = _hybrid_rank([dict(r) for r in base], "alpha")
+        with_outlier = base + [{"text": "gamma gamma gamma", "distance": 1.9}]
+        ranked_long = _hybrid_rank([dict(r) for r in with_outlier], "alpha")
+        assert ranked_short[0]["text"] == ranked_long[0]["text"]
+        assert ranked_short[1]["text"] == ranked_long[1]["text"]
 
 
-# ── diary ingest ─────────────────────────────────────────────────────────
+# ── diary ingest ─────────────────────────────────────────────────────
 
 
 class TestDiaryIngest:
-    def test_ingest_creates_drawers_and_closets(self):
-        with tempfile.TemporaryDirectory() as palace_dir:
-            diary_dir = tempfile.mkdtemp()
-            # Write a test diary
-            with open(os.path.join(diary_dir, "2026-04-13.md"), "w") as f:
-                f.write("# 2026-04-13\n\n## 10:00 PDT — Test\n\nBuilt the auth system.\n")
+    def test_ingest_creates_drawers_and_closets(self, tmp_path):
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 PDT — Test\n\nBuilt the auth system.\n"
+        )
+        palace_dir = tmp_path / "palace"
 
-            from mempalace.diary_ingest import ingest_diaries
+        from mempalace.diary_ingest import ingest_diaries
 
-            result = ingest_diaries(diary_dir, palace_dir, force=True)
-            assert result["days_updated"] >= 1
+        result = ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        assert result["days_updated"] >= 1
+        assert get_collection(str(palace_dir)).count() >= 1
 
-            # Check drawer exists
-            drawers = get_collection(palace_dir)
-            count = drawers.count()
-            assert count >= 1
+    def test_ingest_skips_unchanged_on_second_run(self, tmp_path):
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 — Test\n\nContent here that's long enough.\n"
+        )
+        palace_dir = tmp_path / "palace"
 
-    def test_ingest_skips_unchanged(self):
-        with tempfile.TemporaryDirectory() as palace_dir:
-            diary_dir = tempfile.mkdtemp()
-            with open(os.path.join(diary_dir, "2026-04-13.md"), "w") as f:
-                f.write("# 2026-04-13\n\n## 10:00 — Test\n\nContent.\n")
+        from mempalace.diary_ingest import ingest_diaries
 
-            from mempalace.diary_ingest import ingest_diaries
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        result = ingest_diaries(str(diary_dir), str(palace_dir))
+        assert result["days_updated"] == 0
 
-            ingest_diaries(diary_dir, palace_dir, force=True)
-            result = ingest_diaries(diary_dir, palace_dir)  # second run, no force
-            assert result["days_updated"] == 0
+    def test_state_file_lives_outside_diary_dir(self, tmp_path):
+        # Regression: the original implementation wrote
+        # ``.diary_ingest_state.json`` *inside* the user's diary directory,
+        # polluting their content folder. State must live under
+        # ``~/.mempalace/state/`` instead.
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 — Test\n\nBody content here long enough.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import _state_file_for, ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+
+        # No state file inside the user's diary dir.
+        for entry in diary_dir.iterdir():
+            assert (
+                "diary_ingest" not in entry.name
+            ), f"state file leaked into user diary dir: {entry}"
+
+        # State file does exist under ~/.mempalace/state/.
+        state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
+        assert state_path.exists()
+        assert "/.mempalace/state/" in str(state_path)
+
+    def test_wing_prefixed_drawer_id_prevents_cross_diary_collision(self, tmp_path):
+        # Regression: the original implementation used
+        # ``drawer_diary_{date_str}`` regardless of wing — two diaries with
+        # the same date in different wings would clobber each other.
+        date_md = "# 2026-04-13\n\n## 10:00 — entry\n\nThis is the day's content.\n"
+
+        # Two separate diary dirs, ingested into the same palace under
+        # different wings. Each must produce a distinct drawer.
+        personal_dir = tmp_path / "personal"
+        personal_dir.mkdir()
+        (personal_dir / "2026-04-13.md").write_text(date_md + "Personal-only marker.\n")
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        (work_dir / "2026-04-13.md").write_text(date_md + "Work-only marker.\n")
+
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import _diary_drawer_id, ingest_diaries
+
+        ingest_diaries(str(personal_dir), str(palace_dir), wing="personal", force=True)
+        ingest_diaries(str(work_dir), str(palace_dir), wing="work", force=True)
+
+        col = get_collection(str(palace_dir))
+        personal_id = _diary_drawer_id("personal", "2026-04-13")
+        work_id = _diary_drawer_id("work", "2026-04-13")
+        assert personal_id != work_id
+
+        personal = col.get(ids=[personal_id])
+        work = col.get(ids=[work_id])
+        assert personal["ids"] == [personal_id]
+        assert work["ids"] == [work_id]
+        assert "Personal-only marker." in personal["documents"][0]
+        assert "Work-only marker." in work["documents"][0]
 
 
-# ── tunnels ──────────────────────────────────────────────────────────────
+# ── cross-wing tunnels ───────────────────────────────────────────────
 
 
 class TestTunnels:
+    """Tunnels are explicit cross-wing connections stored in
+    ``~/.mempalace/tunnels.json``. Each test points the module-level
+    ``_TUNNEL_FILE`` at a fresh tmp file so tests don't cross-contaminate
+    or touch the user's real tunnels."""
+
     def setup_method(self):
-        # Use temp tunnel file
-        self._orig = _TUNNEL_FILE
         import mempalace.palace_graph as pg
+
+        self._orig = pg._TUNNEL_FILE
         self._tmpdir = tempfile.mkdtemp()
         pg._TUNNEL_FILE = os.path.join(self._tmpdir, "tunnels.json")
 
     def teardown_method(self):
         import mempalace.palace_graph as pg
+
         pg._TUNNEL_FILE = self._orig
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     def test_create_tunnel(self):
         t = create_tunnel("wing_api", "auth", "wing_db", "users", label="auth uses users table")
         assert t["id"]
         assert t["source"]["wing"] == "wing_api"
+        assert t["source"]["room"] == "auth"
         assert t["target"]["wing"] == "wing_db"
+        assert t["target"]["room"] == "users"
         assert t["label"] == "auth uses users table"
 
-    def test_list_tunnels(self):
+    def test_list_tunnels_with_and_without_filter(self):
         create_tunnel("wing_a", "room1", "wing_b", "room2")
         create_tunnel("wing_a", "room3", "wing_c", "room4")
-        all_t = list_tunnels()
-        assert len(all_t) == 2
-        filtered = list_tunnels("wing_a")
-        assert len(filtered) == 2
-        filtered_c = list_tunnels("wing_c")
-        assert len(filtered_c) == 1
+        assert len(list_tunnels()) == 2
+        # Filtering by a wing that appears on either endpoint.
+        assert len(list_tunnels("wing_a")) == 2
+        assert len(list_tunnels("wing_c")) == 1
+        assert len(list_tunnels("wing_nonexistent")) == 0
 
     def test_delete_tunnel(self):
         t = create_tunnel("wing_x", "r1", "wing_y", "r2")
         delete_tunnel(t["id"])
-        assert len(list_tunnels()) == 0
+        assert list_tunnels() == []
 
-    def test_dedup_same_endpoints(self):
+    def test_dedup_same_endpoints_updates_label(self):
         create_tunnel("wing_a", "r1", "wing_b", "r2", label="first")
         create_tunnel("wing_a", "r1", "wing_b", "r2", label="updated")
         tunnels = list_tunnels()
         assert len(tunnels) == 1
         assert tunnels[0]["label"] == "updated"
 
-    def test_follow_tunnels(self):
+    def test_follow_tunnels_returns_connected_endpoints(self):
         create_tunnel("wing_api", "auth", "wing_db", "users")
         create_tunnel("wing_api", "auth", "wing_frontend", "login")
+        # Unrelated tunnel that must not surface.
+        create_tunnel("wing_other", "notes", "wing_misc", "scratch")
+
         connections = follow_tunnels("wing_api", "auth")
         assert len(connections) == 2
         wings = {c["connected_wing"] for c in connections}
-        assert "wing_db" in wings
-        assert "wing_frontend" in wings
+        assert wings == {"wing_db", "wing_frontend"}
+
+    # ── regression: symmetry, durability, validation, concurrency ─────
+
+    def test_tunnel_is_symmetric(self):
+        """Regression: tunnels are undirected. create(A, B) and create(B, A)
+        must resolve to the same canonical ID and dedupe into one record —
+        the second call updates the label instead of creating a dupe."""
+        first = create_tunnel("wing_a", "r1", "wing_b", "r2", label="forward")
+        second = create_tunnel("wing_b", "r2", "wing_a", "r1", label="reversed")
+        assert first["id"] == second["id"]
+        assert len(list_tunnels()) == 1
+        assert list_tunnels()[0]["label"] == "reversed"
+
+    def test_follow_tunnels_works_from_either_endpoint(self):
+        """Symmetric: you can follow_tunnels from either end of the link."""
+        create_tunnel("wing_api", "auth", "wing_db", "users", label="auth uses users")
+        from_source = follow_tunnels("wing_api", "auth")
+        from_target = follow_tunnels("wing_db", "users")
+        assert len(from_source) == 1
+        assert len(from_target) == 1
+        assert from_source[0]["connected_wing"] == "wing_db"
+        assert from_target[0]["connected_wing"] == "wing_api"
+        # Both surfaces should carry the same label.
+        assert from_source[0]["label"] == "auth uses users"
+        assert from_target[0]["label"] == "auth uses users"
+
+    def test_empty_endpoint_fields_rejected(self):
+        """Regression: create_tunnel must reject empty strings on any
+        endpoint field so the JSON store can't grow phantom tunnels."""
+        import pytest
+
+        for args in [
+            ("", "r1", "wing", "r2"),
+            ("wing", "", "wing", "r2"),
+            ("wing", "r1", "", "r2"),
+            ("wing", "r1", "wing", ""),
+            ("   ", "r1", "wing", "r2"),  # whitespace-only also rejected
+        ]:
+            with pytest.raises(ValueError):
+                create_tunnel(*args)
+
+    def test_corrupt_tunnel_file_does_not_lose_new_writes(self):
+        """A truncated/corrupt tunnels.json (crash mid-write on a system
+        without atomic rename) must not leak into subsequent reads — the
+        file should be treated as empty and a fresh create_tunnel should
+        persist cleanly."""
+        import mempalace.palace_graph as pg
+
+        # Simulate a crash that left a truncated file behind.
+        with open(pg._TUNNEL_FILE, "w") as f:
+            f.write("{not valid json")
+
+        # Load should return [] rather than raising.
+        assert list_tunnels() == []
+
+        # A subsequent create must persist (atomic write replaces the corrupt file).
+        t = create_tunnel("wing_a", "r1", "wing_b", "r2")
+        assert list_tunnels() == [t]
+
+    def test_atomic_write_leaves_no_stray_tmp_file(self):
+        """Regression: _save_tunnels uses write-then-os.replace. After a
+        successful create, there must be no leftover ``tunnels.json.tmp``."""
+        import mempalace.palace_graph as pg
+
+        create_tunnel("wing_a", "r1", "wing_b", "r2")
+        assert os.path.exists(pg._TUNNEL_FILE)
+        assert not os.path.exists(pg._TUNNEL_FILE + ".tmp")
+
+    def test_concurrent_creates_preserve_all_tunnels(self):
+        """Regression: two concurrent create_tunnel calls must not clobber
+        each other. Without the mine_lock around load+save, the later
+        writer's snapshot would overwrite the earlier writer's tunnel."""
+        barrier = threading.Barrier(5)
+        errors: list = []
+
+        def worker(i):
+            try:
+                barrier.wait(timeout=2)
+                create_tunnel(f"wing_{i}", "r", "wing_shared", "hub")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"worker raised: {errors}"
+        tunnels = list_tunnels()
+        assert len(tunnels) == 5, (
+            f"expected 5 concurrent tunnels, got {len(tunnels)} — " "write race dropped some"
+        )
+
+    def test_created_at_is_timezone_aware(self):
+        """Regression: created_at must be tz-aware UTC, not naive."""
+        t = create_tunnel("wing_a", "r1", "wing_b", "r2")
+        # ISO format with tz offset contains '+' or 'Z'.
+        assert t["created_at"].endswith("+00:00") or t["created_at"].endswith("Z")

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1,32 +1,61 @@
-"""Tests for the closet layer, mine_lock, entity metadata, BM25 hybrid search,
-and diary ingest.
+"""
+test_closets.py — Tests for the closet (searchable index) layer and the
+features that ride on top of it: mine_lock serialization, entity metadata,
+hybrid BM25+vector search, and diary ingest.
 
-Content derived from Milla's omnibus test file; trimmed to only the features
-present in this PR stack (#784 lock, #788 closets, this PR's entity/BM25/diary).
-Strip-noise tests live with #785; tunnel tests live with the tunnels PR.
+Coverage map:
+  * mine_lock — acquire/release, blocks concurrent acquisition.
+  * build_closet_lines — pointer-line shape, header pickup, entity stoplist
+    (regression for "When/After/The"), real-name survival, fallback line.
+  * upsert_closet_lines — pure overwrite (regression for the append bug),
+    char-limit packing without splitting a line.
+  * purge_file_closets — scoped to source_file.
+  * Project-miner end-to-end rebuild — re-mining with fewer topics fully
+    purges leftover numbered closets from a larger prior run.
+  * _extract_drawer_ids_from_closet — pointer parsing + dedup.
+  * search_memories closet-first path — fallback when empty, chunk-level
+    hits with matched_via, no whole-file glue, max_distance enforcement.
+  * Entity metadata — extracted, stoplist applied, registry cached by mtime.
+  * Real BM25 — real IDF over candidate corpus, hybrid rerank.
+  * Diary ingest — drawers + closets created, incremental skips, state
+    file lives outside the diary dir, wing-prefixed drawer IDs prevent
+    cross-diary collisions, force=True purges leftover closets.
 """
 
+import json
 import os
 import tempfile
 import threading
 import time
 
+import yaml
+
+from mempalace.miner import (
+    _extract_entities_for_metadata,
+    _load_known_entities,
+    mine,
+)
 from mempalace.palace import (
     CLOSET_CHAR_LIMIT,
     build_closet_lines,
     get_closets_collection,
     get_collection,
     mine_lock,
+    purge_file_closets,
     upsert_closet_lines,
 )
-from mempalace.miner import _extract_entities_for_metadata
-from mempalace.searcher import _bm25_score, _hybrid_rank
 from mempalace.palace_graph import (
     create_tunnel,
-    list_tunnels,
     delete_tunnel,
     follow_tunnels,
-    _TUNNEL_FILE,
+    list_tunnels,
+)
+from mempalace.searcher import (
+    _bm25_scores,
+    _expand_with_neighbors,
+    _extract_drawer_ids_from_closet,
+    _hybrid_rank,
+    search_memories,
 )
 
 
@@ -34,104 +63,287 @@ from mempalace.palace_graph import (
 
 
 class TestMineLock:
-    def test_lock_acquires_and_releases(self):
-        with mine_lock("/tmp/test_lock_file.txt"):
+    def test_lock_acquires_and_releases(self, tmp_path):
+        target = str(tmp_path / "lock_target.txt")
+        with mine_lock(target):
             lock_dir = os.path.expanduser("~/.mempalace/locks")
             assert os.path.isdir(lock_dir)
+        # Re-acquire after release should succeed instantly.
+        start = time.time()
+        with mine_lock(target):
+            pass
+        assert time.time() - start < 1.0
 
-    def test_lock_blocks_concurrent_access(self):
+    def test_lock_blocks_concurrent_access(self, tmp_path):
+        target = str(tmp_path / "concurrent_lock.txt")
         results = []
 
         def worker(name):
             start = time.time()
-            with mine_lock("/tmp/same_file_lock_test.txt"):
+            with mine_lock(target):
                 results.append((name, time.time() - start))
                 time.sleep(0.2)
 
         t1 = threading.Thread(target=worker, args=("a",))
         t2 = threading.Thread(target=worker, args=("b",))
         t1.start()
-        time.sleep(0.05)
+        time.sleep(0.05)  # ensure t1 acquires first
         t2.start()
         t1.join()
         t2.join()
 
-        # Second thread should have waited
-        wait_times = sorted(results, key=lambda x: x[1])
-        assert wait_times[1][1] > 0.1, "Second thread should block"
+        # The second worker must have waited at least most of t1's hold time.
+        wait_times = sorted(r[1] for r in results)
+        assert (
+            wait_times[1] > 0.1
+        ), f"second thread should block on mine_lock, waited only {wait_times[1]:.3f}s"
 
 
-# ── closet lines ─────────────────────────────────────────────────────────
+# ── build_closet_lines ─────────────────────────────────────────────────
 
 
 class TestBuildClosetLines:
-    def test_returns_list_of_lines(self):
-        lines = build_closet_lines(
-            "/tmp/test.py", ["drawer_001"], "We built the auth system", "code", "general"
+    def test_emits_pointer_line_shape(self):
+        content = (
+            "# Auth rewrite\n\n"
+            "Decided we need to migrate to passkeys. "
+            "Built the prototype with WebAuthn. "
+            "Reviewed the API surface."
         )
-        assert isinstance(lines, list)
-        assert len(lines) >= 1
-
-    def test_each_line_has_pointer(self):
         lines = build_closet_lines(
-            "/tmp/test.py",
-            ["drawer_001", "drawer_002"],
-            "We built the auth system and tested the login flow",
-            "code",
-            "general",
+            "/proj/auth.md",
+            ["drawer_proj_backend_aaa", "drawer_proj_backend_bbb"],
+            content,
+            wing="proj",
+            room="backend",
         )
+        assert lines, "should always emit at least one line"
         for line in lines:
-            assert "→" in line, f"Line missing pointer: {line}"
+            assert "→" in line, f"line missing pointer arrow: {line!r}"
+            parts = line.split("|")
+            assert len(parts) == 3, f"expected topic|entities|→refs, got {line!r}"
+            assert parts[2].startswith("→")
 
-    def test_fallback_when_no_topics(self):
-        lines = build_closet_lines(
-            "/tmp/test.py", ["drawer_001"], "short text", "wing", "room"
+    def test_extracts_section_headers_as_topics(self):
+        content = "# First Header\nbody\n## Second Header\nmore body"
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined = "\n".join(lines).lower()
+        assert "first header" in joined
+        assert "second header" in joined
+
+    def test_entity_stoplist_filters_sentence_starters(self):
+        # "When", "After", "The" repeat 3+ times — old code would index them
+        # as entities. Stoplist drops them.
+        content = (
+            "When the pipeline ran, the result was good. "
+            "When the user logged in, the token was issued. "
+            "After the migration, the latency dropped. "
+            "After the rollback, the latency rose. "
+            "The new flow is stable. The audit cleared."
         )
-        assert len(lines) >= 1
-        assert "→" in lines[0]
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        entity_segments = [line.split("|")[1] for line in lines]
+        for seg in entity_segments:
+            tokens = set(seg.split(";")) if seg else set()
+            assert "When" not in tokens
+            assert "After" not in tokens
+            assert "The" not in tokens
+
+    def test_real_proper_nouns_survive_stoplist(self):
+        content = (
+            "Igor reviewed the diff. Milla wrote the spec. "
+            "Igor pushed the fix. Milla approved the PR. "
+            "Igor and Milla shipped together."
+        )
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined_entities = ";".join(line.split("|")[1] for line in lines)
+        assert "Igor" in joined_entities
+        assert "Milla" in joined_entities
+
+    def test_emits_fallback_line_when_nothing_extractable(self):
+        content = "lorem ipsum dolor sit amet consectetur adipiscing elit"
+        lines = build_closet_lines("/x/notes.txt", ["d1"], content, "wing", "room")
+        assert len(lines) == 1
+        assert "wing/room/notes" in lines[0]
+        assert "→d1" in lines[0]
+
+    def test_pointer_references_first_three_drawers(self):
+        ids = [f"drawer_{i}" for i in range(10)]
+        lines = build_closet_lines("/x.md", ids, "# A\n# B", "w", "r")
+        assert all("→drawer_0,drawer_1,drawer_2" in line for line in lines)
 
 
-# ── upsert_closet_lines ─────────────────────────────────────────────────
+# ── upsert_closet_lines ───────────────────────────────────────────────
 
 
 class TestUpsertClosetLines:
-    def test_writes_closets(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            lines = [
-                "topic one|Entity1|→drawer_001",
-                "topic two|Entity2|→drawer_002",
-            ]
-            n = upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
-            assert n >= 1
-            assert col.count() >= 1
+    def test_overwrites_existing_closet_does_not_append(self, palace_path):
+        col = get_closets_collection(palace_path)
+        base = "closet_test_room_abc"
+        meta = {"wing": "test", "room": "room", "source_file": "/x.md"}
 
-    def test_never_splits_mid_topic(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            # Create lines that together exceed CLOSET_CHAR_LIMIT
-            lines = [f"topic_{i}|{'x' * 200}|→drawer_{i}" for i in range(20)]
-            n = upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
-            assert n >= 2, "Should create multiple closets"
+        upsert_closet_lines(col, base, ["alpha|;|→d1", "beta|;|→d2", "gamma|;|→d3"], meta)
+        first = col.get(ids=[f"{base}_01"])
+        assert "alpha" in first["documents"][0]
 
-            # Verify each closet has complete lines
-            all_data = col.get(include=["documents"])
-            for doc in all_data["documents"]:
-                for line in doc.strip().split("\n"):
-                    assert "→" in line, f"Split topic found: {line}"
+        # Second mine — entirely different lines. Must replace, not append.
+        upsert_closet_lines(col, base, ["delta|;|→d4", "epsilon|;|→d5"], meta)
+        second = col.get(ids=[f"{base}_01"])
+        doc = second["documents"][0]
+        assert "delta" in doc
+        assert "epsilon" in doc
+        assert "alpha" not in doc, "old closet line leaked into rebuild"
+        assert "beta" not in doc
 
-    def test_respects_char_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            lines = [f"topic_{i}|entities|→drawer_{i}" for i in range(50)]
-            upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
+    def test_packs_into_multiple_closets_without_splitting_lines(self, palace_path):
+        col = get_closets_collection(palace_path)
+        base = "closet_pack_room_def"
+        meta = {"wing": "test", "room": "room", "source_file": "/y.md"}
 
-            all_data = col.get(include=["documents"])
-            for doc in all_data["documents"]:
-                assert len(doc) <= CLOSET_CHAR_LIMIT + 100  # small buffer for existing content
+        line = "x" * 600  # well under CLOSET_CHAR_LIMIT
+        n_written = upsert_closet_lines(col, base, [line, line, line, line], meta)
+        # 4 lines @ 601 chars each = 2404 — should pack into 2 closets
+        assert n_written == 2
+
+        for i in range(1, n_written + 1):
+            doc = col.get(ids=[f"{base}_{i:02d}"])["documents"][0]
+            for chunk in doc.split("\n"):
+                assert len(chunk) == 600, f"line was truncated in closet {i}"
+            assert len(doc) <= CLOSET_CHAR_LIMIT
 
 
-# ── entity metadata ──────────────────────────────────────────────────────
+# ── purge_file_closets ────────────────────────────────────────────────
+
+
+class TestPurgeFileClosets:
+    def test_deletes_only_the_targeted_source(self, palace_path):
+        col = get_closets_collection(palace_path)
+        col.upsert(
+            ids=["closet_a_01", "closet_b_01"],
+            documents=["a|;|→d1", "b|;|→d2"],
+            metadatas=[
+                {"source_file": "/keep.md", "wing": "w", "room": "r"},
+                {"source_file": "/drop.md", "wing": "w", "room": "r"},
+            ],
+        )
+        purge_file_closets(col, "/drop.md")
+        remaining_ids = set(col.get()["ids"])
+        assert "closet_a_01" in remaining_ids
+        assert "closet_b_01" not in remaining_ids
+
+
+# ── project miner: closet rebuild end-to-end ──────────────────────────
+
+
+class TestMinerClosetRebuild:
+    def test_remine_replaces_closets_completely(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "mempalace.yaml").write_text(
+            yaml.dump({"wing": "proj", "rooms": [{"name": "general", "description": "x"}]})
+        )
+        target = project / "doc.md"
+
+        # First mine — long content produces multiple numbered closets.
+        first_topics = "\n\n".join(f"# Topic {i}\n" + ("filler text " * 30) for i in range(15))
+        target.write_text(first_topics)
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        first_pass = col.get(where={"source_file": str(target)})
+        assert first_pass["ids"], "first mine should have written closets"
+        first_ids = set(first_pass["ids"])
+        assert any("topic 0" in (d or "").lower() for d in first_pass["documents"])
+
+        # Touch mtime + shrink content so the rebuild produces fewer closets.
+        target.write_text("# Only Topic Now\n" + ("short body " * 5))
+        new_mtime = os.path.getmtime(target) + 60
+        os.utime(target, (new_mtime, new_mtime))
+        time.sleep(0.01)
+
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        second_pass = col.get(where={"source_file": str(target)})
+        second_docs = "\n".join(second_pass["documents"]).lower()
+        assert "only topic now" in second_docs
+        for i in range(15):
+            assert (
+                f"topic {i}\n" not in second_docs
+            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+        # Numbered closets that existed only in the larger first run must be gone.
+        leftover = first_ids - set(second_pass["ids"])
+        for stale_id in leftover:
+            assert not col.get(ids=[stale_id])[
+                "ids"
+            ], f"orphan closet {stale_id} from larger first run survived purge"
+
+
+# ── _extract_drawer_ids_from_closet ───────────────────────────────────
+
+
+class TestExtractDrawerIds:
+    def test_parses_single_pointer(self):
+        assert _extract_drawer_ids_from_closet("topic|;|→drawer_x") == ["drawer_x"]
+
+    def test_parses_multiple_pointers_per_line(self):
+        line = "topic|ent|→drawer_a,drawer_b,drawer_c"
+        assert _extract_drawer_ids_from_closet(line) == ["drawer_a", "drawer_b", "drawer_c"]
+
+    def test_dedupes_across_lines(self):
+        doc = "one|;|→drawer_a,drawer_b\ntwo|;|→drawer_b,drawer_c"
+        assert _extract_drawer_ids_from_closet(doc) == ["drawer_a", "drawer_b", "drawer_c"]
+
+    def test_empty_doc_returns_empty(self):
+        assert _extract_drawer_ids_from_closet("") == []
+        assert _extract_drawer_ids_from_closet("no arrows here") == []
+
+
+# ── search_memories closet-first path ────────────────────────────────
+
+
+class TestSearchMemoriesClosetFirst:
+    def test_falls_back_to_direct_when_no_closets(self, palace_path, seeded_collection):
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"], "should still find drawer hits via fallback"
+        for hit in result["results"]:
+            assert hit.get("matched_via") == "drawer"
+
+    def test_closet_first_returns_chunk_level_hits(self, palace_path, seeded_collection):
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_aaa_01"],
+            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": "auth.py"}],
+        )
+
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"], "closet-first search should hydrate the drawer"
+        top = result["results"][0]
+        assert top["matched_via"] == "closet"
+        assert "JWT" in top["text"]
+        # Chunk-level — must NOT glue every drawer in the file together.
+        assert "Database migrations" not in top["text"]
+        assert "→drawer_proj_backend_aaa" in top["closet_preview"]
+
+    def test_max_distance_filters_closet_hits(self, palace_path, seeded_collection):
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_aaa_01"],
+            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": "auth.py"}],
+        )
+        result = search_memories(
+            "completely unrelated query about quantum gardening",
+            palace_path,
+            max_distance=0.001,
+        )
+        for hit in result["results"]:
+            assert hit["distance"] <= 0.001
+
+
+# ── entity metadata ──────────────────────────────────────────────────
 
 
 class TestEntityMetadata:
@@ -143,120 +355,561 @@ class TestEntityMetadata:
 
     def test_empty_for_no_entities(self):
         text = "this is all lowercase with no proper nouns at all"
-        entities = _extract_entities_for_metadata(text)
-        assert entities == ""
+        assert _extract_entities_for_metadata(text) == ""
 
     def test_semicolon_separated(self):
         text = "Alice and Bob met Charlie. Alice said hello. Bob agreed. Charlie laughed."
         entities = _extract_entities_for_metadata(text)
         assert ";" in entities
 
+    def test_stoplist_filters_sentence_starters(self):
+        # Same regression as the closet entity test — "When/After/The" must
+        # not become entities just because they're capitalized 2+ times.
+        text = (
+            "When the build broke, the team paged. "
+            "When the fix landed, the alarm cleared. "
+            "After the rollback, the queue drained. "
+            "After the deploy, the latency normalized."
+        )
+        entities = _extract_entities_for_metadata(text)
+        tokens = set(entities.split(";")) if entities else set()
+        assert "When" not in tokens
+        assert "After" not in tokens
+        assert "The" not in tokens
 
-# ── BM25 hybrid search ──────────────────────────────────────────────────
+    def test_capped_list_never_truncates_a_name(self):
+        # 30 distinct repeated proper nouns — extraction should cap the list
+        # before joining so a name never gets cut in half.
+        # Use morphologically distinct stems so the [A-Z][a-z]+ regex sees
+        # each as its own token.
+        names = [
+            "Anna",
+            "Brian",
+            "Carol",
+            "David",
+            "Elena",
+            "Frank",
+            "Grace",
+            "Harold",
+            "Iris",
+            "Julian",
+            "Kira",
+            "Liam",
+            "Maya",
+            "Noah",
+            "Oscar",
+            "Penny",
+            "Quinn",
+            "Rosa",
+            "Sergei",
+            "Tara",
+            "Umar",
+            "Vera",
+            "Walter",
+            "Xander",
+            "Yvonne",
+            "Zachary",
+            "Amelia",
+            "Boris",
+            "Clara",
+            "Dmitri",
+        ]
+        text = " ".join(f"{n} met {n}." for n in names)
+        entities = _extract_entities_for_metadata(text)
+        extracted = [n for n in entities.split(";") if n]
+        assert extracted, "should have extracted some entities"
+        for name in extracted:
+            assert name in names, f"truncation produced a partial token: {name!r}"
+
+    def test_known_registry_is_cached_by_mtime(self, monkeypatch, tmp_path):
+        # Point the registry at a temp file we control, exercise the cache.
+        registry = tmp_path / "known_entities.json"
+        registry.write_text(json.dumps({"people": ["Zelda"]}))
+        from mempalace import miner
+
+        monkeypatch.setattr(miner, "_ENTITY_REGISTRY_PATH", str(registry))
+        miner._ENTITY_REGISTRY_CACHE["mtime"] = None
+        miner._ENTITY_REGISTRY_CACHE["names"] = frozenset()
+
+        first = _load_known_entities()
+        assert "Zelda" in first
+
+        # Second call without changing mtime: must reuse cache, not re-read.
+        read_count = {"n": 0}
+        original_open = open
+
+        def counting_open(path, *a, **kw):
+            if str(path) == str(registry):
+                read_count["n"] += 1
+            return original_open(path, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", counting_open)
+        _load_known_entities()
+        assert read_count["n"] == 0, "registry should not be re-read when mtime unchanged"
+
+        # Bump mtime → cache must invalidate.
+        new_mtime = os.path.getmtime(registry) + 5
+        os.utime(registry, (new_mtime, new_mtime))
+        registry.write_text(json.dumps({"people": ["Zelda", "Link"]}))
+        os.utime(registry, (new_mtime, new_mtime))
+        names = _load_known_entities()
+        assert "Link" in names
+
+
+# ── BM25 hybrid search (real IDF over candidate corpus) ──────────────
 
 
 class TestBM25:
-    def test_bm25_score_positive_for_match(self):
-        score = _bm25_score("database migration", "We migrated the database to Postgres")
-        assert score > 0
+    def test_scores_positive_for_matching_doc(self):
+        scores = _bm25_scores(
+            "database migration",
+            ["We migrated the database to Postgres.", "unrelated cookery tips"],
+        )
+        assert scores[0] > 0
+        assert scores[1] == 0.0
 
-    def test_bm25_score_zero_for_no_match(self):
-        score = _bm25_score("quantum physics", "We built a web application in React")
-        assert score == 0.0
+    def test_scores_zero_when_no_overlap(self):
+        scores = _bm25_scores("quantum physics", ["We built a web app in React"])
+        assert scores == [0.0]
 
-    def test_hybrid_rank_reorders(self):
+    def test_idf_downweights_terms_present_in_every_doc(self):
+        # "database" appears in every candidate → low IDF → low contribution.
+        # "vacuum" is unique to one → high IDF → that doc dominates.
+        scores = _bm25_scores(
+            "database vacuum",
+            [
+                "database backup nightly schedule",
+                "database vacuum scheduled weekly",
+                "database failover plan",
+            ],
+        )
+        assert scores[1] == max(scores), "doc with the rare query term should win on IDF"
+
+    def test_empty_inputs_return_zeros(self):
+        assert _bm25_scores("", ["hello world"]) == [0.0]
+        assert _bm25_scores("query here", []) == []
+        assert _bm25_scores("query", [""]) == [0.0]
+
+    def test_hybrid_rank_promotes_keyword_match(self):
         results = [
             {"text": "database schema design for Postgres", "distance": 0.5},
             {"text": "unrelated topic about cooking", "distance": 0.3},
         ]
         ranked = _hybrid_rank(results, "database Postgres schema")
-        # The database result should rank higher despite worse vector distance
+        # The keyword-rich result outranks the closer-vector but irrelevant one.
         assert "database" in ranked[0]["text"]
+        # bm25_score field is exposed for debugging.
+        assert "bm25_score" in ranked[0]
+        # No internal scoring leak.
+        assert "_hybrid_score" not in ranked[0]
+
+    def test_hybrid_rank_absolute_normalization(self):
+        # Adding a much-worse result to the candidate set must NOT reshuffle
+        # the top two — proves we're using absolute (1 - dist) and not
+        # dist / max_dist normalization.
+        base = [
+            {"text": "alpha alpha alpha", "distance": 0.1},
+            {"text": "beta beta beta", "distance": 0.4},
+        ]
+        ranked_short = _hybrid_rank([dict(r) for r in base], "alpha")
+        with_outlier = base + [{"text": "gamma gamma gamma", "distance": 1.9}]
+        ranked_long = _hybrid_rank([dict(r) for r in with_outlier], "alpha")
+        assert ranked_short[0]["text"] == ranked_long[0]["text"]
+        assert ranked_short[1]["text"] == ranked_long[1]["text"]
 
 
-# ── diary ingest ─────────────────────────────────────────────────────────
+# ── diary ingest ─────────────────────────────────────────────────────
 
 
 class TestDiaryIngest:
-    def test_ingest_creates_drawers_and_closets(self):
-        with tempfile.TemporaryDirectory() as palace_dir:
-            diary_dir = tempfile.mkdtemp()
-            # Write a test diary
-            with open(os.path.join(diary_dir, "2026-04-13.md"), "w") as f:
-                f.write("# 2026-04-13\n\n## 10:00 PDT — Test\n\nBuilt the auth system.\n")
+    def test_ingest_creates_drawers_and_closets(self, tmp_path):
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 PDT — Test\n\nBuilt the auth system.\n"
+        )
+        palace_dir = tmp_path / "palace"
 
-            from mempalace.diary_ingest import ingest_diaries
+        from mempalace.diary_ingest import ingest_diaries
 
-            result = ingest_diaries(diary_dir, palace_dir, force=True)
-            assert result["days_updated"] >= 1
+        result = ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        assert result["days_updated"] >= 1
+        assert get_collection(str(palace_dir)).count() >= 1
 
-            # Check drawer exists
-            drawers = get_collection(palace_dir)
-            count = drawers.count()
-            assert count >= 1
+    def test_ingest_skips_unchanged_on_second_run(self, tmp_path):
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 — Test\n\nContent here that's long enough.\n"
+        )
+        palace_dir = tmp_path / "palace"
 
-    def test_ingest_skips_unchanged(self):
-        with tempfile.TemporaryDirectory() as palace_dir:
-            diary_dir = tempfile.mkdtemp()
-            with open(os.path.join(diary_dir, "2026-04-13.md"), "w") as f:
-                f.write("# 2026-04-13\n\n## 10:00 — Test\n\nContent.\n")
+        from mempalace.diary_ingest import ingest_diaries
 
-            from mempalace.diary_ingest import ingest_diaries
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        result = ingest_diaries(str(diary_dir), str(palace_dir))
+        assert result["days_updated"] == 0
 
-            ingest_diaries(diary_dir, palace_dir, force=True)
-            result = ingest_diaries(diary_dir, palace_dir)  # second run, no force
-            assert result["days_updated"] == 0
+    def test_state_file_lives_outside_diary_dir(self, tmp_path):
+        # Regression: the original implementation wrote
+        # ``.diary_ingest_state.json`` *inside* the user's diary directory,
+        # polluting their content folder. State must live under
+        # ``~/.mempalace/state/`` instead.
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 — Test\n\nBody content here long enough.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import _state_file_for, ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+
+        # No state file inside the user's diary dir.
+        for entry in diary_dir.iterdir():
+            assert (
+                "diary_ingest" not in entry.name
+            ), f"state file leaked into user diary dir: {entry}"
+
+        # State file does exist under ~/.mempalace/state/.
+        state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
+        assert state_path.exists()
+        assert "/.mempalace/state/" in str(state_path)
+
+    def test_wing_prefixed_drawer_id_prevents_cross_diary_collision(self, tmp_path):
+        # Regression: the original implementation used
+        # ``drawer_diary_{date_str}`` regardless of wing — two diaries with
+        # the same date in different wings would clobber each other.
+        date_md = "# 2026-04-13\n\n## 10:00 — entry\n\nThis is the day's content.\n"
+
+        # Two separate diary dirs, ingested into the same palace under
+        # different wings. Each must produce a distinct drawer.
+        personal_dir = tmp_path / "personal"
+        personal_dir.mkdir()
+        (personal_dir / "2026-04-13.md").write_text(date_md + "Personal-only marker.\n")
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        (work_dir / "2026-04-13.md").write_text(date_md + "Work-only marker.\n")
+
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import _diary_drawer_id, ingest_diaries
+
+        ingest_diaries(str(personal_dir), str(palace_dir), wing="personal", force=True)
+        ingest_diaries(str(work_dir), str(palace_dir), wing="work", force=True)
+
+        col = get_collection(str(palace_dir))
+        personal_id = _diary_drawer_id("personal", "2026-04-13")
+        work_id = _diary_drawer_id("work", "2026-04-13")
+        assert personal_id != work_id
+
+        personal = col.get(ids=[personal_id])
+        work = col.get(ids=[work_id])
+        assert personal["ids"] == [personal_id]
+        assert work["ids"] == [work_id]
+        assert "Personal-only marker." in personal["documents"][0]
+        assert "Work-only marker." in work["documents"][0]
 
 
-# ── tunnels ──────────────────────────────────────────────────────────────
+# ── cross-wing tunnels ───────────────────────────────────────────────
 
 
 class TestTunnels:
+    """Tunnels are explicit cross-wing connections stored in
+    ``~/.mempalace/tunnels.json``. Each test points the module-level
+    ``_TUNNEL_FILE`` at a fresh tmp file so tests don't cross-contaminate
+    or touch the user's real tunnels."""
+
     def setup_method(self):
-        # Use temp tunnel file
-        self._orig = _TUNNEL_FILE
         import mempalace.palace_graph as pg
+
+        self._orig = pg._TUNNEL_FILE
         self._tmpdir = tempfile.mkdtemp()
         pg._TUNNEL_FILE = os.path.join(self._tmpdir, "tunnels.json")
 
     def teardown_method(self):
         import mempalace.palace_graph as pg
+
         pg._TUNNEL_FILE = self._orig
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     def test_create_tunnel(self):
         t = create_tunnel("wing_api", "auth", "wing_db", "users", label="auth uses users table")
         assert t["id"]
         assert t["source"]["wing"] == "wing_api"
+        assert t["source"]["room"] == "auth"
         assert t["target"]["wing"] == "wing_db"
+        assert t["target"]["room"] == "users"
         assert t["label"] == "auth uses users table"
 
-    def test_list_tunnels(self):
+    def test_list_tunnels_with_and_without_filter(self):
         create_tunnel("wing_a", "room1", "wing_b", "room2")
         create_tunnel("wing_a", "room3", "wing_c", "room4")
-        all_t = list_tunnels()
-        assert len(all_t) == 2
-        filtered = list_tunnels("wing_a")
-        assert len(filtered) == 2
-        filtered_c = list_tunnels("wing_c")
-        assert len(filtered_c) == 1
+        assert len(list_tunnels()) == 2
+        # Filtering by a wing that appears on either endpoint.
+        assert len(list_tunnels("wing_a")) == 2
+        assert len(list_tunnels("wing_c")) == 1
+        assert len(list_tunnels("wing_nonexistent")) == 0
 
     def test_delete_tunnel(self):
         t = create_tunnel("wing_x", "r1", "wing_y", "r2")
         delete_tunnel(t["id"])
-        assert len(list_tunnels()) == 0
+        assert list_tunnels() == []
 
-    def test_dedup_same_endpoints(self):
+    def test_dedup_same_endpoints_updates_label(self):
         create_tunnel("wing_a", "r1", "wing_b", "r2", label="first")
         create_tunnel("wing_a", "r1", "wing_b", "r2", label="updated")
         tunnels = list_tunnels()
         assert len(tunnels) == 1
         assert tunnels[0]["label"] == "updated"
 
-    def test_follow_tunnels(self):
+    def test_follow_tunnels_returns_connected_endpoints(self):
         create_tunnel("wing_api", "auth", "wing_db", "users")
         create_tunnel("wing_api", "auth", "wing_frontend", "login")
+        # Unrelated tunnel that must not surface.
+        create_tunnel("wing_other", "notes", "wing_misc", "scratch")
+
         connections = follow_tunnels("wing_api", "auth")
         assert len(connections) == 2
         wings = {c["connected_wing"] for c in connections}
-        assert "wing_db" in wings
-        assert "wing_frontend" in wings
+        assert wings == {"wing_db", "wing_frontend"}
+
+    # ── regression: symmetry, durability, validation, concurrency ─────
+
+    def test_tunnel_is_symmetric(self):
+        """Regression: tunnels are undirected. create(A, B) and create(B, A)
+        must resolve to the same canonical ID and dedupe into one record —
+        the second call updates the label instead of creating a dupe."""
+        first = create_tunnel("wing_a", "r1", "wing_b", "r2", label="forward")
+        second = create_tunnel("wing_b", "r2", "wing_a", "r1", label="reversed")
+        assert first["id"] == second["id"]
+        assert len(list_tunnels()) == 1
+        assert list_tunnels()[0]["label"] == "reversed"
+
+    def test_follow_tunnels_works_from_either_endpoint(self):
+        """Symmetric: you can follow_tunnels from either end of the link."""
+        create_tunnel("wing_api", "auth", "wing_db", "users", label="auth uses users")
+        from_source = follow_tunnels("wing_api", "auth")
+        from_target = follow_tunnels("wing_db", "users")
+        assert len(from_source) == 1
+        assert len(from_target) == 1
+        assert from_source[0]["connected_wing"] == "wing_db"
+        assert from_target[0]["connected_wing"] == "wing_api"
+        # Both surfaces should carry the same label.
+        assert from_source[0]["label"] == "auth uses users"
+        assert from_target[0]["label"] == "auth uses users"
+
+    def test_empty_endpoint_fields_rejected(self):
+        """Regression: create_tunnel must reject empty strings on any
+        endpoint field so the JSON store can't grow phantom tunnels."""
+        import pytest
+
+        for args in [
+            ("", "r1", "wing", "r2"),
+            ("wing", "", "wing", "r2"),
+            ("wing", "r1", "", "r2"),
+            ("wing", "r1", "wing", ""),
+            ("   ", "r1", "wing", "r2"),  # whitespace-only also rejected
+        ]:
+            with pytest.raises(ValueError):
+                create_tunnel(*args)
+
+    def test_corrupt_tunnel_file_does_not_lose_new_writes(self):
+        """A truncated/corrupt tunnels.json (crash mid-write on a system
+        without atomic rename) must not leak into subsequent reads — the
+        file should be treated as empty and a fresh create_tunnel should
+        persist cleanly."""
+        import mempalace.palace_graph as pg
+
+        # Simulate a crash that left a truncated file behind.
+        with open(pg._TUNNEL_FILE, "w") as f:
+            f.write("{not valid json")
+
+        # Load should return [] rather than raising.
+        assert list_tunnels() == []
+
+        # A subsequent create must persist (atomic write replaces the corrupt file).
+        t = create_tunnel("wing_a", "r1", "wing_b", "r2")
+        assert list_tunnels() == [t]
+
+    def test_atomic_write_leaves_no_stray_tmp_file(self):
+        """Regression: _save_tunnels uses write-then-os.replace. After a
+        successful create, there must be no leftover ``tunnels.json.tmp``."""
+        import mempalace.palace_graph as pg
+
+        create_tunnel("wing_a", "r1", "wing_b", "r2")
+        assert os.path.exists(pg._TUNNEL_FILE)
+        assert not os.path.exists(pg._TUNNEL_FILE + ".tmp")
+
+    def test_concurrent_creates_preserve_all_tunnels(self):
+        """Regression: two concurrent create_tunnel calls must not clobber
+        each other. Without the mine_lock around load+save, the later
+        writer's snapshot would overwrite the earlier writer's tunnel."""
+        barrier = threading.Barrier(5)
+        errors: list = []
+
+        def worker(i):
+            try:
+                barrier.wait(timeout=2)
+                create_tunnel(f"wing_{i}", "r", "wing_shared", "hub")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"worker raised: {errors}"
+        tunnels = list_tunnels()
+        assert len(tunnels) == 5, (
+            f"expected 5 concurrent tunnels, got {len(tunnels)} — " "write race dropped some"
+        )
+
+    def test_created_at_is_timezone_aware(self):
+        """Regression: created_at must be tz-aware UTC, not naive."""
+        t = create_tunnel("wing_a", "r1", "wing_b", "r2")
+        # ISO format with tz offset contains '+' or 'Z'.
+        assert t["created_at"].endswith("+00:00") or t["created_at"].endswith("Z")
+
+
+# ── drawer-grep neighbor expansion ────────────────────────────────────
+#
+# When a closet hit lands on a drawer whose chunk boundary clips a thought
+# (matched chunk says "here's a breakdown:" and the breakdown lives in the
+# next chunk), the closet path now expands to ±1 neighbor chunks from the
+# same source file. These tests pin that behavior end-to-end and at the
+# helper level.
+
+
+class TestDrawerGrepExpansion:
+    def _seed_source_file(self, palace_path, source: str, n_chunks: int):
+        """Helper: put N sequential drawers for a single source file into
+        the palace and return the drawer IDs keyed by chunk_index."""
+        col = get_collection(palace_path)
+        ids = [f"drawer_test_room_{source.replace('/', '_')}_{i:03d}" for i in range(n_chunks)]
+        docs = [f"chunk_{i} content about topic alpha" for i in range(n_chunks)]
+        metas = [
+            {
+                "wing": "test",
+                "room": "room",
+                "source_file": source,
+                "chunk_index": i,
+                "filed_at": "2026-04-13T00:00:00",
+            }
+            for i in range(n_chunks)
+        ]
+        col.upsert(ids=ids, documents=docs, metadatas=metas)
+        return col, {i: ids[i] for i in range(n_chunks)}
+
+    def test_expand_returns_matched_plus_neighbors(self, palace_path):
+        col, by_idx = self._seed_source_file(palace_path, "/proj/doc.md", n_chunks=5)
+        matched_meta = {"source_file": "/proj/doc.md", "chunk_index": 2}
+        matched_doc = "chunk_2 content about topic alpha"
+
+        out = _expand_with_neighbors(col, matched_doc, matched_meta, radius=1)
+        assert out["drawer_index"] == 2
+        assert out["total_drawers"] == 5
+        # Expect chunks 1, 2, 3 joined in chunk_index order.
+        text = out["text"]
+        assert "chunk_1" in text
+        assert "chunk_2" in text
+        assert "chunk_3" in text
+        # No leakage of non-neighbors.
+        assert "chunk_0" not in text
+        assert "chunk_4" not in text
+        # Ordering preserved — chunk_1 before chunk_2 before chunk_3.
+        assert text.index("chunk_1") < text.index("chunk_2") < text.index("chunk_3")
+
+    def test_expand_at_start_of_file_only_has_next_neighbor(self, palace_path):
+        col, _ = self._seed_source_file(palace_path, "/proj/edge_start.md", n_chunks=3)
+        out = _expand_with_neighbors(
+            col,
+            "chunk_0 content",
+            {"source_file": "/proj/edge_start.md", "chunk_index": 0},
+        )
+        assert out["drawer_index"] == 0
+        assert out["total_drawers"] == 3
+        assert "chunk_0" in out["text"]
+        assert "chunk_1" in out["text"]
+        # No chunk_-1 could exist; the expansion must not invent one.
+        assert "chunk_-1" not in out["text"]
+
+    def test_expand_at_end_of_file_only_has_prev_neighbor(self, palace_path):
+        col, _ = self._seed_source_file(palace_path, "/proj/edge_end.md", n_chunks=3)
+        out = _expand_with_neighbors(
+            col,
+            "chunk_2 content",
+            {"source_file": "/proj/edge_end.md", "chunk_index": 2},
+        )
+        assert out["drawer_index"] == 2
+        assert out["total_drawers"] == 3
+        assert "chunk_1" in out["text"]
+        assert "chunk_2" in out["text"]
+        # No chunk_3 exists.
+        assert "chunk_3" not in out["text"]
+
+    def test_expand_single_drawer_file_returns_just_matched(self, palace_path):
+        col, _ = self._seed_source_file(palace_path, "/proj/lone.md", n_chunks=1)
+        out = _expand_with_neighbors(
+            col,
+            "chunk_0 content",
+            {"source_file": "/proj/lone.md", "chunk_index": 0},
+        )
+        assert out["drawer_index"] == 0
+        assert out["total_drawers"] == 1
+        assert out["text"] == "chunk_0 content about topic alpha"
+
+    def test_expand_falls_back_when_metadata_missing(self, palace_path):
+        col = get_collection(palace_path)
+        # No source_file / chunk_index in meta — degrade gracefully.
+        out = _expand_with_neighbors(col, "matched doc", {})
+        assert out["text"] == "matched doc"
+        assert out["drawer_index"] is None
+        assert out["total_drawers"] is None
+
+    def test_closet_first_search_includes_drawer_index_and_total(self, palace_path):
+        """End-to-end: closet-first search must populate drawer_index
+        and total_drawers on each hit (the public contract of this PR)."""
+        col = get_collection(palace_path)
+        source = "/proj/indexed.md"
+        # Seed 5 drawers for one source file.
+        for i in range(5):
+            col.upsert(
+                ids=[f"drawer_proj_backend_indexed_{i:03d}"],
+                documents=[f"chunk_{i} talks about JWT authentication flow"],
+                metadatas=[
+                    {
+                        "wing": "project",
+                        "room": "backend",
+                        "source_file": source,
+                        "chunk_index": i,
+                        "filed_at": "2026-04-13T00:00:00",
+                    }
+                ],
+            )
+        # Closet pointing at chunk_2.
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_indexed_01"],
+            documents=["JWT auth|;|→drawer_proj_backend_indexed_002"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": source}],
+        )
+
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"]
+        top = result["results"][0]
+        assert top["matched_via"] == "closet"
+        assert top["drawer_index"] == 2
+        assert top["total_drawers"] == 5
+        # Neighbor expansion: chunk_1, chunk_2, chunk_3 all present.
+        assert "chunk_1" in top["text"]
+        assert "chunk_2" in top["text"]
+        assert "chunk_3" in top["text"]
+        assert "chunk_0" not in top["text"]
+        assert "chunk_4" not in top["text"]

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1,0 +1,316 @@
+"""
+test_closets.py — Tests for the closet (searchable index) layer.
+
+Covers:
+  * build_closet_lines — pointer-line shape, entity extraction, stoplist,
+    quote/header pickup, and the "always emit one line" guarantee.
+  * upsert_closet_lines — pure overwrite (no append), char-limit packing,
+    atomic-line guarantee.
+  * purge_file_closets — wipes prior closets so a re-mine starts clean.
+  * The end-to-end rebuild: re-mining a file fully replaces its closets,
+    including when the prior run produced more numbered closets.
+  * search_memories closet-first path — returns chunk-level hits parsed
+    from `→drawer_ids` pointers, falls back when closets are empty,
+    respects max_distance.
+"""
+
+from mempalace.miner import mine
+from mempalace.palace import (
+    CLOSET_CHAR_LIMIT,
+    build_closet_lines,
+    get_closets_collection,
+    purge_file_closets,
+    upsert_closet_lines,
+)
+from mempalace.searcher import _extract_drawer_ids_from_closet, search_memories
+
+
+# ── build_closet_lines ─────────────────────────────────────────────────
+
+
+class TestBuildClosetLines:
+    def test_emits_pointer_line_shape(self, tmp_path):
+        content = (
+            "# Auth rewrite\n\n"
+            "Decided we need to migrate to passkeys. "
+            "Built the prototype with WebAuthn. "
+            "Reviewed the API surface."
+        )
+        lines = build_closet_lines(
+            "/proj/auth.md",
+            ["drawer_proj_backend_aaa", "drawer_proj_backend_bbb"],
+            content,
+            wing="proj",
+            room="backend",
+        )
+        assert lines, "should always emit at least one line"
+        for line in lines:
+            assert "→" in line, f"line missing pointer arrow: {line!r}"
+            parts = line.split("|")
+            assert len(parts) == 3, f"expected topic|entities|→refs, got {line!r}"
+            assert parts[2].startswith("→")
+
+    def test_extracts_section_headers_as_topics(self):
+        content = "# First Header\nbody\n## Second Header\nmore body"
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined = "\n".join(lines).lower()
+        assert "first header" in joined
+        assert "second header" in joined
+
+    def test_entity_stoplist_filters_sentence_starters(self):
+        # "When", "After", "The" repeat 3+ times — old code would index them
+        # as entities. New code's stoplist drops them.
+        content = (
+            "When the pipeline ran, the result was good. "
+            "When the user logged in, the token was issued. "
+            "After the migration, the latency dropped. "
+            "After the rollback, the latency rose. "
+            "The new flow is stable. The audit cleared."
+        )
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        # Entities sit between the two pipes
+        entity_segments = [line.split("|")[1] for line in lines]
+        for seg in entity_segments:
+            tokens = set(seg.split(";")) if seg else set()
+            assert "When" not in tokens
+            assert "After" not in tokens
+            assert "The" not in tokens
+
+    def test_real_proper_nouns_survive_stoplist(self):
+        content = (
+            "Igor reviewed the diff. Milla wrote the spec. "
+            "Igor pushed the fix. Milla approved the PR. "
+            "Igor and Milla shipped together."
+        )
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        entity_segments = [line.split("|")[1] for line in lines]
+        joined_entities = ";".join(entity_segments)
+        assert "Igor" in joined_entities
+        assert "Milla" in joined_entities
+
+    def test_emits_fallback_line_when_nothing_extractable(self):
+        # No headers, no action verbs, no quotes, no repeated capitalized words
+        content = "lorem ipsum dolor sit amet consectetur adipiscing elit"
+        lines = build_closet_lines("/x/notes.txt", ["d1"], content, "wing", "room")
+        assert len(lines) == 1
+        assert "wing/room/notes" in lines[0]
+        assert "→d1" in lines[0]
+
+    def test_pointer_references_first_three_drawers(self):
+        ids = [f"drawer_{i}" for i in range(10)]
+        lines = build_closet_lines("/x.md", ids, "# A\n# B", "w", "r")
+        assert all("→drawer_0,drawer_1,drawer_2" in line for line in lines)
+
+
+# ── upsert_closet_lines ───────────────────────────────────────────────
+
+
+class TestUpsertClosetLines:
+    def test_overwrites_existing_closet_does_not_append(self, palace_path):
+        col = get_closets_collection(palace_path)
+        base = "closet_test_room_abc"
+        meta = {"wing": "test", "room": "room", "source_file": "/x.md"}
+
+        # First mine — three short lines.
+        upsert_closet_lines(col, base, ["alpha|;|→d1", "beta|;|→d2", "gamma|;|→d3"], meta)
+        first = col.get(ids=[f"{base}_01"])
+        assert "alpha" in first["documents"][0]
+        assert "beta" in first["documents"][0]
+
+        # Second mine — entirely different lines. Must replace, not append.
+        upsert_closet_lines(col, base, ["delta|;|→d4", "epsilon|;|→d5"], meta)
+        second = col.get(ids=[f"{base}_01"])
+        doc = second["documents"][0]
+        assert "delta" in doc
+        assert "epsilon" in doc
+        assert "alpha" not in doc, "old closet line leaked into rebuild"
+        assert "beta" not in doc
+
+    def test_packs_into_multiple_closets_without_splitting_lines(self, palace_path):
+        col = get_closets_collection(palace_path)
+        base = "closet_pack_room_def"
+        meta = {"wing": "test", "room": "room", "source_file": "/y.md"}
+
+        # Build lines that approach but never exceed the limit.
+        line = "x" * 600  # well under CLOSET_CHAR_LIMIT
+        n_written = upsert_closet_lines(col, base, [line, line, line, line], meta)
+        # 4 lines @ 600+1 chars = 2404 — should pack into 2 closets (≤1500 each)
+        assert n_written == 2
+
+        for i in range(1, n_written + 1):
+            doc = col.get(ids=[f"{base}_{i:02d}"])["documents"][0]
+            # Every line is intact (never split mid-line)
+            for chunk in doc.split("\n"):
+                assert len(chunk) == 600, f"line was truncated in closet {i}"
+            # Closet stays under the cap
+            assert len(doc) <= CLOSET_CHAR_LIMIT
+
+
+# ── purge_file_closets ────────────────────────────────────────────────
+
+
+class TestPurgeFileClosets:
+    def test_deletes_only_the_targeted_source(self, palace_path):
+        col = get_closets_collection(palace_path)
+        col.upsert(
+            ids=["closet_a_01", "closet_b_01"],
+            documents=["a|;|→d1", "b|;|→d2"],
+            metadatas=[
+                {"source_file": "/keep.md", "wing": "w", "room": "r"},
+                {"source_file": "/drop.md", "wing": "w", "room": "r"},
+            ],
+        )
+        purge_file_closets(col, "/drop.md")
+
+        remaining_ids = set(col.get()["ids"])
+        assert "closet_a_01" in remaining_ids
+        assert "closet_b_01" not in remaining_ids
+
+
+# ── End-to-end rebuild via the project miner ──────────────────────────
+
+
+class TestMinerClosetRebuild:
+    def test_remine_replaces_closets_completely(self, tmp_path):
+        import yaml
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "mempalace.yaml").write_text(
+            yaml.dump({"wing": "proj", "rooms": [{"name": "general", "description": "x"}]})
+        )
+        target = project / "doc.md"
+
+        # First mine — long content produces multiple numbered closets.
+        first_topics = "\n\n".join(f"# Topic {i}\n" + ("filler text " * 30) for i in range(15))
+        target.write_text(first_topics)
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        first_pass = col.get(where={"source_file": str(target)})
+        assert first_pass["ids"], "first mine should have written closets"
+        first_ids = set(first_pass["ids"])
+        assert any("topic 0" in (d or "").lower() for d in first_pass["documents"])
+
+        # Touch mtime so file_already_mined doesn't short-circuit, and
+        # rewrite with fewer topics (so the rebuild produces fewer closets
+        # than the first run).
+        import os
+        import time
+
+        target.write_text("# Only Topic Now\n" + ("short body " * 5))
+        new_mtime = os.path.getmtime(target) + 60
+        os.utime(target, (new_mtime, new_mtime))
+        time.sleep(0.01)  # ensure mtime delta is visible
+
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        second_pass = col.get(where={"source_file": str(target)})
+        second_docs = "\n".join(second_pass["documents"]).lower()
+        assert "only topic now" in second_docs
+        for i in range(15):
+            assert (
+                f"topic {i}\n" not in second_docs
+            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+        # Numbered closets that existed only in the larger first run must be gone.
+        leftover = first_ids - set(second_pass["ids"])
+        for stale_id in leftover:
+            assert not col.get(ids=[stale_id])[
+                "ids"
+            ], f"orphan closet {stale_id} from larger first run survived purge"
+
+
+# ── _extract_drawer_ids_from_closet ───────────────────────────────────
+
+
+class TestExtractDrawerIds:
+    def test_parses_single_pointer(self):
+        assert _extract_drawer_ids_from_closet("topic|;|→drawer_x") == ["drawer_x"]
+
+    def test_parses_multiple_pointers_per_line(self):
+        line = "topic|ent|→drawer_a,drawer_b,drawer_c"
+        assert _extract_drawer_ids_from_closet(line) == [
+            "drawer_a",
+            "drawer_b",
+            "drawer_c",
+        ]
+
+    def test_dedupes_across_lines(self):
+        doc = "one|;|→drawer_a,drawer_b\ntwo|;|→drawer_b,drawer_c"
+        assert _extract_drawer_ids_from_closet(doc) == [
+            "drawer_a",
+            "drawer_b",
+            "drawer_c",
+        ]
+
+    def test_empty_doc_returns_empty(self):
+        assert _extract_drawer_ids_from_closet("") == []
+        assert _extract_drawer_ids_from_closet("no arrows here") == []
+
+
+# ── search_memories closet-first path ────────────────────────────────
+
+
+class TestSearchMemoriesClosetFirst:
+    def test_falls_back_to_direct_when_no_closets(self, palace_path, seeded_collection):
+        # seeded_collection populates only mempalace_drawers, not closets.
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"], "should still find drawer hits via fallback"
+        for hit in result["results"]:
+            assert hit.get("matched_via") == "drawer"
+
+    def test_closet_first_returns_chunk_level_hits(self, palace_path, seeded_collection):
+        # Build a closet that points at the JWT drawer specifically.
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_aaa_01"],
+            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
+            metadatas=[
+                {
+                    "wing": "project",
+                    "room": "backend",
+                    "source_file": "auth.py",
+                }
+            ],
+        )
+
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"], "closet-first search should hydrate the drawer"
+        top = result["results"][0]
+        assert top["matched_via"] == "closet"
+        # Must be the chunk-level drawer text, not a concatenation of every
+        # drawer in the file.
+        assert "JWT" in top["text"]
+        assert (
+            "Database migrations" not in top["text"]
+        ), "closet path should not glue unrelated drawers together"
+        assert "closet_preview" in top
+        assert "→drawer_proj_backend_aaa" in top["closet_preview"]
+
+    def test_max_distance_filters_closet_hits(self, palace_path, seeded_collection):
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_aaa_01"],
+            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
+            metadatas=[
+                {
+                    "wing": "project",
+                    "room": "backend",
+                    "source_file": "auth.py",
+                }
+            ],
+        )
+
+        # max_distance=0.001 is essentially "must match exactly". The closet
+        # path should reject everything and the caller falls back to direct
+        # search (which also filters with the same threshold).
+        result = search_memories(
+            "completely unrelated query about quantum gardening",
+            palace_path,
+            max_distance=0.001,
+        )
+        # Either no results, or every result respected the threshold.
+        for hit in result["results"]:
+            assert hit["distance"] <= 0.001

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1,130 +1,341 @@
-"""Tests for the closet layer, mine_lock, entity metadata, BM25 hybrid search,
-and diary ingest.
+"""
+test_closets.py — Tests for the closet (searchable index) layer and the
+features that ride on top of it: mine_lock serialization, entity metadata,
+hybrid BM25+vector search, and diary ingest.
 
-Content derived from Milla's omnibus test file; trimmed to only the features
-present in this PR stack (#784 lock, #788 closets, this PR's entity/BM25/diary).
-Strip-noise tests live with #785; tunnel tests live with the tunnels PR.
+Coverage map:
+  * mine_lock — acquire/release, blocks concurrent acquisition.
+  * build_closet_lines — pointer-line shape, header pickup, entity stoplist
+    (regression for "When/After/The"), real-name survival, fallback line.
+  * upsert_closet_lines — pure overwrite (regression for the append bug),
+    char-limit packing without splitting a line.
+  * purge_file_closets — scoped to source_file.
+  * Project-miner end-to-end rebuild — re-mining with fewer topics fully
+    purges leftover numbered closets from a larger prior run.
+  * _extract_drawer_ids_from_closet — pointer parsing + dedup.
+  * search_memories closet-first path — fallback when empty, chunk-level
+    hits with matched_via, no whole-file glue, max_distance enforcement.
+  * Entity metadata — extracted, stoplist applied, registry cached by mtime.
+  * Real BM25 — real IDF over candidate corpus, hybrid rerank.
+  * Diary ingest — drawers + closets created, incremental skips, state
+    file lives outside the diary dir, wing-prefixed drawer IDs prevent
+    cross-diary collisions, force=True purges leftover closets.
 """
 
+import json
 import os
-import tempfile
 import threading
 import time
 
+import yaml
+
+from mempalace.miner import (
+    _extract_entities_for_metadata,
+    _load_known_entities,
+    mine,
+)
 from mempalace.palace import (
     CLOSET_CHAR_LIMIT,
     build_closet_lines,
     get_closets_collection,
     get_collection,
     mine_lock,
+    purge_file_closets,
     upsert_closet_lines,
 )
-from mempalace.miner import _extract_entities_for_metadata
-from mempalace.searcher import _bm25_score, _hybrid_rank
+from mempalace.searcher import (
+    _bm25_scores,
+    _extract_drawer_ids_from_closet,
+    _hybrid_rank,
+    search_memories,
+)
 
 
 # ── mine_lock ────────────────────────────────────────────────────────────
 
 
 class TestMineLock:
-    def test_lock_acquires_and_releases(self):
-        with mine_lock("/tmp/test_lock_file.txt"):
+    def test_lock_acquires_and_releases(self, tmp_path):
+        target = str(tmp_path / "lock_target.txt")
+        with mine_lock(target):
             lock_dir = os.path.expanduser("~/.mempalace/locks")
             assert os.path.isdir(lock_dir)
+        # Re-acquire after release should succeed instantly.
+        start = time.time()
+        with mine_lock(target):
+            pass
+        assert time.time() - start < 1.0
 
-    def test_lock_blocks_concurrent_access(self):
+    def test_lock_blocks_concurrent_access(self, tmp_path):
+        target = str(tmp_path / "concurrent_lock.txt")
         results = []
 
         def worker(name):
             start = time.time()
-            with mine_lock("/tmp/same_file_lock_test.txt"):
+            with mine_lock(target):
                 results.append((name, time.time() - start))
                 time.sleep(0.2)
 
         t1 = threading.Thread(target=worker, args=("a",))
         t2 = threading.Thread(target=worker, args=("b",))
         t1.start()
-        time.sleep(0.05)
+        time.sleep(0.05)  # ensure t1 acquires first
         t2.start()
         t1.join()
         t2.join()
 
-        # Second thread should have waited
-        wait_times = sorted(results, key=lambda x: x[1])
-        assert wait_times[1][1] > 0.1, "Second thread should block"
+        # The second worker must have waited at least most of t1's hold time.
+        wait_times = sorted(r[1] for r in results)
+        assert (
+            wait_times[1] > 0.1
+        ), f"second thread should block on mine_lock, waited only {wait_times[1]:.3f}s"
 
 
-# ── closet lines ─────────────────────────────────────────────────────────
+# ── build_closet_lines ─────────────────────────────────────────────────
 
 
 class TestBuildClosetLines:
-    def test_returns_list_of_lines(self):
-        lines = build_closet_lines(
-            "/tmp/test.py", ["drawer_001"], "We built the auth system", "code", "general"
+    def test_emits_pointer_line_shape(self):
+        content = (
+            "# Auth rewrite\n\n"
+            "Decided we need to migrate to passkeys. "
+            "Built the prototype with WebAuthn. "
+            "Reviewed the API surface."
         )
-        assert isinstance(lines, list)
-        assert len(lines) >= 1
-
-    def test_each_line_has_pointer(self):
         lines = build_closet_lines(
-            "/tmp/test.py",
-            ["drawer_001", "drawer_002"],
-            "We built the auth system and tested the login flow",
-            "code",
-            "general",
+            "/proj/auth.md",
+            ["drawer_proj_backend_aaa", "drawer_proj_backend_bbb"],
+            content,
+            wing="proj",
+            room="backend",
         )
+        assert lines, "should always emit at least one line"
         for line in lines:
-            assert "→" in line, f"Line missing pointer: {line}"
+            assert "→" in line, f"line missing pointer arrow: {line!r}"
+            parts = line.split("|")
+            assert len(parts) == 3, f"expected topic|entities|→refs, got {line!r}"
+            assert parts[2].startswith("→")
 
-    def test_fallback_when_no_topics(self):
-        lines = build_closet_lines(
-            "/tmp/test.py", ["drawer_001"], "short text", "wing", "room"
+    def test_extracts_section_headers_as_topics(self):
+        content = "# First Header\nbody\n## Second Header\nmore body"
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined = "\n".join(lines).lower()
+        assert "first header" in joined
+        assert "second header" in joined
+
+    def test_entity_stoplist_filters_sentence_starters(self):
+        # "When", "After", "The" repeat 3+ times — old code would index them
+        # as entities. Stoplist drops them.
+        content = (
+            "When the pipeline ran, the result was good. "
+            "When the user logged in, the token was issued. "
+            "After the migration, the latency dropped. "
+            "After the rollback, the latency rose. "
+            "The new flow is stable. The audit cleared."
         )
-        assert len(lines) >= 1
-        assert "→" in lines[0]
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        entity_segments = [line.split("|")[1] for line in lines]
+        for seg in entity_segments:
+            tokens = set(seg.split(";")) if seg else set()
+            assert "When" not in tokens
+            assert "After" not in tokens
+            assert "The" not in tokens
+
+    def test_real_proper_nouns_survive_stoplist(self):
+        content = (
+            "Igor reviewed the diff. Milla wrote the spec. "
+            "Igor pushed the fix. Milla approved the PR. "
+            "Igor and Milla shipped together."
+        )
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined_entities = ";".join(line.split("|")[1] for line in lines)
+        assert "Igor" in joined_entities
+        assert "Milla" in joined_entities
+
+    def test_emits_fallback_line_when_nothing_extractable(self):
+        content = "lorem ipsum dolor sit amet consectetur adipiscing elit"
+        lines = build_closet_lines("/x/notes.txt", ["d1"], content, "wing", "room")
+        assert len(lines) == 1
+        assert "wing/room/notes" in lines[0]
+        assert "→d1" in lines[0]
+
+    def test_pointer_references_first_three_drawers(self):
+        ids = [f"drawer_{i}" for i in range(10)]
+        lines = build_closet_lines("/x.md", ids, "# A\n# B", "w", "r")
+        assert all("→drawer_0,drawer_1,drawer_2" in line for line in lines)
 
 
-# ── upsert_closet_lines ─────────────────────────────────────────────────
+# ── upsert_closet_lines ───────────────────────────────────────────────
 
 
 class TestUpsertClosetLines:
-    def test_writes_closets(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            lines = [
-                "topic one|Entity1|→drawer_001",
-                "topic two|Entity2|→drawer_002",
-            ]
-            n = upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
-            assert n >= 1
-            assert col.count() >= 1
+    def test_overwrites_existing_closet_does_not_append(self, palace_path):
+        col = get_closets_collection(palace_path)
+        base = "closet_test_room_abc"
+        meta = {"wing": "test", "room": "room", "source_file": "/x.md"}
 
-    def test_never_splits_mid_topic(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            # Create lines that together exceed CLOSET_CHAR_LIMIT
-            lines = [f"topic_{i}|{'x' * 200}|→drawer_{i}" for i in range(20)]
-            n = upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
-            assert n >= 2, "Should create multiple closets"
+        upsert_closet_lines(col, base, ["alpha|;|→d1", "beta|;|→d2", "gamma|;|→d3"], meta)
+        first = col.get(ids=[f"{base}_01"])
+        assert "alpha" in first["documents"][0]
 
-            # Verify each closet has complete lines
-            all_data = col.get(include=["documents"])
-            for doc in all_data["documents"]:
-                for line in doc.strip().split("\n"):
-                    assert "→" in line, f"Split topic found: {line}"
+        # Second mine — entirely different lines. Must replace, not append.
+        upsert_closet_lines(col, base, ["delta|;|→d4", "epsilon|;|→d5"], meta)
+        second = col.get(ids=[f"{base}_01"])
+        doc = second["documents"][0]
+        assert "delta" in doc
+        assert "epsilon" in doc
+        assert "alpha" not in doc, "old closet line leaked into rebuild"
+        assert "beta" not in doc
 
-    def test_respects_char_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            col = get_closets_collection(tmpdir)
-            lines = [f"topic_{i}|entities|→drawer_{i}" for i in range(50)]
-            upsert_closet_lines(col, "test_closet", lines, {"wing": "test"})
+    def test_packs_into_multiple_closets_without_splitting_lines(self, palace_path):
+        col = get_closets_collection(palace_path)
+        base = "closet_pack_room_def"
+        meta = {"wing": "test", "room": "room", "source_file": "/y.md"}
 
-            all_data = col.get(include=["documents"])
-            for doc in all_data["documents"]:
-                assert len(doc) <= CLOSET_CHAR_LIMIT + 100  # small buffer for existing content
+        line = "x" * 600  # well under CLOSET_CHAR_LIMIT
+        n_written = upsert_closet_lines(col, base, [line, line, line, line], meta)
+        # 4 lines @ 601 chars each = 2404 — should pack into 2 closets
+        assert n_written == 2
+
+        for i in range(1, n_written + 1):
+            doc = col.get(ids=[f"{base}_{i:02d}"])["documents"][0]
+            for chunk in doc.split("\n"):
+                assert len(chunk) == 600, f"line was truncated in closet {i}"
+            assert len(doc) <= CLOSET_CHAR_LIMIT
 
 
-# ── entity metadata ──────────────────────────────────────────────────────
+# ── purge_file_closets ────────────────────────────────────────────────
+
+
+class TestPurgeFileClosets:
+    def test_deletes_only_the_targeted_source(self, palace_path):
+        col = get_closets_collection(palace_path)
+        col.upsert(
+            ids=["closet_a_01", "closet_b_01"],
+            documents=["a|;|→d1", "b|;|→d2"],
+            metadatas=[
+                {"source_file": "/keep.md", "wing": "w", "room": "r"},
+                {"source_file": "/drop.md", "wing": "w", "room": "r"},
+            ],
+        )
+        purge_file_closets(col, "/drop.md")
+        remaining_ids = set(col.get()["ids"])
+        assert "closet_a_01" in remaining_ids
+        assert "closet_b_01" not in remaining_ids
+
+
+# ── project miner: closet rebuild end-to-end ──────────────────────────
+
+
+class TestMinerClosetRebuild:
+    def test_remine_replaces_closets_completely(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "mempalace.yaml").write_text(
+            yaml.dump({"wing": "proj", "rooms": [{"name": "general", "description": "x"}]})
+        )
+        target = project / "doc.md"
+
+        # First mine — long content produces multiple numbered closets.
+        first_topics = "\n\n".join(f"# Topic {i}\n" + ("filler text " * 30) for i in range(15))
+        target.write_text(first_topics)
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        first_pass = col.get(where={"source_file": str(target)})
+        assert first_pass["ids"], "first mine should have written closets"
+        first_ids = set(first_pass["ids"])
+        assert any("topic 0" in (d or "").lower() for d in first_pass["documents"])
+
+        # Touch mtime + shrink content so the rebuild produces fewer closets.
+        target.write_text("# Only Topic Now\n" + ("short body " * 5))
+        new_mtime = os.path.getmtime(target) + 60
+        os.utime(target, (new_mtime, new_mtime))
+        time.sleep(0.01)
+
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        second_pass = col.get(where={"source_file": str(target)})
+        second_docs = "\n".join(second_pass["documents"]).lower()
+        assert "only topic now" in second_docs
+        for i in range(15):
+            assert (
+                f"topic {i}\n" not in second_docs
+            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+        # Numbered closets that existed only in the larger first run must be gone.
+        leftover = first_ids - set(second_pass["ids"])
+        for stale_id in leftover:
+            assert not col.get(ids=[stale_id])[
+                "ids"
+            ], f"orphan closet {stale_id} from larger first run survived purge"
+
+
+# ── _extract_drawer_ids_from_closet ───────────────────────────────────
+
+
+class TestExtractDrawerIds:
+    def test_parses_single_pointer(self):
+        assert _extract_drawer_ids_from_closet("topic|;|→drawer_x") == ["drawer_x"]
+
+    def test_parses_multiple_pointers_per_line(self):
+        line = "topic|ent|→drawer_a,drawer_b,drawer_c"
+        assert _extract_drawer_ids_from_closet(line) == ["drawer_a", "drawer_b", "drawer_c"]
+
+    def test_dedupes_across_lines(self):
+        doc = "one|;|→drawer_a,drawer_b\ntwo|;|→drawer_b,drawer_c"
+        assert _extract_drawer_ids_from_closet(doc) == ["drawer_a", "drawer_b", "drawer_c"]
+
+    def test_empty_doc_returns_empty(self):
+        assert _extract_drawer_ids_from_closet("") == []
+        assert _extract_drawer_ids_from_closet("no arrows here") == []
+
+
+# ── search_memories closet-first path ────────────────────────────────
+
+
+class TestSearchMemoriesClosetFirst:
+    def test_falls_back_to_direct_when_no_closets(self, palace_path, seeded_collection):
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"], "should still find drawer hits via fallback"
+        for hit in result["results"]:
+            assert hit.get("matched_via") == "drawer"
+
+    def test_closet_first_returns_chunk_level_hits(self, palace_path, seeded_collection):
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_aaa_01"],
+            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": "auth.py"}],
+        )
+
+        result = search_memories("JWT authentication", palace_path)
+        assert result["results"], "closet-first search should hydrate the drawer"
+        top = result["results"][0]
+        assert top["matched_via"] == "closet"
+        assert "JWT" in top["text"]
+        # Chunk-level — must NOT glue every drawer in the file together.
+        assert "Database migrations" not in top["text"]
+        assert "→drawer_proj_backend_aaa" in top["closet_preview"]
+
+    def test_max_distance_filters_closet_hits(self, palace_path, seeded_collection):
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_aaa_01"],
+            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": "auth.py"}],
+        )
+        result = search_memories(
+            "completely unrelated query about quantum gardening",
+            palace_path,
+            max_distance=0.001,
+        )
+        for hit in result["results"]:
+            assert hit["distance"] <= 0.001
+
+
+# ── entity metadata ──────────────────────────────────────────────────
 
 
 class TestEntityMetadata:
@@ -136,66 +347,259 @@ class TestEntityMetadata:
 
     def test_empty_for_no_entities(self):
         text = "this is all lowercase with no proper nouns at all"
-        entities = _extract_entities_for_metadata(text)
-        assert entities == ""
+        assert _extract_entities_for_metadata(text) == ""
 
     def test_semicolon_separated(self):
         text = "Alice and Bob met Charlie. Alice said hello. Bob agreed. Charlie laughed."
         entities = _extract_entities_for_metadata(text)
         assert ";" in entities
 
+    def test_stoplist_filters_sentence_starters(self):
+        # Same regression as the closet entity test — "When/After/The" must
+        # not become entities just because they're capitalized 2+ times.
+        text = (
+            "When the build broke, the team paged. "
+            "When the fix landed, the alarm cleared. "
+            "After the rollback, the queue drained. "
+            "After the deploy, the latency normalized."
+        )
+        entities = _extract_entities_for_metadata(text)
+        tokens = set(entities.split(";")) if entities else set()
+        assert "When" not in tokens
+        assert "After" not in tokens
+        assert "The" not in tokens
 
-# ── BM25 hybrid search ──────────────────────────────────────────────────
+    def test_capped_list_never_truncates_a_name(self):
+        # 30 distinct repeated proper nouns — extraction should cap the list
+        # before joining so a name never gets cut in half.
+        # Use morphologically distinct stems so the [A-Z][a-z]+ regex sees
+        # each as its own token.
+        names = [
+            "Anna",
+            "Brian",
+            "Carol",
+            "David",
+            "Elena",
+            "Frank",
+            "Grace",
+            "Harold",
+            "Iris",
+            "Julian",
+            "Kira",
+            "Liam",
+            "Maya",
+            "Noah",
+            "Oscar",
+            "Penny",
+            "Quinn",
+            "Rosa",
+            "Sergei",
+            "Tara",
+            "Umar",
+            "Vera",
+            "Walter",
+            "Xander",
+            "Yvonne",
+            "Zachary",
+            "Amelia",
+            "Boris",
+            "Clara",
+            "Dmitri",
+        ]
+        text = " ".join(f"{n} met {n}." for n in names)
+        entities = _extract_entities_for_metadata(text)
+        extracted = [n for n in entities.split(";") if n]
+        assert extracted, "should have extracted some entities"
+        for name in extracted:
+            assert name in names, f"truncation produced a partial token: {name!r}"
+
+    def test_known_registry_is_cached_by_mtime(self, monkeypatch, tmp_path):
+        # Point the registry at a temp file we control, exercise the cache.
+        registry = tmp_path / "known_entities.json"
+        registry.write_text(json.dumps({"people": ["Zelda"]}))
+        from mempalace import miner
+
+        monkeypatch.setattr(miner, "_ENTITY_REGISTRY_PATH", str(registry))
+        miner._ENTITY_REGISTRY_CACHE["mtime"] = None
+        miner._ENTITY_REGISTRY_CACHE["names"] = frozenset()
+
+        first = _load_known_entities()
+        assert "Zelda" in first
+
+        # Second call without changing mtime: must reuse cache, not re-read.
+        read_count = {"n": 0}
+        original_open = open
+
+        def counting_open(path, *a, **kw):
+            if str(path) == str(registry):
+                read_count["n"] += 1
+            return original_open(path, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", counting_open)
+        _load_known_entities()
+        assert read_count["n"] == 0, "registry should not be re-read when mtime unchanged"
+
+        # Bump mtime → cache must invalidate.
+        new_mtime = os.path.getmtime(registry) + 5
+        os.utime(registry, (new_mtime, new_mtime))
+        registry.write_text(json.dumps({"people": ["Zelda", "Link"]}))
+        os.utime(registry, (new_mtime, new_mtime))
+        names = _load_known_entities()
+        assert "Link" in names
+
+
+# ── BM25 hybrid search (real IDF over candidate corpus) ──────────────
 
 
 class TestBM25:
-    def test_bm25_score_positive_for_match(self):
-        score = _bm25_score("database migration", "We migrated the database to Postgres")
-        assert score > 0
+    def test_scores_positive_for_matching_doc(self):
+        scores = _bm25_scores(
+            "database migration",
+            ["We migrated the database to Postgres.", "unrelated cookery tips"],
+        )
+        assert scores[0] > 0
+        assert scores[1] == 0.0
 
-    def test_bm25_score_zero_for_no_match(self):
-        score = _bm25_score("quantum physics", "We built a web application in React")
-        assert score == 0.0
+    def test_scores_zero_when_no_overlap(self):
+        scores = _bm25_scores("quantum physics", ["We built a web app in React"])
+        assert scores == [0.0]
 
-    def test_hybrid_rank_reorders(self):
+    def test_idf_downweights_terms_present_in_every_doc(self):
+        # "database" appears in every candidate → low IDF → low contribution.
+        # "vacuum" is unique to one → high IDF → that doc dominates.
+        scores = _bm25_scores(
+            "database vacuum",
+            [
+                "database backup nightly schedule",
+                "database vacuum scheduled weekly",
+                "database failover plan",
+            ],
+        )
+        assert scores[1] == max(scores), "doc with the rare query term should win on IDF"
+
+    def test_empty_inputs_return_zeros(self):
+        assert _bm25_scores("", ["hello world"]) == [0.0]
+        assert _bm25_scores("query here", []) == []
+        assert _bm25_scores("query", [""]) == [0.0]
+
+    def test_hybrid_rank_promotes_keyword_match(self):
         results = [
             {"text": "database schema design for Postgres", "distance": 0.5},
             {"text": "unrelated topic about cooking", "distance": 0.3},
         ]
         ranked = _hybrid_rank(results, "database Postgres schema")
-        # The database result should rank higher despite worse vector distance
+        # The keyword-rich result outranks the closer-vector but irrelevant one.
         assert "database" in ranked[0]["text"]
+        # bm25_score field is exposed for debugging.
+        assert "bm25_score" in ranked[0]
+        # No internal scoring leak.
+        assert "_hybrid_score" not in ranked[0]
+
+    def test_hybrid_rank_absolute_normalization(self):
+        # Adding a much-worse result to the candidate set must NOT reshuffle
+        # the top two — proves we're using absolute (1 - dist) and not
+        # dist / max_dist normalization.
+        base = [
+            {"text": "alpha alpha alpha", "distance": 0.1},
+            {"text": "beta beta beta", "distance": 0.4},
+        ]
+        ranked_short = _hybrid_rank([dict(r) for r in base], "alpha")
+        with_outlier = base + [{"text": "gamma gamma gamma", "distance": 1.9}]
+        ranked_long = _hybrid_rank([dict(r) for r in with_outlier], "alpha")
+        assert ranked_short[0]["text"] == ranked_long[0]["text"]
+        assert ranked_short[1]["text"] == ranked_long[1]["text"]
 
 
-# ── diary ingest ─────────────────────────────────────────────────────────
+# ── diary ingest ─────────────────────────────────────────────────────
 
 
 class TestDiaryIngest:
-    def test_ingest_creates_drawers_and_closets(self):
-        with tempfile.TemporaryDirectory() as palace_dir:
-            diary_dir = tempfile.mkdtemp()
-            # Write a test diary
-            with open(os.path.join(diary_dir, "2026-04-13.md"), "w") as f:
-                f.write("# 2026-04-13\n\n## 10:00 PDT — Test\n\nBuilt the auth system.\n")
+    def test_ingest_creates_drawers_and_closets(self, tmp_path):
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 PDT — Test\n\nBuilt the auth system.\n"
+        )
+        palace_dir = tmp_path / "palace"
 
-            from mempalace.diary_ingest import ingest_diaries
+        from mempalace.diary_ingest import ingest_diaries
 
-            result = ingest_diaries(diary_dir, palace_dir, force=True)
-            assert result["days_updated"] >= 1
+        result = ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        assert result["days_updated"] >= 1
+        assert get_collection(str(palace_dir)).count() >= 1
 
-            # Check drawer exists
-            drawers = get_collection(palace_dir)
-            count = drawers.count()
-            assert count >= 1
+    def test_ingest_skips_unchanged_on_second_run(self, tmp_path):
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 — Test\n\nContent here that's long enough.\n"
+        )
+        palace_dir = tmp_path / "palace"
 
-    def test_ingest_skips_unchanged(self):
-        with tempfile.TemporaryDirectory() as palace_dir:
-            diary_dir = tempfile.mkdtemp()
-            with open(os.path.join(diary_dir, "2026-04-13.md"), "w") as f:
-                f.write("# 2026-04-13\n\n## 10:00 — Test\n\nContent.\n")
+        from mempalace.diary_ingest import ingest_diaries
 
-            from mempalace.diary_ingest import ingest_diaries
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        result = ingest_diaries(str(diary_dir), str(palace_dir))
+        assert result["days_updated"] == 0
 
-            ingest_diaries(diary_dir, palace_dir, force=True)
-            result = ingest_diaries(diary_dir, palace_dir)  # second run, no force
-            assert result["days_updated"] == 0
+    def test_state_file_lives_outside_diary_dir(self, tmp_path):
+        # Regression: the original implementation wrote
+        # ``.diary_ingest_state.json`` *inside* the user's diary directory,
+        # polluting their content folder. State must live under
+        # ``~/.mempalace/state/`` instead.
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n## 10:00 — Test\n\nBody content here long enough.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import _state_file_for, ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+
+        # No state file inside the user's diary dir.
+        for entry in diary_dir.iterdir():
+            assert (
+                "diary_ingest" not in entry.name
+            ), f"state file leaked into user diary dir: {entry}"
+
+        # State file does exist under ~/.mempalace/state/.
+        state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
+        assert state_path.exists()
+        assert "/.mempalace/state/" in str(state_path)
+
+    def test_wing_prefixed_drawer_id_prevents_cross_diary_collision(self, tmp_path):
+        # Regression: the original implementation used
+        # ``drawer_diary_{date_str}`` regardless of wing — two diaries with
+        # the same date in different wings would clobber each other.
+        date_md = "# 2026-04-13\n\n## 10:00 — entry\n\nThis is the day's content.\n"
+
+        # Two separate diary dirs, ingested into the same palace under
+        # different wings. Each must produce a distinct drawer.
+        personal_dir = tmp_path / "personal"
+        personal_dir.mkdir()
+        (personal_dir / "2026-04-13.md").write_text(date_md + "Personal-only marker.\n")
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        (work_dir / "2026-04-13.md").write_text(date_md + "Work-only marker.\n")
+
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import _diary_drawer_id, ingest_diaries
+
+        ingest_diaries(str(personal_dir), str(palace_dir), wing="personal", force=True)
+        ingest_diaries(str(work_dir), str(palace_dir), wing="work", force=True)
+
+        col = get_collection(str(palace_dir))
+        personal_id = _diary_drawer_id("personal", "2026-04-13")
+        work_id = _diary_drawer_id("work", "2026-04-13")
+        assert personal_id != work_id
+
+        personal = col.get(ids=[personal_id])
+        work = col.get(ids=[work_id])
+        assert personal["ids"] == [personal_id]
+        assert work["ids"] == [work_id]
+        assert "Personal-only marker." in personal["documents"][0]
+        assert "Work-only marker." in work["documents"][0]

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -75,3 +75,86 @@ def test_mine_convos_does_not_reprocess_empty_chunk_files(capsys):
         assert "Files skipped (already filed): 1" in out2
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
+    """When stored drawers have an older normalize_version, the next mine
+    silently purges them and refiles — no manual erase required.
+
+    This is what makes the strip_noise upgrade apply to existing corpora:
+    users just run `mempalace mine` again and old noise-filled drawers get
+    replaced with clean ones."""
+    from mempalace.palace import NORMALIZE_VERSION
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        convo_path = Path(tmpdir) / "chat.txt"
+        convo_path.write_text(
+            "> What is memory?\nMemory is persistence.\n\n"
+            "> Why does it matter?\nIt enables continuity.\n\n"
+            "> How do we build it?\nWith structured storage.\n"
+        )
+        palace_path = os.path.join(tmpdir, "palace")
+
+        # First mine — stamps drawers with NORMALIZE_VERSION
+        mine_convos(tmpdir, palace_path, wing="test")
+        capsys.readouterr()
+
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+        resolved = str(Path(tmpdir).resolve() / "chat.txt")
+        first_pass = col.get(where={"source_file": resolved})
+        first_ids = set(first_pass["ids"])
+        assert first_ids, "first mine should produce drawers"
+        for meta in first_pass["metadatas"]:
+            assert meta.get("normalize_version") == NORMALIZE_VERSION
+
+        # Simulate pre-v2 drawers: rewrite metadata to an older version,
+        # and replace content with "noise" so we can see it get cleaned up.
+        stale_metas = []
+        for meta in first_pass["metadatas"]:
+            stale = dict(meta)
+            stale["normalize_version"] = 1
+            stale_metas.append(stale)
+        col.update(
+            ids=list(first_pass["ids"]),
+            documents=["STALE NOISE"] * len(first_pass["ids"]),
+            metadatas=stale_metas,
+        )
+        # Add an extra orphan drawer that should also be purged.
+        col.add(
+            ids=["orphan_drawer"],
+            documents=["OLD ORPHAN"],
+            metadatas=[
+                {
+                    "wing": "test",
+                    "room": "default",
+                    "source_file": resolved,
+                    "chunk_index": 999,
+                    "normalize_version": 1,
+                }
+            ],
+        )
+        del col, client
+
+        # Second mine — version gate should trigger rebuild
+        mine_convos(tmpdir, palace_path, wing="test")
+        out = capsys.readouterr().out
+        assert (
+            "Files skipped (already filed): 0" in out
+        ), "stale drawers should force a rebuild, not a skip"
+
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+        rebuilt = col.get(where={"source_file": resolved})
+        # Orphan is gone
+        assert "orphan_drawer" not in rebuilt["ids"]
+        # No stale content survived
+        assert all("STALE NOISE" not in d for d in rebuilt["documents"])
+        assert all("OLD ORPHAN" not in d for d in rebuilt["documents"])
+        # All rebuilt drawers carry the current version
+        for meta in rebuilt["metadatas"]:
+            assert meta.get("normalize_version") == NORMALIZE_VERSION
+        del col, client
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -1,0 +1,288 @@
+"""
+test_fact_checker.py — Regression + integration tests for fact_checker.
+
+Covers every detection path + the three bugs the original PR silently
+hid behind ``except Exception: pass``:
+
+  * ``kg.query()`` doesn't exist — code must use ``query_entity``.
+  * ``KnowledgeGraph(palace_path=...)`` is not a valid kwarg — code
+    must pass ``db_path``.
+  * O(n²) edit-distance over the full registry — must filter to names
+    actually mentioned in the text.
+
+Also pins the three feature contracts:
+  * similar_name  — "Mila" vs "Milla" in a registry with both.
+  * relationship_mismatch — "Bob is Alice's brother" vs KG "husband".
+  * stale_fact   — claim matches a triple whose valid_to is in the past.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mempalace.fact_checker import (
+    _check_entity_confusion,
+    _edit_distance,
+    _extract_claims,
+    _flatten_names,
+    check_text,
+)
+from mempalace.knowledge_graph import KnowledgeGraph
+
+
+# ── claim extraction ─────────────────────────────────────────────────
+
+
+class TestExtractClaims:
+    def test_parses_x_is_ys_z(self):
+        claims = _extract_claims("Bob is Alice's brother")
+        assert len(claims) == 1
+        assert claims[0] == {
+            "subject": "Bob",
+            "predicate": "brother",
+            "object": "Alice",
+            "span": "Bob is Alice's brother",
+        }
+
+    def test_parses_xs_z_is_y(self):
+        claims = _extract_claims("Alice's brother is Bob")
+        assert len(claims) == 1
+        assert claims[0]["subject"] == "Bob"
+        assert claims[0]["predicate"] == "brother"
+        assert claims[0]["object"] == "Alice"
+
+    def test_ignores_sentences_without_possessive_role(self):
+        assert _extract_claims("Bob drove to the store today") == []
+        assert _extract_claims("Just some prose without relationships") == []
+
+    def test_multiple_claims_in_one_text(self):
+        claims = _extract_claims("Bob is Alice's brother. Carol is Dave's sister.")
+        subjects = {c["subject"] for c in claims}
+        assert subjects == {"Bob", "Carol"}
+
+
+# ── entity confusion ─────────────────────────────────────────────────
+
+
+class TestEntityConfusion:
+    def test_flags_near_name_when_only_one_mentioned(self):
+        registry = {"people": ["Milla", "Mila"]}
+        issues = _check_entity_confusion("I spoke with Mila today.", registry)
+        # "Mila" mentioned, "Milla" not — registry has both at edit-distance 1,
+        # flag the possible confusion.
+        assert len(issues) == 1
+        assert issues[0]["type"] == "similar_name"
+        assert set(issues[0]["names"]) == {"Mila", "Milla"}
+        assert issues[0]["distance"] == 1
+
+    def test_no_false_positive_when_both_names_mentioned(self):
+        """Regression: a text discussing both Mila and Milla is fine —
+        the user clearly knows they're different. Don't nag."""
+        registry = {"people": ["Milla", "Mila"]}
+        issues = _check_entity_confusion("Mila and Milla met for lunch.", registry)
+        assert issues == []
+
+    def test_no_issues_when_registry_empty(self):
+        assert _check_entity_confusion("Bob said hi", {}) == []
+        assert _check_entity_confusion("Bob said hi", {"people": []}) == []
+
+    def test_no_issues_when_no_mentioned_names(self):
+        registry = {"people": ["Zelda", "Link", "Sheik"]}
+        assert _check_entity_confusion("nothing relevant here", registry) == []
+
+    def test_registry_dict_shape_is_supported(self):
+        # Some registries store {"people": {"Alice": {...meta}}}; we still
+        # need to surface the keys as candidate names.
+        registry = {"people": {"Milla": {"role": "creator"}, "Mila": {}}}
+        issues = _check_entity_confusion("I messaged Mila yesterday", registry)
+        assert any("Milla" in (i["names"] or []) for i in issues)
+
+
+class TestEditDistance:
+    def test_basic_distances(self):
+        assert _edit_distance("kitten", "sitting") == 3
+        assert _edit_distance("mila", "milla") == 1
+        assert _edit_distance("abc", "abc") == 0
+
+    def test_empty_strings(self):
+        assert _edit_distance("", "") == 0
+        assert _edit_distance("abc", "") == 3
+        assert _edit_distance("", "abc") == 3
+
+    def test_performance_bounded_by_mentioned_names(self):
+        """Regression: an earlier implementation did O(n²) pairwise
+        edit-distance over every registry entry on every check_text call.
+        With 100 names and zero mentions, the call must return in a blink
+        because no edit-distance comparison should even start."""
+        import time
+
+        # 500 random names, none of which appear in the text.
+        registry = {"people": [f"Zelda{i:03d}" for i in range(500)]}
+        text = "completely irrelevant prose with no registered names at all"
+
+        start = time.perf_counter()
+        issues = _check_entity_confusion(text, registry)
+        elapsed = time.perf_counter() - start
+
+        assert issues == []
+        # Even an unoptimized implementation should beat this by orders
+        # of magnitude once we've filtered to mentioned names (which is
+        # 0 here) — if it's still doing O(n²), we'll blow past.
+        assert elapsed < 0.2, f"entity confusion took {elapsed:.3f}s on empty mentions"
+
+
+# ── _flatten_names helper ────────────────────────────────────────────
+
+
+class TestFlattenNames:
+    def test_handles_list_categories(self):
+        assert _flatten_names({"people": ["Ada", "Bob"]}) == {"Ada", "Bob"}
+
+    def test_handles_dict_categories(self):
+        assert _flatten_names({"people": {"Ada": {}, "Bob": {}}}) == {"Ada", "Bob"}
+
+    def test_skips_falsy_entries(self):
+        assert _flatten_names({"people": ["Ada", "", None, "Bob"]}) == {"Ada", "Bob"}
+
+
+# ── KG integration (uses a real tmp SQLite palace) ───────────────────
+
+
+@pytest.fixture
+def palace_with_kg(tmp_path):
+    """Palace directory with a real KG pre-seeded with a few triples.
+
+    The KG file lives at ``<palace>/knowledge_graph.sqlite3`` — same
+    convention used by the MCP server. Fact-checker must find it via
+    that path, not via a bogus ``palace_path`` kwarg.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    db = str(palace / "knowledge_graph.sqlite3")
+    kg = KnowledgeGraph(db_path=db)
+    yield palace, kg
+
+
+class TestKGContradictions:
+    def test_kg_init_uses_db_path_not_palace_path_kwarg(self):
+        """Regression: the original code passed ``palace_path=`` to a
+        constructor whose only kwarg is ``db_path``. That raised
+        TypeError — silently swallowed — and the KG path became dead
+        code. This test pins the correct call signature."""
+        # Simply construct via the correct signature; raising means the
+        # KG constructor has changed in a way that fact_checker must too.
+        kg = KnowledgeGraph(db_path=":memory:")
+        # query_entity must exist (this is the method fact_checker calls).
+        assert callable(getattr(kg, "query_entity", None))
+        # The API that fact_checker used to call does NOT exist.
+        assert not hasattr(kg, "query")
+
+    def test_relationship_mismatch_detected(self, palace_with_kg):
+        """The feature's headline example: text says brother, KG says husband."""
+        palace, kg = palace_with_kg
+        kg.add_triple("Bob", "husband_of", "Alice", valid_from="2020-01-01")
+
+        issues = check_text("Bob is Alice's husband_of", str(palace))
+        # Exact-predicate + same object → no mismatch.
+        assert all(i["type"] != "relationship_mismatch" for i in issues)
+
+        issues = check_text("Bob is Alice's brother", str(palace))
+        mismatches = [i for i in issues if i["type"] == "relationship_mismatch"]
+        assert mismatches, "should flag text/KG mismatch for same (subject, object)"
+        m = mismatches[0]
+        assert m["entity"] == "Bob"
+        assert m["claim"]["predicate"] == "brother"
+        assert m["kg_fact"]["predicate"] == "husband_of"
+
+    def test_no_false_positive_when_kg_has_no_facts_about_subject(self, palace_with_kg):
+        palace, _ = palace_with_kg
+        # KG is empty → no mismatch should fire.
+        assert check_text("Bob is Alice's brother", str(palace)) == []
+
+    def test_stale_fact_detected(self, palace_with_kg):
+        palace, kg = palace_with_kg
+        # An old relationship that was superseded in 2023. Using a
+        # possessive-shape claim so the narrow claim-extraction regex
+        # actually reaches the stale-fact branch.
+        kg.add_triple(
+            "Bob",
+            "brother",
+            "Alice",
+            valid_from="2010-01-01",
+            valid_to="2023-06-01",
+        )
+        issues = check_text("Bob is Alice's brother", str(palace))
+        stale = [i for i in issues if i["type"] == "stale_fact"]
+        assert stale, "should flag closed-window fact as stale"
+        assert stale[0]["entity"] == "Bob"
+        assert stale[0]["valid_to"].startswith("2023")
+
+    def test_current_fact_same_triple_is_not_flagged(self, palace_with_kg):
+        palace, kg = palace_with_kg
+        kg.add_triple("Bob", "brother", "Alice", valid_from="2010-01-01")
+        issues = check_text("Bob is Alice's brother", str(palace))
+        assert issues == []
+
+    def test_missing_palace_does_not_crash(self, tmp_path):
+        """Brand-new palace (no KG file yet) — check_text must return []
+        rather than raising or hanging."""
+        nonexistent = str(tmp_path / "never_created")
+        assert check_text("Bob is Alice's brother", nonexistent) == []
+
+
+# ── end-to-end check_text contract ───────────────────────────────────
+
+
+class TestCheckTextContract:
+    def test_empty_text_returns_empty_list(self, tmp_path):
+        assert check_text("", str(tmp_path / "palace")) == []
+
+    def test_registry_confusion_path_isolated_from_kg(self, tmp_path, monkeypatch):
+        """If the registry file is present but the KG is missing, the
+        similar-name path must still fire. Prior implementations had
+        such entangled state that one failure killed both paths."""
+        # Bypass the real registry by pointing cache at a temp file.
+        registry = tmp_path / "known_entities.json"
+        registry.write_text(json.dumps({"people": ["Milla", "Mila"]}))
+        from mempalace import miner
+
+        monkeypatch.setattr(miner, "_ENTITY_REGISTRY_PATH", str(registry))
+        miner._ENTITY_REGISTRY_CACHE.update({"mtime": None, "names": frozenset(), "raw": {}})
+
+        issues = check_text("Chatted with Mila.", str(tmp_path / "nonexistent_palace"))
+        assert any(i["type"] == "similar_name" for i in issues)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+class TestCLI:
+    def test_exits_nonzero_when_issues_found(self, tmp_path, monkeypatch, capsys):
+        """The CLI exit code is how shell scripts / hooks know to act —
+        pin it explicitly."""
+        registry = tmp_path / "known_entities.json"
+        registry.write_text(json.dumps({"people": ["Milla", "Mila"]}))
+        from mempalace import fact_checker, miner
+
+        monkeypatch.setattr(miner, "_ENTITY_REGISTRY_PATH", str(registry))
+        miner._ENTITY_REGISTRY_CACHE.update({"mtime": None, "names": frozenset(), "raw": {}})
+
+        # Simulate argv: "Mila said hi"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["fact_checker", "Mila said hi", "--palace", str(tmp_path / "palace")],
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            # Re-exec the __main__ block via runpy.
+            import runpy
+
+            runpy.run_module("mempalace.fact_checker", run_name="__main__")
+        # Issues found → exit code 1.
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        assert "similar_name" in out
+        # Silence unused import warning.
+        _ = (MagicMock, patch, fact_checker)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,0 +1,133 @@
+"""Tests for the hybrid closet+drawer retrieval in search_memories.
+
+The hybrid path queries drawers directly (the floor) AND closets, applying a
+rank-based boost to drawers whose source_file appears in top closet hits.
+This avoids the "weak-closets regression" where low-signal closets (from
+regex extraction on narrative content) could hide drawers that direct
+search would have found.
+"""
+
+from mempalace.palace import (
+    get_closets_collection,
+    get_collection,
+    upsert_closet_lines,
+)
+from mempalace.searcher import search_memories
+
+
+def _seed_drawers(palace_path):
+    """Insert 4 short drawers with deterministic content."""
+    col = get_collection(palace_path, create=True)
+    col.upsert(
+        ids=["D1", "D2", "D3", "D4"],
+        documents=[
+            "We switched the auth service to use JWT tokens with a 24h expiry.",
+            "Database migration to PostgreSQL 15 completed last Tuesday.",
+            "The frontend team is debating whether to adopt TanStack Query.",
+            "Kafka consumer rebalance timeout set to 45 seconds after incident.",
+        ],
+        metadatas=[
+            {"wing": "backend", "room": "auth", "source_file": "fixture_D1.md"},
+            {"wing": "backend", "room": "db", "source_file": "fixture_D2.md"},
+            {"wing": "frontend", "room": "state", "source_file": "fixture_D3.md"},
+            {"wing": "backend", "room": "queue", "source_file": "fixture_D4.md"},
+        ],
+    )
+
+
+def _seed_strong_closet_for(palace_path, drawer_id, source_file, topics):
+    """Insert a closet whose content strongly overlaps the query keywords."""
+    col = get_closets_collection(palace_path)
+    lines = [f"{t}||→{drawer_id}" for t in topics]
+    upsert_closet_lines(
+        col,
+        closet_id_base=f"closet_{drawer_id}",
+        lines=lines,
+        metadata={
+            "wing": "backend",
+            "room": "auth",
+            "source_file": source_file,
+            "generated_by": "test",
+        },
+    )
+
+
+# ── core invariant: closets can only HELP, never HIDE ─────────────────────
+
+
+class TestHybridInvariant:
+    def test_no_closets_degrades_to_direct_drawer_search(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        # No closets created.
+        result = search_memories("Kafka rebalance timeout", palace, n_results=3)
+        ids = [h["source_file"] for h in result["results"]]
+        assert ids, "should return results"
+        assert "fixture_D4.md" in ids, "direct drawer search alone should surface the Kafka drawer"
+
+    def test_weak_closets_do_not_hide_direct_drawer_hits(self, tmp_path):
+        """A closet that points at a wrong drawer must NOT suppress the
+        drawer that direct search would have ranked first."""
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        # Seed a misleading closet: it matches a generic phrase but points at D3.
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D3",
+            source_file="fixture_D3.md",
+            topics=["Kafka queue tuning", "consumer rebalance config"],
+        )
+        result = search_memories("Kafka consumer rebalance timeout", palace, n_results=5)
+        ids = [h["source_file"] for h in result["results"]]
+        assert "fixture_D4.md" in ids, (
+            "D4 must appear — direct drawer search alone would rank it first. "
+            "Closet pointing to D3 should only boost D3, never hide D4."
+        )
+
+    def test_closet_boost_lifts_matching_drawer(self, tmp_path):
+        """When a closet agrees with direct search, the matching drawer
+        should be boosted to rank 1."""
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D1",
+            source_file="fixture_D1.md",
+            topics=["JWT auth tokens", "session expiry", "authentication service"],
+        )
+        result = search_memories("JWT auth tokens expiry", palace, n_results=3)
+        ids = [h["source_file"] for h in result["results"]]
+        assert ids[0] == "fixture_D1.md"
+        top = result["results"][0]
+        assert top["matched_via"] == "drawer+closet"
+        assert top["closet_boost"] > 0
+
+
+# ── closet_boost metadata ────────────────────────────────────────────────
+
+
+class TestClosetMetadata:
+    def test_closet_preview_exposed_when_boosted(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D1",
+            source_file="fixture_D1.md",
+            topics=["JWT auth tokens", "24h expiry", "authentication"],
+        )
+        result = search_memories("JWT authentication", palace, n_results=2)
+        top = result["results"][0]
+        assert top["source_file"] == "fixture_D1.md"
+        assert "closet_preview" in top
+
+    def test_drawer_only_hits_have_no_closet_preview(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        # No closets
+        result = search_memories("TanStack Query", palace, n_results=2)
+        assert result["results"]
+        for h in result["results"]:
+            assert h["matched_via"] == "drawer"
+            assert "closet_preview" not in h
+            assert h["closet_boost"] == 0.0

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,0 +1,141 @@
+"""Tests for the hybrid closet+drawer retrieval in search_memories.
+
+The hybrid path queries drawers directly (the floor) AND closets, applying a
+rank-based boost to drawers whose source_file appears in top closet hits.
+This avoids the "weak-closets regression" where low-signal closets (from
+regex extraction on narrative content) could hide drawers that direct
+search would have found.
+"""
+
+import os
+import tempfile
+
+import chromadb
+import pytest
+
+from mempalace.palace import (
+    get_collection,
+    get_closets_collection,
+    upsert_closet_lines,
+)
+from mempalace.searcher import search_memories
+
+
+def _seed_drawers(palace_path):
+    """Insert 4 short drawers with deterministic content."""
+    col = get_collection(palace_path, create=True)
+    col.upsert(
+        ids=["D1", "D2", "D3", "D4"],
+        documents=[
+            "We switched the auth service to use JWT tokens with a 24h expiry.",
+            "Database migration to PostgreSQL 15 completed last Tuesday.",
+            "The frontend team is debating whether to adopt TanStack Query.",
+            "Kafka consumer rebalance timeout set to 45 seconds after incident.",
+        ],
+        metadatas=[
+            {"wing": "backend", "room": "auth", "source_file": "fixture_D1.md"},
+            {"wing": "backend", "room": "db", "source_file": "fixture_D2.md"},
+            {"wing": "frontend", "room": "state", "source_file": "fixture_D3.md"},
+            {"wing": "backend", "room": "queue", "source_file": "fixture_D4.md"},
+        ],
+    )
+
+
+def _seed_strong_closet_for(palace_path, drawer_id, source_file, topics):
+    """Insert a closet whose content strongly overlaps the query keywords."""
+    col = get_closets_collection(palace_path)
+    lines = [f"{t}||→{drawer_id}" for t in topics]
+    upsert_closet_lines(
+        col,
+        closet_id_base=f"closet_{drawer_id}",
+        lines=lines,
+        metadata={
+            "wing": "backend",
+            "room": "auth",
+            "source_file": source_file,
+            "generated_by": "test",
+        },
+    )
+
+
+# ── core invariant: closets can only HELP, never HIDE ─────────────────────
+
+
+class TestHybridInvariant:
+    def test_no_closets_degrades_to_direct_drawer_search(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        # No closets created.
+        result = search_memories("Kafka rebalance timeout", palace, n_results=3)
+        ids = [h["source_file"] for h in result["results"]]
+        assert ids, "should return results"
+        assert "fixture_D4.md" in ids, (
+            "direct drawer search alone should surface the Kafka drawer"
+        )
+
+    def test_weak_closets_do_not_hide_direct_drawer_hits(self, tmp_path):
+        """A closet that points at a wrong drawer must NOT suppress the
+        drawer that direct search would have ranked first."""
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        # Seed a misleading closet: it matches a generic phrase but points at D3.
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D3",
+            source_file="fixture_D3.md",
+            topics=["Kafka queue tuning", "consumer rebalance config"],
+        )
+        result = search_memories("Kafka consumer rebalance timeout", palace, n_results=5)
+        ids = [h["source_file"] for h in result["results"]]
+        assert "fixture_D4.md" in ids, (
+            "D4 must appear — direct drawer search alone would rank it first. "
+            "Closet pointing to D3 should only boost D3, never hide D4."
+        )
+
+    def test_closet_boost_lifts_matching_drawer(self, tmp_path):
+        """When a closet agrees with direct search, the matching drawer
+        should be boosted to rank 1."""
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D1",
+            source_file="fixture_D1.md",
+            topics=["JWT auth tokens", "session expiry", "authentication service"],
+        )
+        result = search_memories("JWT auth tokens expiry", palace, n_results=3)
+        ids = [h["source_file"] for h in result["results"]]
+        assert ids[0] == "fixture_D1.md"
+        top = result["results"][0]
+        assert top["matched_via"] == "drawer+closet"
+        assert top["closet_boost"] > 0
+
+
+# ── closet_boost metadata ────────────────────────────────────────────────
+
+
+class TestClosetMetadata:
+    def test_closet_preview_exposed_when_boosted(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D1",
+            source_file="fixture_D1.md",
+            topics=["JWT auth tokens", "24h expiry", "authentication"],
+        )
+        result = search_memories("JWT authentication", palace, n_results=2)
+        top = result["results"][0]
+        assert top["source_file"] == "fixture_D1.md"
+        assert "closet_preview" in top
+
+    def test_drawer_only_hits_have_no_closet_preview(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        # No closets
+        result = search_memories("TanStack Query", palace, n_results=2)
+        assert result["results"]
+        for h in result["results"]:
+            assert h["matched_via"] == "drawer"
+            assert "closet_preview" not in h
+            assert h["closet_boost"] == 0.0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,6 +6,7 @@ dispatch layer (integration-level). Uses isolated palace + KG fixtures
 via monkeypatch to avoid touching real data.
 """
 
+from datetime import datetime
 import json
 import sys
 
@@ -642,6 +643,48 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+    def test_diary_write_same_second_shared_prefix_no_collision(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+
+        from mempalace import mcp_server
+
+        class FrozenDateTime:
+            calls = [
+                datetime(2026, 4, 13, 22, 15, 30, 123456),
+                datetime(2026, 4, 13, 22, 15, 30, 123457),
+            ]
+            fallback = datetime(2026, 4, 13, 22, 15, 30, 123457)
+
+            @classmethod
+            def now(cls):
+                if cls.calls:
+                    return cls.calls.pop(0)
+                return cls.fallback
+
+        monkeypatch.setattr(mcp_server, "datetime", FrozenDateTime)
+
+        from mempalace.mcp_server import tool_diary_read, tool_diary_write
+
+        entry1 = "A" * 50 + " entry one"
+        entry2 = "A" * 50 + " entry two"
+
+        result1 = tool_diary_write(agent_name="TestAgent", entry=entry1, topic="status")
+        result2 = tool_diary_write(agent_name="TestAgent", entry=entry2, topic="status")
+
+        assert result1["success"] is True
+        assert result2["success"] is True
+        assert result1["entry_id"] != result2["entry_id"]
+
+        read_result = tool_diary_read(agent_name="TestAgent")
+        contents = [entry["content"] for entry in read_result["entries"]]
+        assert read_result["total"] == 2
+        assert entry1 in contents
+        assert entry2 in contents
 
 
 # ── Cache Invalidation (inode/mtime) ──────────────────────────────────

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -7,7 +7,7 @@ import chromadb
 import yaml
 
 from mempalace.miner import mine, scan_project, status
-from mempalace.palace import file_already_mined
+from mempalace.palace import NORMALIZE_VERSION, file_already_mined
 
 
 def write_file(path: Path, content: str):
@@ -227,11 +227,17 @@ def test_file_already_mined_check_mtime():
         assert file_already_mined(col, test_file) is False
         assert file_already_mined(col, test_file, check_mtime=True) is False
 
-        # Add it with mtime
+        # Add it with mtime + current normalize_version
         col.add(
             ids=["d1"],
             documents=["hello world"],
-            metadatas=[{"source_file": test_file, "source_mtime": str(mtime)}],
+            metadatas=[
+                {
+                    "source_file": test_file,
+                    "source_mtime": str(mtime),
+                    "normalize_version": NORMALIZE_VERSION,
+                }
+            ],
         )
 
         # Already mined (no mtime check)
@@ -253,7 +259,12 @@ def test_file_already_mined_check_mtime():
         col.add(
             ids=["d2"],
             documents=["other"],
-            metadatas=[{"source_file": "/fake/no_mtime.txt"}],
+            metadatas=[
+                {
+                    "source_file": "/fake/no_mtime.txt",
+                    "normalize_version": NORMALIZE_VERSION,
+                }
+            ],
         )
         assert file_already_mined(col, "/fake/no_mtime.txt", check_mtime=True) is False
     finally:
@@ -296,3 +307,78 @@ def test_status_missing_palace_does_not_create_empty_collection(tmp_path, capsys
     out = capsys.readouterr().out
     assert "No palace found" in out
     assert not palace_path.exists()
+
+
+# ── normalize_version schema gate ───────────────────────────────────────
+#
+# When the normalization pipeline changes shape (e.g., strip_noise lands),
+# `NORMALIZE_VERSION` is bumped so pre-existing drawers can be silently
+# rebuilt on the next mine. These tests pin that contract.
+
+
+def test_file_already_mined_returns_false_for_stale_normalize_version():
+    """Pre-v2 drawers (no field, or older integer) must not short-circuit."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        palace_path = os.path.join(tmpdir, "palace")
+        os.makedirs(palace_path)
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_or_create_collection("mempalace_drawers")
+
+        # Pre-v2 drawer: no normalize_version field at all
+        col.add(
+            ids=["d_old"],
+            documents=["old"],
+            metadatas=[{"source_file": "/fake/old.jsonl"}],
+        )
+        assert file_already_mined(col, "/fake/old.jsonl") is False
+
+        # Explicitly older version
+        col.add(
+            ids=["d_v1"],
+            documents=["v1"],
+            metadatas=[{"source_file": "/fake/v1.jsonl", "normalize_version": 1}],
+        )
+        assert file_already_mined(col, "/fake/v1.jsonl") is False
+
+        # Current version — short-circuits
+        col.add(
+            ids=["d_current"],
+            documents=["cur"],
+            metadatas=[
+                {
+                    "source_file": "/fake/current.jsonl",
+                    "normalize_version": NORMALIZE_VERSION,
+                }
+            ],
+        )
+        assert file_already_mined(col, "/fake/current.jsonl") is True
+    finally:
+        del col, client
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_add_drawer_stamps_normalize_version(tmp_path):
+    """Fresh drawers carry the current schema version so future upgrades work."""
+    from mempalace.miner import add_drawer
+
+    palace_path = tmp_path / "palace"
+    palace_path.mkdir()
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_or_create_collection("mempalace_drawers")
+    try:
+        added = add_drawer(
+            collection=col,
+            wing="test",
+            room="notes",
+            content="hello",
+            source_file=str(tmp_path / "src.md"),
+            chunk_index=0,
+            agent="unit",
+        )
+        assert added is True
+        stored = col.get(limit=1)
+        meta = stored["metadatas"][0]
+        assert meta["normalize_version"] == NORMALIZE_VERSION
+    finally:
+        del col, client

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -13,6 +13,7 @@ from mempalace.normalize import (
     _try_normalize_json,
     _try_slack_json,
     normalize,
+    strip_noise,
 )
 
 
@@ -1048,3 +1049,148 @@ def test_normalize_rejects_large_file():
             assert False, "Should have raised IOError"
         except IOError as e:
             assert "too large" in str(e).lower()
+
+
+# ── strip_noise() — verbatim-safety boundary tests ─────────────────────
+#
+# The "Verbatim always" design principle requires that we never delete
+# user-authored text. These tests pin down the boundary between system
+# noise (which we strip) and user prose that happens to mention the same
+# strings (which must survive untouched).
+
+
+class TestStripNoisePreservesUserContent:
+    """User prose that mentions noise strings inline must be preserved."""
+
+    def test_user_discusses_stop_hook_in_prose(self):
+        # Regression: original regex with IGNORECASE + `.*\n?` ate the second
+        # sentence from real user commentary.
+        text = (
+            "> User:\n"
+            "> Our CI has a stop hook that rejects merges after 5pm. "
+            "Ran 2 stop hooks last week.\n"
+            "> Assistant:\n"
+            "> Got it."
+        )
+        assert strip_noise(text) == text.strip()
+
+    def test_user_mentions_system_reminder_inline(self):
+        # Inline <system-reminder> tags inside user prose (e.g. documenting
+        # Claude Code behavior) must not be stripped.
+        text = (
+            "> User:\n"
+            "> Here is what Claude Code emits: "
+            "<system-reminder>Auto-save reminder...</system-reminder>"
+            " — I want to ignore it."
+        )
+        assert strip_noise(text) == text.strip()
+
+    def test_ctrl_o_hint_in_prose_preserved(self):
+        # Regression: original `.*\(ctrl\+o to expand\).*\n?` nuked the whole
+        # line whenever a user documented the TUI shortcut.
+        text = (
+            "> User:\n"
+            "> In the TUI you hit (ctrl+o to expand) to see more. "
+            "That is the shortcut I want to document."
+        )
+        assert strip_noise(text) == text.strip()
+
+    def test_current_time_inline_in_prose(self):
+        text = "> User:\n> At CURRENT TIME: the meeting starts, not before."
+        assert strip_noise(text) == text.strip()
+
+    def test_plus_n_lines_marker_inline(self):
+        text = "> User:\n> The log showed … +50 lines of stack trace, useful."
+        assert strip_noise(text) == text.strip()
+
+    def test_dangling_open_tag_does_not_span_messages(self):
+        # THE span-eating bug: a stray unclosed <system-reminder> in one
+        # message must NOT merge with a closing tag in another message and
+        # silently delete everything in between.
+        text = (
+            "> User 1: normal content <system-reminder>A\n"
+            "> Assistant: reply\n"
+            "> User 2: more content</system-reminder> tail"
+        )
+        out = strip_noise(text)
+        assert "Assistant: reply" in out
+        assert "User 2: more content" in out
+        assert "User 1: normal content" in out
+
+
+class TestStripNoiseRemovesSystemChrome:
+    """System-injected noise with standalone/line-anchored shape must be stripped."""
+
+    def test_strips_line_anchored_system_reminder_block(self):
+        text = (
+            "> User:\n"
+            "<system-reminder>\n"
+            "Auto-save reminder...\n"
+            "</system-reminder>\n"
+            "> Real message."
+        )
+        out = strip_noise(text)
+        assert "system-reminder" not in out
+        assert "Auto-save reminder" not in out
+        assert "Real message." in out
+
+    def test_strips_system_reminder_with_blockquote_prefix(self):
+        # _messages_to_transcript prefixes lines with "> ", so the line
+        # anchor must also accept that shape.
+        text = "> User:\n" "> <system-reminder>Injected noise</system-reminder>\n" "> Real message."
+        out = strip_noise(text)
+        assert "Injected noise" not in out
+        assert "Real message." in out
+
+    def test_strips_standalone_ran_hook_line(self):
+        text = "Ran 2 Stop hook\n> User: real content"
+        out = strip_noise(text)
+        assert "Ran 2 Stop hook" not in out
+        assert "real content" in out
+
+    def test_strips_known_hook_names(self):
+        for hook in ("Stop", "PreCompact", "PreToolUse", "PostToolUse", "UserPromptSubmit"):
+            text = f"Ran 1 {hook} hook\n> User: content"
+            assert hook not in strip_noise(text)
+
+    def test_strips_current_time_standalone(self):
+        text = "CURRENT TIME: 2026-04-13 10:00 UTC\n> User: Hello"
+        out = strip_noise(text)
+        assert "CURRENT TIME" not in out
+        assert "Hello" in out
+
+    def test_strips_collapsed_lines_marker(self):
+        text = "… +42 lines\n> User: Hello"
+        out = strip_noise(text)
+        assert "+42 lines" not in out
+        assert "Hello" in out
+
+    def test_strips_token_count_ctrl_o_chrome(self):
+        # Claude Code's actual collapsed-output chrome: "[N tokens] (ctrl+o to expand)"
+        text = "> Assistant: some output [5 tokens] (ctrl+o to expand)\n> User: ok"
+        out = strip_noise(text)
+        assert "(ctrl+o to expand)" not in out
+        assert "[5 tokens]" not in out
+        assert "some output" in out
+
+    def test_strips_each_known_noise_tag(self):
+        for tag in (
+            "system-reminder",
+            "command-message",
+            "command-name",
+            "task-notification",
+            "user-prompt-submit-hook",
+            "hook_output",
+        ):
+            text = f"> User:\n<{tag}>junk</{tag}>\n> Real."
+            out = strip_noise(text)
+            assert tag not in out, f"{tag} leaked into output"
+            assert "Real." in out
+
+    def test_collapses_excessive_blank_lines(self):
+        text = "line one\n\n\n\n\n\nline two"
+        out = strip_noise(text)
+        assert "line one" in out
+        assert "line two" in out
+        # Should collapse to no more than 3 newlines
+        assert "\n\n\n\n" not in out


### PR DESCRIPTION
## Summary

Optional LLM-based closet regeneration, **vendor-agnostic**. User brings their own endpoint via `LLM_ENDPOINT` / `LLM_KEY` / `LLM_MODEL`. Regex closets remain the default — core memory stays API-free.

> **Stacked on #792** (full chain: #784 → #788 → #789 → #790 → #791 → #792).

## Context

The original bundled commit `935f657` included a `closet_llm.py` that imported `anthropic` directly and required `ANTHROPIC_API_KEY`. That conflicts with CLAUDE.md's **"Local-first, zero API"** principle and the Contributing guideline *"we do not accept features requiring API keys for core memory"*.

This PR **replaces** that module with a vendor-agnostic version that preserves the same prompt, parsing, and orchestration — only the transport was generalised. Milla is co-author on the commit; the prompt template and `regenerate_closets()` flow are her work.

## Configuration (env vars or CLI flags)

```bash
# Local (Ollama, zero cost)
LLM_ENDPOINT=http://localhost:11434/v1 \
LLM_MODEL=llama3:8b \
python -m mempalace.closet_llm --palace ~/.mempalace/palace

# Cloud (OpenAI, OpenRouter, etc.)
LLM_ENDPOINT=https://api.openai.com/v1 \
LLM_KEY=sk-... \
LLM_MODEL=gpt-4o-mini \
python -m mempalace.closet_llm --palace ~/.mempalace/palace

# CLI flags override env vars
python -m mempalace.closet_llm \
    --palace ~/.mempalace/palace \
    --endpoint http://localhost:11434/v1 \
    --model qwen2.5:7b
```

Any OpenAI-compatible `/chat/completions` endpoint works: Ollama, vLLM, llama.cpp server, OpenAI, OpenRouter, Azure OpenAI, Together, Groq, and so on.

## Design decisions

1. **OpenAI Chat Completions shape** — universal lingua franca across providers
2. **Zero new dependencies** — uses stdlib `urllib.request`; no `anthropic`, `openai`, `requests`, or `httpx` added to `pyproject.toml`
3. **Key is optional** — local inference servers typically don't authenticate. `Authorization` header only set when a key is provided.
4. **Graceful failure on missing config** — CLI prints a clear message listing what's missing; `regenerate_closets()` returns `{"error": "missing-config", "missing": [...]}`
5. **Retries with backoff on HTTP 429 / 503** — same behavior as the original
6. **Cost reporting removed** — no hardcoded pricing table; just reports prompt/completion tokens since cost depends on the provider the user chose

## Test plan

- [x] **13 new unit tests** in `tests/test_closet_llm.py` — mocked `urllib` so tests never touch the network. Covers:
  - `LLMConfig` env/flag resolution, trailing-slash stripping, key-optional behavior
  - `_parsed_to_closet_lines` — topics → pointers, caps at 15, quotes + summary
  - `_call_llm` — request URL, model, headers (with/without auth), code-fence stripping, invalid-JSON handling
  - `regenerate_closets` — missing-config error path
- [x] Full suite: **721/721 pass** (2 version-consistency tests deselected — pre-existing develop bug)
- [ ] Manual verification against a real Ollama instance — reviewer or follow-up PR

## Callouts for reviewers

1. **Drops `anthropic` SDK usage** — this is intentional. If the team wants to ship an Anthropic-flavored default, it should be a config preset, not hardcoded imports.
2. **Prompt unchanged from Milla's version** — same `PROMPT_TEMPLATE`, same parsing, same caps (15 topics, 5 quotes, 1 summary).
3. **`generated_by` metadata** now says `llm:{model}` instead of `haiku` — preserves traceability without locking to one vendor.
4. **Stacked on #792** — full chain of 8 PRs. Each is independently reviewable; all target v3.3.
