### PR TITLE
feat: add mempalace-mcp entry point for uv compatibility

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -1,9 +1,6 @@
 {
   "mempalace": {
-    "command": "python3",
-    "args": [
-      "-m",
-      "mempalace.mcp_server"
-    ]
+    "command": "mempalace-mcp",
+    "args": []
   }
 }

--- a/.claude-plugin/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin/hooks/mempal-precompact-hook.sh
@@ -2,4 +2,4 @@
 # MemPalace PreCompact Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
 INPUT=$(cat)
-echo "$INPUT" | python3 -m mempalace hook run --hook precompact --harness claude-code
+echo "$INPUT" | mempalace hook run --hook precompact --harness claude-code

--- a/.claude-plugin/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin/hooks/mempal-stop-hook.sh
@@ -2,4 +2,4 @@
 # MemPalace Stop Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
 INPUT=$(cat)
-echo "$INPUT" | python3 -m mempalace hook run --hook stop --harness claude-code
+echo "$INPUT" | mempalace hook run --hook stop --harness claude-code

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,11 +9,8 @@
   "commands": [],
   "mcpServers": {
     "mempalace": {
-      "command": "python3",
-      "args": [
-        "-m",
-        "mempalace.mcp_server"
-      ]
+      "command": "mempalace-mcp",
+      "args": []
     }
   },
   "keywords": [

--- a/.codex-plugin/hooks/mempal-hook.sh
+++ b/.codex-plugin/hooks/mempal-hook.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 HOOK_NAME="${1:?Usage: mempal-hook.sh <hook-name>}"
 INPUT_FILE=$(mktemp) || { echo "Failed to create temp file" >&2; exit 1; }
 cat > "$INPUT_FILE"
-cat "$INPUT_FILE" | python3 -m mempalace hook run --hook "$HOOK_NAME" --harness codex
+cat "$INPUT_FILE" | mempalace hook run --hook "$HOOK_NAME" --harness codex
 EXIT_CODE=$?
 rm -f "$INPUT_FILE" 2>/dev/null
 exit $EXIT_CODE

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,11 +21,8 @@
   "hooks": "./hooks.json",
   "mcpServers": {
     "mempalace": {
-      "command": "python3",
-      "args": [
-        "-m",
-        "mempalace.mcp_server"
-      ]
+      "command": "mempalace-mcp",
+      "args": []
     }
   },
   "interface": {

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ venv/
 
 # ChromaDB local data
 *.sqlite3-journal
+/.serena
+/.testmondata
+/site

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Stay safe out there.
 ## Quick Start
 
 ```bash
+# With uv (recommended)
+uv tool install mempalace
+
+# Or with pip
 pip install mempalace
 
 # Set up your world — who you work with, what your projects are
@@ -728,6 +732,10 @@ mempalace/
 No API key. No internet after install. Everything local.
 
 ```bash
+# With uv (recommended)
+uv tool install mempalace
+
+# Or with pip
 pip install mempalace
 ```
 

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -65,7 +65,7 @@ echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     REPO_DIR="$(dirname "$SCRIPT_DIR")"
-    python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
+    mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
 # Notify — compaction is about to happen but filing is handled in background

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -137,7 +137,7 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         REPO_DIR="$(dirname "$SCRIPT_DIR")"
-        python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
+        mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 
     # Notify the AI that a checkpoint happened — but do NOT ask it to write

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -276,7 +276,7 @@ def cmd_instructions(args):
 
 def cmd_mcp(args):
     """Show how to wire MemPalace into MCP-capable hosts."""
-    base_server_cmd = "python -m mempalace.mcp_server"
+    base_server_cmd = "mempalace-mcp"
 
     if args.palace:
         resolved_palace = str(Path(args.palace).expanduser())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ Repository = "https://github.com/milla-jovovich/mempalace"
 
 [project.scripts]
 mempalace = "mempalace.cli:main"
+mempalace-mcp = "mempalace.mcp_server:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -334,9 +334,9 @@ def test_mcp_command_prints_setup_guidance(monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert "MemPalace MCP quick setup:" in captured.out
-    assert "claude mcp add mempalace -- python -m mempalace.mcp_server" in captured.out
+    assert "claude mcp add mempalace -- mempalace-mcp" in captured.out
     assert "\nOptional custom palace:\n" in captured.out
-    assert "python -m mempalace.mcp_server --palace /path/to/palace" in captured.out
+    assert "mempalace-mcp --palace /path/to/palace" in captured.out
     assert "[--palace /path/to/palace]" not in captured.out
     assert captured.err == ""
 
@@ -349,7 +349,7 @@ def test_mcp_command_uses_custom_palace_path_when_provided(monkeypatch, capsys):
     captured = capsys.readouterr()
     expanded = str(Path("~/tmp/my palace").expanduser())
 
-    assert "python -m mempalace.mcp_server --palace" in captured.out
+    assert "mempalace-mcp --palace" in captured.out
     assert expanded in captured.out
     assert "Optional custom palace:" not in captured.out
     assert "[--palace /path/to/palace]" not in captured.out

--- a/tests/test_closet_llm.py
+++ b/tests/test_closet_llm.py
@@ -288,9 +288,9 @@ class TestRegenerateClosets:
         survivors = closets.get(where={"source_file": source}, include=["documents", "metadatas"])
         assert survivors["ids"], "LLM closets should have been written"
         joined = "\n".join(survivors["documents"])
-        assert (
-            "STALE_REGEX_TOPIC" not in joined
-        ), "pre-existing regex closet was not purged before LLM write"
+        assert "STALE_REGEX_TOPIC" not in joined, (
+            "pre-existing regex closet was not purged before LLM write"
+        )
         assert "jwt auth" in joined
         for meta in survivors["metadatas"]:
             assert meta.get("generated_by", "").startswith("llm:")

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -139,9 +139,9 @@ class TestMineLock:
         # Sort by entry time and verify the second entry is after the first exit.
         intervals.sort(key=lambda iv: iv[1])
         (_, enter_a, exit_a), (_, enter_b, exit_b) = intervals
-        assert (
-            enter_a < exit_a <= enter_b < exit_b
-        ), f"critical sections overlapped — lock failed to serialize: {intervals}"
+        assert enter_a < exit_a <= enter_b < exit_b, (
+            f"critical sections overlapped — lock failed to serialize: {intervals}"
+        )
 
 
 # ── build_closet_lines ─────────────────────────────────────────────────
@@ -314,15 +314,15 @@ class TestMinerClosetRebuild:
         second_docs = "\n".join(second_pass["documents"]).lower()
         assert "only topic now" in second_docs
         for i in range(15):
-            assert (
-                f"topic {i}\n" not in second_docs
-            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+            assert f"topic {i}\n" not in second_docs, (
+                f"stale 'Topic {i}' from first mine survived the rebuild"
+            )
         # Numbered closets that existed only in the larger first run must be gone.
         leftover = first_ids - set(second_pass["ids"])
         for stale_id in leftover:
-            assert not col.get(ids=[stale_id])[
-                "ids"
-            ], f"orphan closet {stale_id} from larger first run survived purge"
+            assert not col.get(ids=[stale_id])["ids"], (
+                f"orphan closet {stale_id} from larger first run survived purge"
+            )
 
 
 # ── _extract_drawer_ids_from_closet ───────────────────────────────────
@@ -623,9 +623,9 @@ class TestDiaryIngest:
 
         # No state file inside the user's diary dir.
         for entry in diary_dir.iterdir():
-            assert (
-                "diary_ingest" not in entry.name
-            ), f"state file leaked into user diary dir: {entry}"
+            assert "diary_ingest" not in entry.name, (
+                f"state file leaked into user diary dir: {entry}"
+            )
 
         # State file does exist under ~/.mempalace/state/.
         state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
@@ -826,7 +826,7 @@ class TestTunnels:
         assert not errors, f"worker raised: {errors}"
         tunnels = list_tunnels()
         assert len(tunnels) == 5, (
-            f"expected 5 concurrent tunnels, got {len(tunnels)} — " "write race dropped some"
+            f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
         )
 
     def test_created_at_is_timezone_aware(self):

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -140,9 +140,9 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         # Second mine — version gate should trigger rebuild
         mine_convos(tmpdir, palace_path, wing="test")
         out = capsys.readouterr().out
-        assert (
-            "Files skipped (already filed): 0" in out
-        ), "stale drawers should force a rebuild, not a skip"
+        assert "Files skipped (already filed): 0" in out, (
+            "stale drawers should force a rebuild, not a skip"
+        )
 
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")

--- a/tests/test_mcp_entrypoint.py
+++ b/tests/test_mcp_entrypoint.py
@@ -1,0 +1,64 @@
+"""Tests for mempalace-mcp entry point and uv compatibility."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestMcpEntryPoint:
+    """Verify mempalace-mcp console_script is properly configured."""
+
+    def test_mcp_server_main_is_importable_and_callable(self):
+        from mempalace.mcp_server import main
+
+        assert callable(main)
+
+    def test_pyproject_defines_mempalace_mcp_entry_point(self):
+        pyproject = (ROOT / "pyproject.toml").read_text()
+        assert 'mempalace-mcp = "mempalace.mcp_server:main"' in pyproject
+
+
+class TestMcpConfigs:
+    """MCP config files must use mempalace-mcp, not python3."""
+
+    def test_claude_plugin_mcp_json_uses_entry_point(self):
+        config = json.loads((ROOT / ".claude-plugin" / ".mcp.json").read_text())
+        server = config["mempalace"]
+        assert server["command"] == "mempalace-mcp"
+        assert "-m" not in server.get("args", [])
+
+    def test_claude_plugin_json_uses_entry_point(self):
+        config = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text())
+        server = config["mcpServers"]["mempalace"]
+        assert server["command"] == "mempalace-mcp"
+        assert "-m" not in server.get("args", [])
+
+    def test_codex_plugin_json_uses_entry_point(self):
+        config = json.loads((ROOT / ".codex-plugin" / "plugin.json").read_text())
+        server = config["mcpServers"]["mempalace"]
+        assert server["command"] == "mempalace-mcp"
+        assert "-m" not in server.get("args", [])
+
+
+class TestHookScripts:
+    """Hook scripts must use `mempalace` entry point, not `python3 -m mempalace`."""
+
+    @pytest.mark.parametrize(
+        "hook_path",
+        [
+            ".claude-plugin/hooks/mempal-stop-hook.sh",
+            ".claude-plugin/hooks/mempal-precompact-hook.sh",
+            ".codex-plugin/hooks/mempal-hook.sh",
+            "hooks/mempal_save_hook.sh",
+            "hooks/mempal_precompact_hook.sh",
+        ],
+    )
+    def test_hook_does_not_use_python3_m_mempalace(self, hook_path):
+        content = (ROOT / hook_path).read_text()
+        # python3 -c is fine (stdlib JSON parsing), only python3 -m mempalace is wrong
+        for line in content.splitlines():
+            if "python3 -m mempalace" in line:
+                pytest.fail(f"{hook_path} still uses 'python3 -m mempalace': {line.strip()}")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -425,9 +425,9 @@ class TestWriteTools:
 
         assert result1["success"] is True
         assert result2["success"] is True
-        assert (
-            result1["drawer_id"] != result2["drawer_id"]
-        ), "Documents with shared header but different content must have distinct drawer IDs"
+        assert result1["drawer_id"] != result2["drawer_id"], (
+            "Documents with shared header but different content must have distinct drawer IDs"
+        )
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1123,11 +1123,7 @@ class TestStripNoiseRemovesSystemChrome:
 
     def test_strips_line_anchored_system_reminder_block(self):
         text = (
-            "> User:\n"
-            "<system-reminder>\n"
-            "Auto-save reminder...\n"
-            "</system-reminder>\n"
-            "> Real message."
+            "> User:\n<system-reminder>\nAuto-save reminder...\n</system-reminder>\n> Real message."
         )
         out = strip_noise(text)
         assert "system-reminder" not in out
@@ -1137,7 +1133,7 @@ class TestStripNoiseRemovesSystemChrome:
     def test_strips_system_reminder_with_blockquote_prefix(self):
         # _messages_to_transcript prefixes lines with "> ", so the line
         # anchor must also accept that shape.
-        text = "> User:\n" "> <system-reminder>Injected noise</system-reminder>\n" "> Real message."
+        text = "> User:\n> <system-reminder>Injected noise</system-reminder>\n> Real message."
         out = strip_noise(text)
         assert "Injected noise" not in out
         assert "Real message." in out

--- a/tests/test_readme_claims.py
+++ b/tests/test_readme_claims.py
@@ -573,13 +573,13 @@ class TestBackendAbstraction:
         """Claim: pluggable backends.
         backends/base.py must define an abstract base class."""
         path = MEMPALACE_PKG / "backends" / "base.py"
-        assert (
-            path.is_file()
-        ), "mempalace/backends/base.py does not exist. Backend abstraction layer is missing."
+        assert path.is_file(), (
+            "mempalace/backends/base.py does not exist. Backend abstraction layer is missing."
+        )
         src = _read(path)
-        assert (
-            "ABC" in src or "abstractmethod" in src
-        ), "backends/base.py does not define an abstract base class."
+        assert "ABC" in src or "abstractmethod" in src, (
+            "backends/base.py does not define an abstract base class."
+        )
 
     def test_backends_chroma_exists(self):
         """Claim: ChromaDB backend implementation.
@@ -587,9 +587,9 @@ class TestBackendAbstraction:
         path = MEMPALACE_PKG / "backends" / "chroma.py"
         assert path.is_file(), "mempalace/backends/chroma.py does not exist."
         src = _read(path)
-        assert (
-            "BaseCollection" in src or "base" in src
-        ), "backends/chroma.py does not reference the base class."
+        assert "BaseCollection" in src or "base" in src, (
+            "backends/chroma.py does not reference the base class."
+        )
 
     def test_backends_importable(self):
         """Both backend modules should be importable."""
@@ -626,9 +626,9 @@ class TestI18n:
     def test_english_baseline_exists(self):
         """en.json must exist as the baseline language file."""
         path = MEMPALACE_PKG / "i18n" / "en.json"
-        assert (
-            path.is_file()
-        ), "mempalace/i18n/en.json does not exist. English baseline is required."
+        assert path.is_file(), (
+            "mempalace/i18n/en.json does not exist. English baseline is required."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -713,9 +713,9 @@ class TestReadmeToolCountConsistency:
         counts = re.findall(r"(\d+)\s+tools", readme)
         if len(counts) > 1:
             unique = set(counts)
-            assert (
-                len(unique) == 1
-            ), f"README mentions different tool counts: {counts}. All occurrences must agree."
+            assert len(unique) == 1, (
+                f"README mentions different tool counts: {counts}. All occurrences must agree."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "autocorrect", marker = "extra == 'spellcheck'", specifier = ">=2.0" },
-    { name = "chromadb", specifier = ">=0.5.0,<0.7" },
+    { name = "chromadb", specifier = ">=0.5.0" },
     { name = "psutil", marker = "extra == 'dev'", specifier = ">=5.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },


### PR DESCRIPTION
## What does this PR do?

Adds support for installing MemPalace with [uv](https://docs.astral.sh/uv/), the fast Python package manager that's become the standard (for many) for modern Python tooling.

When MemPalace is installed via `uv tool install mempalace`, the MCP server and hooks fail because they hardcode `python3 -m mempalace.mcp_server` — which hits the system Python that doesn't have chromadb or other dependencies. The uv-managed venv has everything, but nothing points to it.

This PR adds a dedicated `mempalace-mcp` console script entry point and updates all configs and hooks to use it. Both `pip install` and `uv tool install` create the same entry point, so this is fully backwards compatible.

### Changes

- **New entry point**: `mempalace-mcp = "mempalace.mcp_server:main"` in pyproject.toml
- **MCP configs**: `.claude-plugin/.mcp.json`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json` now use `mempalace-mcp` instead of `python3 -m mempalace.mcp_server`
- **Hook scripts**: All 5 hooks (`claude-plugin`, `codex-plugin`, `hooks/`) now use `mempalace` CLI entry point instead of `python3 -m mempalace`
- **CLI help**: `mempalace mcp` now prints `mempalace-mcp` as the setup command
- **README**: Added `uv tool install mempalace` as recommended install method
- **Tests**: New `test_mcp_entrypoint.py` verifying entry point, configs, and hooks don't regress

### What stays the same

- `python -m mempalace.mcp_server` still works (for existing setups)
- `python3 -c` calls in legacy hooks untouched (stdlib-only JSON parsing, no mempalace imports)
- No new CLI subcommands — `mempalace-mcp` is the MCP server entry point

## How to test

```bash
uv tool install .
which mempalace-mcp        # should resolve
mempalace-mcp              # starts MCP server (JSON-RPC on stdin)
mempalace mcp              # prints updated setup instructions
python -m pytest tests/ -v # 699 tests pass
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)