### PR TITLE
ci: add pip caching and bump Python on macOS/Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -v --ignore=tests/benchmarks --cov=mempalace --cov-report=term-missing --cov-fail-under=80 --durations=10
 
@@ -26,7 +27,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.11"
+          cache: 'pip'
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -v --ignore=tests/benchmarks --cov=mempalace --cov-report=term-missing --cov-fail-under=80 --durations=10
 
@@ -36,7 +38,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.11"
+          cache: 'pip'
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -v --ignore=tests/benchmarks --cov=mempalace --cov-report=term-missing --cov-fail-under=80 --durations=10
   lint:
@@ -46,6 +49,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: 'pip'
       - run: pip install "ruff>=0.4.0,<0.5"
       - run: ruff check .
       - run: ruff format --check .


### PR DESCRIPTION
## What

- Enable `setup-python`'s built-in `cache: 'pip'` on all four CI jobs (test-linux, test-windows, test-macos, lint). Avoids re-downloading ~300 MB of dependencies (chromadb, onnxruntime, hnswlib) on every run.
- Bump macOS and Windows from Python 3.9 to 3.11. Linux matrix already covers 3.9/3.11/3.13, so cross-platform runs on 3.9 are redundant. Python 3.11 is meaningfully faster and has better ARM support on macOS.

## Why

test-windows typically takes 3m30s–5m vs ~1m30s on Linux. Dependency installation accounts for ~95 MB of wheel downloads per push, which `cache: 'pip'` avoids on subsequent runs.

## Related

#277 also proposes bumping Windows to 3.11 (as part of a broader CI restructure). This PR is a smaller, standalone change that can land independently.

## Test plan

- [x] CI passes on all platforms (Linux 3.9/3.11/3.13, Windows 3.11, macOS 3.11, lint)
- [x] `cache: 'pip'` active on all four jobs (visible in the `Set up Python` step)


