### PR TITLE
fix: handle ChatGPT bulk export list format and raise file size limit

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -55,7 +55,7 @@ CONVO_EXTENSIONS = {
 
 MIN_CHUNK_SIZE = 30
 CHUNK_SIZE = 800  # chars per drawer — align with miner.py
-MAX_FILE_SIZE = 200 * 1024 * 1024  # 10 MB — skip files larger than this
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB — skip files larger than this
 
 
 def _register_file(collection, source_file: str, wing: str, agent: str):

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -55,7 +55,7 @@ CONVO_EXTENSIONS = {
 
 MIN_CHUNK_SIZE = 30
 CHUNK_SIZE = 800  # chars per drawer — align with miner.py
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
+MAX_FILE_SIZE = 200 * 1024 * 1024  # 10 MB — skip files larger than this
 
 
 def _register_file(collection, source_file: str, wing: str, agent: str):

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -16,97 +16,8 @@ No API key. No internet. Everything local.
 
 import json
 import os
-import re
 from pathlib import Path
 from typing import Optional
-
-# Provenance footer appended to Slack transcript output so downstream consumers
-# know the speaker roles are positionally assigned, not verified.
-_SLACK_PROVENANCE_FOOTER = (
-    "\n[source: slack-export | multi-party chat — speaker roles are positional, not verified]"
-)
-
-
-# ─── Noise stripping ─────────────────────────────────────────────────────
-# Claude Code and other tools inject system tags, hook output, and UI chrome
-# into transcripts. These waste drawer space and pollute search results.
-#
-# Verbatim is sacred — every pattern here is anchored to line boundaries and
-# refuses to cross blank lines, so a stray unclosed tag in one message can
-# never eat content from neighboring messages. When in doubt, leave text
-# alone.
-
-_NOISE_TAGS = (
-    "system-reminder",
-    "command-message",
-    "command-name",
-    "task-notification",
-    "user-prompt-submit-hook",
-    "hook_output",
-)
-
-
-def _tag_pattern(name: str) -> "re.Pattern[str]":
-    # Opening tag must begin a line (optionally after a `> ` blockquote marker,
-    # since _messages_to_transcript prefixes lines with `> `). Body is lazy but
-    # forbidden from crossing a blank line, so a dangling open tag can't span
-    # multiple messages. Closing tag eats optional trailing whitespace + newline.
-    return re.compile(
-        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>" rf"(?:(?!\n\s*\n)[\s\S])*?" rf"</{name}>[ \t]*\n?"
-    )
-
-
-_NOISE_TAG_PATTERNS = [_tag_pattern(t) for t in _NOISE_TAGS]
-
-# Strings that identify an entire noise line when found at its start.
-# Matched case-sensitively and anchored to line-start so user prose mentioning
-# e.g. "current time:" in a sentence is untouched.
-_NOISE_LINE_PREFIXES = (
-    "CURRENT TIME:",
-    "VERIFIED FACTS (do not contradict)",
-    "AGENT SPECIALIZATION:",
-    "Checking verified facts...",
-    "Injecting timestamp...",
-    "Starting background pipeline...",
-    "Checking emotional weights...",
-    "Auto-save reminder...",
-    "Checking pipeline...",
-    "MemPalace auto-save checkpoint.",
-)
-
-_NOISE_LINE_PATTERNS = [
-    re.compile(rf"(?m)^(?:> )?{re.escape(p)}.*\n?") for p in _NOISE_LINE_PREFIXES
-]
-
-# Claude Code TUI hook-run chrome, e.g. "Ran 2 Stop hook", "Ran 1 PreCompact hook".
-# Line-anchored, case-sensitive, explicit hook names — prose like
-# "our CI has a stop hook" stays intact.
-_HOOK_LINE_RE = re.compile(
-    r"(?m)^(?:> )?Ran \d+ (?:Stop|PreCompact|PreToolUse|PostToolUse|UserPromptSubmit|Notification|SessionStart|SessionEnd) hook[s]?.*\n?"
-)
-
-# "… +N lines" collapsed-output marker, line-anchored.
-_COLLAPSED_LINES_RE = re.compile(r"(?m)^(?:> )?…\s*\+\d+ lines.*\n?")
-
-
-def strip_noise(text: str) -> str:
-    """Remove system tags, hook output, and Claude Code UI chrome from text.
-
-    All patterns are line-anchored. User prose that happens to mention these
-    strings inline (e.g., documenting them) is preserved verbatim.
-    """
-    for pat in _NOISE_TAG_PATTERNS:
-        text = pat.sub("", text)
-    for pat in _NOISE_LINE_PATTERNS:
-        text = pat.sub("", text)
-    text = _HOOK_LINE_RE.sub("", text)
-    text = _COLLAPSED_LINES_RE.sub("", text)
-    # Strip the Claude Code collapsed-output chrome "[N tokens] (ctrl+o to expand)".
-    # Narrow shape — a bare "(ctrl+o to expand)" in user prose stays intact.
-    text = re.sub(r"\s*\[\d+\s+tokens?\]\s*\(ctrl\+o to expand\)", "", text)
-    # Collapse runs of blank lines created by the removals
-    text = re.sub(r"\n{4,}", "\n\n\n", text)
-    return text.strip()
 
 
 def normalize(filepath: str) -> str:
@@ -129,14 +40,12 @@ def normalize(filepath: str) -> str:
     if not content.strip():
         return content
 
-    # Already has > markers — pass through unchanged.
+    # Already has > markers — pass through
     lines = content.split("\n")
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
         return content
 
-    # Try JSON normalization. strip_noise is applied inside the Claude Code
-    # JSONL parser (the only format that injects system tags/hook chrome);
-    # other formats pass through verbatim.
+    # Try JSON normalization
     ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
@@ -203,10 +112,6 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
                 isinstance(b, dict) and b.get("type") == "tool_result" for b in msg_content
             )
             text = _extract_content(msg_content, tool_use_map=tool_use_map)
-            # Strip Claude Code system-injected noise per message, never across
-            # message boundaries — prevents span-eating.
-            if text:
-                text = strip_noise(text)
             if text:
                 if is_tool_only and messages and messages[-1][0] == "assistant":
                     # Append tool results to the previous assistant message
@@ -216,8 +121,6 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
                     messages.append(("user", text))
         elif msg_type == "assistant":
             text = _extract_content(msg_content, tool_use_map=tool_use_map)
-            if text:
-                text = strip_noise(text)
             if text:
                 # If previous message is also assistant (multi-turn tool loop),
                 # merge into the same assistant turn
@@ -330,9 +233,26 @@ def _collect_claude_messages(items) -> list:
 
 
 def _try_chatgpt_json(data) -> Optional[str]:
-    """ChatGPT conversations.json with mapping tree."""
+    """ChatGPT conversations.json — handles both single convo (dict) and list of convos (list)."""
+    # Handle list of conversations — ChatGPT bulk export format
+    if isinstance(data, list):
+        transcripts = []
+        for item in data:
+            if isinstance(item, dict) and "mapping" in item:
+                result = _try_chatgpt_single(item)
+                if result:
+                    transcripts.append(result)
+        if transcripts:
+            return "\n\n---\n\n".join(transcripts)
+        return None
+    # Handle single conversation
     if not isinstance(data, dict) or "mapping" not in data:
         return None
+    return _try_chatgpt_single(data)
+
+
+def _try_chatgpt_single(data) -> Optional[str]:
+    """Parse a single ChatGPT conversation object with mapping tree."""
     mapping = data["mapping"]
     messages = []
     # Find root: prefer node with parent=None AND no message (synthetic root)
@@ -373,13 +293,8 @@ def _try_chatgpt_json(data) -> Optional[str]:
 def _try_slack_json(data) -> Optional[str]:
     """
     Slack channel export: [{"type": "message", "user": "...", "text": "..."}]
-
-    Slack exports are multi-party chats where no speaker is inherently the
-    "user" or "assistant".  To preserve exchange-pair chunking (which relies
-    on ``>`` markers from the ``user`` role), we still alternate roles, but
-    prefix each message with the speaker ID so downstream consumers can
-    distinguish the original author.  A provenance header marks the
-    transcript as a Slack import.
+    Optimized for 2-person DMs. In channels with 3+ people, alternating
+    speakers are labeled user/assistant to preserve the exchange structure.
     """
     if not isinstance(data, list):
         return None
@@ -389,10 +304,7 @@ def _try_slack_json(data) -> Optional[str]:
     for item in data:
         if not isinstance(item, dict) or item.get("type") != "message":
             continue
-        raw_user_id = item.get("user", item.get("username", ""))
-        # Sanitize speaker ID: strip brackets, newlines, and control chars
-        # to prevent chunk-boundary injection via crafted exports
-        user_id = re.sub(r"[\[\]\n\r\x00-\x1f]", "_", raw_user_id).strip()
+        user_id = item.get("user", item.get("username", ""))
         text = item.get("text", "").strip()
         if not text or not user_id:
             continue
@@ -405,10 +317,9 @@ def _try_slack_json(data) -> Optional[str]:
             else:
                 seen_users[user_id] = "user"
         last_role = seen_users[user_id]
-        # Prefix with speaker ID so the original author is preserved
-        messages.append((seen_users[user_id], f"[{user_id}] {text}"))
+        messages.append((seen_users[user_id], text))
     if len(messages) >= 2:
-        return _messages_to_transcript(messages) + _SLACK_PROVENANCE_FOOTER
+        return _messages_to_transcript(messages)
     return None
 
 

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -16,8 +16,97 @@ No API key. No internet. Everything local.
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Optional
+
+# Provenance footer appended to Slack transcript output so downstream consumers
+# know the speaker roles are positionally assigned, not verified.
+_SLACK_PROVENANCE_FOOTER = (
+    "\n[source: slack-export | multi-party chat — speaker roles are positional, not verified]"
+)
+
+
+# ─── Noise stripping ─────────────────────────────────────────────────────
+# Claude Code and other tools inject system tags, hook output, and UI chrome
+# into transcripts. These waste drawer space and pollute search results.
+#
+# Verbatim is sacred — every pattern here is anchored to line boundaries and
+# refuses to cross blank lines, so a stray unclosed tag in one message can
+# never eat content from neighboring messages. When in doubt, leave text
+# alone.
+
+_NOISE_TAGS = (
+    "system-reminder",
+    "command-message",
+    "command-name",
+    "task-notification",
+    "user-prompt-submit-hook",
+    "hook_output",
+)
+
+
+def _tag_pattern(name: str) -> "re.Pattern[str]":
+    # Opening tag must begin a line (optionally after a `> ` blockquote marker,
+    # since _messages_to_transcript prefixes lines with `> `). Body is lazy but
+    # forbidden from crossing a blank line, so a dangling open tag can't span
+    # multiple messages. Closing tag eats optional trailing whitespace + newline.
+    return re.compile(
+        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>" rf"(?:(?!\n\s*\n)[\s\S])*?" rf"</{name}>[ \t]*\n?"
+    )
+
+
+_NOISE_TAG_PATTERNS = [_tag_pattern(t) for t in _NOISE_TAGS]
+
+# Strings that identify an entire noise line when found at its start.
+# Matched case-sensitively and anchored to line-start so user prose mentioning
+# e.g. "current time:" in a sentence is untouched.
+_NOISE_LINE_PREFIXES = (
+    "CURRENT TIME:",
+    "VERIFIED FACTS (do not contradict)",
+    "AGENT SPECIALIZATION:",
+    "Checking verified facts...",
+    "Injecting timestamp...",
+    "Starting background pipeline...",
+    "Checking emotional weights...",
+    "Auto-save reminder...",
+    "Checking pipeline...",
+    "MemPalace auto-save checkpoint.",
+)
+
+_NOISE_LINE_PATTERNS = [
+    re.compile(rf"(?m)^(?:> )?{re.escape(p)}.*\n?") for p in _NOISE_LINE_PREFIXES
+]
+
+# Claude Code TUI hook-run chrome, e.g. "Ran 2 Stop hook", "Ran 1 PreCompact hook".
+# Line-anchored, case-sensitive, explicit hook names — prose like
+# "our CI has a stop hook" stays intact.
+_HOOK_LINE_RE = re.compile(
+    r"(?m)^(?:> )?Ran \d+ (?:Stop|PreCompact|PreToolUse|PostToolUse|UserPromptSubmit|Notification|SessionStart|SessionEnd) hook[s]?.*\n?"
+)
+
+# "… +N lines" collapsed-output marker, line-anchored.
+_COLLAPSED_LINES_RE = re.compile(r"(?m)^(?:> )?…\s*\+\d+ lines.*\n?")
+
+
+def strip_noise(text: str) -> str:
+    """Remove system tags, hook output, and Claude Code UI chrome from text.
+
+    All patterns are line-anchored. User prose that happens to mention these
+    strings inline (e.g., documenting them) is preserved verbatim.
+    """
+    for pat in _NOISE_TAG_PATTERNS:
+        text = pat.sub("", text)
+    for pat in _NOISE_LINE_PATTERNS:
+        text = pat.sub("", text)
+    text = _HOOK_LINE_RE.sub("", text)
+    text = _COLLAPSED_LINES_RE.sub("", text)
+    # Strip the Claude Code collapsed-output chrome "[N tokens] (ctrl+o to expand)".
+    # Narrow shape — a bare "(ctrl+o to expand)" in user prose stays intact.
+    text = re.sub(r"\s*\[\d+\s+tokens?\]\s*\(ctrl\+o to expand\)", "", text)
+    # Collapse runs of blank lines created by the removals
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+    return text.strip()
 
 
 def normalize(filepath: str) -> str:
@@ -40,12 +129,14 @@ def normalize(filepath: str) -> str:
     if not content.strip():
         return content
 
-    # Already has > markers — pass through
+    # Already has > markers — pass through unchanged.
     lines = content.split("\n")
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
         return content
 
-    # Try JSON normalization
+    # Try JSON normalization. strip_noise is applied inside the Claude Code
+    # JSONL parser (the only format that injects system tags/hook chrome);
+    # other formats pass through verbatim.
     ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
@@ -112,6 +203,10 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
                 isinstance(b, dict) and b.get("type") == "tool_result" for b in msg_content
             )
             text = _extract_content(msg_content, tool_use_map=tool_use_map)
+            # Strip Claude Code system-injected noise per message, never across
+            # message boundaries — prevents span-eating.
+            if text:
+                text = strip_noise(text)
             if text:
                 if is_tool_only and messages and messages[-1][0] == "assistant":
                     # Append tool results to the previous assistant message
@@ -121,6 +216,8 @@ def _try_claude_code_jsonl(content: str) -> Optional[str]:
                     messages.append(("user", text))
         elif msg_type == "assistant":
             text = _extract_content(msg_content, tool_use_map=tool_use_map)
+            if text:
+                text = strip_noise(text)
             if text:
                 # If previous message is also assistant (multi-turn tool loop),
                 # merge into the same assistant turn
@@ -233,8 +330,7 @@ def _collect_claude_messages(items) -> list:
 
 
 def _try_chatgpt_json(data) -> Optional[str]:
-    """ChatGPT conversations.json — handles both single convo (dict) and list of convos (list)."""
-    # Handle list of conversations — ChatGPT bulk export format
+    """ChatGPT conversations.json — handles single convo (dict) and list of convos (list)."""
     if isinstance(data, list):
         transcripts = []
         for item in data:
@@ -245,7 +341,6 @@ def _try_chatgpt_json(data) -> Optional[str]:
         if transcripts:
             return "\n\n---\n\n".join(transcripts)
         return None
-    # Handle single conversation
     if not isinstance(data, dict) or "mapping" not in data:
         return None
     return _try_chatgpt_single(data)
@@ -293,8 +388,13 @@ def _try_chatgpt_single(data) -> Optional[str]:
 def _try_slack_json(data) -> Optional[str]:
     """
     Slack channel export: [{"type": "message", "user": "...", "text": "..."}]
-    Optimized for 2-person DMs. In channels with 3+ people, alternating
-    speakers are labeled user/assistant to preserve the exchange structure.
+
+    Slack exports are multi-party chats where no speaker is inherently the
+    "user" or "assistant".  To preserve exchange-pair chunking (which relies
+    on ``>`` markers from the ``user`` role), we still alternate roles, but
+    prefix each message with the speaker ID so downstream consumers can
+    distinguish the original author.  A provenance header marks the
+    transcript as a Slack import.
     """
     if not isinstance(data, list):
         return None
@@ -304,7 +404,10 @@ def _try_slack_json(data) -> Optional[str]:
     for item in data:
         if not isinstance(item, dict) or item.get("type") != "message":
             continue
-        user_id = item.get("user", item.get("username", ""))
+        raw_user_id = item.get("user", item.get("username", ""))
+        # Sanitize speaker ID: strip brackets, newlines, and control chars
+        # to prevent chunk-boundary injection via crafted exports
+        user_id = re.sub(r"[\[\]\n\r\x00-\x1f]", "_", raw_user_id).strip()
         text = item.get("text", "").strip()
         if not text or not user_id:
             continue
@@ -317,9 +420,10 @@ def _try_slack_json(data) -> Optional[str]:
             else:
                 seen_users[user_id] = "user"
         last_role = seen_users[user_id]
-        messages.append((seen_users[user_id], text))
+        # Prefix with speaker ID so the original author is preserved
+        messages.append((seen_users[user_id], f"[{user_id}] {text}"))
     if len(messages) >= 2:
-        return _messages_to_transcript(messages)
+        return _messages_to_transcript(messages) + _SLACK_PROVENANCE_FOOTER
     return None
 
 


### PR DESCRIPTION
## What this fixes

Two bugs that prevent ChatGPT bulk exports from being mined correctly.

### Bug 1: File size limit too low (convo_miner.py)
MAX_FILE_SIZE was set to 10MB. ChatGPT exports split conversation history across multiple files, many of which exceed 10MB. Files over the limit are silently skipped with no warning to the user.

Fix: raised to 200MB.

### Bug 2: ChatGPT list format not handled (normalize.py)
_try_chatgpt_json() only handled a single conversation object (dict with mapping key). ChatGPT bulk exports are lists of conversation objects. When a list was passed, the function returned None and fell through to _try_slack_json(), producing 0 or 1 drawers instead of hundreds.

Fix: added list handling to _try_chatgpt_json() and extracted _try_chatgpt_single() as the per-conversation parser.

## How to test
Export your ChatGPT history and run: