### PR TITLE
fix: ship CNAME in Pages build to pin mempalaceofficial.com

### DIFF
--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+mempalaceofficial.com


### PR DESCRIPTION
## Summary

Adds [website/public/CNAME](website/public/CNAME) containing `mempalaceofficial.com` so the VitePress build always emits `/CNAME\` into the Pages artifact. Today the custom-domain setting only lives in the repo's Pages API config (visible in Settings → Pages); ship it in source as well so any future workflow refactor or org change can't silently drop it.

## What this does NOT fix

The site is currently down because `mempalaceofficial.com` has **no DNS records** — `dig +short mempalaceofficial.com` returns nothing.

Once DNS resolves, GitHub will provision the Let's Encrypt cert (up to ~24h) and HTTPS will work. This PR is the belt-and-suspenders so the domain is pinned in source from then on.

## Test plan

- [ ] After merge to `develop`, the Deploy Docs workflow runs and the deployed artifact contains `CNAME` with `mempalaceofficial.com`.
- [ ] Once DNS is fixed, https://mempalaceofficial.com/ resolves to the docs site.