### PR TITLE
docs: fix stale org URLs in website and plugin manifests (#787)

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -11,7 +11,7 @@ A Claude Code plugin that gives your AI a persistent memory system. Mine project
 ### Claude Code Marketplace
 
 ```bash
-claude plugin marketplace add milla-jovovich/mempalace
+claude plugin marketplace add MemPalace/mempalace
 claude plugin install --scope user mempalace
 ```
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -25,5 +25,5 @@
     "palace",
     "search"
   ],
-  "repository": "https://github.com/milla-jovovich/mempalace"
+  "repository": "https://github.com/MemPalace/mempalace"
 }

--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -35,7 +35,7 @@ codex /init
 1. Clone the MemPalace repository:
 
 ```bash
-git clone https://github.com/milla-jovovich/mempalace.git
+git clone https://github.com/MemPalace/mempalace.git
 cd mempalace
 ```
 
@@ -71,5 +71,5 @@ Set the `MEMPAL_DIR` environment variable to a directory path to automatically r
 
 ## Support
 
-- Repository: https://github.com/milla-jovovich/mempalace
-- Issues: https://github.com/milla-jovovich/mempalace/issues
+- Repository: https://github.com/MemPalace/mempalace
+- Issues: https://github.com/MemPalace/mempalace/issues

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -5,8 +5,8 @@
   "author": {
     "name": "milla-jovovich"
   },
-  "homepage": "https://github.com/milla-jovovich/mempalace",
-  "repository": "https://github.com/milla-jovovich/mempalace",
+  "homepage": "https://github.com/MemPalace/mempalace",
+  "repository": "https://github.com/MemPalace/mempalace",
   "license": "MIT",
   "keywords": [
     "memory",
@@ -39,9 +39,9 @@
       "Read",
       "Write"
     ],
-    "websiteURL": "https://github.com/milla-jovovich/mempalace",
-    "privacyPolicyURL": "https://github.com/milla-jovovich/mempalace",
-    "termsOfServiceURL": "https://github.com/milla-jovovich/mempalace",
+    "websiteURL": "https://github.com/MemPalace/mempalace",
+    "privacyPolicyURL": "https://github.com/MemPalace/mempalace",
+    "termsOfServiceURL": "https://github.com/MemPalace/mempalace",
     "defaultPrompt": [
       "Search my memories for recent decisions",
       "Mine this project into my memory palace",

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -86,7 +86,7 @@ export default withMermaid(
       },
 
       socialLinks: [
-        { icon: 'github', link: 'https://github.com/milla-jovovich/mempalace' },
+        { icon: 'github', link: 'https://github.com/MemPalace/mempalace' },
         { icon: 'discord', link: 'https://discord.com/invite/ycTQQCu6kn' },
       ],
 
@@ -100,7 +100,7 @@ export default withMermaid(
       },
 
       editLink: {
-        pattern: `https://github.com/milla-jovovich/mempalace/edit/${editBranch}/website/:path`,
+        pattern: `https://github.com/MemPalace/mempalace/edit/${editBranch}/website/:path`,
         text: 'Edit this page on GitHub',
       },
     },

--- a/website/guide/claude-code.md
+++ b/website/guide/claude-code.md
@@ -5,7 +5,7 @@ The recommended way to use MemPalace with Claude Code — native marketplace ins
 ## Installation
 
 ```bash
-claude plugin marketplace add milla-jovovich/mempalace
+claude plugin marketplace add MemPalace/mempalace
 claude plugin install --scope user mempalace
 ```
 

--- a/website/guide/gemini-cli.md
+++ b/website/guide/gemini-cli.md
@@ -11,7 +11,7 @@ MemPalace works natively with [Gemini CLI](https://github.com/google/gemini-cli)
 
 ```bash
 # Clone the repository
-git clone https://github.com/milla-jovovich/mempalace.git
+git clone https://github.com/MemPalace/mempalace.git
 cd mempalace
 
 # Create a virtual environment

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -9,7 +9,7 @@ pip install mempalace
 ```
 
 ::: danger Security Warning
-The domain `mempalace.tech` is a **brand-squatting site** not affiliated with this project. It is known to run ad-redirects and potential malware. The official MemPalace distribution is only available via this [GitHub repository](https://github.com/milla-jovovich/mempalace) and [PyPI](https://pypi.org/project/mempalace/). Never install binaries or scripts from unofficial domains.
+The domain `mempalace.tech` is a **brand-squatting site** not affiliated with this project. It is known to run ad-redirects and potential malware. The official MemPalace distribution is only available via this [GitHub repository](https://github.com/MemPalace/mempalace) and [PyPI](https://pypi.org/project/mempalace/). Never install binaries or scripts from unofficial domains.
 :::
 
 ### Requirements
@@ -23,7 +23,7 @@ No API key required for the core local workflow. After installation, the main st
 ### From Source
 
 ```bash
-git clone https://github.com/milla-jovovich/mempalace.git
+git clone https://github.com/MemPalace/mempalace.git
 cd mempalace
 pip install -e ".[dev]"
 ```

--- a/website/index.md
+++ b/website/index.md
@@ -17,7 +17,7 @@ hero:
       link: /concepts/the-palace
     - theme: alt
       text: GitHub ↗
-      link: https://github.com/milla-jovovich/mempalace
+      link: https://github.com/MemPalace/mempalace
 
 features:
   - icon:

--- a/website/reference/benchmarks.md
+++ b/website/reference/benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-Curated summary of MemPalace benchmark results. For the full 725-line progression with every experiment, see [`benchmarks/BENCHMARKS.md`](https://github.com/milla-jovovich/mempalace/blob/main/benchmarks/BENCHMARKS.md) in the repository.
+Curated summary of MemPalace benchmark results. For the full 725-line progression with every experiment, see [`benchmarks/BENCHMARKS.md`](https://github.com/MemPalace/mempalace/blob/main/benchmarks/BENCHMARKS.md) in the repository.
 
 ## The Core Finding
 
@@ -76,7 +76,7 @@ On this benchmark, MemPalace materially outperforms the Mem0 result cited in the
 All benchmarks are reproducible with public datasets:
 
 ```bash
-git clone https://github.com/milla-jovovich/mempalace.git
+git clone https://github.com/MemPalace/mempalace.git
 cd mempalace
 pip install chromadb pyyaml
 
@@ -92,4 +92,4 @@ python benchmarks/longmemeval_bench.py /tmp/longmemeval_s_cleaned.json
 Results are deterministic. Same data + same script = same result every time. Every result JSONL file contains every question, every retrieved document, every score.
 :::
 
-For complete reproduction instructions, benchmark integrity notes, and the full score progression, see the [full benchmark documentation](https://github.com/milla-jovovich/mempalace/blob/main/benchmarks/BENCHMARKS.md).
+For complete reproduction instructions, benchmark integrity notes, and the full score progression, see the [full benchmark documentation](https://github.com/MemPalace/mempalace/blob/main/benchmarks/BENCHMARKS.md).

--- a/website/reference/contributing.md
+++ b/website/reference/contributing.md
@@ -5,7 +5,7 @@ PRs welcome. MemPalace is open source and we welcome contributions of all sizes 
 ## Getting Started
 
 ```bash
-git clone https://github.com/milla-jovovich/mempalace.git
+git clone https://github.com/MemPalace/mempalace.git
 cd mempalace
 pip install -e ".[dev]"
 ```
@@ -53,7 +53,7 @@ See [Benchmarks](/reference/benchmarks) for data download instructions.
 
 ## Good First Issues
 
-Check the [Issues](https://github.com/milla-jovovich/mempalace/issues) tab:
+Check the [Issues](https://github.com/MemPalace/mempalace/issues) tab:
 
 - **New chat formats** — add import support for Cursor, Copilot, or other AI tool exports
 - **Room detection** — improve pattern matching in `room_detector_local.py`
@@ -73,8 +73,8 @@ If you're planning a significant change, open an issue first. Key principles:
 ## Community
 
 - [Discord](https://discord.com/invite/ycTQQCu6kn)
-- [GitHub Issues](https://github.com/milla-jovovich/mempalace/issues) — bug reports and feature requests
-- [GitHub Discussions](https://github.com/milla-jovovich/mempalace/discussions) — questions and ideas
+- [GitHub Issues](https://github.com/MemPalace/mempalace/issues) — bug reports and feature requests
+- [GitHub Discussions](https://github.com/MemPalace/mempalace/discussions) — questions and ideas
 
 ## License
 


### PR DESCRIPTION
Follow-up to #766 (which covers version.py, pyproject.toml, README, CHANGELOG, CONTRIBUTING).

These 11 files still reference the old `milla-jovovich` GitHub org in URLs:

**website/** (VitePress docs site, merged via #439):
- `.vitepress/config.mts` -- GitHub nav link + edit-page URL pattern
- `index.md` -- hero action link
- `guide/claude-code.md`, `guide/getting-started.md`, `guide/gemini-cli.md` -- clone URLs
- `reference/contributing.md` -- clone URL, issues link, discussions link
- `reference/benchmarks.md` -- 3 repo links

**Plugin manifests:**
- `.claude-plugin/plugin.json` -- repository URL
- `.claude-plugin/README.md` -- marketplace command
- `.codex-plugin/plugin.json` -- homepage, repository, websiteURL, privacyPolicyURL, termsOfServiceURL
- `.codex-plugin/README.md` -- clone URL, repo links

Author name fields (`"name": "milla-jovovich"`, `developerName`) are intentionally unchanged -- those refer to the person, not the org.

**Note:** also includes `version.py` 3.1.0 -> 3.2.0 to unblock CI (#771) -- same workaround every open PR on develop needs until #766 lands.

Relates to #787.