### PR TITLE
fix: LLM retry on JSONDecodeError + exporter symlink resolution

### DIFF
--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -160,7 +160,7 @@ def _call_llm(cfg: LLMConfig, source_file: str, wing: str, room: str, content: s
             parsed = json.loads(text)
             return parsed, payload.get("usage")
         except json.JSONDecodeError:
-            return None, None
+            continue  # LLM output is nondeterministic; retry
         except urllib.error.HTTPError as e:
             # 429 / 503 = retry with backoff
             if e.code in (429, 503) and attempt < 2:

--- a/mempalace/exporter.py
+++ b/mempalace/exporter.py
@@ -48,6 +48,7 @@ def export_palace(palace_path: str, output_dir: str, format: str = "markdown") -
         print("  Palace is empty — nothing to export.")
         return {"wings": 0, "rooms": 0, "drawers": 0}
 
+    output_dir = os.path.realpath(output_dir)
     os.makedirs(output_dir, exist_ok=True)
     try:
         os.chmod(output_dir, 0o700)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1118,10 +1118,17 @@ def tool_reconnect():
     Use after external scripts or CLI commands modify the palace database
     directly, which can leave the in-memory HNSW index stale.
     """
-    global _collection_cache, _palace_db_inode, _palace_db_mtime
+    global \
+        _collection_cache, \
+        _palace_db_inode, \
+        _palace_db_mtime, \
+        _metadata_cache, \
+        _metadata_cache_time
     _collection_cache = None
     _palace_db_inode = 0
     _palace_db_mtime = 0.0
+    _metadata_cache = None
+    _metadata_cache_time = 0
     try:
         col = _get_collection()
         if col is None:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1118,17 +1118,10 @@ def tool_reconnect():
     Use after external scripts or CLI commands modify the palace database
     directly, which can leave the in-memory HNSW index stale.
     """
-    global \
-        _collection_cache, \
-        _palace_db_inode, \
-        _palace_db_mtime, \
-        _metadata_cache, \
-        _metadata_cache_time
+    global _collection_cache, _palace_db_inode, _palace_db_mtime
     _collection_cache = None
     _palace_db_inode = 0
     _palace_db_mtime = 0.0
-    _metadata_cache = None
-    _metadata_cache_time = 0
     try:
         col = _get_collection()
         if col is None:


### PR DESCRIPTION
## Summary

Two independent resilience fixes. Finding 6 (metadata cache reset in `tool_reconnect`) was dropped after @mvalentsev's call-chain analysis showed `_get_client` already clears the cache via the inode/mtime mismatch branch.

Refs: #934 — specifically #1155 (finding 5) and #1156 (finding 7).

## What changed

### `mempalace/closet_llm.py` — retry on JSONDecodeError (#1155)

`_call_llm` runs a 3-attempt retry loop. HTTP 429/503 correctly `continue`, but `json.JSONDecodeError` from malformed LLM output immediately returned `(None, None)`, exiting the loop on first bad response. LLM output is nondeterministic — a single malformed response should not permanently skip the source file.

```python
# Before
except json.JSONDecodeError:
    return None, None    # exits the loop

# After
except json.JSONDecodeError:
    continue              # LLM output is nondeterministic; retry
```

### `mempalace/exporter.py` — resolve symlinks on output path (#1156)

`os.makedirs(output_dir)` follows symlinks. The miner already refuses symlinked inputs (`miner.py`, `convo_miner.py`); the exporter should apply the same rule to outputs. Defense-in-depth.

```python
# Before
os.makedirs(output_dir, exist_ok=True)

# After
output_dir = os.path.realpath(output_dir)
os.makedirs(output_dir, exist_ok=True)
```

## Dropped: finding 6 (metadata cache reset)

Dropped in d7e3197. The "fix" was redundant — `tool_reconnect` already clears `_metadata_cache` indirectly through the `_get_client` mismatch path.

## Checklist

- [x] `ruff check` — passed
- [x] `ruff format --check` — passed