### PR TITLE
fix(diary): detect same-length edits via sha256 (#925)

### DIFF
--- a/mempalace/diary_ingest.py
+++ b/mempalace/diary_ingest.py
@@ -120,11 +120,14 @@ def ingest_diaries(
             continue
         date_str = date_match.group(1)
 
-        # Skip if content hasn't changed
+        # Skip if content hasn't changed. Hash the text so same-length edits
+        # (e.g. typo fix "teh" -> "the") still trigger re-ingest. Length alone
+        # would silently keep the stale drawer, violating verbatim recall.
         state_key = f"{wing}|{diary_path.name}"
-        prev_size = state.get(state_key, {}).get("size", 0)
-        curr_size = len(text)
-        if curr_size == prev_size and not force:
+        curr_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        prev_entry = state.get(state_key, {})
+        prev_hash = prev_entry.get("sha256")
+        if prev_hash == curr_hash and not force:
             continue
 
         now_iso = datetime.now(timezone.utc).isoformat()
@@ -152,7 +155,7 @@ def ingest_diaries(
             )
 
             entries = _split_entries(text)
-            prev_entry_count = state.get(state_key, {}).get("entry_count", 0)
+            prev_entry_count = prev_entry.get("entry_count", 0)
             new_entries = entries if force else entries[prev_entry_count:]
 
             if new_entries:
@@ -183,7 +186,7 @@ def ingest_diaries(
                     closets_created += n
 
             state[state_key] = {
-                "size": curr_size,
+                "sha256": curr_hash,
                 "entry_count": len(entries),
                 "ingested_at": now_iso,
             }

--- a/tests/test_diary_ingest_content_hash.py
+++ b/tests/test_diary_ingest_content_hash.py
@@ -1,0 +1,90 @@
+"""Regression tests for issue #925 — diary re-ingest must detect same-length edits.
+
+Before the fix, ``diary_ingest`` compared ``len(text)`` to the previously
+recorded byte length to decide whether a file changed. Same-length edits
+(typo fix ``teh`` -> ``the``, character swaps, equal-length word substitutions)
+were silently skipped and the palace kept the stale drawer — violating the
+verbatim-recall promise.
+
+The fix records a sha256 of the file content in the state file instead.
+"""
+
+import json
+from pathlib import Path
+
+from mempalace.diary_ingest import _state_file_for, ingest_diaries
+
+
+def _write_diary(diary_dir: Path, name: str, body: str) -> Path:
+    path = diary_dir / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _state_for(palace_path: str, diary_dir: Path) -> dict:
+    state_file = _state_file_for(palace_path, diary_dir)
+    return json.loads(state_file.read_text())
+
+
+def test_same_length_edit_triggers_reingest(tmp_path, palace_path):
+    """A typo fix (same byte length) must re-ingest the drawer.
+
+    Without the fix this assertion failed: the second ingest reported
+    ``days_updated == 0`` and the drawer kept the stale text.
+    """
+    diary_dir = tmp_path / "diary"
+    diary_dir.mkdir()
+
+    original = (
+        "## Morning\n"
+        "teh quick brown fox jumps over the lazy dog. "
+        "Some padding so the file passes the 50-char minimum length check.\n"
+    )
+    diary_file = _write_diary(diary_dir, "2026-04-15.md", original)
+    first = ingest_diaries(diary_dir=str(diary_dir), palace_path=palace_path)
+    assert first["days_updated"] == 1
+
+    corrected = original.replace("teh quick", "the quick", 1)
+    assert len(corrected) == len(original), "test premise: same-length edit"
+    diary_file.write_text(corrected, encoding="utf-8")
+
+    second = ingest_diaries(diary_dir=str(diary_dir), palace_path=palace_path)
+    assert second["days_updated"] == 1, "same-length typo fix must trigger re-ingest (issue #925)"
+
+
+def test_unchanged_file_is_skipped(tmp_path, palace_path):
+    """Re-running ingest on an unchanged file is still a no-op."""
+    diary_dir = tmp_path / "diary"
+    diary_dir.mkdir()
+
+    body = (
+        "## Notes\n"
+        "Stable content that is not edited between ingest runs. "
+        "Long enough to clear the 50-char minimum.\n"
+    )
+    _write_diary(diary_dir, "2026-04-16.md", body)
+
+    first = ingest_diaries(diary_dir=str(diary_dir), palace_path=palace_path)
+    second = ingest_diaries(diary_dir=str(diary_dir), palace_path=palace_path)
+
+    assert first["days_updated"] == 1
+    assert second["days_updated"] == 0
+
+
+def test_state_file_records_sha256(tmp_path, palace_path):
+    """State file must persist the content hash, not byte length."""
+    diary_dir = tmp_path / "diary"
+    diary_dir.mkdir()
+
+    body = (
+        "## Entry\n"
+        "Content used to verify the on-disk state schema. "
+        "Padding to clear the 50-char minimum length.\n"
+    )
+    _write_diary(diary_dir, "2026-04-17.md", body)
+
+    ingest_diaries(diary_dir=str(diary_dir), palace_path=palace_path)
+    state = _state_for(palace_path, diary_dir.resolve())
+    entry = next(iter(state.values()))
+    assert "sha256" in entry and len(entry["sha256"]) == 64
+    assert "size" not in entry  # legacy key removed


### PR DESCRIPTION
## What and Why

`diary_ingest` decided whether a diary file changed by comparing **byte length**. Any in-place edit that preserved total length (typo fix `teh`→`the`, equal-length word swap, character reorder) was silently skipped on re-ingest. The drawer kept the stale text and the **Verbatim always** / **100% recall** promise was broken until the user ran `--force`.

## Root Cause

[`mempalace/diary_ingest.py:123-128`](https://github.com/MemPalace/mempalace/blob/develop/mempalace/diary_ingest.py#L123-L128) before this change:

```python
prev_size = state.get(state_key, {}).get("size", 0)
curr_size = len(text)
if curr_size == prev_size and not force:
    continue
```

## Reproduction

1. Write `~/diary/2026-04-15.md` with `teh quick brown fox …` and ingest.
2. Edit `teh` → `the` (same byte length). Save.
3. Re-run ingest.

**Expected:** drawer + closets reflect the corrected text.
**Actual (before fix):** file skipped, drawer still contains `teh`.

## Change Summary

- `mempalace/diary_ingest.py` — replace `len(text) == prev_size` with `sha256(text) == prev_hash`. State key renamed `size` → `sha256`. Old state files with no `sha256` key fall through naturally and the file is re-ingested once on first run after upgrade (no migration step needed).
- `tests/test_diary_ingest_content_hash.py` — three regression tests covering: same-length edit triggers re-ingest, unchanged file still skipped, state file persists the hash.

## Test Plan

- [x] `ruff check .` and `ruff format --check .` — clean
- [x] Full suite: `pytest tests/ --ignore=tests/benchmarks` — **948 passed**
- [x] New regression tests pass and prove the bug existed (asserting `days_updated == 1` after a same-length edit fails on `develop`)
- [x] Manually confirmed an unchanged file is still a no-op on the second run

Closes #925