### PR TITLE
fix(init): auto-add per-project files to .gitignore in git repos (#185)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -36,6 +36,37 @@ from pathlib import Path
 from .config import MempalaceConfig
 
 
+_MEMPALACE_PROJECT_FILES = ("mempalace.yaml", "entities.json")
+
+
+def _ensure_mempalace_files_gitignored(project_dir) -> bool:
+    """If project_dir is a git repo, ensure MemPalace's per-project files
+    are listed in .gitignore so they don't get committed by accident.
+
+    Returns True if .gitignore was updated, False otherwise. Issue #185:
+    `mempalace init` writes mempalace.yaml + entities.json into the
+    project root, where they previously had no protection against being
+    staged into git.
+    """
+    from pathlib import Path
+
+    project_path = Path(project_dir).expanduser().resolve()
+    if not (project_path / ".git").exists():
+        return False
+    gitignore = project_path / ".gitignore"
+    existing = gitignore.read_text() if gitignore.exists() else ""
+    existing_lines = {line.strip() for line in existing.splitlines()}
+    missing = [p for p in _MEMPALACE_PROJECT_FILES if p not in existing_lines]
+    if not missing:
+        return False
+    prefix = "" if not existing or existing.endswith("\n") else "\n"
+    block = prefix + "\n# MemPalace per-project files (issue #185)\n" + "\n".join(missing) + "\n"
+    with open(gitignore, "a") as f:
+        f.write(block)
+    print(f"  Added {', '.join(missing)} to {gitignore.name}")
+    return True
+
+
 def cmd_init(args):
     import json
     from pathlib import Path
@@ -63,6 +94,9 @@ def cmd_init(args):
     # Pass 2: detect rooms from folder structure
     detect_rooms_local(project_dir=args.dir, yes=getattr(args, "yes", False))
     MempalaceConfig().init()
+
+    # Pass 3: protect git repos from accidentally committing per-project files
+    _ensure_mempalace_files_gitignored(args.dir)
 
 
 def cmd_mine(args):

--- a/tests/test_init_gitignore_protection.py
+++ b/tests/test_init_gitignore_protection.py
@@ -1,0 +1,62 @@
+"""Regression tests for issue #185 — gitignore protection on `mempalace init`.
+
+Issue #185 reports that `mempalace init <dir>` writes `mempalace.yaml` and
+`entities.json` into the project root, where they could be committed by
+accident. The fix adds `_ensure_mempalace_files_gitignored()` which appends
+the two filenames to `.gitignore` when `<dir>` is a git repository.
+"""
+
+from pathlib import Path
+
+from mempalace.cli import _ensure_mempalace_files_gitignored
+
+
+def _git_init(path: Path) -> None:
+    """Mark a directory as a git repo without invoking git itself."""
+    (path / ".git").mkdir()
+
+
+def test_no_op_when_not_a_git_repo(tmp_path):
+    assert _ensure_mempalace_files_gitignored(tmp_path) is False
+    assert not (tmp_path / ".gitignore").exists()
+
+
+def test_creates_gitignore_with_both_entries(tmp_path):
+    _git_init(tmp_path)
+    assert _ensure_mempalace_files_gitignored(tmp_path) is True
+    contents = (tmp_path / ".gitignore").read_text()
+    assert "mempalace.yaml" in contents
+    assert "entities.json" in contents
+    assert "issue #185" in contents
+
+
+def test_appends_only_missing_entries(tmp_path):
+    _git_init(tmp_path)
+    (tmp_path / ".gitignore").write_text("node_modules/\nmempalace.yaml\n")
+    assert _ensure_mempalace_files_gitignored(tmp_path) is True
+    contents = (tmp_path / ".gitignore").read_text()
+    # mempalace.yaml must not be duplicated
+    assert contents.count("mempalace.yaml") == 1
+    # entities.json was missing → must now be present
+    assert "entities.json" in contents
+    # original entries preserved
+    assert "node_modules/" in contents
+
+
+def test_idempotent_when_both_already_present(tmp_path):
+    _git_init(tmp_path)
+    initial = "mempalace.yaml\nentities.json\n"
+    (tmp_path / ".gitignore").write_text(initial)
+    assert _ensure_mempalace_files_gitignored(tmp_path) is False
+    assert (tmp_path / ".gitignore").read_text() == initial
+
+
+def test_handles_gitignore_without_trailing_newline(tmp_path):
+    _git_init(tmp_path)
+    (tmp_path / ".gitignore").write_text("dist")  # no trailing newline
+    assert _ensure_mempalace_files_gitignored(tmp_path) is True
+    contents = (tmp_path / ".gitignore").read_text()
+    # Original entry preserved on its own line, not glued to the new block
+    assert "dist\n" in contents
+    assert "mempalace.yaml" in contents
+    assert "entities.json" in contents


### PR DESCRIPTION
## What and Why

Partially addresses #185.

`mempalace init <dir>` writes `mempalace.yaml` and `entities.json` into the project root. When `<dir>` is a git repository, those files have **no default protection** against being staged into git — the loudest concern in the original report:

> Files in project root risk being committed to git (no default `.gitignore` entry added)

## Scope and Tradeoffs

The full proposal in #185 is to relocate the files to `~/.mempalace/wings/<wing>/`. That is a behavioral change touching the miner, the config loader, every example in the docs, and existing user setups, and it warrants its own design discussion (likely with #857 / PR #857 in mind). I deliberately scoped this PR down to the **gitignore safeguard** so the immediate risk is removed without breaking any existing flow. Happy to follow up with the relocation if the maintainers want to take that route.

## Change Summary

- `mempalace/cli.py` — new `_ensure_mempalace_files_gitignored(project_dir)` helper. Runs as the last step of `cmd_init()`. Conservative: only runs when `<dir>/.git` exists (no-op otherwise), skips entries already present, preserves existing `.gitignore` content, and handles files without trailing newlines. Adds a clearly-marked block referencing #185 so future readers know why the entries are there.
- `tests/test_init_gitignore_protection.py` — 5 cases: no git repo (no-op), fresh `.gitignore` creation, partial append (only missing entries), idempotency (no duplicates), trailing-newline edge case.

## Test Plan

- [x] `pytest tests/test_init_gitignore_protection.py -v` — all 5 pass
- [x] `ruff check` and `ruff format --check` clean
- [x] No changes to existing init flow when run outside a git repo

Refs #185 (this PR addresses the gitignore concern; the file-relocation question remains open)