### PR TITLE
fix: sync version.py to 3.2.0

### DIFF
--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"


### PR DESCRIPTION
## Summary

Commit 6614b9b ("bump version v3.2.0") updated `pyproject.toml` to `3.2.0` but missed `mempalace/version.py`, which still reads `3.1.0`. This breaks `test_version_consistency.py` on every open PR's CI (currently 2 failures across all 5 test matrix jobs).

## Test plan

- [x] `pytest tests/test_version_consistency.py` — 2/2 pass