### PR TITLE
fix: add explicit UTF-8 encoding to read_text() calls (#776)

### DIFF
--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -308,7 +308,7 @@ class EntityRegistry:
         path = (Path(config_dir) / "entity_registry.json") if config_dir else cls.DEFAULT_PATH
         if path.exists():
             try:
-                data = json.loads(path.read_text())
+                data = json.loads(path.read_text(encoding="utf-8"))
                 return cls(data, path)
             except (json.JSONDecodeError, OSError):
                 pass

--- a/mempalace/instructions_cli.py
+++ b/mempalace/instructions_cli.py
@@ -25,4 +25,4 @@ def run_instructions(name: str):
         print(f"Instructions file not found: {md_path}", file=sys.stderr)
         sys.exit(1)
 
-    print(md_path.read_text())
+    print(md_path.read_text(encoding="utf-8"))

--- a/mempalace/split_mega_files.py
+++ b/mempalace/split_mega_files.py
@@ -50,7 +50,7 @@ def _load_known_names_config(force_reload: bool = False):
 
     if _KNOWN_NAMES_PATH.exists():
         try:
-            _KNOWN_NAMES_CACHE = json.loads(_KNOWN_NAMES_PATH.read_text())
+            _KNOWN_NAMES_CACHE = json.loads(_KNOWN_NAMES_PATH.read_text(encoding="utf-8"))
             return _KNOWN_NAMES_CACHE
         except (json.JSONDecodeError, OSError):
             pass
@@ -184,7 +184,7 @@ def split_file(filepath, output_dir, dry_run=False):
     path = Path(filepath)
     max_size = 500 * 1024 * 1024  # 500 MB safety limit
     if path.stat().st_size > max_size:
-        print(f"  SKIP: {path.name} exceeds {max_size // (1024*1024)} MB limit")
+        print(f"  SKIP: {path.name} exceeds {max_size // (1024 * 1024)} MB limit")
         return []
     lines = path.read_text(errors="replace").splitlines(keepends=True)
 
@@ -273,7 +273,7 @@ def main():
     max_scan_size = 500 * 1024 * 1024  # 500 MB
     for f in files:
         if f.stat().st_size > max_scan_size:
-            print(f"  SKIP: {f.name} exceeds {max_scan_size // (1024*1024)} MB limit")
+            print(f"  SKIP: {f.name} exceeds {max_scan_size // (1024 * 1024)} MB limit")
             continue
         lines = f.read_text(errors="replace").splitlines(keepends=True)
         boundaries = find_session_boundaries(lines)

--- a/tests/test_instructions_cli.py
+++ b/tests/test_instructions_cli.py
@@ -10,7 +10,7 @@ from mempalace.instructions_cli import AVAILABLE, INSTRUCTIONS_DIR, run_instruct
 def test_run_instructions_valid_name(capsys):
     """Valid name prints the .md file content."""
     name = "init"
-    expected = (INSTRUCTIONS_DIR / f"{name}.md").read_text()
+    expected = (INSTRUCTIONS_DIR / f"{name}.md").read_text(encoding="utf-8")
     run_instructions(name)
     captured = capsys.readouterr()
     assert captured.out.strip() == expected.strip()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -157,7 +157,7 @@ def test_generate_aaak_bootstrap_entities_content(tmp_path):
     wings = ["family"]
     _generate_aaak_bootstrap(people, projects, wings, "personal", config_dir=tmp_path)
 
-    content = (tmp_path / "aaak_entities.md").read_text()
+    content = (tmp_path / "aaak_entities.md").read_text(encoding="utf-8")
     assert "Riley" in content
     assert "RIL" in content  # entity code
     assert "MemPalace" in content
@@ -171,7 +171,7 @@ def test_generate_aaak_bootstrap_facts_content(tmp_path):
     wings = ["projects"]
     _generate_aaak_bootstrap(people, projects, wings, "work", config_dir=tmp_path)
 
-    content = (tmp_path / "critical_facts.md").read_text()
+    content = (tmp_path / "critical_facts.md").read_text(encoding="utf-8")
     assert "Alice" in content
     assert "Acme" in content
     assert "work" in content.lower()
@@ -190,7 +190,7 @@ def test_generate_aaak_bootstrap_collision(tmp_path):
         {"name": "Alison", "relationship": "coworker", "context": "work"},
     ]
     _generate_aaak_bootstrap(people, [], ["work"], "work", config_dir=tmp_path)
-    content = (tmp_path / "aaak_entities.md").read_text()
+    content = (tmp_path / "aaak_entities.md").read_text(encoding="utf-8")
     assert "ALI" in content
     assert "ALIS" in content
 
@@ -199,7 +199,7 @@ def test_generate_aaak_bootstrap_no_relationship(tmp_path):
     """Person without relationship string still generates entry."""
     people = [{"name": "Bob", "context": "work"}]
     _generate_aaak_bootstrap(people, [], ["work"], "work", config_dir=tmp_path)
-    content = (tmp_path / "aaak_entities.md").read_text()
+    content = (tmp_path / "aaak_entities.md").read_text(encoding="utf-8")
     assert "BOB=Bob" in content
 
 


### PR DESCRIPTION
## What

`Path.read_text()` without `encoding` defaults to platform encoding on Windows. On locales like GBK this breaks any file written as UTF-8.

8 call sites fixed across 5 files:
- **tests/test_onboarding.py** (4x) -- the reported bug: onboarding writes UTF-8 (lines 315, 362), tests read without encoding
- **tests/test_instructions_cli.py** (1x) -- reads UTF-8 markdown
- **mempalace/entity_registry.py** (1x) -- reads JSON with non-ASCII entity names
- **mempalace/split_mega_files.py** (1x) -- reads JSON with non-ASCII known names
- **mempalace/instructions_cli.py** (1x) -- prints UTF-8 markdown to terminal

## Why explicit encoding, not PYTHONUTF8

Considered alternatives:

- **`PYTHONUTF8=1` in CI** -- must be set before Python starts, so it can't go in conftest.py. Works for CI but doesn't fix local test runs on Windows. Also a global override of all I/O which can mask real encoding bugs.
- **PEP 686 (Python 3.15)** -- UTF-8 will become the default, but mempalace supports >=3.9 so that's years away.
- **Explicit `encoding="utf-8"` per call** -- PEP 597 recommendation. Works on all Python versions, all platforms, no env setup needed.

## Test plan

- [ ] CI passes on all platforms (especially test-windows)
- [ ] `pytest tests/test_onboarding.py tests/test_instructions_cli.py -v` -- 52 passed locally