### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Please check the table below for the supported versions that are currently receiving security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `main` / `develop` | :white_check_mark: |
+| `< 1.0.0` | :x:                |
+
+*(Note: Adjust the table above to reflect MemPalace's actual release cycle)*
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+We take the security of MemPalace seriously. If you believe you have found a security vulnerability, please report it to us privately using one of the following methods:
+
+1. **GitHub Private Vulnerability Reporting:** Navigate to the "Security" tab in this repository, click on "Advisories," and select "Report a vulnerability."
+2. **Direct Contact:** If private reporting is not enabled, please email the core maintainers directly at `[Insert Maintainer Email Here]`.
+
+### What to include in your report:
+* A descriptive summary of the vulnerability.
+* Detailed steps to reproduce the issue (including any proof-of-concept scripts or specific file paths).
+* The potential impact and severity of the vulnerability.
+
+### What to expect:
+* We aim to acknowledge receipt of your vulnerability report within 48 hours.
+* We will triage the issue and keep you updated on our progress toward a patch.
+* Once the vulnerability is resolved and an update is released, we will publish a security advisory and credit you for the discovery (if you wish to be credited).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,30 +2,32 @@
 
 ## Supported Versions
 
-Please check the table below for the supported versions that are currently receiving security updates.
+MemPalace follows semantic versioning. Security fixes land on the current major version line.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| `main` / `develop` | :white_check_mark: |
-| `< 1.0.0` | :x:                |
-
-*(Note: Adjust the table above to reflect MemPalace's actual release cycle)*
+| Version            | Supported |
+| ------------------ | --------- |
+| 3.x (current)      | Yes       |
+| 2.x and earlier    | No        |
 
 ## Reporting a Vulnerability
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-We take the security of MemPalace seriously. If you believe you have found a security vulnerability, please report it to us privately using one of the following methods:
+We take the security of MemPalace seriously. If you believe you have found a security vulnerability, please report it privately using **GitHub Private Vulnerability Reporting**:
 
-1. **GitHub Private Vulnerability Reporting:** Navigate to the "Security" tab in this repository, click on "Advisories," and select "Report a vulnerability."
-2. **Direct Contact:** If private reporting is not enabled, please email the core maintainers directly at `[Insert Maintainer Email Here]`.
+1. Open the [Security tab](https://github.com/MemPalace/mempalace/security) of this repository.
+2. Click **Advisories** → **Report a vulnerability**.
+3. Fill in the form with the details below.
 
-### What to include in your report:
-* A descriptive summary of the vulnerability.
-* Detailed steps to reproduce the issue (including any proof-of-concept scripts or specific file paths).
-* The potential impact and severity of the vulnerability.
+### What to include in your report
 
-### What to expect:
-* We aim to acknowledge receipt of your vulnerability report within 48 hours.
-* We will triage the issue and keep you updated on our progress toward a patch.
-* Once the vulnerability is resolved and an update is released, we will publish a security advisory and credit you for the discovery (if you wish to be credited).
+- A descriptive summary of the vulnerability.
+- Detailed steps to reproduce the issue (including any proof-of-concept scripts or specific file paths).
+- The affected version(s) and platform(s).
+- The potential impact and severity.
+
+### What to expect
+
+- We aim to acknowledge receipt within 48 hours.
+- We will triage the issue and keep you updated on progress toward a patch.
+- Once the vulnerability is resolved and an update is released, we will publish a security advisory and credit you for the discovery (if you wish to be credited).


### PR DESCRIPTION
This PR introduces a standard SECURITY.md policy file to the repository. 

While reviewing the codebase, I noticed there wasn't a defined channel for the private, responsible disclosure of security vulnerabilities. Adding this policy helps protect the project by guiding researchers to report bugs privately rather than in public issues. 

I highly recommend merging this and enabling GitHub's "Private Vulnerability Reporting" feature in your repository settings. I currently have some security findings I would like to share with the maintainers securely once a private channel or contact method is established.

## What does this PR do?

## How to test

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)
