### PR TITLE
fix: paginate status() metadata fetch to avoid SQLite variable limit

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -631,8 +631,12 @@ def status(palace_path: str):
 
     # Count by wing and room
     total = col.count()
-    r = col.get(limit=total, include=["metadatas"]) if total else {"metadatas": []}
-    metas = r["metadatas"]
+    metas = []
+    if total:
+        _batch = 5000
+        for _off in range(0, total, _batch):
+            _r = col.get(limit=_batch, offset=_off, include=["metadatas"])
+            metas.extend(_r["metadatas"])
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:


### PR DESCRIPTION
## Summary

- `mempalace status` crashes with `sqlite3.OperationalError: too many SQL variables` on palaces with >~30k drawers
- Root cause: `col.get(limit=total, include=["metadatas"])` passes the full count as limit; SQLite binds one variable per metadata item and hits the compile-time limit (~32766)
- Fix: paginate in batches of 5000 using the existing `offset` parameter on `col.get()`

Fixes #802

## Test plan

- [ ] `python -m pytest tests/ -v --ignore=tests/benchmarks` — 687 tests pass (2 pre-existing failures in `test_version_consistency.py` unrelated to this change)
- [ ] `ruff check .` — clean
- [ ] Manual: `mempalace status` on a palace with 50k+ drawers completes without error
