### PR TITLE
ci: serve docs from develop only

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [main, develop]
+    branches: [develop]
     paths:
       - ".github/workflows/deploy-docs.yml"
       - "website/**"
@@ -51,7 +51,7 @@ jobs:
           path: website/.vitepress/dist
 
   deploy:
-    if: github.ref_name == 'main' || github.ref_name == 'develop'
+    if: github.ref_name == 'develop'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Docs serve from develop for faster iteration cycles. Main was failing the Deploy Docs step on every release merge (v3.2.0, v3.3.0) with *"Branch 'main' is not allowed to deploy to github-pages due to environment protection rules"* — noise without signal.

## Change

Two lines in [.github/workflows/deploy-docs.yml](.github/workflows/deploy-docs.yml):

- `branches: [main, develop]` → `branches: [develop]`
- `if: github.ref_name == 'main' || github.ref_name == 'develop'` → `if: github.ref_name == 'develop'`

## Impact

- Develop continues to deploy docs exactly as before
- Main no longer triggers the workflow, so the `github-pages` environment protection rule no longer reports a failure on main merges
- Manual dispatch (`workflow_dispatch`) still works for both branches

## Test plan

- [x] YAML structure unchanged apart from the two edits
- [ ] CI run on this PR reflects only develop-triggered deploys going forward