### PR TITLE
fix: release Chroma handles before migrate swap on Windows

### DIFF
--- a/mempalace/migrate.py
+++ b/mempalace/migrate.py
@@ -16,9 +16,11 @@ Usage:
     mempalace migrate --dry-run                # show what would be migrated
 """
 
+import gc
 import os
 import shutil
 import sqlite3
+import time
 from collections import defaultdict
 from datetime import datetime
 
@@ -132,6 +134,81 @@ def confirm_destructive_action(
     return True
 
 
+def _release_chroma_handles(*objs, delay_seconds: float = 0.25) -> None:
+    """Best-effort Chroma handle release before filesystem swaps on Windows."""
+    systems = []
+    for obj in objs:
+        if obj is None:
+            continue
+
+        candidates = [
+            obj,
+            getattr(obj, "_collection", None),
+            getattr(getattr(obj, "_collection", None), "_client", None),
+            getattr(obj, "_client", None),
+        ]
+        clients = getattr(obj, "_clients", None)
+        if isinstance(clients, dict):
+            candidates.extend(clients.values())
+            try:
+                clients.clear()
+            except Exception:
+                pass
+
+        for candidate in candidates:
+            if candidate is None:
+                continue
+            system = getattr(candidate, "_system", None)
+            if system is not None and system not in systems:
+                systems.append(system)
+
+            close_method = getattr(candidate, "close", None)
+            if callable(close_method):
+                try:
+                    close_method()
+                except Exception:
+                    pass
+
+            clear_method = getattr(candidate, "clear_system_cache", None)
+            if callable(clear_method):
+                try:
+                    clear_method()
+                except Exception:
+                    pass
+
+    for system in reversed(systems):
+        stop_method = getattr(system, "stop", None)
+        if callable(stop_method):
+            try:
+                stop_method()
+            except Exception:
+                pass
+
+    gc.collect()
+    if delay_seconds > 0:
+        time.sleep(delay_seconds)
+
+
+def _replace_palace_dir(
+    temp_palace: str, palace_path: str, retries: int = 8, delay_seconds: float = 0.5
+) -> None:
+    """Replace the palace directory, retrying while Windows releases SQLite handles."""
+    last_error = None
+    for attempt in range(1, retries + 1):
+        try:
+            if os.path.exists(palace_path):
+                shutil.rmtree(palace_path)
+            shutil.move(temp_palace, palace_path)
+            return
+        except PermissionError as exc:
+            last_error = exc
+            if attempt == retries:
+                break
+            print(f"  Waiting for filesystem handles to release ({attempt}/{retries - 1})...")
+            _release_chroma_handles(delay_seconds=delay_seconds)
+    raise last_error
+
+
 def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
     """Migrate a palace to the currently installed ChromaDB version."""
     from .backends.chroma import ChromaBackend
@@ -157,15 +234,22 @@ def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
     print(f"  Target:    ChromaDB {target_version}")
 
     # Try reading with current chromadb first
+    read_backend = None
+    read_collection = None
     try:
-        col = ChromaBackend().get_collection(palace_path, "mempalace_drawers")
-        count = col.count()
+        read_backend = ChromaBackend()
+        read_collection = read_backend.get_collection(palace_path, "mempalace_drawers")
+        count = read_collection.count()
         print(f"\n  Palace is already readable by chromadb {target_version}.")
         print(f"  {count} drawers found. No migration needed.")
         return True
     except Exception:
         print(f"\n  Palace is NOT readable by chromadb {target_version}.")
         print("  Extracting from SQLite directly...")
+    finally:
+        _release_chroma_handles(read_collection, read_backend)
+        read_collection = None
+        read_backend = None
 
     # Extract all drawers via raw SQL
     drawers = extract_drawers_from_sqlite(db_path)
@@ -226,13 +310,13 @@ def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
 
     # Verify before swapping
     final_count = col.count()
-    del col
-    del fresh_backend
+    _release_chroma_handles(col, fresh_backend, delay_seconds=0.5)
+    col = None
+    fresh_backend = None
 
     # Swap: remove old palace, move new one into place
     print("  Swapping old palace for migrated version...")
-    shutil.rmtree(palace_path)
-    shutil.move(temp_palace, palace_path)
+    _replace_palace_dir(temp_palace, palace_path)
 
     print("\n  Migration complete.")
     print(f"  Drawers migrated: {final_count}")

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,6 +1,6 @@
 """Tests for destructive-operation safety in mempalace.migrate."""
 
-from types import SimpleNamespace
+import os
 from unittest.mock import MagicMock, patch
 
 from mempalace.migrate import migrate
@@ -23,13 +23,16 @@ def test_migrate_aborts_without_confirmation(tmp_path, capsys):
     # Presence of chroma.sqlite3 is the safety gate; validity is mocked below.
     (palace_dir / "chroma.sqlite3").write_text("db")
 
-    mock_chromadb = SimpleNamespace(
-        __version__="0.6.0",
-        PersistentClient=MagicMock(side_effect=Exception("unreadable")),
-    )
+    read_client = MagicMock()
+    read_client._system = MagicMock()
+    read_backend = MagicMock()
+    read_backend._clients = {str(palace_dir): read_client}
+    read_backend.get_collection.side_effect = Exception("unreadable")
+    mock_backend_cls = MagicMock(return_value=read_backend)
+    mock_backend_cls.backend_version.return_value = "0.6.0"
 
     with (
-        patch.dict("sys.modules", {"chromadb": mock_chromadb}),
+        patch("mempalace.backends.chroma.ChromaBackend", mock_backend_cls),
         patch("mempalace.migrate.detect_chromadb_version", return_value="0.5.x"),
         patch(
             "mempalace.migrate.extract_drawers_from_sqlite",
@@ -46,3 +49,56 @@ def test_migrate_aborts_without_confirmation(tmp_path, capsys):
     assert "Aborted." in out
     mock_copytree.assert_not_called()
     mock_rmtree.assert_not_called()
+
+
+def test_migrate_retries_palace_swap_after_windows_lock(tmp_path, capsys):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_text("db")
+
+    read_client = MagicMock()
+    read_client._system = MagicMock()
+    read_backend = MagicMock()
+    read_backend._clients = {str(palace_dir): read_client}
+    read_backend.get_collection.side_effect = Exception("unreadable")
+
+    temp_collection = MagicMock()
+    temp_collection.count.return_value = 1
+    temp_collection._collection = MagicMock()
+    temp_collection._collection._client = MagicMock()
+    temp_collection._collection._client._system = MagicMock()
+
+    write_client = MagicMock()
+    write_client._system = MagicMock()
+    write_backend = MagicMock()
+    write_backend._clients = {"C:\\temp\\migrated-palace": write_client}
+    write_backend.get_or_create_collection.return_value = temp_collection
+
+    mock_backend_cls = MagicMock(side_effect=[read_backend, write_backend])
+    mock_backend_cls.backend_version.return_value = "0.6.0"
+
+    with (
+        patch("mempalace.backends.chroma.ChromaBackend", mock_backend_cls),
+        patch("mempalace.migrate.detect_chromadb_version", return_value="1.x"),
+        patch(
+            "mempalace.migrate.extract_drawers_from_sqlite",
+            return_value=[{"id": "id1", "document": "doc", "metadata": {"wing": "w", "room": "r"}}],
+        ),
+        patch("mempalace.migrate.shutil.copytree"),
+        patch("tempfile.mkdtemp", return_value="C:\\temp\\migrated-palace"),
+        patch(
+            "mempalace.migrate.shutil.rmtree",
+            side_effect=[PermissionError("locked"), None],
+        ) as mock_rmtree,
+        patch("mempalace.migrate.shutil.move") as mock_move,
+        patch("mempalace.migrate.gc.collect"),
+        patch("mempalace.migrate.time.sleep") as mock_sleep,
+    ):
+        result = migrate(str(palace_dir), confirm=True)
+
+    out = capsys.readouterr().out
+    assert result is True
+    assert "Waiting for filesystem handles to release" in out
+    assert mock_rmtree.call_count == 2
+    mock_move.assert_called_once_with("C:\\temp\\migrated-palace", os.path.abspath(str(palace_dir)))
+    assert mock_sleep.called


### PR DESCRIPTION
## Summary

Fix a Windows-specific `mempalace migrate` failure where the final palace swap can raise `PermissionError: [WinError 32]` on `chroma.sqlite3` even after the import finished successfully.

## Root cause

`migrate()` was importing drawers into a fresh palace and then immediately calling `shutil.rmtree(palace_path)`.

On Windows, Chroma-backed clients can keep SQLite handles alive longer than plain object deletion suggests. In the current codebase, those handles can sit behind:

- the temporary `ChromaCollection`
- the backend wrapper's `_clients` cache
- the underlying Chroma shared system cache

That means the migrate path can successfully import everything and still fail at the last filesystem step.

## Changes

- add `_release_chroma_handles()` to stop/clear best-effort Chroma client state before directory replacement
- teach the helper to walk through backend-cached clients (`_clients`) as well as wrapped collection/client objects
- add `_replace_palace_dir()` with bounded retry on `PermissionError`
- release handles after the initial readability probe and again before the destructive swap
- update `tests/test_migrate.py` to match the current `ChromaBackend` path
- add a regression test that simulates a first-attempt Windows lock during the palace swap

## Why this is scoped this way

This keeps the fix local to `migrate.py` rather than changing backend lifecycle semantics for the whole app.

That felt like the safest way to land a real Windows fix quickly while staying aligned with the current architecture.

## Validation

Local targeted checks:

- `python -m pytest tests/test_migrate.py -q`
- `python -m ruff check mempalace/migrate.py tests/test_migrate.py`

Real Windows reproduction / rerun:

- restored a copied 16,468-drawer palace that was unreadable without migration under the current runtime
- ran:
  - `python -m mempalace.cli --palace C:\Users\fuzzy\.mempalace\palace-upgrade-eval migrate --yes`
- confirmed migration completed successfully without manual directory swap
- confirmed follow-up `status` on the migrated copy reports all 16,468 drawers correctly

## Related context

This is in the same family as other Windows Chroma handle issues already seen in the repo, but I did not find an open PR specifically fixing the migrate swap path.

Related prior Windows handle discussions / fixes:

- #286
- #757
