### PR TITLE
fix: set hnsw:num_threads to 1 for thread-safe HNSW inserts

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -126,7 +126,7 @@ class ChromaBackend:
         client = self._client(palace_path)
         if create:
             collection = client.get_or_create_collection(
-                collection_name, metadata={"hnsw:space": "cosine"}
+                collection_name, metadata={"hnsw:space": "cosine", "hnsw:num_threads": "1"}
             )
         else:
             collection = client.get_collection(collection_name)
@@ -147,6 +147,6 @@ class ChromaBackend:
     ) -> "ChromaCollection":
         """Create (not get-or-create) *collection_name* with cosine HNSW space."""
         collection = self._client(palace_path).create_collection(
-            collection_name, metadata={"hnsw:space": hnsw_space}
+            collection_name, metadata={"hnsw:space": hnsw_space, "hnsw:num_threads": "1"}
         )
         return ChromaCollection(collection)


### PR DESCRIPTION
Fixes SIGSEGV in HNSW parallel inserts by limiting HNSW to single-threaded inserts.

## Summary
When multiple threads insert in parallel to an HNSW index, the Rust compactor crashes with SIGSEGV. This fix adds `hnsw:num_threads: 1` to the collection metadata, ensuring thread-safe HNSW operations.

## Changes
- `mempalace/backends/chroma.py`: Added `"hnsw:num_threads": "1"` to metadata in:
  - `get_or_create_collection()` - line 129
  - `create_collection()` - line 150

## Testing
This fix prevents the SIGSEGV crash when running parallel insert workloads against the HNSW index.