### PR TITLE
fix(website): correct false claims and stale numbers in live docs

### DIFF
--- a/website/.vitepress/theme/Landing.vue
+++ b/website/.vitepress/theme/Landing.vue
@@ -415,8 +415,8 @@ onBeforeUnmount(() => {
       </h1>
       <p class="lede">
         An AI that forgets cannot know you. MemPalace keeps every word you have
-        shared — verbatim, on your machine, forever available. One hundred
-        percent recall by design.
+        shared — verbatim, on your machine, permanent. Designed for total
+        recall.
       </p>
       <form class="waitlist waitlist-hero" data-source="hero" novalidate>
         <div class="waitlist-head">
@@ -520,7 +520,7 @@ onBeforeUnmount(() => {
       <article class="demo-pane demo-remember">
         <header>
           <span class="pane-tag">with mempalace</span>
-          <span class="pane-meta">verbatim &middot; retrieved &lt;<em>50&nbsp;ms</em></span>
+          <span class="pane-meta">verbatim &middot; retrieved <em>instantly</em></span>
         </header>
         <div class="chat" data-pane="remember" aria-live="polite"></div>
       </article>
@@ -539,10 +539,10 @@ onBeforeUnmount(() => {
         </h2>
       </div>
       <p class="lede">
-        A two-thousand-year-old memory technique, reworked for a machine.
-        Broad categories nest time-based groupings; time-based groupings hold
-        verbatim drawers. A symbolic index lets the model scan thousands of
-        drawers in a single breath and open only the ones it needs.
+        An ancient memory technique, reworked for a machine. Broad categories
+        nest time-based groupings; time-based groupings hold verbatim drawers.
+        A symbolic index lets the model scan thousands of drawers in a single
+        pass and open only the ones it needs.
       </p>
     </div>
 
@@ -609,8 +609,8 @@ onBeforeUnmount(() => {
       </h2>
       <p class="lede">
         The content stays verbatim — always. The <em>index</em> above it is written
-        in AAAK: a dense symbolic dialect an LLM can scan at a glance. Tens of
-        thousands of entries, one pass, exact drawer located.
+        in AAAK: a dense symbolic dialect an LLM can scan at a glance. Thousands
+        of entries, one pass, exact drawer located.
       </p>
     </div>
 
@@ -657,8 +657,8 @@ onBeforeUnmount(() => {
     </div>
 
     <p class="dialect-caption">
-      Ninety-plus percent compression on the pointer layer. One hundred percent
-      fidelity on the content layer. You get speed without ever losing a word.
+      Dense compression on the pointer layer. Full fidelity on the content
+      layer. You get speed without ever losing a word.
     </p>
   </section>
 
@@ -760,7 +760,7 @@ onBeforeUnmount(() => {
 <span class="ok">  ✓</span> palace created at <span class="dim">~/.mempalace</span>
 <span class="ok">  ✓</span> hooks registered <span class="dim">(stop, precompact)</span>
 <span class="ok">  ✓</span> knowledge graph initialized
-<span class="prompt">$</span> mempalace remember <span class="dim">"memory is identity."</span>
+<span class="prompt">$</span> mempalace mine <span class="dim">./notes</span>
 <span class="ok">  ✓</span> filed · <span class="c">W-001/R-01/D-001</span></pre>
     </div>
 

--- a/website/guide/claude-code.md
+++ b/website/guide/claude-code.md
@@ -15,7 +15,7 @@ Restart Claude Code, then type `/skills` to verify "mempalace" appears.
 
 With the plugin installed, Claude Code automatically:
 - Starts the MemPalace MCP server on launch
-- Has access to all 19 tools
+- Has access to all 29 tools
 - Learns the AAAK dialect and memory protocol from the `mempalace_status` response
 - Searches the palace before answering questions about past work
 

--- a/website/guide/gemini-cli.md
+++ b/website/guide/gemini-cli.md
@@ -40,12 +40,14 @@ You can optionally create or edit:
 Register MemPalace as an MCP server:
 
 ```bash
-gemini mcp add mempalace /absolute/path/to/mempalace/.venv/bin/python3 \
-  -m mempalace.mcp_server --scope user
+gemini mcp add --scope user mempalace \
+  -- /absolute/path/to/mempalace/.venv/bin/python -m mempalace.mcp_server
 ```
 
 ::: warning
-Use the **absolute path** to the Python binary to ensure it works from any directory.
+Use the **absolute path** to the Python binary so the server starts from any
+working directory. The `--` separator prevents Gemini from parsing
+`-m mempalace.mcp_server` as its own flags.
 :::
 
 ## Enable Auto-Saving

--- a/website/guide/mcp-integration.md
+++ b/website/guide/mcp-integration.md
@@ -1,6 +1,6 @@
 # MCP Integration
 
-MemPalace provides 19 tools through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), giving any MCP-compatible AI full read/write access to your palace.
+MemPalace provides 29 tools through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), giving any MCP-compatible AI full read/write access to your palace.
 
 ## Setup
 
@@ -24,7 +24,7 @@ claude mcp add mempalace -- python -m mempalace.mcp_server
 claude mcp add mempalace -- python -m mempalace.mcp_server --palace /path/to/palace
 ```
 
-Now your AI has all 19 tools available. Ask it anything:
+Now your AI has all 29 tools available. Ask it anything:
 
 > *"What did we decide about auth last month?"*
 
@@ -66,11 +66,19 @@ This protocol is what turns storage into memory — the AI knows to verify befor
 | `mempalace_check_duplicate` | Check before filing |
 | `mempalace_get_aaak_spec` | AAAK dialect reference |
 
+### Drawers (read)
+
+| Tool | What |
+|------|------|
+| `mempalace_get_drawer` | Fetch a single drawer by ID |
+| `mempalace_list_drawers` | List drawers with pagination |
+
 ### Palace (write)
 
 | Tool | What |
 |------|------|
 | `mempalace_add_drawer` | File verbatim content |
+| `mempalace_update_drawer` | Update drawer content or metadata |
 | `mempalace_delete_drawer` | Remove by ID |
 
 ### Knowledge Graph
@@ -91,11 +99,28 @@ This protocol is what turns storage into memory — the AI knows to verify befor
 | `mempalace_find_tunnels` | Find rooms bridging two wings |
 | `mempalace_graph_stats` | Graph connectivity overview |
 
+### Tunnels
+
+| Tool | What |
+|------|------|
+| `mempalace_create_tunnel` | Create an explicit cross-wing tunnel |
+| `mempalace_list_tunnels` | List all explicit tunnels |
+| `mempalace_delete_tunnel` | Delete an explicit tunnel |
+| `mempalace_follow_tunnels` | Follow tunnels out from a room |
+
 ### Agent Diary
 
 | Tool | What |
 |------|------|
 | `mempalace_diary_write` | Write AAAK diary entry |
 | `mempalace_diary_read` | Read recent diary entries |
+
+### System
+
+| Tool | What |
+|------|------|
+| `mempalace_hook_settings` | Get or set hook behavior |
+| `mempalace_memories_filed_away` | Check whether the last checkpoint was saved |
+| `mempalace_reconnect` | Force reconnect to the database |
 
 For detailed schemas and parameters, see [MCP Tools Reference](/reference/mcp-tools).

--- a/website/guide/openclaw.md
+++ b/website/guide/openclaw.md
@@ -27,7 +27,7 @@ Or by directly editing your OpenClaw configuration:
 
 ## How It Works
 
-Once connected, OpenClaw agents receive all 19 tools along with the **Memory Protocol**—a strict behavioral guide indicating they should:
+Once connected, OpenClaw agents receive all 29 tools along with the **Memory Protocol**—a strict behavioral guide indicating they should:
 1. **Never guess**: Query `mempalace_search` or `mempalace_kg_query` before confidently answering.
 2. **Keep an agent diary**: Maintain continuity between sessions by writing to `mempalace_diary_write`.
 3. **Manage the Knowledge Graph**: Update declarative facts when things change using `mempalace_kg_add` and `mempalace_kg_invalidate`.

--- a/website/reference/api-reference.md
+++ b/website/reference/api-reference.md
@@ -108,7 +108,7 @@ Unified 4-layer interface.
 
 | Method | Parameters | Returns | Description |
 |--------|-----------|---------|-------------|
-| `wake_up(wing=None)` | Optional wing | `str` | L0 + L1 context (~170–900 tokens) |
+| `wake_up(wing=None)` | Optional wing | `str` | L0 + L1 context (~600–900 tokens) |
 | `recall(wing, room, n_results=10)` | Filters | `str` | L2 on-demand retrieval |
 | `search(query, wing, room, n_results=5)` | Query + filters | `str` | L3 deep search |
 | `status()` | — | `dict` | All layer status info |

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -89,7 +89,7 @@ mempalace split <dir> --output-dir ~/split-output/
 
 ## `mempalace wake-up`
 
-Show L0 + L1 wake-up context (~170–900 tokens).
+Show L0 + L1 wake-up context (~600–900 tokens).
 
 ```bash
 mempalace wake-up

--- a/website/reference/modules.md
+++ b/website/reference/modules.md
@@ -9,7 +9,7 @@ mempalace/
 ├── README.md                  ← project documentation
 ├── mempalace/                 ← core package
 │   ├── cli.py                 ← CLI entry point
-│   ├── mcp_server.py          ← MCP server (19 tools)
+│   ├── mcp_server.py          ← MCP server (29 tools)
 │   ├── knowledge_graph.py     ← temporal entity graph
 │   ├── palace_graph.py        ← room navigation graph
 │   ├── dialect.py             ← AAAK compression
@@ -56,7 +56,7 @@ Argparse-based CLI with subcommands: `init`, `mine`, `split`, `search`, `compres
 
 ### `mcp_server.py` — MCP Server
 
-JSON-RPC over stdin/stdout. Implements the MCP protocol with 19 tools covering palace read/write, knowledge graph, navigation, and agent diary operations. Includes the Memory Protocol and AAAK Spec in status responses.
+JSON-RPC over stdin/stdout. Implements the MCP protocol with 29 tools covering palace read/write, drawer CRUD, knowledge graph, navigation, tunnels, agent diary, and system operations. Includes the Memory Protocol and AAAK Spec in status responses.
 
 ### `searcher.py` — Semantic Search
 

--- a/website/reference/python-api.md
+++ b/website/reference/python-api.md
@@ -36,7 +36,7 @@ from mempalace.layers import MemoryStack
 stack = MemoryStack()  # uses default paths from MempalaceConfig
 
 # Wake-up: L0 (identity) + L1 (essential story)
-context = stack.wake_up(wing="myapp")  # ~170-900 tokens
+context = stack.wake_up(wing="myapp")  # ~600-900 tokens
 
 # On-demand: L2 retrieval
 recall = stack.recall(wing="myapp", room="auth", n_results=10)


### PR DESCRIPTION
## Summary

The live docs site had several false claims, stale numbers, and unverifiable marketing absolutes. This PR fixes them without changing any product behavior — it's docs/copy only.

### Factual fixes
- **Landing page terminal demo** showed a `mempalace remember` command that doesn't exist in [cli.py](mempalace/cli.py). Replaced with real `mempalace mine ./notes`.
- **MCP tool count: 19 → 29** across [mcp-integration.md](website/guide/mcp-integration.md), [claude-code.md](website/guide/claude-code.md), [openclaw.md](website/guide/openclaw.md), and [modules.md](website/reference/modules.md). Verified by counting `"mempalace_*"` entries in the `TOOLS` dict of [mcp_server.py](mempalace/mcp_server.py).
- **Tool Overview in [mcp-integration.md](website/guide/mcp-integration.md)** was missing entire categories. Added Drawers (`get_drawer`, `list_drawers`, `update_drawer`), Tunnels (`create_tunnel`, `list_tunnels`, `delete_tunnel`, `follow_tunnels`), and System (`hook_settings`, `memories_filed_away`, `reconnect`).
- **Wake-up token range `~170–900` → `~600–900`** in [cli.md](website/reference/cli.md), [api-reference.md](website/reference/api-reference.md), and [python-api.md](website/reference/python-api.md) to match the CLI help text in [cli.py](mempalace/cli.py) and the concept doc in [memory-stack.md](website/concepts/memory-stack.md).
- **Gemini CLI command** in [gemini-cli.md](website/guide/gemini-cli.md) had ambiguous flag order — `--scope user` trailing after `-m mempalace.mcp_server` could be parsed as a module arg. Moved `--scope user` before the target name and added the standard `--` separator.

### Marketing softening (unverifiable absolutes)
- "forever available. One hundred percent recall by design." → "permanent. Designed for total recall."
- "retrieved <50 ms" → "retrieved instantly" (no published latency benchmark backed the 50 ms figure)
- "Ninety-plus percent compression... One hundred percent fidelity" → "Dense compression... Full fidelity"
- "A two-thousand-year-old memory technique" → "An ancient memory technique" (method of loci is ~2,500 years old, and CLAUDE.md already says "thousands of years")
- "Tens of thousands of entries, one pass" → "Thousands of entries, one pass"
- "in a single breath" → "in a single pass"

## Test plan

- [ ] `cd website && bun run dev` and spot-check the landing page — hero copy, terminal demo, dialect caption, and the "without/with mempalace" comparison pane
- [ ] Build the VitePress site (`bun run build`) and confirm no broken links
- [ ] Re-read [mcp-integration.md](website/guide/mcp-integration.md) top-to-bottom — tool count matches [mcp-tools.md](website/reference/mcp-tools.md) reference
- [ ] Verify the Gemini CLI command from [gemini-cli.md](website/guide/gemini-cli.md) against current Gemini CLI docs if you have an install handy