### PR TITLE
feat: include created_at timestamp in search results

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -397,7 +397,7 @@ def search_memories(
             "wing": meta.get("wing", "unknown"),
             "room": meta.get("room", "unknown"),
             "source_file": Path(source).name if source else "?",
-            "created_at": meta.get("filed_at"),
+            "created_at": meta.get("filed_at", "unknown"),
             "similarity": round(max(0.0, 1 - effective_dist), 3),
             "distance": round(dist, 4),
             "effective_distance": round(effective_dist, 4),

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -397,6 +397,7 @@ def search_memories(
             "wing": meta.get("wing", "unknown"),
             "room": meta.get("room", "unknown"),
             "source_file": Path(source).name if source else "?",
+            "created_at": meta.get("filed_at"),
             "similarity": round(max(0.0, 1 - effective_dist), 3),
             "distance": round(dist, 4),
             "effective_distance": round(effective_dist, 4),

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -59,6 +59,21 @@ class TestSearchMemories:
         hit = result["results"][0]
         assert hit["created_at"] == "2026-01-01T00:00:00"
 
+    def test_created_at_fallback_when_filed_at_missing(self):
+        """created_at defaults to 'unknown' when filed_at is absent."""
+        mock_col = MagicMock()
+        mock_col.query.return_value = {
+            "ids": [["drawer_no_date"]],
+            "documents": [["Some text without a date"]],
+            "metadatas": [[{"wing": "project", "room": "backend", "source_file": "x.py"}]],
+            "distances": [[0.1]],
+        }
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("test", "/fake/path")
+        hit = result["results"][0]
+        assert hit["created_at"] == "unknown"
+
     def test_search_memories_query_error(self):
         """search_memories returns error dict when query raises."""
         mock_col = MagicMock()

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -51,6 +51,13 @@ class TestSearchMemories:
         assert "source_file" in hit
         assert "similarity" in hit
         assert isinstance(hit["similarity"], float)
+        assert "created_at" in hit
+
+    def test_created_at_contains_filed_at(self, palace_path, seeded_collection):
+        """created_at surfaces the filed_at metadata from the drawer."""
+        result = search_memories("JWT authentication", palace_path)
+        hit = result["results"][0]
+        assert hit["created_at"] == "2026-01-01T00:00:00"
 
     def test_search_memories_query_error(self):
         """search_memories returns error dict when query raises."""


### PR DESCRIPTION
## Summary
- Surfaces the existing `filed_at` metadata as `created_at` in search result objects returned by `search_memories()`
- Enables temporal reasoning over search hits without additional queries (e.g., "what did I say last week?")
- Zero breaking changes — additive field only

Closes #465

## Changes
- `mempalace/searcher.py`: Added `created_at` field to search result entry dict, sourced from `meta.get("filed_at")`
- `tests/test_searcher.py`: Added `created_at` presence check to `test_result_fields`, plus new `test_created_at_contains_filed_at` verifying the value matches the stored `filed_at` metadata

## Test plan
- [x] `test_result_fields` — verifies `created_at` key exists in search results
- [x] `test_created_at_contains_filed_at` — verifies value matches the seeded `filed_at` metadata (`2026-01-01T00:00:00`)
- [x] Full test suite: 865 passed, 84% coverage
- [x] Lint clean (`ruff check .`, `ruff format --check .` with CI-pinned ruff >=0.4.0,<0.5)