### PR TITLE
fix: clamp similarity scores to [0,1] to prevent negative values

### DIFF
--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -287,7 +287,7 @@ class Layer3:
         for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
             meta = meta or {}
             doc = doc or ""
-            similarity = round(1 - dist, 3)
+            similarity = round(max(0.0, 1 - dist), 3)
             wing_name = meta.get("wing", "?")
             room_name = meta.get("room", "?")
             source = Path(meta.get("source_file", "")).name if meta.get("source_file") else ""

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -740,7 +740,7 @@ def tool_check_duplicate(content: str, threshold: float = 0.9):
         if results["ids"] and results["ids"][0]:
             for i, drawer_id in enumerate(results["ids"][0]):
                 dist = results["distances"][0][i]
-                similarity = round(1 - dist, 3)
+                similarity = round(max(0.0, 1 - dist), 3)
                 if similarity >= threshold:
                     # Chroma 1.5.x can return None for partially-flushed rows;
                     # coerce to empty sentinels so downstream .get() is safe.


### PR DESCRIPTION
## Fix: Clamp similarity scores to [0,1]

Both \ and \ were returning negative similarity scores
for very dissimilar content.

### Root Cause
Both used \ to convert cosine distance to similarity.
With \, ChromaDB distances can exceed 1.0 for maximally
dissimilar vectors, making \ negative.

The rest of the codebase already handles this correctly:
\ line 285 uses \.

### Changes
- **mempalace/mcp_server.py**: - **mempalace/layers.py**: 
Fixes #978.
