### PR TITLE
fix: harden KnowledgeGraph and MCP server for multi-process access

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -35,16 +35,66 @@ Usage:
     kg.invalidate("Max", "has_issue", "sports_injury", ended="2026-02-15")
 """
 
+import atexit
+import functools
 import hashlib
 import json
+import logging
 import os
+import random
 import sqlite3
 import threading
+import time
 from datetime import date, datetime
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
 
 DEFAULT_KG_PATH = os.path.expanduser("~/.mempalace/knowledge_graph.sqlite3")
+
+
+def _sqlite_retry(max_retries=5, base_delay=0.1, max_delay=5.0):
+    """Retry on ``sqlite3.OperationalError`` caused by database locking.
+
+    When multiple processes (e.g. separate mcp-proxy SSE connections) share the
+    same SQLite file, the built-in ``busy_timeout`` handles most contention.
+    This decorator is the safety-net for the rare case where ``busy_timeout``
+    expires (e.g. during a long WAL checkpoint).
+
+    Only errors containing "locked" or "busy" are retried — other
+    ``OperationalError`` variants (corrupt DB, disk full) propagate
+    immediately.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            last_exc = None
+            for attempt in range(max_retries + 1):
+                try:
+                    return func(*args, **kwargs)
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc).lower()
+                    if "locked" not in msg and "busy" not in msg:
+                        raise
+                    last_exc = exc
+                    if attempt < max_retries:
+                        delay = min(base_delay * (2**attempt), max_delay)
+                        jitter = delay * 0.5 * random.random()
+                        sleep_time = delay + jitter
+                        logger.warning(
+                            "SQLite locked (attempt %d/%d), retrying in %.2fs: %s",
+                            attempt + 1,
+                            max_retries,
+                            sleep_time,
+                            func.__name__,
+                        )
+                        time.sleep(sleep_time)
+            raise last_exc
+
+        return wrapper
+
+    return decorator
 
 
 class KnowledgeGraph:
@@ -59,6 +109,7 @@ class KnowledgeGraph:
         self._connection = None
         self._lock = threading.Lock()
         self._init_db()
+        atexit.register(self.close)
 
     def _init_db(self):
         conn = self._conn()
@@ -97,8 +148,10 @@ class KnowledgeGraph:
 
     def _conn(self):
         if self._connection is None:
-            self._connection = sqlite3.connect(self.db_path, timeout=10, check_same_thread=False)
+            self._connection = sqlite3.connect(self.db_path, timeout=60, check_same_thread=False)
             self._connection.execute("PRAGMA journal_mode=WAL")
+            self._connection.execute("PRAGMA wal_autocheckpoint=1000")
+            self._connection.execute("PRAGMA journal_size_limit=67108864")
             self._connection.row_factory = sqlite3.Row
         return self._connection
 
@@ -109,24 +162,38 @@ class KnowledgeGraph:
                 self._connection.close()
                 self._connection = None
 
+    def __del__(self):
+        try:
+            if self._connection is not None:
+                self._connection.close()
+        except Exception:
+            pass
+
     def _entity_id(self, name: str) -> str:
         return name.lower().replace(" ", "_").replace("'", "")
 
     # ── Write operations ──────────────────────────────────────────────────
 
+    @_sqlite_retry()
     def add_entity(self, name: str, entity_type: str = "unknown", properties: dict = None):
         """Add or update an entity node."""
         eid = self._entity_id(name)
         props = json.dumps(properties or {})
         with self._lock:
             conn = self._conn()
-            with conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
                 conn.execute(
                     "INSERT OR REPLACE INTO entities (id, name, type, properties) VALUES (?, ?, ?, ?)",
                     (eid, name, entity_type, props),
                 )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
         return eid
 
+    @_sqlite_retry()
     def add_triple(
         self,
         subject: str,
@@ -153,7 +220,8 @@ class KnowledgeGraph:
         # Auto-create entities if they don't exist
         with self._lock:
             conn = self._conn()
-            with conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
                 conn.execute(
                     "INSERT OR IGNORE INTO entities (id, name) VALUES (?, ?)", (sub_id, subject)
                 )
@@ -168,6 +236,7 @@ class KnowledgeGraph:
                 ).fetchone()
 
                 if existing:
+                    conn.commit()
                     return existing["id"]  # Already exists and still valid
 
                 triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.sha256(f'{valid_from}{datetime.now().isoformat()}'.encode()).hexdigest()[:12]}"
@@ -187,8 +256,13 @@ class KnowledgeGraph:
                         source_file,
                     ),
                 )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
         return triple_id
 
+    @_sqlite_retry()
     def invalidate(self, subject: str, predicate: str, obj: str, ended: str = None):
         """Mark a relationship as no longer valid (set valid_to date)."""
         sub_id = self._entity_id(subject)
@@ -198,14 +272,20 @@ class KnowledgeGraph:
 
         with self._lock:
             conn = self._conn()
-            with conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
                 conn.execute(
                     "UPDATE triples SET valid_to=? WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
                     (ended, sub_id, pred, obj_id),
                 )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
 
     # ── Query operations ──────────────────────────────────────────────────
 
+    @_sqlite_retry()
     def query_entity(self, name: str, as_of: str = None, direction: str = "outgoing"):
         """
         Get all relationships for an entity.
@@ -263,6 +343,7 @@ class KnowledgeGraph:
 
         return results
 
+    @_sqlite_retry()
     def query_relationship(self, predicate: str, as_of: str = None):
         """Get all triples with a given relationship type."""
         pred = predicate.lower().replace(" ", "_")
@@ -294,6 +375,7 @@ class KnowledgeGraph:
                 )
         return results
 
+    @_sqlite_retry()
     def timeline(self, entity_name: str = None):
         """Get all facts in chronological order, optionally filtered by entity."""
         with self._lock:
@@ -336,6 +418,7 @@ class KnowledgeGraph:
 
     # ── Stats ─────────────────────────────────────────────────────────────
 
+    @_sqlite_retry()
     def stats(self):
         with self._lock:
             conn = self._conn()

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -107,6 +107,8 @@ _client_cache = None
 _collection_cache = None
 _palace_db_inode = 0  # inode of chroma.sqlite3 at cache time
 _palace_db_mtime = 0.0  # mtime of chroma.sqlite3 at cache time
+_last_mtime_check = 0.0  # monotonic timestamp of last inode/mtime check
+_MTIME_CHECK_INTERVAL = 5.0  # seconds — don't re-stat chroma.sqlite3 more often than this
 
 
 # ==================== WRITE-AHEAD LOG ====================
@@ -168,6 +170,13 @@ def _get_client():
     inode check alone misses in-place modifications that invalidate the
     in-memory HNSW index.
 
+    Mtime checks are rate-limited to once per ``_MTIME_CHECK_INTERVAL``
+    seconds to avoid constant ``PersistentClient`` recreation when multiple
+    mcp-proxy processes write to the same database concurrently.  Each
+    reconnect reloads the full HNSW index from disk — expensive for large
+    palaces.  The explicit ``tool_reconnect`` tool and ``_refresh_db_mtime``
+    helper handle the cases that the cooldown intentionally skips.
+
     Note: FAT/exFAT may return 0 for st_ino — the ``current_inode != 0``
     guard skips reconnect detection on those filesystems (safe fallback).
     """
@@ -177,8 +186,45 @@ def _get_client():
         _palace_db_inode, \
         _palace_db_mtime, \
         _metadata_cache, \
-        _metadata_cache_time
+        _metadata_cache_time, \
+        _last_mtime_check
+
+    # First call — no client yet, must create one.
+    if _client_cache is None:
+        db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+        try:
+            st = os.stat(db_path)
+            _palace_db_inode = st.st_ino
+            _palace_db_mtime = st.st_mtime
+        except OSError:
+            _palace_db_inode = 0
+            _palace_db_mtime = 0.0
+        _client_cache = ChromaBackend.make_client(_config.palace_path)
+        _collection_cache = None
+        _metadata_cache = None
+        _metadata_cache_time = 0
+        _last_mtime_check = time.monotonic()
+        return _client_cache
+
     db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+
+    # Safety-critical: if the DB file disappeared (e.g. during rebuild),
+    # always invalidate immediately — don't wait for the cooldown.
+    if not os.path.isfile(db_path) and _collection_cache is not None:
+        _client_cache = None
+        _collection_cache = None
+        _palace_db_inode = 0
+        _palace_db_mtime = 0.0
+        _last_mtime_check = 0.0
+        return _get_client()  # recurse once to create fresh client
+
+    # Rate-limit inode/mtime checks to avoid expensive reconnects when
+    # multiple mcp-proxy processes write concurrently.
+    now = time.monotonic()
+    if (now - _last_mtime_check) < _MTIME_CHECK_INTERVAL:
+        return _client_cache
+    _last_mtime_check = now
+
     try:
         st = os.stat(db_path)
         current_inode = st.st_ino
@@ -187,21 +233,10 @@ def _get_client():
         current_inode = 0
         current_mtime = 0.0
 
-    # If the DB file disappeared (e.g. during rebuild) but we have a cached
-    # collection, invalidate so we don't serve stale data.  Without this,
-    # both stored and current values are 0 on the first call after deletion,
-    # making inode_changed and mtime_changed both False.
-    if not os.path.isfile(db_path) and _collection_cache is not None:
-        _client_cache = None
-        _collection_cache = None
-        _palace_db_inode = 0
-        _palace_db_mtime = 0.0
-        # Fall through to normal reconnect which will handle missing DB
-
     inode_changed = current_inode != 0 and current_inode != _palace_db_inode
     mtime_changed = current_mtime != 0.0 and abs(current_mtime - _palace_db_mtime) > 0.01
 
-    if _client_cache is None or inode_changed or mtime_changed:
+    if inode_changed or mtime_changed:
         _client_cache = ChromaBackend.make_client(_config.palace_path)
         _collection_cache = None
         _metadata_cache = None
@@ -231,6 +266,22 @@ def _get_collection(create=False):
         return _collection_cache
     except Exception:
         return None
+
+
+def _refresh_db_mtime():
+    """Update the stored mtime after a write so our own changes don't trigger a reconnect.
+
+    Without this, every write changes chroma.sqlite3's mtime.  The next call
+    to ``_get_client()`` (after the cooldown) would see a stale stored mtime,
+    recreate the ``PersistentClient``, and reload the entire HNSW index — even
+    though this process already has the data in memory.
+    """
+    global _palace_db_mtime
+    db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+    try:
+        _palace_db_mtime = os.stat(db_path).st_mtime
+    except OSError:
+        pass
 
 
 def _no_palace():
@@ -653,6 +704,7 @@ def tool_add_drawer(
                 }
             ],
         )
+        _refresh_db_mtime()
         _metadata_cache = None
         logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
         return {"success": True, "drawer_id": drawer_id, "wing": wing, "room": room}
@@ -684,6 +736,7 @@ def tool_delete_drawer(drawer_id: str):
 
     try:
         col.delete(ids=[drawer_id])
+        _refresh_db_mtime()
         _metadata_cache = None
         logger.info(f"Deleted drawer: {drawer_id}")
         return {"success": True, "drawer_id": drawer_id}
@@ -820,6 +873,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
         update_kwargs["metadatas"] = [new_meta]
         col.update(**update_kwargs)
 
+        _refresh_db_mtime()
         _metadata_cache = None
 
         logger.info(f"Updated drawer: {drawer_id}")
@@ -971,6 +1025,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
                 }
             ],
         )
+        _refresh_db_mtime()
         logger.info(f"Diary entry: {entry_id} → {wing}/diary/{topic}")
         return {
             "success": True,
@@ -1118,10 +1173,12 @@ def tool_reconnect():
     Use after external scripts or CLI commands modify the palace database
     directly, which can leave the in-memory HNSW index stale.
     """
-    global _collection_cache, _palace_db_inode, _palace_db_mtime
+    global _collection_cache, _palace_db_inode, _palace_db_mtime, _last_mtime_check, _client_cache
+    _client_cache = None
     _collection_cache = None
     _palace_db_inode = 0
     _palace_db_mtime = 0.0
+    _last_mtime_check = 0.0
     try:
         col = _get_collection()
         if col is None:

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -2,8 +2,18 @@
 test_knowledge_graph.py — Tests for the temporal knowledge graph.
 
 Covers: entity CRUD, triple CRUD, temporal queries, invalidation,
-timeline, stats, and edge cases (duplicate triples, ID collisions).
+timeline, stats, and edge cases (duplicate triples, ID collisions),
+multi-process locking, retry decorator, and connection pragmas.
 """
+
+import multiprocessing
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from mempalace.knowledge_graph import KnowledgeGraph, _sqlite_retry
 
 
 class TestEntityOperations:
@@ -137,3 +147,142 @@ class TestStats:
         assert stats["triples"] == 5
         assert stats["current_facts"] == 4  # 1 expired (Acme Corp)
         assert stats["expired_facts"] == 1
+
+
+# ── Retry decorator tests ────────────────────────────────────────────
+
+
+class TestSQLiteRetryDecorator:
+    def test_retry_succeeds_on_second_attempt(self):
+        call_count = 0
+
+        @_sqlite_retry(max_retries=3, base_delay=0.01)
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise sqlite3.OperationalError("database is locked")
+            return "ok"
+
+        assert flaky() == "ok"
+        assert call_count == 2
+
+    def test_retry_raises_after_max_retries(self):
+        @_sqlite_retry(max_retries=2, base_delay=0.01)
+        def always_locked():
+            raise sqlite3.OperationalError("database is locked")
+
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            always_locked()
+
+    def test_no_retry_on_non_lock_error(self):
+        call_count = 0
+
+        @_sqlite_retry(max_retries=3, base_delay=0.01)
+        def disk_error():
+            nonlocal call_count
+            call_count += 1
+            raise sqlite3.OperationalError("disk I/O error")
+
+        with pytest.raises(sqlite3.OperationalError, match="disk I/O"):
+            disk_error()
+        assert call_count == 1  # no retry
+
+    def test_no_retry_on_other_exception_types(self):
+        call_count = 0
+
+        @_sqlite_retry(max_retries=3, base_delay=0.01)
+        def value_error():
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("bad value")
+
+        with pytest.raises(ValueError):
+            value_error()
+        assert call_count == 1
+
+    def test_retry_on_busy_error(self):
+        """The 'database is busy' variant should also be retried."""
+        call_count = 0
+
+        @_sqlite_retry(max_retries=3, base_delay=0.01)
+        def busy_then_ok():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise sqlite3.OperationalError("database is busy")
+            return "ok"
+
+        assert busy_then_ok() == "ok"
+        assert call_count == 2
+
+
+# ── Connection pragma tests ──────────────────────────────────────────
+
+
+class TestConnectionPragmas:
+    def test_wal_autocheckpoint(self, kg):
+        conn = kg._conn()
+        result = conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]
+        assert result == 1000
+
+    def test_journal_size_limit(self, kg):
+        conn = kg._conn()
+        result = conn.execute("PRAGMA journal_size_limit").fetchone()[0]
+        assert result == 67108864
+
+    def test_journal_mode_is_wal(self, kg):
+        conn = kg._conn()
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode == "wal"
+
+
+# ── Multi-process locking test ───────────────────────────────────────
+
+
+def _worker_write_triples(db_path, worker_id, count, error_list):
+    """Worker function for multi-process test. Runs in a separate process."""
+    try:
+        kg = KnowledgeGraph(db_path=db_path)
+        for i in range(count):
+            kg.add_triple(f"worker_{worker_id}", "wrote", f"item_{worker_id}_{i}")
+        kg.close()
+    except Exception as e:
+        error_list.append(f"worker_{worker_id}: {e}")
+
+
+class TestMultiProcessLocking:
+    @pytest.mark.slow
+    def test_concurrent_process_writes(self):
+        """Spawn N processes all writing to the same KG file simultaneously."""
+        with tempfile.TemporaryDirectory(prefix="mempalace_mp_") as tmp:
+            db_path = os.path.join(tmp, "test_mp.sqlite3")
+            num_workers = 4
+            triples_per_worker = 20
+
+            manager = multiprocessing.Manager()
+            errors = manager.list()
+
+            processes = []
+            for wid in range(num_workers):
+                p = multiprocessing.Process(
+                    target=_worker_write_triples,
+                    args=(db_path, wid, triples_per_worker, errors),
+                )
+                processes.append(p)
+
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join(timeout=120)
+
+            assert list(errors) == [], f"Worker errors: {list(errors)}"
+
+            # Verify all triples were written
+            kg = KnowledgeGraph(db_path=db_path)
+            stats = kg.stats()
+            expected_triples = num_workers * triples_per_worker
+            assert stats["triples"] == expected_triples, (
+                f"Expected {expected_triples} triples, got {stats['triples']}"
+            )
+            kg.close()


### PR DESCRIPTION
## Summary

When mempalace runs behind `mcp-proxy` (SSE mode) with multiple concurrent clients, two classes of concurrency bugs surface:

1. **SQLite "database is locked"** in KnowledgeGraph — `busy_timeout` was only 10s with no application-level retry. Concurrent writers from separate mcp-proxy processes exhaust the timeout.

2. **ChromaDB client cache thrashing** — every write changes `chroma.sqlite3` mtime. Other processes detect this and recreate `PersistentClient`, reloading the full HNSW index from disk on every operation.

### KnowledgeGraph fixes
- `busy_timeout` 10s → 60s
- `_sqlite_retry` decorator: exponential backoff with jitter (5 retries, only for "locked"/"busy" errors)
- `BEGIN IMMEDIATE` for write transactions (detect contention at start, not mid-transaction)
- `PRAGMA wal_autocheckpoint=1000` + `journal_size_limit=64MB` (manage WAL growth)
- `atexit.register(self.close)` for clean WAL checkpointing on shutdown

### MCP server fixes
- Rate-limit `chroma.sqlite3` stat/mtime checks to 5-second intervals
- `_refresh_db_mtime()` after writes prevents self-inflicted client recreation
- Bypass cooldown for safety-critical DB disappearance detection (rebuild scenarios)
- `tool_reconnect` now fully clears client + mtime state

### Tests
- `TestSQLiteRetryDecorator` — 5 cases: retry success, exhaustion, non-lock errors, busy variant
- `TestConnectionPragmas` — 3 cases: autocheckpoint, journal_size_limit, WAL mode
- `TestMultiProcessLocking` — 4 processes x 20 triples to same DB file, zero failures

## Test plan
- [x] `python -m pytest tests/ -v --ignore=tests/benchmarks` — 958 passed
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Manual: connect 2+ Claude Code sessions via SSE, trigger concurrent kg_add calls
- [ ] Manual: concurrent add_drawer calls from multiple clients — no cache thrashing