### PR TITLE
fix: pin chromadb to <1.0 to avoid 1.5.x queue-stall regression (#1006)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "chromadb>=0.5.0",
+    "chromadb>=0.5.0,<1.0",
     "pyyaml>=6.0,<7",
 ]
 


### PR DESCRIPTION
## Summary

Fixes #1006.

`chromadb>=0.5.0` with no upper bound lets fresh `pip install mempalace` pull the latest `chromadb==1.5.8`, which has a queue-processor regression that makes writes invisible. Mine reports success; `mempalace status` / `search` show 0 drawers. `chromadb==0.6.3` verified working.

## Change

One line in `pyproject.toml`:

```diff
- "chromadb>=0.5.0",
+ "chromadb>=0.5.0,<1.0",
```

## Test plan

- [ ] Fresh venv + `pip install` from this branch — verify chromadb resolves below 1.0
- [ ] `mempalace mine <dir> --mode convos` reports filed drawers
- [ ] `mempalace status` shows the filed drawers (not 0)
- [ ] `mempalace search` returns real content with non-None metadata

## Root cause

The 1.x architecture introduced async segment materialization via `embeddings_queue`. In 1.5.x that processor isn't running from `PersistentClient` alone — writes durably queue but never reach the `embeddings` / `embedding_metadata` tables. SQLite-level evidence in #1006.

Upstream fix not investigated in this PR. Long-term: contribute to ChromaDB or raise the ceiling once a 1.x version ships with the processor restored.

## Note for affected users

Users who already pulled 1.5.x can recover without losing data:

```bash
pip install "chromadb<1.0"
# re-mine — deterministic IDs, safe upsert
```