### PR TITLE
docs: use real ~/.claude/projects/ path in first-run help and README (#996)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ mempalace init ~/projects/myapp
 ```bash
 # Mine content into the palace
 mempalace mine ~/projects/myapp                    # project files
-mempalace mine ~/chats/ --mode convos              # conversation exports
+mempalace mine ~/.claude/projects/ --mode convos   # Claude Code sessions (scope with --wing per project)
 
 # Search
 mempalace search "why did we switch to GraphQL"

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -4,7 +4,7 @@ MemPalace — Give your AI a memory. No API key required.
 
 Two ways to ingest:
   Projects:      mempalace mine ~/projects/my_app          (code, docs, notes)
-  Conversations: mempalace mine ~/chats/ --mode convos     (Claude, ChatGPT, Slack)
+  Conversations: mempalace mine <convo-dir> --mode convos     (Claude Code, Claude.ai, ChatGPT, Slack exports)
 
 Same palace. Same search. Different ingest strategies.
 
@@ -22,7 +22,7 @@ Commands:
 Examples:
     mempalace init ~/projects/my_app
     mempalace mine ~/projects/my_app
-    mempalace mine ~/chats/claude-sessions --mode convos
+    mempalace mine ~/.claude/projects/-Users-you-Projects-my_app --mode convos --wing my_app
     mempalace search "why did we switch to GraphQL"
     mempalace search "pricing discussion" --wing my_app --room costs
 """


### PR DESCRIPTION
## Summary

Fixes #996.

First-time users who ran `mempalace --help` saw `~/chats/` — a path that doesn't exist on any machine. Real location where Claude Code writes session JSONL is `~/.claude/projects/<escaped-project-path>/`. Three user-visible strings updated.

## Change

Three lines across two files:

- `mempalace/cli.py:7` — "Two ways to ingest" help block
- `mempalace/cli.py:25` — Examples block
- `README.md:58` — Quickstart

The website guides (`website/guide/mining.md`, `getting-started.md`) still use `~/chats/` as a placeholder for ChatGPT/Slack export scenarios where it remains reasonable. Those can tilt toward Claude Code examples in a follow-up if the maintainers prefer.

## Test plan

- [ ] `mempalace --help` shows `~/.claude/projects/` (no `~/chats/` in output)
- [ ] `grep -r "~/chats" mempalace/ README.md` returns nothing
- [ ] README Quickstart command copy-paste resolves to a real path on the user's machine