### PR TITLE
fix: centralize embedding model config to prevent query/ingest mismatch

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -164,10 +164,19 @@ class ChromaBackend:
         self._client(palace_path).delete_collection(collection_name)
 
     def create_collection(
-        self, palace_path: str, collection_name: str, hnsw_space: str = "cosine"
+        self,
+        palace_path: str,
+        collection_name: str,
+        hnsw_space: str = "cosine",
+        embedding_function=None,
+        embedding_model_name: str = None,
     ) -> "ChromaCollection":
-        """Create (not get-or-create) *collection_name* with cosine HNSW space."""
+        """Create (not get-or-create) *collection_name* with HNSW space and optional embedding config."""
+        metadata = {"hnsw:space": hnsw_space}
+        if embedding_model_name:
+            metadata["embedding_model"] = embedding_model_name
+        ef_kwargs = {"embedding_function": embedding_function} if embedding_function else {}
         collection = self._client(palace_path).create_collection(
-            collection_name, metadata={"hnsw:space": hnsw_space}
+            collection_name, metadata=metadata, **ef_kwargs
         )
         return ChromaCollection(collection)

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -112,7 +112,14 @@ class ChromaBackend:
     # Collection lifecycle
     # ------------------------------------------------------------------
 
-    def get_collection(self, palace_path: str, collection_name: str, create: bool = False):
+    def get_collection(
+        self,
+        palace_path: str,
+        collection_name: str,
+        create: bool = False,
+        embedding_function=None,
+        embedding_model_name: str = None,
+    ):
         if not create and not os.path.isdir(palace_path):
             raise FileNotFoundError(palace_path)
 
@@ -124,19 +131,33 @@ class ChromaBackend:
                 pass
 
         client = self._client(palace_path)
+        ef_kwargs = {"embedding_function": embedding_function} if embedding_function else {}
         if create:
+            metadata = {"hnsw:space": "cosine"}
+            if embedding_model_name:
+                metadata["embedding_model"] = embedding_model_name
             collection = client.get_or_create_collection(
-                collection_name, metadata={"hnsw:space": "cosine"}
+                collection_name, metadata=metadata, **ef_kwargs
             )
         else:
-            collection = client.get_collection(collection_name)
+            collection = client.get_collection(collection_name, **ef_kwargs)
         return ChromaCollection(collection)
 
     def get_or_create_collection(
-        self, palace_path: str, collection_name: str
+        self,
+        palace_path: str,
+        collection_name: str,
+        embedding_function=None,
+        embedding_model_name: str = None,
     ) -> "ChromaCollection":
         """Shorthand for get_collection(..., create=True)."""
-        return self.get_collection(palace_path, collection_name, create=True)
+        return self.get_collection(
+            palace_path,
+            collection_name,
+            create=True,
+            embedding_function=embedding_function,
+            embedding_model_name=embedding_model_name,
+        )
 
     def delete_collection(self, palace_path: str, collection_name: str) -> None:
         """Delete *collection_name* from the palace at *palace_path*."""

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -277,9 +277,25 @@ def cmd_repair(args):
     print(f"  Backing up to {backup_path}...")
     shutil.copytree(palace_path, backup_path)
 
+    # Read the embedding model from the existing collection before deleting
+    from .embedding import get_embedding_function, resolve_model_from_metadata
+
+    try:
+        raw_client = backend._client(palace_path)
+        raw_col = raw_client.get_collection("mempalace_drawers")
+        repair_model = resolve_model_from_metadata(raw_col.metadata)
+    except Exception:
+        repair_model = resolve_model_from_metadata(None)
+    repair_ef = get_embedding_function(repair_model)
+
     print("  Rebuilding collection...")
     backend.delete_collection(palace_path, "mempalace_drawers")
-    new_col = backend.create_collection(palace_path, "mempalace_drawers")
+    new_col = backend.create_collection(
+        palace_path,
+        "mempalace_drawers",
+        embedding_function=repair_ef,
+        embedding_model_name=repair_model,
+    )
 
     filed = 0
     for i in range(0, len(all_ids), batch_size):

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -207,6 +207,20 @@ class MempalaceConfig:
         """Whether the stop hook shows a desktop notification via notify-send."""
         return self._file_config.get("hooks", {}).get("desktop_toast", False)
 
+    @property
+    def embedding_model(self):
+        """Preferred embedding model for new palaces.
+
+        Used only when creating a new palace. Existing palaces read
+        the model from their collection metadata (see embedding.py).
+        """
+        from .embedding import NEW_PALACE_MODEL
+
+        env = os.environ.get("MEMPALACE_EMBEDDING_MODEL")
+        if env:
+            return env
+        return self._file_config.get("embedding_model", NEW_PALACE_MODEL)
+
     def set_hook_setting(self, key: str, value: bool):
         """Update a hook setting and write config to disk."""
         if "hooks" not in self._file_config:

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -1,0 +1,51 @@
+"""
+embedding.py — Centralized embedding model configuration.
+
+Single source of truth for which embedding model the palace uses.
+Resolves model from ChromaDB collection metadata (stamped at build time),
+with fallback to legacy default for existing palaces.
+"""
+
+import os
+
+# Legacy model — used by all palaces created before this feature.
+# ChromaDB 0.6.3 uses this as its built-in default (384 dimensions).
+DEFAULT_MODEL = "all-MiniLM-L6-v2"
+
+# Model for newly created palaces — better search quality (768 dimensions).
+NEW_PALACE_MODEL = "all-mpnet-base-v2"
+
+
+def get_embedding_function(model_name: str):
+    """Return a ChromaDB-compatible embedding function for the given model.
+
+    Uses ChromaDB's built-in SentenceTransformerEmbeddingFunction which
+    auto-downloads and caches the model on first use.
+    """
+    from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
+
+    return SentenceTransformerEmbeddingFunction(model_name=model_name)
+
+
+def resolve_model_from_metadata(collection_metadata: dict) -> str:
+    """Resolve which embedding model was used from collection metadata.
+
+    Returns DEFAULT_MODEL if metadata is missing or doesn't contain the key —
+    this means the palace was created before embedding model tracking existed.
+    """
+    if collection_metadata and "embedding_model" in collection_metadata:
+        return collection_metadata["embedding_model"]
+    return DEFAULT_MODEL
+
+
+def new_palace_model(config=None) -> str:
+    """Return the embedding model to use for new palace creation.
+
+    Resolution: env var > config > NEW_PALACE_MODEL constant.
+    """
+    env = os.environ.get("MEMPALACE_EMBEDDING_MODEL")
+    if env:
+        return env
+    if config is not None and hasattr(config, "embedding_model"):
+        return config.embedding_model
+    return NEW_PALACE_MODEL

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -214,18 +214,30 @@ def _get_client():
 def _get_collection(create=False):
     """Return the ChromaDB collection, caching the client between calls."""
     global _collection_cache, _metadata_cache, _metadata_cache_time
+    from .embedding import get_embedding_function, new_palace_model, resolve_model_from_metadata
+
     try:
         client = _get_client()
         if create:
+            model = new_palace_model(_config)
+            ef = get_embedding_function(model)
             _collection_cache = ChromaCollection(
                 client.get_or_create_collection(
-                    _config.collection_name, metadata={"hnsw:space": "cosine"}
+                    _config.collection_name,
+                    metadata={"hnsw:space": "cosine", "embedding_model": model},
+                    embedding_function=ef,
                 )
             )
             _metadata_cache = None
             _metadata_cache_time = 0
         elif _collection_cache is None:
-            _collection_cache = ChromaCollection(client.get_collection(_config.collection_name))
+            # Read metadata to resolve model, then open with correct EF
+            raw_col = client.get_collection(_config.collection_name)
+            model = resolve_model_from_metadata(raw_col.metadata)
+            ef = get_embedding_function(model)
+            _collection_cache = ChromaCollection(
+                client.get_collection(_config.collection_name, embedding_function=ef)
+            )
             _metadata_cache = None
             _metadata_cache_time = 0
         return _collection_cache
@@ -312,6 +324,15 @@ def tool_status():
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
     }
+    # Report which embedding model this palace uses
+    from .embedding import resolve_model_from_metadata
+
+    try:
+        raw_client = _get_client()
+        raw_col = raw_client.get_collection(_config.collection_name)
+        result["embedding_model"] = resolve_model_from_metadata(raw_col.metadata)
+    except Exception:
+        result["embedding_model"] = "unknown"
     try:
         all_meta = _get_cached_metadata(col)
         for m in all_meta:

--- a/mempalace/migrate.py
+++ b/mempalace/migrate.py
@@ -208,8 +208,17 @@ def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
 
     temp_palace = tempfile.mkdtemp(prefix="mempalace_migrate_")
     print(f"  Creating fresh palace in {temp_palace}...")
+    from .embedding import get_embedding_function, new_palace_model
+
+    migrate_model = new_palace_model()
+    migrate_ef = get_embedding_function(migrate_model)
     fresh_backend = ChromaBackend()
-    col = fresh_backend.get_or_create_collection(temp_palace, "mempalace_drawers")
+    col = fresh_backend.get_or_create_collection(
+        temp_palace,
+        "mempalace_drawers",
+        embedding_function=migrate_ef,
+        embedding_model_name=migrate_model,
+    )
 
     # Re-import in batches
     batch_size = 500

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -54,11 +54,49 @@ def get_collection(
     collection_name: str = "mempalace_drawers",
     create: bool = True,
 ):
-    """Get the palace collection through the backend layer."""
+    """Get the palace collection through the backend layer.
+
+    Resolves the correct embedding model:
+    - On create: uses new_palace_model() (mpnet by default)
+    - On read: reads model from collection metadata, falls back to MiniLM
+    """
+    from .embedding import (
+        get_embedding_function,
+        new_palace_model,
+        resolve_model_from_metadata,
+    )
+
+    if create:
+        model = new_palace_model()
+        ef = get_embedding_function(model)
+        return _DEFAULT_BACKEND.get_collection(
+            palace_path,
+            collection_name=collection_name,
+            create=True,
+            embedding_function=ef,
+            embedding_model_name=model,
+        )
+
+    # For existing palaces: read metadata to determine model.
+    # Check path existence first — _client() would create the directory
+    # as a side effect of PersistentClient(), which breaks callers that
+    # expect FileNotFoundError for missing palaces (e.g. status()).
+    if not os.path.isdir(palace_path):
+        raise FileNotFoundError(palace_path)
+
+    try:
+        raw_client = _DEFAULT_BACKEND._client(palace_path)
+        raw_col = raw_client.get_collection(collection_name)
+        model = resolve_model_from_metadata(raw_col.metadata)
+    except Exception:
+        model = resolve_model_from_metadata(None)
+
+    ef = get_embedding_function(model)
     return _DEFAULT_BACKEND.get_collection(
         palace_path,
         collection_name=collection_name,
-        create=create,
+        create=False,
+        embedding_function=ef,
     )
 
 

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -53,11 +53,12 @@ def get_collection(
     palace_path: str,
     collection_name: str = "mempalace_drawers",
     create: bool = True,
+    config=None,
 ):
     """Get the palace collection through the backend layer.
 
     Resolves the correct embedding model:
-    - On create: uses new_palace_model() (mpnet by default)
+    - On create: uses new_palace_model(config) (mpnet by default)
     - On read: reads model from collection metadata, falls back to MiniLM
     """
     from .embedding import (
@@ -67,7 +68,7 @@ def get_collection(
     )
 
     if create:
-        model = new_palace_model()
+        model = new_palace_model(config)
         ef = get_embedding_function(model)
         return _DEFAULT_BACKEND.get_collection(
             palace_path,

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -260,10 +260,25 @@ def rebuild_index(palace_path=None):
         shutil.copy2(sqlite_path, backup_path)
         print(f"  Backup: {backup_path}")
 
-    # Rebuild with correct HNSW settings
+    # Read the embedding model from the existing collection before deleting
+    from .embedding import get_embedding_function, resolve_model_from_metadata
+
+    try:
+        raw_client = backend._client(palace_path)
+        raw_col = raw_client.get_collection(COLLECTION_NAME)
+        rebuild_model = resolve_model_from_metadata(raw_col.metadata)
+    except Exception:
+        rebuild_model = resolve_model_from_metadata(None)
+    rebuild_ef = get_embedding_function(rebuild_model)
+
     print("  Rebuilding collection with hnsw:space=cosine...")
     backend.delete_collection(palace_path, COLLECTION_NAME)
-    new_col = backend.create_collection(palace_path, COLLECTION_NAME)
+    new_col = backend.create_collection(
+        palace_path,
+        COLLECTION_NAME,
+        embedding_function=rebuild_ef,
+        embedding_model_name=rebuild_model,
+    )
 
     filed = 0
     for i in range(0, len(all_ids), batch_size):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -4,6 +4,7 @@ import chromadb
 import pytest
 
 from mempalace.backends.chroma import ChromaBackend, ChromaCollection, _fix_blob_seq_ids
+from mempalace.embedding import DEFAULT_MODEL, get_embedding_function
 
 
 class _FakeCollection:
@@ -140,3 +141,56 @@ def test_fix_blob_seq_ids_noop_without_blobs(tmp_path):
 def test_fix_blob_seq_ids_noop_without_database(tmp_path):
     """No error when palace has no chroma.sqlite3."""
     _fix_blob_seq_ids(str(tmp_path))  # should not raise
+
+
+def test_chroma_backend_stamps_embedding_model_on_create(tmp_path):
+    palace_path = tmp_path / "palace"
+    ef = get_embedding_function(DEFAULT_MODEL)
+
+    ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=True,
+        embedding_function=ef,
+        embedding_model_name=DEFAULT_MODEL,
+    )
+
+    # Verify model name was stamped in collection metadata
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_collection("mempalace_drawers")
+    assert col.metadata.get("embedding_model") == DEFAULT_MODEL
+
+
+def test_chroma_backend_passes_embedding_function_on_get(tmp_path):
+    palace_path = tmp_path / "palace"
+    ef = get_embedding_function(DEFAULT_MODEL)
+
+    # Create first
+    ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=True,
+        embedding_function=ef,
+        embedding_model_name=DEFAULT_MODEL,
+    )
+
+    # Get with embedding function — should not raise
+    col = ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=False,
+        embedding_function=ef,
+    )
+    assert col.count() == 0
+
+
+def test_chroma_backend_works_without_embedding_function(tmp_path):
+    """Backwards compatibility — no embedding_function still works."""
+    palace_path = tmp_path / "palace"
+
+    col = ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=True,
+    )
+    assert col.count() == 0

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import chromadb
 
 from mempalace.convo_miner import mine_convos
+from mempalace.embedding import get_embedding_function, resolve_model_from_metadata
 from mempalace.palace import file_already_mined
 
 
@@ -20,7 +21,10 @@ def test_convo_mining():
     mine_convos(tmpdir, palace_path, wing="test_convos")
 
     client = chromadb.PersistentClient(path=palace_path)
-    col = client.get_collection("mempalace_drawers")
+    raw_col = client.get_collection("mempalace_drawers")
+    model = resolve_model_from_metadata(raw_col.metadata)
+    ef = get_embedding_function(model)
+    col = client.get_collection("mempalace_drawers", embedding_function=ef)
     assert col.count() >= 2
 
     # Verify search works
@@ -101,7 +105,10 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         capsys.readouterr()
 
         client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        raw_col = client.get_collection("mempalace_drawers")
+        model = resolve_model_from_metadata(raw_col.metadata)
+        ef = get_embedding_function(model)
+        col = client.get_collection("mempalace_drawers", embedding_function=ef)
         resolved = str(Path(tmpdir).resolve() / "chat.txt")
         first_pass = col.get(where={"source_file": resolved})
         first_ids = set(first_pass["ids"])
@@ -140,12 +147,12 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         # Second mine — version gate should trigger rebuild
         mine_convos(tmpdir, palace_path, wing="test")
         out = capsys.readouterr().out
-        assert (
-            "Files skipped (already filed): 0" in out
-        ), "stale drawers should force a rebuild, not a skip"
+        assert "Files skipped (already filed): 0" in out, (
+            "stale drawers should force a rebuild, not a skip"
+        )
 
         client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
+        col = client.get_collection("mempalace_drawers", embedding_function=ef)
         rebuilt = col.get(where={"source_file": resolved})
         # Orphan is gone
         assert "orphan_drawer" not in rebuilt["ids"]

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,6 +1,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+import chromadb
+
 from mempalace.config import MempalaceConfig
 from mempalace.embedding import (
     DEFAULT_MODEL,
@@ -9,6 +11,7 @@ from mempalace.embedding import (
     new_palace_model,
     resolve_model_from_metadata,
 )
+from mempalace.palace import get_collection
 
 
 def test_default_model_is_miniLM():
@@ -83,3 +86,30 @@ def test_new_palace_model_respects_config(tmp_path):
     config = MempalaceConfig(config_dir=str(cfg_dir))
     os.environ.pop("MEMPALACE_EMBEDDING_MODEL", None)
     assert new_palace_model(config) == "config-model"
+
+
+def test_get_collection_stamps_model_on_create(tmp_path):
+    """New palace creation stamps the embedding model in metadata."""
+    palace_path = str(tmp_path / "palace")
+    os.environ.pop("MEMPALACE_EMBEDDING_MODEL", None)
+
+    get_collection(palace_path, create=True)
+
+    # Verify the model was stamped
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_collection("mempalace_drawers")
+    assert col.metadata.get("embedding_model") == NEW_PALACE_MODEL
+
+
+def test_get_collection_legacy_palace_uses_default(tmp_path):
+    """Palace without embedding_model metadata resolves to MiniLM."""
+    palace_path = str(tmp_path / "palace")
+
+    # Create a legacy palace (no embedding_model in metadata)
+    client = chromadb.PersistentClient(path=palace_path)
+    client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
+    del client
+
+    # get_collection should detect legacy and use MiniLM — should not raise
+    col = get_collection(palace_path, create=False)
+    assert col is not None

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,59 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from mempalace.embedding import (
+    DEFAULT_MODEL,
+    NEW_PALACE_MODEL,
+    get_embedding_function,
+    new_palace_model,
+    resolve_model_from_metadata,
+)
+
+
+def test_default_model_is_miniLM():
+    assert DEFAULT_MODEL == "all-MiniLM-L6-v2"
+
+
+def test_new_palace_model_is_mpnet():
+    assert NEW_PALACE_MODEL == "all-mpnet-base-v2"
+
+
+def test_resolve_from_metadata_returns_stored_model():
+    metadata = {"hnsw:space": "cosine", "embedding_model": "custom-model-v1"}
+    assert resolve_model_from_metadata(metadata) == "custom-model-v1"
+
+
+def test_resolve_from_metadata_returns_default_when_absent():
+    metadata = {"hnsw:space": "cosine"}
+    assert resolve_model_from_metadata(metadata) == DEFAULT_MODEL
+
+
+def test_resolve_from_metadata_handles_none():
+    assert resolve_model_from_metadata(None) == DEFAULT_MODEL
+
+
+def test_resolve_from_metadata_handles_empty_dict():
+    assert resolve_model_from_metadata({}) == DEFAULT_MODEL
+
+
+def test_new_palace_model_returns_mpnet_by_default():
+    os.environ.pop("MEMPALACE_EMBEDDING_MODEL", None)
+    assert new_palace_model() == NEW_PALACE_MODEL
+
+
+def test_new_palace_model_respects_env_var(monkeypatch):
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "my-custom-model")
+    assert new_palace_model() == "my-custom-model"
+
+
+def test_get_embedding_function_returns_callable():
+    mock_ef_class = MagicMock()
+    mock_ef_instance = MagicMock()
+    mock_ef_class.return_value = mock_ef_instance
+    with patch(
+        "chromadb.utils.embedding_functions.SentenceTransformerEmbeddingFunction",
+        mock_ef_class,
+    ):
+        ef = get_embedding_function(DEFAULT_MODEL)
+        assert callable(ef)
+        mock_ef_class.assert_called_once_with(model_name=DEFAULT_MODEL)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import MagicMock, patch
 
+from mempalace.config import MempalaceConfig
 from mempalace.embedding import (
     DEFAULT_MODEL,
     NEW_PALACE_MODEL,
@@ -57,3 +58,28 @@ def test_get_embedding_function_returns_callable():
         ef = get_embedding_function(DEFAULT_MODEL)
         assert callable(ef)
         mock_ef_class.assert_called_once_with(model_name=DEFAULT_MODEL)
+
+
+def test_config_embedding_model_default(tmp_path):
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text("{}")
+    config = MempalaceConfig(config_dir=str(cfg_dir))
+    assert config.embedding_model == NEW_PALACE_MODEL
+
+
+def test_config_embedding_model_from_file(tmp_path):
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text('{"embedding_model": "custom-model"}')
+    config = MempalaceConfig(config_dir=str(cfg_dir))
+    assert config.embedding_model == "custom-model"
+
+
+def test_new_palace_model_respects_config(tmp_path):
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text('{"embedding_model": "config-model"}')
+    config = MempalaceConfig(config_dir=str(cfg_dir))
+    os.environ.pop("MEMPALACE_EMBEDDING_MODEL", None)
+    assert new_palace_model(config) == "config-model"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -291,6 +291,15 @@ class TestReadTools:
         result = tool_status()
         assert "error" in result
 
+    def test_status_reports_embedding_model(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_status
+
+        result = tool_status()
+        assert "embedding_model" in result
+
 
 # ── Search Tool ─────────────────────────────────────────────────────────
 
@@ -444,9 +453,9 @@ class TestWriteTools:
 
         assert result1["success"] is True
         assert result2["success"] is True
-        assert (
-            result1["drawer_id"] != result2["drawer_id"]
-        ), "Documents with shared header but different content must have distinct drawer IDs"
+        assert result1["drawer_id"] != result2["drawer_id"], (
+            "Documents with shared header but different content must have distinct drawer IDs"
+        )
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -226,19 +226,36 @@ def test_rebuild_index_success(mock_backend_cls, mock_shutil, tmp_path):
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
     }
 
+    # Fake raw collection metadata for embedding model resolution
+    mock_raw_col = MagicMock()
+    mock_raw_col.metadata = {"hnsw:space": "cosine", "embedding_model": "test-model"}
+
     mock_new_col = MagicMock()
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
     mock_backend.create_collection.return_value = mock_new_col
+    mock_raw_client = MagicMock()
+    mock_raw_client.get_collection.return_value = mock_raw_col
+    mock_backend._client.return_value = mock_raw_client
 
-    repair.rebuild_index(palace_path=str(tmp_path))
+    mock_ef = MagicMock()
+    with (
+        patch("mempalace.embedding.get_embedding_function", return_value=mock_ef),
+        patch("mempalace.embedding.resolve_model_from_metadata", return_value="test-model"),
+    ):
+        repair.rebuild_index(palace_path=str(tmp_path))
 
     # Verify: backed up sqlite only (not copytree)
     mock_shutil.copy2.assert_called_once()
     assert "chroma.sqlite3" in str(mock_shutil.copy2.call_args)
 
-    # Verify: deleted and recreated (cosine is the backend default)
+    # Verify: deleted and recreated with embedding config
     mock_backend.delete_collection.assert_called_once_with(str(tmp_path), "mempalace_drawers")
-    mock_backend.create_collection.assert_called_once_with(str(tmp_path), "mempalace_drawers")
+    mock_backend.create_collection.assert_called_once_with(
+        str(tmp_path),
+        "mempalace_drawers",
+        embedding_function=mock_ef,
+        embedding_model_name="test-model",
+    )
 
     # Verify: used upsert not add
     mock_new_col.upsert.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #903

Adds centralized embedding model configuration so the MCP server, CLI search, and all ingest paths use the same model — fixing silent query failures when models mismatch.

### Design Decisions

1. **Storage approach:** Embedding model name stored in ChromaDB collection metadata (not a separate file). Atomic with the collection, can't desync. Absence of the key = legacy palace.

2. **Default for new palaces:** `all-mpnet-base-v2` (768-dim) — better search quality (+3.5pp on LoCoMo R@10 benchmarks over MiniLM).

3. **Default for existing palaces:** `all-MiniLM-L6-v2` (384-dim) — backwards compatible, no re-mining required. Detected by absence of `embedding_model` key in collection metadata.

4. **Resolution chain:** Collection metadata (authoritative) > config file / env var (new palaces only) > built-in default. This means once a palace is created, its model is locked in and self-describing.

5. **No migration tool in this PR:** Re-embedding existing palaces from MiniLM to mpnet is a separate concern. This PR prevents the mismatch; migrating existing palaces is a follow-up.

6. **All create paths stamp the model:** Repair, rebuild, and migrate operations preserve the original model through the delete/recreate cycle.

### Resolution chain
```
1. Collection metadata "embedding_model" key (authoritative, stamped at build)
2. If absent → legacy palace → all-MiniLM-L6-v2
3. config.json "embedding_model" or MEMPALACE_EMBEDDING_MODEL env var → new palace creation only
```

### Files changed
- **New:** `mempalace/embedding.py` — model registry, resolution, embedding function factory
- **Modified:** `mempalace/config.py` — `embedding_model` property on MempalaceConfig
- **Modified:** `mempalace/backends/chroma.py` — `get_collection()`, `get_or_create_collection()`, `create_collection()` accept `embedding_function` + `embedding_model_name`
- **Modified:** `mempalace/palace.py` — resolves model from metadata on read, stamps on create
- **Modified:** `mempalace/mcp_server.py` — `_get_collection()` uses correct embedding function, `tool_status()` reports active model
- **Modified:** `mempalace/cli.py`, `mempalace/repair.py`, `mempalace/migrate.py` — all collection-create paths now stamp embedding model

### Known follow-ups (not in scope)
- Performance: double `get_collection` call on read paths for metadata resolution (~ms overhead, within budget)
- Migration tool to re-embed existing MiniLM palaces with mpnet
- OpenAI/external embedding support (#756)
- GPU acceleration (#515)

## Test plan
- [x] 936/936 tests pass locally
- [x] Legacy palace (no metadata key) resolves to MiniLM
- [x] New palace creation stamps mpnet in collection metadata
- [x] Config override and env var override work
- [x] Repair/migrate preserve embedding model through rebuild
- [x] `mempalace_status` reports active embedding model
- [x] `ruff check` and `ruff format` clean
