### PR TITLE
fix: sanitize topic parameter in tool_diary_write

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -925,6 +925,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
     try:
         agent_name = sanitize_name(agent_name, "agent_name")
         entry = sanitize_content(entry)
+        topic = sanitize_name(topic, "topic")
     except ValueError as e:
         return {"success": False, "error": str(e)}
 


### PR DESCRIPTION
## What does this PR do?

`tool_diary_write` validates `agent_name` via `sanitize_name()` (line 926) and `entry` via `sanitize_content()` (line 927), but stores `topic` raw into ChromaDB metadata at line 967. Any string — including null bytes, path traversal sequences, or megabyte-length payloads — passes through unchecked.

```python
# Before
def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
    agent_name = sanitize_name(agent_name, "agent_name")  # ✓
    entry = sanitize_content(entry)                         # ✓
    # topic — stored raw at line 967                        # ✗

# After
def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
    agent_name = sanitize_name(agent_name, "agent_name")  # ✓
    entry = sanitize_content(entry)                         # ✓
    topic = sanitize_name(topic, "topic")                   # ✓ added
```

This is consistent with the input validation pattern already applied to every other MCP tool parameter (e.g. `wing`, `room`, `agent_name` in `tool_add_drawer`; `subject`/`predicate`/`object` in `tool_kg_add` via `sanitize_kg_value`).

Refs: #934 (Finding 4)

## How to test

```python
from mempalace.mcp_server import tool_diary_write

# Should be rejected (null byte)
result = tool_diary_write("test_agent", "hello", topic="bad\x00topic")
assert result["success"] is False

# Should be rejected (too long)
result = tool_diary_write("test_agent", "hello", topic="x" * 200)
assert result["success"] is False

# Should succeed (normal topic)
result = tool_diary_write("test_agent", "hello", topic="daily_standup")
assert result["success"] is True
```

## Checklist

- [x] `ruff check mempalace/mcp_server.py` — passed
- [x] `ruff format --check mempalace/mcp_server.py` — passed