### PR TITLE
fix: guard searcher loop against None doc/meta from ChromaDB (#1007)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -282,6 +282,13 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     print(f"{'=' * 60}\n")
 
     for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
+        # ChromaDB may return None for doc/meta when a drawer's HNSW entry
+        # exists but its metadata/document rows haven't been materialized
+        # (partial-flush states, mid-delete, schema upgrade boundaries).
+        # Degrade gracefully rather than crash — the hit still appears with
+        # real distance; storage fields show "?" where content is missing.
+        meta = meta or {}
+        doc = doc or ""
         similarity = round(max(0.0, 1 - dist), 3)
         source = Path(meta.get("source_file", "?")).name
         wing_name = meta.get("wing", "?")


### PR DESCRIPTION
## Summary

Fixes #1007.

\`mempalace search\` crashes with \`AttributeError: 'NoneType' object has no attribute 'get'\` when any result has \`None\` metadata. Happens routinely in partial-flush states (very common on chromadb 1.5.x per #1006, but also possible during interrupted mines or schema upgrades even on fixed versions).

## Change

Two-line defensive coercion at the top of the results loop in \`mempalace/searcher.py\`:

\`\`\`diff
 for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
+    meta = meta or {}
+    doc = doc or ""
     similarity = round(max(0.0, 1 - dist), 3)
     source = Path(meta.get("source_file", "?")).name
\`\`\`

Result: the hit still shows with its real distance, source/wing/room fall back to \`"?"\`, the document body prints empty. User sees that a hit exists even if its content row is missing — strictly more useful than crashing.

## Test plan

- [ ] Reproduce the crash on a palace with pending \`embeddings_queue\` entries (any chromadb 1.5.x install with a recent mine — see #1006)
- [ ] With this patch, \`mempalace search "anything"\` completes and prints hit placeholders
- [ ] Existing searches on fully-flushed palaces return unchanged output

## Related

- #1006 — root cause for why \`None\` metadata appears routinely today
- \`searcher.py:295\` \`doc.strip()\` also needs the \`doc\` guard (covered by this patch)