### PR TITLE
fix: use microsecond timestamp and full content hash in diary entry ID

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -836,7 +836,10 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
         return _no_palace()
 
     now = datetime.now()
-    entry_id = f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S')}_{hashlib.sha256(entry[:50].encode()).hexdigest()[:12]}"
+    entry_id = (
+        f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_"
+        f"{hashlib.sha256(entry.encode()).hexdigest()[:12]}"
+    )
 
     _wal_log(
         "diary_write",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,6 +6,7 @@ dispatch layer (integration-level). Uses isolated palace + KG fixtures
 via monkeypatch to avoid touching real data.
 """
 
+from datetime import datetime
 import json
 import sys
 
@@ -642,6 +643,48 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+    def test_diary_write_same_second_shared_prefix_no_collision(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+
+        from mempalace import mcp_server
+
+        class FrozenDateTime:
+            calls = [
+                datetime(2026, 4, 13, 22, 15, 30, 123456),
+                datetime(2026, 4, 13, 22, 15, 30, 123457),
+            ]
+            fallback = datetime(2026, 4, 13, 22, 15, 30, 123457)
+
+            @classmethod
+            def now(cls):
+                if cls.calls:
+                    return cls.calls.pop(0)
+                return cls.fallback
+
+        monkeypatch.setattr(mcp_server, "datetime", FrozenDateTime)
+
+        from mempalace.mcp_server import tool_diary_read, tool_diary_write
+
+        entry1 = "A" * 50 + " entry one"
+        entry2 = "A" * 50 + " entry two"
+
+        result1 = tool_diary_write(agent_name="TestAgent", entry=entry1, topic="status")
+        result2 = tool_diary_write(agent_name="TestAgent", entry=entry2, topic="status")
+
+        assert result1["success"] is True
+        assert result2["success"] is True
+        assert result1["entry_id"] != result2["entry_id"]
+
+        read_result = tool_diary_read(agent_name="TestAgent")
+        contents = [entry["content"] for entry in read_result["entries"]]
+        assert read_result["total"] == 2
+        assert entry1 in contents
+        assert entry2 in contents
 
 
 # ── Cache Invalidation (inode/mtime) ──────────────────────────────────


### PR DESCRIPTION
fix: use microsecond timestamp and full content hash in diary entry ID

`tool_diary_write` used a second-precision timestamp and only the first 50 characters of the entry to build the ChromaDB document ID. Two entries written in the same second that share a 50-char prefix received the same ID; `col.add()` silently kept the first and dropped the second.

Fix: extend timestamp to microsecond precision (`%Y%m%d_%H%M%S%f`) and hash the full entry text so every distinct entry gets a unique ID.

Regression test: `test_diary_write_same_second_shared_prefix_no_collision`

## What does this PR do?

Fixes a silent data-loss bug in `tool_diary_write` (`mcp_server.py`). The diary entry ID was built from:

```python
# Before (buggy)
f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S')}_{hashlib.sha256(entry[:50].encode()).hexdigest()[:12]}"
```

Two different entries written in the same second that share a 50-character prefix produce the same ID. ChromaDB's `col.add()` silently ignores the duplicate — the second entry is lost with no error raised.

The fix uses microsecond precision and hashes the full entry:

```python
# After (fixed)
f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_{hashlib.sha256(entry.encode()).hexdigest()[:12]}"
```

Closes #818
## How to test

```bash
python -m pytest tests/test_mcp_server.py::TestDiaryTools::test_diary_write_same_second_shared_prefix_no_collision -v
```

The new regression test freezes the clock to force a same-second collision, writes two entries with an identical 50-char prefix but different suffixes, then asserts both are stored.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
