### PR TITLE
fix(hooks): stop precompact hook from blocking compaction (#856, #858)

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -36,6 +36,11 @@ PRECOMPACT_BLOCK_REASON = (
     "Save everything to MemPalace, then allow compaction to proceed."
 )
 
+PRECOMPACT_ALLOW_REASON = (
+    "MemPalace pre-compaction save. Your conversation has been saved "
+    "in the background. Compaction can proceed safely."
+)
+
 
 def _sanitize_session_id(session_id: str) -> str:
     """Only allow alnum, dash, underscore to prevent path traversal."""
@@ -122,20 +127,53 @@ def _output(data: dict):
     print(json.dumps(data, indent=2, ensure_ascii=False))
 
 
-def _maybe_auto_ingest():
-    """If MEMPAL_DIR is set and exists, run mempalace mine in background."""
+def _get_mine_dir(transcript_path: str = "") -> str:
+    """Determine directory to mine from MEMPAL_DIR or transcript path."""
     mempal_dir = os.environ.get("MEMPAL_DIR", "")
     if mempal_dir and os.path.isdir(mempal_dir):
-        try:
-            log_path = STATE_DIR / "hook.log"
-            with open(log_path, "a") as log_f:
-                subprocess.Popen(
-                    [sys.executable, "-m", "mempalace", "mine", mempal_dir],
-                    stdout=log_f,
-                    stderr=log_f,
-                )
-        except OSError:
-            pass
+        return mempal_dir
+    if transcript_path:
+        path = Path(transcript_path).expanduser()
+        if path.is_file():
+            return str(path.parent)
+    return ""
+
+
+def _maybe_auto_ingest(transcript_path: str = ""):
+    """Run mempalace mine in background if a mine directory is available."""
+    mine_dir = _get_mine_dir(transcript_path)
+    if not mine_dir:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        log_path = STATE_DIR / "hook.log"
+        with open(log_path, "a") as log_f:
+            subprocess.Popen(
+                [sys.executable, "-m", "mempalace", "mine", mine_dir],
+                stdout=log_f,
+                stderr=log_f,
+            )
+    except OSError:
+        pass
+
+
+def _mine_sync(transcript_path: str = ""):
+    """Run mempalace mine synchronously (for precompact -- data must land first)."""
+    mine_dir = _get_mine_dir(transcript_path)
+    if not mine_dir:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        log_path = STATE_DIR / "hook.log"
+        with open(log_path, "a") as log_f:
+            subprocess.run(
+                [sys.executable, "-m", "mempalace", "mine", mine_dir],
+                stdout=log_f,
+                stderr=log_f,
+                timeout=60,
+            )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
 
 
 SUPPORTED_HARNESSES = {"claude-code", "codex"}
@@ -192,7 +230,7 @@ def hook_stop(data: dict, harness: str):
         _log(f"TRIGGERING SAVE at exchange {exchange_count}")
 
         # Optional: auto-ingest if MEMPAL_DIR is set
-        _maybe_auto_ingest()
+        _maybe_auto_ingest(transcript_path)
 
         _output({"decision": "block", "reason": STOP_BLOCK_REASON})
     else:
@@ -214,29 +252,17 @@ def hook_session_start(data: dict, harness: str):
 
 
 def hook_precompact(data: dict, harness: str):
-    """Precompact hook: always block with comprehensive save instruction."""
+    """Precompact hook: mine transcript synchronously, then allow compaction."""
     parsed = _parse_harness_input(data, harness)
     session_id = parsed["session_id"]
+    transcript_path = parsed["transcript_path"]
 
     _log(f"PRE-COMPACT triggered for session {session_id}")
 
-    # Optional: auto-ingest synchronously before compaction (so memories land first)
-    mempal_dir = os.environ.get("MEMPAL_DIR", "")
-    if mempal_dir and os.path.isdir(mempal_dir):
-        try:
-            log_path = STATE_DIR / "hook.log"
-            with open(log_path, "a") as log_f:
-                subprocess.run(
-                    [sys.executable, "-m", "mempalace", "mine", mempal_dir],
-                    stdout=log_f,
-                    stderr=log_f,
-                    timeout=60,
-                )
-        except OSError:
-            pass
+    # Mine synchronously so data lands before compaction proceeds
+    _mine_sync(transcript_path)
 
-    # Always block -- compaction = save everything
-    _output({"decision": "block", "reason": PRECOMPACT_BLOCK_REASON})
+    _output({"decision": "allow", "reason": PRECOMPACT_ALLOW_REASON})
 
 
 def run_hook(hook_name: str, harness: str):

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -36,11 +36,6 @@ PRECOMPACT_BLOCK_REASON = (
     "Save everything to MemPalace, then allow compaction to proceed."
 )
 
-PRECOMPACT_ALLOW_REASON = (
-    "MemPalace pre-compaction save. Your conversation has been saved "
-    "in the background. Compaction can proceed safely."
-)
-
 
 def _sanitize_session_id(session_id: str) -> str:
     """Only allow alnum, dash, underscore to prevent path traversal."""
@@ -262,7 +257,7 @@ def hook_precompact(data: dict, harness: str):
     # Mine synchronously so data lands before compaction proceeds
     _mine_sync(transcript_path)
 
-    _output({"decision": "allow", "reason": PRECOMPACT_ALLOW_REASON})
+    _output({})
 
 
 def run_hook(hook_name: str, harness: str):

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,8 +10,9 @@ import pytest
 from mempalace.hooks_cli import (
     SAVE_INTERVAL,
     STOP_BLOCK_REASON,
-    PRECOMPACT_BLOCK_REASON,
+    PRECOMPACT_ALLOW_REASON,
     _count_human_messages,
+    _get_mine_dir,
     _log,
     _maybe_auto_ingest,
     _parse_harness_input,
@@ -205,14 +207,14 @@ def test_session_start_passes_through(tmp_path):
 # --- hook_precompact ---
 
 
-def test_precompact_always_blocks(tmp_path):
+def test_precompact_allows(tmp_path):
     result = _capture_hook_output(
         hook_precompact,
         {"session_id": "test"},
         state_dir=tmp_path,
     )
-    assert result["decision"] == "block"
-    assert result["reason"] == PRECOMPACT_BLOCK_REASON
+    assert result["decision"] == "allow"
+    assert result["reason"] == PRECOMPACT_ALLOW_REASON
 
 
 # --- _log ---
@@ -238,7 +240,7 @@ def test_log_oserror_is_silenced(tmp_path):
 
 
 def test_maybe_auto_ingest_no_env(tmp_path):
-    """Without MEMPAL_DIR set, does nothing."""
+    """Without MEMPAL_DIR or transcript_path, does nothing."""
     with patch.dict("os.environ", {}, clear=True):
         with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
             _maybe_auto_ingest()  # should not raise
@@ -255,6 +257,17 @@ def test_maybe_auto_ingest_with_env(tmp_path):
                 mock_popen.assert_called_once()
 
 
+def test_maybe_auto_ingest_with_transcript(tmp_path):
+    """Falls back to transcript directory when MEMPAL_DIR is not set."""
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli.subprocess.Popen") as mock_popen:
+                _maybe_auto_ingest(str(transcript))
+                mock_popen.assert_called_once()
+
+
 def test_maybe_auto_ingest_oserror(tmp_path):
     """OSError during subprocess spawn is silenced."""
     mempal_dir = tmp_path / "project"
@@ -263,6 +276,33 @@ def test_maybe_auto_ingest_oserror(tmp_path):
         with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
             with patch("mempalace.hooks_cli.subprocess.Popen", side_effect=OSError("fail")):
                 _maybe_auto_ingest()  # should not raise
+
+
+# --- _get_mine_dir ---
+
+
+def test_get_mine_dir_mempal_dir(tmp_path):
+    """MEMPAL_DIR takes priority over transcript_path."""
+    mempal_dir = tmp_path / "project"
+    mempal_dir.mkdir()
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    with patch.dict("os.environ", {"MEMPAL_DIR": str(mempal_dir)}):
+        assert _get_mine_dir(str(transcript)) == str(mempal_dir)
+
+
+def test_get_mine_dir_transcript_fallback(tmp_path):
+    """Falls back to transcript parent dir when MEMPAL_DIR is not set."""
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    with patch.dict("os.environ", {}, clear=True):
+        assert _get_mine_dir(str(transcript)) == str(tmp_path)
+
+
+def test_get_mine_dir_empty():
+    """Returns empty string when nothing is available."""
+    with patch.dict("os.environ", {}, clear=True):
+        assert _get_mine_dir("") == ""
 
 
 # --- _parse_harness_input ---
@@ -333,7 +373,7 @@ def test_stop_hook_oserror_on_write(tmp_path):
 
 
 def test_precompact_with_mempal_dir(tmp_path):
-    """Precompact runs subprocess.run when MEMPAL_DIR is set."""
+    """Precompact runs subprocess.run (sync) when MEMPAL_DIR is set."""
     mempal_dir = tmp_path / "project"
     mempal_dir.mkdir()
     with patch.dict("os.environ", {"MEMPAL_DIR": str(mempal_dir)}):
@@ -343,7 +383,7 @@ def test_precompact_with_mempal_dir(tmp_path):
                 {"session_id": "test"},
                 state_dir=tmp_path,
             )
-    assert result["decision"] == "block"
+    assert result["decision"] == "allow"
     mock_run.assert_called_once()
 
 
@@ -358,7 +398,40 @@ def test_precompact_with_mempal_dir_oserror(tmp_path):
                 {"session_id": "test"},
                 state_dir=tmp_path,
             )
-    assert result["decision"] == "block"
+    assert result["decision"] == "allow"
+
+
+def test_precompact_with_timeout(tmp_path):
+    """Precompact handles TimeoutExpired gracefully -- still allows."""
+    mempal_dir = tmp_path / "project"
+    mempal_dir.mkdir()
+    with patch.dict("os.environ", {"MEMPAL_DIR": str(mempal_dir)}):
+        with patch(
+            "mempalace.hooks_cli.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="mine", timeout=60),
+        ):
+            result = _capture_hook_output(
+                hook_precompact, {"session_id": "test"}, state_dir=tmp_path
+            )
+    assert result["decision"] == "allow"
+
+
+def test_precompact_mines_transcript_dir(tmp_path, monkeypatch):
+    """Precompact mines transcript directory when no MEMPAL_DIR."""
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    monkeypatch.delenv("MEMPAL_DIR", raising=False)
+    with patch("mempalace.hooks_cli.subprocess.run") as mock_run:
+        result = _capture_hook_output(
+            hook_precompact,
+            {"session_id": "test", "transcript_path": str(transcript)},
+            state_dir=tmp_path,
+        )
+    assert result["decision"] == "allow"
+    mock_run.assert_called_once()
+    # Verify mine dir is the transcript's parent
+    call_args = mock_run.call_args[0][0]
+    assert str(tmp_path) in call_args[-1]
 
 
 # --- run_hook ---
@@ -401,7 +474,7 @@ def test_run_hook_dispatches_precompact(tmp_path):
                 run_hook("precompact", "claude-code")
     mock_output.assert_called_once()
     call_args = mock_output.call_args[0][0]
-    assert call_args["decision"] == "block"
+    assert call_args["decision"] == "allow"
 
 
 def test_run_hook_unknown_hook():

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -10,7 +10,6 @@ import pytest
 from mempalace.hooks_cli import (
     SAVE_INTERVAL,
     STOP_BLOCK_REASON,
-    PRECOMPACT_ALLOW_REASON,
     _count_human_messages,
     _get_mine_dir,
     _log,
@@ -213,8 +212,7 @@ def test_precompact_allows(tmp_path):
         {"session_id": "test"},
         state_dir=tmp_path,
     )
-    assert result["decision"] == "allow"
-    assert result["reason"] == PRECOMPACT_ALLOW_REASON
+    assert result == {}
 
 
 # --- _log ---
@@ -383,7 +381,7 @@ def test_precompact_with_mempal_dir(tmp_path):
                 {"session_id": "test"},
                 state_dir=tmp_path,
             )
-    assert result["decision"] == "allow"
+    assert result == {}
     mock_run.assert_called_once()
 
 
@@ -398,7 +396,7 @@ def test_precompact_with_mempal_dir_oserror(tmp_path):
                 {"session_id": "test"},
                 state_dir=tmp_path,
             )
-    assert result["decision"] == "allow"
+    assert result == {}
 
 
 def test_precompact_with_timeout(tmp_path):
@@ -413,7 +411,7 @@ def test_precompact_with_timeout(tmp_path):
             result = _capture_hook_output(
                 hook_precompact, {"session_id": "test"}, state_dir=tmp_path
             )
-    assert result["decision"] == "allow"
+    assert result == {}
 
 
 def test_precompact_mines_transcript_dir(tmp_path, monkeypatch):
@@ -427,7 +425,7 @@ def test_precompact_mines_transcript_dir(tmp_path, monkeypatch):
             {"session_id": "test", "transcript_path": str(transcript)},
             state_dir=tmp_path,
         )
-    assert result["decision"] == "allow"
+    assert result == {}
     mock_run.assert_called_once()
     # Verify mine dir is the transcript's parent
     call_args = mock_run.call_args[0][0]
@@ -472,9 +470,7 @@ def test_run_hook_dispatches_precompact(tmp_path):
         with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
             with patch("mempalace.hooks_cli._output") as mock_output:
                 run_hook("precompact", "claude-code")
-    mock_output.assert_called_once()
-    call_args = mock_output.call_args[0][0]
-    assert call_args["decision"] == "allow"
+    mock_output.assert_called_once_with({})
 
 
 def test_run_hook_unknown_hook():


### PR DESCRIPTION
## Problem

The precompact hook in `hooks_cli.py` unconditionally returns `{"decision": "block"}`. Claude Code treats `block` on a PreCompact hook as a cancellation with no retry -- so `/compact` is permanently broken for anyone using the plugin.

The standalone bash hooks in `hooks/` were updated separately (#885), but `hooks_cli.py` (called by the plugin wrapper) still returned `block`.

Closes #856, closes #858.

## Changes

- `hook_precompact()` now mines the transcript directory synchronously (so data lands before compaction proceeds), then returns `{}` (empty JSON, not blocking compaction)
- Extracted `_get_mine_dir(transcript_path)` helper that resolves the mine directory from `MEMPAL_DIR` env var or the transcript file location
- Added `_mine_sync()` for synchronous mining with a 60-second timeout
- Extended `_maybe_auto_ingest()` to also accept `transcript_path` (falls back to `MEMPAL_DIR`)
- Stop hook behavior is intentionally unchanged -- #673 handles the full silent save path for that

## Test plan

- [x] `pytest tests/test_hooks_cli.py -v` -- 46 passed
- [x] `pytest tests/ --ignore=tests/benchmarks` -- 869 passed (1 pre-existing flaky unrelated)
- [x] `ruff check` + `ruff format --check` clean
- [x] Real hook invocation: `echo '{"session_id":"x"}' | python -m mempalace hook run --hook precompact --harness claude-code` returns `{}`
- [x] Stop hook still returns `block` at interval (unchanged)

## Scope note

This PR intentionally only fixes the precompact hook. The stop hook has several open PRs (#673, #711, #804) working on the broader silent save / configurable interval redesign. Kept this focused on the critical bug -- compaction should not be permanently broken.

---

p.s. Sorry for the PR volume from my side lately -- trying to keep each one small and focused rather than bundling unrelated fixes.