### PR TITLE
fix: guard Layer3.search_raw against None doc/meta from ChromaDB (#1011)

### DIFF
--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -281,6 +281,8 @@ class Layer3:
 
         lines = [f'## L3 — SEARCH RESULTS for "{query}"']
         for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
+            meta = meta or {}
+            doc = doc or ""
             similarity = round(1 - dist, 3)
             wing_name = meta.get("wing", "?")
             room_name = meta.get("room", "?")
@@ -327,6 +329,13 @@ class Layer3:
             _first_or_empty(results, "metadatas"),
             _first_or_empty(results, "distances"),
         ):
+            # ChromaDB may return None for doc/meta when a drawer's HNSW entry
+            # exists but its metadata/document rows haven't been materialized
+            # (partial-flush states, mid-delete, schema upgrade boundaries).
+            # Degrade gracefully — the hit still appears with real distance;
+            # storage fields show their fallback where content is missing.
+            meta = meta or {}
+            doc = doc or ""
             hits.append(
                 {
                     "text": doc,


### PR DESCRIPTION
## Summary

Fixes #1011.

`Layer3.search_raw()` in `mempalace/layers.py` has the same unguarded `meta.get(...)` pattern that #1007 / PR #999 fix in `searcher.py`. Applies the same two-line defensive coercion at the top of the results loop.

## Change

One file, defensive guard added at the top of the `search_raw` results loop:

```diff
 for ...
+    meta = meta or {}
+    doc = doc or ""
     # ... downstream meta.get() / doc.* calls
```

## Test plan

- [ ] Reproduce on a palace with `None` metadata in ChromaDB query results (any 1.5.x install per #1006)
- [ ] `Layer3.search_raw("query")` completes and returns results
- [ ] Existing callers unaffected on fully-flushed palaces

## Related

- #1007, PR #999 — same class of bug in `searcher.py`
- #1006, #1010 — chromadb 1.5.x queue-stall root cause and fix