### PR TITLE
fix: align plugin manifests with release tags and guard future drift (#874)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,14 +2,14 @@
   "name": "mempalace",
   "owner": {
     "name": "milla-jovovich",
-    "url": "https://github.com/milla-jovovich"
+    "url": "https://github.com/MemPalace"
   },
   "plugins": [
     {
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.0.14",
+      "version": "3.3.0",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.14",
+  "version": "3.3.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.0.14",
+  "version": "3.3.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,85 @@
+name: Version Guard
+
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'mempalace/version.py'
+      - '.claude-plugin/marketplace.json'
+      - '.claude-plugin/plugin.json'
+      - '.codex-plugin/plugin.json'
+      - '.github/workflows/version-guard.yml'
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract versions from all sources
+        id: versions
+        run: |
+          set -euo pipefail
+          py_version=$(grep -E '^__version__' mempalace/version.py | cut -d'"' -f2)
+          pyproject_version=$(grep -E '^version' pyproject.toml | head -1 | cut -d'"' -f2)
+          marketplace_version=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+          plugin_version=$(jq -r '.version' .claude-plugin/plugin.json)
+          codex_version=$(jq -r '.version' .codex-plugin/plugin.json)
+
+          echo "py_version=$py_version" >> "$GITHUB_OUTPUT"
+          echo "pyproject_version=$pyproject_version" >> "$GITHUB_OUTPUT"
+          echo "marketplace_version=$marketplace_version" >> "$GITHUB_OUTPUT"
+          echo "plugin_version=$plugin_version" >> "$GITHUB_OUTPUT"
+          echo "codex_version=$codex_version" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Detected versions"
+            echo ""
+            echo "| Source | Version |"
+            echo "| --- | --- |"
+            echo "| mempalace/version.py | \`$py_version\` |"
+            echo "| pyproject.toml | \`$pyproject_version\` |"
+            echo "| .claude-plugin/marketplace.json | \`$marketplace_version\` |"
+            echo "| .claude-plugin/plugin.json | \`$plugin_version\` |"
+            echo "| .codex-plugin/plugin.json | \`$codex_version\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify all sources agree
+        env:
+          PY: ${{ steps.versions.outputs.py_version }}
+          PYPROJECT: ${{ steps.versions.outputs.pyproject_version }}
+          MARKETPLACE: ${{ steps.versions.outputs.marketplace_version }}
+          PLUGIN: ${{ steps.versions.outputs.plugin_version }}
+          CODEX: ${{ steps.versions.outputs.codex_version }}
+        run: |
+          set -euo pipefail
+          fail=0
+          check() {
+            local name="$1" value="$2" expected="$3"
+            if [[ "$value" != "$expected" ]]; then
+              echo "::error file=$name::version mismatch — expected $expected, got $value"
+              fail=1
+            fi
+          }
+          # All five must agree with each other (use version.py as the reference, per CLAUDE.md)
+          check "pyproject.toml" "$PYPROJECT" "$PY"
+          check ".claude-plugin/marketplace.json" "$MARKETPLACE" "$PY"
+          check ".claude-plugin/plugin.json" "$PLUGIN" "$PY"
+          check ".codex-plugin/plugin.json" "$CODEX" "$PY"
+          exit $fail
+
+      - name: Verify tag matches manifest (tag pushes only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          PY: ${{ steps.versions.outputs.py_version }}
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [[ "$tag_version" != "$PY" ]]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match manifest version $PY"
+            echo "Bump mempalace/version.py, pyproject.toml, and all plugin manifests before tagging."
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME matches manifest version $PY"

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -77,9 +77,25 @@ jobs:
         run: |
           set -euo pipefail
           tag_version="${GITHUB_REF_NAME#v}"
+
+          # Semver pre-release tags (v3.4.0-rc1, v1.0.0-beta.2, ...) are treated
+          # as internal/staging and are not validated against the manifest. They
+          # do not flow to end users via `/plugin update`, which reads the
+          # manifest on the default branch.
+          if [[ "$tag_version" == *-* ]]; then
+            echo "Pre-release tag $GITHUB_REF_NAME — skipping strict manifest match."
+            {
+              echo ""
+              echo "> Pre-release tag detected: \`$GITHUB_REF_NAME\`."
+              echo "> Manifest ($PY) is not required to match. Pre-releases are not published via \`/plugin update\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           if [[ "$tag_version" != "$PY" ]]; then
             echo "::error::tag $GITHUB_REF_NAME does not match manifest version $PY"
-            echo "Bump mempalace/version.py, pyproject.toml, and all plugin manifests before tagging."
+            echo "Bump mempalace/version.py, pyproject.toml, and all plugin manifests before tagging a stable release."
+            echo "For an internal/staging tag, use a semver pre-release suffix (e.g. v${PY}-rc1)."
             exit 1
           fi
           echo "Tag $GITHUB_REF_NAME matches manifest version $PY"


### PR DESCRIPTION
Closes #874.

## Summary

- Bumps `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` from `3.0.14` to `3.3.0` so they agree with `mempalace/version.py` and `pyproject.toml`. This unblocks `/plugin update` for users who have been stuck on `3.0.14` through the v3.1.0, v3.2.0, and v3.3.0 tags.
- Fixes the stale `owner.url` in `marketplace.json` (`github.com/milla-jovovich` → `github.com/MemPalace`). `owner.name` / `author.name` are preserved as creator attribution.
- Adds `.github/workflows/version-guard.yml` so this drift cannot happen again silently:
  - On PRs touching any version file: fails if the five version sources (`version.py`, `pyproject.toml`, both `.claude-plugin/*.json`, `.codex-plugin/plugin.json`) don't all agree with `version.py`.
  - On stable tag push (`vX.Y.Z`): fails if the tag doesn't match `version.py`.
  - On semver pre-release tag push (`vX.Y.Z-rc1`, `-beta.2`, etc.): skips the strict match. Pre-releases don't flow to end users via `/plugin update` — they're distributed through PyPI / direct GitHub install — so the manifest isn't required to track them.

## Test plan

- [x] All five version sources now report `3.3.0` locally (`jq` / `grep` sanity check).
- [x] JSON files parse cleanly (`jq .`).
- [x] Guard classifier dry-run: stable tag matches → pass; mismatched stable tag → fail; `vX.Y.Z-*` pre-release → skip.
- [ ] After merge, CI Version Guard job passes on this PR.
- [ ] Next release: cut a stable tag `v3.3.1` (or chosen target) and confirm the guard's tag-push job runs green.
- [ ] End-user `/plugin update mempalace` surfaces `3.3.0` after merge to `develop` → `main`.

## Notes for reviewer

- Scoped intentionally. Other stale `milla-jovovich/*` URLs in `pyproject.toml`, `README.md`, `.github/CODEOWNERS` were not touched — they're a separate cleanup (#787 addressed a prior wave but missed those).
- If you'd rather bump to a different target (e.g. `3.3.1` to mark a fresh release cut rather than retroactively reusing `3.3.0`), happy to adjust — just let me know before merge.