### PR TITLE
feat: add VSCode devcontainer matching CI environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "MemPalace",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.debugpy",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["tests/", "-v", "--ignore=tests/benchmarks"],
+        "ruff.importStrategy": "fromEnvironment",
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "charliermarsh.ruff"
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== MemPalace Dev Container Setup ==="
+
+pip install -e ".[dev]"
+
+# Match CI's ruff pin (pyproject only sets a floor; without this contributors
+# get a newer ruff locally than CI runs, causing phantom lint failures).
+pip install "ruff>=0.4.0,<0.5"
+
+pip install pre-commit
+pre-commit install
+
+echo ""
+echo "=== Verification ==="
+echo "python: $(python --version)"
+echo "pytest: $(python -m pytest --version 2>&1 | head -1)"
+echo "ruff:   $(python -m ruff --version 2>&1 | head -1)"
+echo ""
+echo "Ready. Run: pytest tests/ -v --ignore=tests/benchmarks"


### PR DESCRIPTION
## Summary
- Adds a one-click VSCode devcontainer that mirrors CI exactly — Python 3.11 (middle of the 3.9/3.11/3.13 matrix), `pip install -e ".[dev]"`, and pytest/ruff preconfigured.
- `postCreateCommand` delegates to `.devcontainer/post-create.sh`, which also installs `pre-commit` and wires up the hooks from the existing `.pre-commit-config.yaml`.
- The load-bearing detail: `pyproject.toml` only sets `ruff>=0.4.0`, but CI pins `>=0.4.0,<0.5`. Without an explicit pin, the devcontainer would install ruff 0.15.x and phantom-fail lint locally. The script pins ruff to match CI.
- Sets `ruff.importStrategy: fromEnvironment` so the VSCode extension uses the pinned venv ruff instead of its bundled copy.

## Test plan
- [x] `devcontainer up` builds cleanly against a fresh image
- [x] Verification block reports Python 3.11.15, pytest 9.0.3, ruff 0.4.10
- [x] `pre-commit install` succeeds; `pre-commit run` passes ruff + ruff-format hooks
- [x] `ruff check .` and `ruff format --check .` pass inside the container
- [x] `pytest --collect-only` discovers 884 tests; `pytest tests/test_config.py` passes