### PR TITLE
fix(website): update vitepress base url for custom domain

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -5,6 +5,7 @@ node_modules
 out
 dist
 .vitepress/dist
+.vitepress/cache
 .vitepress/.temp
 *.tgz
 

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -9,7 +9,7 @@ function normalizeBase(base?: string): string {
   return base.endsWith('/') ? base : `${base}/`
 }
 
-const docsBase = normalizeBase(process.env.DOCS_BASE || '/mempalace/')
+const docsBase = normalizeBase(process.env.DOCS_BASE || '/')
 const editBranch = process.env.DOCS_EDIT_BRANCH || 'main'
 
 export default withMermaid(


### PR DESCRIPTION
Updates VitePress base URL from `/mempalace/` to `/` to support the custom domain at mempalaceofficial.com.