### PR TITLE
fix: restrict file permissions on sensitive palace data

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -227,4 +227,8 @@ class MempalaceConfig:
         self._config_dir.mkdir(parents=True, exist_ok=True)
         with open(self._people_map_file, "w") as f:
             json.dump(people_map, f, indent=2)
+        try:
+            self._people_map_file.chmod(0o600)
+        except (OSError, NotImplementedError):
+            pass
         return self._people_map_file

--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -309,7 +309,15 @@ class EntityRegistry:
 
     def save(self):
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._path.parent.chmod(0o700)
+        except (OSError, NotImplementedError):
+            pass
         self._path.write_text(json.dumps(self._data, indent=2), encoding="utf-8")
+        try:
+            self._path.chmod(0o600)
+        except (OSError, NotImplementedError):
+            pass
 
     @staticmethod
     def _empty() -> dict:

--- a/mempalace/exporter.py
+++ b/mempalace/exporter.py
@@ -56,6 +56,8 @@ def export_palace(palace_path: str, output_dir: str, format: str = "markdown") -
 
     # Track which room files have been opened (so we can append vs overwrite)
     opened_rooms: set[tuple[str, str]] = set()
+    # Track which wing directories have been created and chmoded
+    created_wing_dirs: set[str] = set()
     # Track stats per wing: {wing: {room: count}}
     wing_stats: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
     total_drawers = 0
@@ -86,11 +88,13 @@ def export_palace(palace_path: str, output_dir: str, format: str = "markdown") -
         for wing, rooms in batch_grouped.items():
             safe_wing = _safe_path_component(wing)
             wing_dir = os.path.join(output_dir, safe_wing)
-            os.makedirs(wing_dir, exist_ok=True)
-            try:
-                os.chmod(wing_dir, 0o700)
-            except (OSError, NotImplementedError):
-                pass
+            if wing_dir not in created_wing_dirs:
+                os.makedirs(wing_dir, exist_ok=True)
+                try:
+                    os.chmod(wing_dir, 0o700)
+                except (OSError, NotImplementedError):
+                    pass
+                created_wing_dirs.add(wing_dir)
 
             for room, drawers in rooms.items():
                 safe_room = _safe_path_component(room)

--- a/mempalace/exporter.py
+++ b/mempalace/exporter.py
@@ -49,6 +49,10 @@ def export_palace(palace_path: str, output_dir: str, format: str = "markdown") -
         return {"wings": 0, "rooms": 0, "drawers": 0}
 
     os.makedirs(output_dir, exist_ok=True)
+    try:
+        os.chmod(output_dir, 0o700)
+    except (OSError, NotImplementedError):
+        pass
 
     # Track which room files have been opened (so we can append vs overwrite)
     opened_rooms: set[tuple[str, str]] = set()
@@ -83,6 +87,10 @@ def export_palace(palace_path: str, output_dir: str, format: str = "markdown") -
             safe_wing = _safe_path_component(wing)
             wing_dir = os.path.join(output_dir, safe_wing)
             os.makedirs(wing_dir, exist_ok=True)
+            try:
+                os.chmod(wing_dir, 0o700)
+            except (OSError, NotImplementedError):
+                pass
 
             for room, drawers in rooms.items():
                 safe_room = _safe_path_component(room)

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -86,10 +86,18 @@ def _log(message: str):
     """Append to hook state log file."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
+        try:
+            STATE_DIR.chmod(0o700)
+        except (OSError, NotImplementedError):
+            pass
         log_path = STATE_DIR / "hook.log"
         timestamp = datetime.now().strftime("%H:%M:%S")
         with open(log_path, "a") as f:
             f.write(f"[{timestamp}] {message}\n")
+        try:
+            log_path.chmod(0o600)
+        except (OSError, NotImplementedError):
+            pass
     except OSError:
         pass
 

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -82,22 +82,30 @@ def _count_human_messages(transcript_path: str) -> int:
     return count
 
 
+_state_dir_initialized = False
+
+
 def _log(message: str):
     """Append to hook state log file."""
+    global _state_dir_initialized
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        try:
-            STATE_DIR.chmod(0o700)
-        except (OSError, NotImplementedError):
-            pass
+        if not _state_dir_initialized:
+            STATE_DIR.mkdir(parents=True, exist_ok=True)
+            try:
+                STATE_DIR.chmod(0o700)
+            except (OSError, NotImplementedError):
+                pass
+            _state_dir_initialized = True
         log_path = STATE_DIR / "hook.log"
+        is_new = not log_path.exists()
         timestamp = datetime.now().strftime("%H:%M:%S")
         with open(log_path, "a") as f:
             f.write(f"[{timestamp}] {message}\n")
-        try:
-            log_path.chmod(0o600)
-        except (OSError, NotImplementedError):
-            pass
+        if is_new:
+            try:
+                log_path.chmod(0o600)
+            except (OSError, NotImplementedError):
+                pass
     except OSError:
         pass
 

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -50,7 +50,12 @@ DEFAULT_KG_PATH = os.path.expanduser("~/.mempalace/knowledge_graph.sqlite3")
 class KnowledgeGraph:
     def __init__(self, db_path: str = None):
         self.db_path = db_path or DEFAULT_KG_PATH
-        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        db_parent = Path(self.db_path).parent
+        db_parent.mkdir(parents=True, exist_ok=True)
+        try:
+            db_parent.chmod(0o700)
+        except (OSError, NotImplementedError):
+            pass
         self._connection = None
         self._lock = threading.Lock()
         self._init_db()

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -102,7 +102,6 @@ _WAL_FILE = _WAL_DIR / "write_log.jsonl"
 try:
     _fd = os.open(str(_WAL_FILE), os.O_CREAT | os.O_WRONLY, 0o600)
     os.close(_fd)
-    _WAL_FILE.chmod(0o600)
 except (OSError, NotImplementedError):
     pass
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -96,14 +96,15 @@ try:
 except (OSError, NotImplementedError):
     pass
 _WAL_FILE = _WAL_DIR / "write_log.jsonl"
-# Pre-create WAL file with restricted permissions to avoid race condition
-if not _WAL_FILE.exists():
-    _WAL_FILE.touch(mode=0o600)
-else:
-    try:
-        _WAL_FILE.chmod(0o600)
-    except (OSError, NotImplementedError):
-        pass
+# Atomically create WAL file with restricted permissions (no TOCTOU race).
+# os.open with O_CREAT|O_WRONLY and mode 0o600 creates the file if absent
+# or opens it if present, both in a single syscall.
+try:
+    _fd = os.open(str(_WAL_FILE), os.O_CREAT | os.O_WRONLY, 0o600)
+    os.close(_fd)
+    _WAL_FILE.chmod(0o600)
+except (OSError, NotImplementedError):
+    pass
 
 # Keys whose values should be redacted in WAL entries to avoid logging sensitive content
 _WAL_REDACT_KEYS = frozenset(


### PR DESCRIPTION
## Summary

On Linux with default umask (022), several files and directories containing personal data were created world-readable (644/755). Any local user on a shared machine could read entity names, relationships, temporal facts, and exported memories.

This patch applies `chmod 0o700` to directories and `chmod 0o600` to files immediately after creation, all wrapped in `try/except (OSError, NotImplementedError): pass` for Windows compatibility.

Refs: #809 (Finding 5)

## What changed

| File | What was exposed | Fix |
|------|-----------------|-----|
| `mempalace/hooks_cli.py` | `~/.mempalace/hook_state/` — session IDs, timestamps | `chmod 0o700` on dir, `0o600` on hook.log |
| `mempalace/entity_registry.py` | `entity_registry.json` — names, relationships, aliases | `chmod 0o700` on parent, `0o600` on file |
| `mempalace/knowledge_graph.py` | `knowledge_graph.sqlite3` parent dir — all temporal facts | `chmod 0o700` on parent dir |
| `mempalace/exporter.py` | Export output dir + wing subdirs — complete verbatim palace | `chmod 0o700` on output_dir and wing_dir |
| `mempalace/config.py` | `people_map.json` — name variant mappings | `chmod 0o600` on file |
| `mempalace/mcp_server.py` | WAL file — write audit log (TOCTOU race) | Atomic `os.open(O_CREAT\|O_WRONLY, 0o600)` replaces check-then-create |

## Test plan

- [x] `pytest tests/ -v --ignore=tests/benchmarks` — 686 passed, 2 failed (pre-existing version mismatch)
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — all files formatted
- [x] No new dependencies added
- [x] All chmod calls wrapped in try/except for Windows compatibility