### PR TITLE
docs(cli): clarify that 'mempalace init' requires <dir> (#210)

### DIFF
--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -34,14 +34,20 @@ Three steps: **init**, **mine**, **search**.
 
 ### 1. Initialize Your Palace
 
+`mempalace init` requires a project directory to scan. Pass a path,
+or `.` to use the current directory.
+
 ```bash
 mempalace init ~/projects/myapp
+# or, from inside the project:
+mempalace init .
 ```
 
 This scans your project directory and:
+
 - Detects people and projects from file content
 - Creates rooms from your folder structure
-- Sets up `~/.mempalace/` config directory
+- Ensures the `~/.mempalace/` config directory exists
 
 ### 2. Mine Your Data
 

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -4,23 +4,29 @@ All commands accept `--palace <path>` to override the default palace location.
 
 ## `mempalace init`
 
-Detect rooms from your folder structure and set up the palace.
+Scan a project directory for people, projects, and rooms, and set up the palace.
 
 ```bash
-mempalace init <dir>
-mempalace init <dir> --yes  # non-interactive mode
+mempalace init <dir>                 # <dir> is required
+mempalace init <dir> --yes           # non-interactive mode
+mempalace init ~/projects/myapp      # example
+mempalace init .                     # initialize from the current directory
 ```
 
-| Option | Description |
-|--------|-------------|
-| `<dir>` | Project directory to scan |
-| `--yes` | Auto-accept all detected entities |
+| Option  | Description                                                                  |
+|---------|------------------------------------------------------------------------------|
+| `<dir>` | **Required.** Project directory to scan. Pass `.` for the current directory. |
+| `--yes` | Auto-accept all detected entities                                            |
 
 What it does:
-1. Scans for people and projects in file content
-2. Detects rooms from folder structure
-3. Creates `~/.mempalace/` config directory
-4. Saves detected entities to `<dir>/entities.json`
+
+1. Scans `<dir>` for people and projects in file content
+2. Detects rooms from `<dir>`'s folder structure
+3. Saves detected entities to `<dir>/entities.json`
+4. Ensures the global `~/.mempalace/` config directory exists
+
+Running `mempalace init` with no argument will exit with
+`error: the following arguments are required: dir`.
 
 ## `mempalace mine`
 


### PR DESCRIPTION
## What and Why

Closes #210. The reporter ran `mempalace init` with no argument and hit
`error: the following arguments are required: dir`, because the docs led them
to believe `init` just sets up `~/.mempalace/`.

## Root Cause

Two doc locations de-emphasized the required positional `<dir>`:

- `website/reference/cli.md` — the "What it does" list made "Creates `~/.mempalace/` config directory" sound like the primary effect of `init`, without reinforcing that `<dir>` is required.
- `website/guide/getting-started.md` — the Quick Start walked straight into `mempalace init ~/projects/myapp` without noting that a directory argument is mandatory.

## Change Summary

- `website/reference/cli.md` — mark `<dir>` as **Required**, add `mempalace init .` as the current-directory usage, re-order the "What it does" list so scanning `<dir>` is listed first, and add a short note about the argparse error users see when they forget the argument.
- `website/guide/getting-started.md` — add a one-line note that `<dir>` is required, show `mempalace init .` as an alternative, and soften "Sets up" to "Ensures … exists" to avoid implying init's only job is creating the global dir.

No CLI/code changes — this is a documentation-only PR and does not conflict with #857 (init directory creation/normalization).

## Test Plan

- [x] Manually re-read both docs to confirm `<dir>` is now unambiguously required
- [x] Verified the CLI still rejects `mempalace init` with no arg (expected behavior kept; docs now match)

Closes #210