### PR TITLE
feat(cli): add version display and version flag to CLI

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -34,6 +34,7 @@ import argparse
 from pathlib import Path
 
 from .config import MempalaceConfig
+from .version import __version__
 
 
 _MEMPALACE_PROJECT_FILES = ("mempalace.yaml", "entities.json")
@@ -470,10 +471,17 @@ def cmd_compress(args):
 
 
 def main():
+    version_label = f"MemPalace {__version__}"
     parser = argparse.ArgumentParser(
         description="MemPalace — Give your AI a memory. No API key required.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__,
+        epilog=f"{version_label}\n\n{__doc__}",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=version_label,
+        help="Show version and exit",
     )
     parser.add_argument(
         "--palace",


### PR DESCRIPTION
Introduces a version label to the command-line interface, displaying the current MemPalace version in the help text. Adds a `--version` flag to allow users to easily check the version and exit.

## What does this PR do?

## How to test
python -m mempalace.cli --version

## Checklist
- [X] Tests pass (`python -m pytest tests/ -v`)
- [X] No hardcoded paths
- [X] Linter passes (`ruff check .`)
