### PR TITLE
fix(mcp): handle null JSON-RPC request payloads safely

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1969,7 +1969,11 @@ SUPPORTED_PROTOCOL_VERSIONS = [
 
 def handle_request(request):
     if not isinstance(request, dict):
-        return {"jsonrpc": "2.0", "id": None, "error": {"code": -32600, "message": "Invalid Request"}}
+        return {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32600, "message": "Invalid Request"},
+        }
     method = request.get("method") or ""
     params = request.get("params") or {}
     req_id = request.get("id")
@@ -2011,7 +2015,10 @@ def handle_request(request):
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "error": {"code": -32602, "message": "Invalid params: 'name' is required for tools/call"},
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid params: 'name' is required for tools/call",
+                },
             }
         tool_name = params.get("name")
         tool_args = params.get("arguments") or {}

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1969,7 +1969,7 @@ SUPPORTED_PROTOCOL_VERSIONS = [
 
 def handle_request(request):
     if not isinstance(request, dict):
-        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}}
+        return {"jsonrpc": "2.0", "id": None, "error": {"code": -32600, "message": "Invalid Request"}}
     method = request.get("method") or ""
     params = request.get("params") or {}
     req_id = request.get("id")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1968,6 +1968,8 @@ SUPPORTED_PROTOCOL_VERSIONS = [
 
 
 def handle_request(request):
+    if not isinstance(request, dict):
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}}
     method = request.get("method") or ""
     params = request.get("params") or {}
     req_id = request.get("id")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2007,6 +2007,12 @@ def handle_request(request):
             },
         }
     elif method == "tools/call":
+        if not isinstance(params, dict) or "name" not in params:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32602, "message": "Invalid params: 'name' is required for tools/call"},
+            }
         tool_name = params.get("name")
         tool_args = params.get("arguments") or {}
         if tool_name not in TOOLS:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -190,6 +190,13 @@ class TestHandleRequest:
         resp = handle_request({"method": None, "id": 99, "params": {}})
         assert resp["error"]["code"] == -32601
 
+    @pytest.mark.parametrize("payload", [None, [], "plain", 42, True])
+    def test_handle_request_invalid_payload_returns_jsonrpc_error(self, payload):
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request(payload)
+        assert resp == {"jsonrpc": "2.0", "id": None, "error": {"code": -32600, "message": "Invalid Request"}}
+
     def test_tools_call_dispatches(self, monkeypatch, config, palace_path, seeded_kg):
         _patch_mcp_server(monkeypatch, config, seeded_kg)
         from mempalace.mcp_server import handle_request

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -209,7 +209,11 @@ class TestHandleRequest:
         from mempalace.mcp_server import handle_request
 
         resp = handle_request(payload)
-        assert resp == {"jsonrpc": "2.0", "id": None, "error": {"code": -32600, "message": "Invalid Request"}}
+        assert resp == {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32600, "message": "Invalid Request"},
+        }
 
     def test_tools_call_dispatches(self, monkeypatch, config, palace_path, seeded_kg):
         _patch_mcp_server(monkeypatch, config, seeded_kg)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -148,6 +148,20 @@ class TestHandleRequest:
         )
         assert resp["error"]["code"] == -32601
 
+    def test_tools_call_missing_params(self):
+        from mempalace.mcp_server import handle_request
+
+        for bad_params in [None, {}, {"arguments": {}}]:
+            resp = handle_request(
+                {
+                    "method": "tools/call",
+                    "id": 15,
+                    "params": bad_params,
+                }
+            )
+            assert resp["error"]["code"] == -32602
+            assert "Invalid params" in resp["error"]["message"]
+
     def test_unknown_method(self):
         from mempalace.mcp_server import handle_request
 


### PR DESCRIPTION
## What does this PR do?
When an MCP client sends a malformed or `null` top-level request, `handle_request(request)` crashes with an `AttributeError` because it attempts to call `.get()` on a non-dictionary object. 

This PR adds explicit dictionary type validation at the top of the handler. Instead of crashing the server and disconnecting the client, it now gracefully returns a standard JSON-RPC Error `-32600` (Invalid Request), adhering to robust null-handling practices for JSON-RPC parameters.

## How to test
1. Run the MemPalace MCP server locally.
2. Send a malformed payload (e.g., `null`, `[]`, or a plain string) to the standard input.
3. Observe that instead of throwing an exception (which forces a restart), the server correctly replies with:
`{"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}}`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
