### PR TITLE
Fix stale status display by paginating drawer metadata

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -653,9 +653,15 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
+    # Count by wing and room — paginate so we don't cap at 10k.
+    total = col.count()
+    metas: list = []
+    offset = 0
+    page = 5000
+    while offset < total:
+        r = col.get(limit=page, offset=offset, include=["metadatas"])
+        metas.extend(r["metadatas"])
+        offset += page
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:


### PR DESCRIPTION
## Summary
- `mempalace status` hard-caps `col.get(limit=10000, ...)` which makes the header literally display `MemPalace Status — 10000 drawers` once a palace exceeds 10k drawers.
- Room totals freeze at whatever fell inside the first 10k page, so long-lived palaces silently drift out of sync with Chroma.
- This patch paginates in 5k chunks up to `col.count()` so the reported totals match what's actually stored.

Before:
```
MemPalace Status — 10000 drawers
  WING: migration_ops
    ROOM: technical   5401 drawers
    ROOM: general        7 drawers  (actual: 19,475)
```

After:
```
MemPalace Status — 45743 drawers
  WING: migration_ops
    ROOM: general    19475 drawers
    ROOM: technical   5401 drawers
    ...
```

## Test plan
- [x] Run `mempalace status` against a palace with >10k drawers — totals now match `col.count()`
- [x] Run against an empty palace — no divide-by-zero / empty-list issues
- [ ] Run against a palace at exactly 10k drawers (boundary) — should loop once with `offset=0`, then exit