### PR TITLE
fix: return empty status instead of error on cold-start palace (#830)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -269,7 +269,11 @@ def _sanitize_optional_name(value: str = None, field_name: str = "name") -> str:
 
 
 def tool_status():
-    col = _get_collection()
+    # Use create=True only when a palace DB already exists on disk -- this
+    # bootstraps the ChromaDB collection on a valid-but-empty palace without
+    # accidentally creating a palace in a non-existent directory (#830).
+    db_exists = os.path.isfile(os.path.join(_config.palace_path, "chroma.sqlite3"))
+    col = _get_collection(create=db_exists)
     if not col:
         return _no_palace()
     count = col.count()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -212,6 +212,25 @@ class TestHandleRequest:
 
 
 class TestReadTools:
+    def test_status_cold_start_no_collection(self, monkeypatch, config, palace_path, kg):
+        """Status on a valid palace with no ChromaDB collection yet (#830).
+
+        After `mempalace init`, chroma.sqlite3 exists but the mempalace_drawers
+        collection has not been created (no mine or add_drawer yet).  Status
+        should return total_drawers: 0, not 'No palace found'.
+        """
+        import chromadb
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        # Create the DB file (init does this) but NOT the collection
+        client = chromadb.PersistentClient(path=palace_path)
+        del client
+        from mempalace.mcp_server import tool_status
+
+        result = tool_status()
+        assert "error" not in result, f"cold-start should not error: {result}"
+        assert result["total_drawers"] == 0
+
     def test_status_empty_palace(self, monkeypatch, config, palace_path, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         _client, _col = _get_collection(palace_path, create=True)


### PR DESCRIPTION
Closes #830. Fix suggested by @hkevinchu -- props for the clear diagnosis.

`tool_status()` called `_get_collection()` with the default `create=False`. On a valid palace where `init` completed but no drawers were added yet, the ChromaDB collection doesn't exist. `client.get_collection()` throws, the exception is swallowed, and status returns `{"error": "No palace found"}` with a misleading hint to re-run init.

**Fix:** `_get_collection(create=db_exists)` in `tool_status()`, where `db_exists` checks whether `chroma.sqlite3` is present on disk. This bootstraps the ChromaDB collection on a valid-but-empty palace (init ran, DB file exists, but no drawers yet) without accidentally creating a palace in a non-existent or misconfigured directory. When the palace path is genuinely wrong, `_get_client()` still fails and `_no_palace()` fires correctly.

**Changes (2 files, +24/-1):**
- `mempalace/mcp_server.py`: `_get_collection()` -> `_get_collection(create=db_exists)` with `db_exists = os.path.isfile(...)` guard
- `tests/test_mcp_server.py`: new `test_status_cold_start_no_collection` -- calls status without pre-creating the collection, asserts `total_drawers: 0` instead of error