### PR TITLE
fix(status): paginate col.get() to stay under SQLite variable limit

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -847,10 +847,16 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
+    # Count by wing and room. Paginate col.get() to stay under SQLite's
+    # SQLITE_MAX_VARIABLE_NUMBER (default 32766). A single col.get(limit=total)
+    # raises `too many SQL variables` once a palace exceeds that many drawers.
     total = col.count()
-    r = col.get(limit=total, include=["metadatas"]) if total else {"metadatas": []}
-    metas = r["metadatas"]
+    metas: list = []
+    if total:
+        BATCH = 10000
+        for offset in range(0, total, BATCH):
+            r = col.get(limit=BATCH, offset=offset, include=["metadatas"])
+            metas.extend(r.get("metadatas", []) or [])
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:


### PR DESCRIPTION
Fixes #1015.

## Summary

`mempalace status` crashes on any palace with more than ~32 766 drawers with:

```
chromadb.errors.InternalError: Error executing plan:
  Internal error: error returned from database:
  (code: 1) too many SQL variables
```

Root cause: `miner.py::status()` calls `col.get(limit=total)` unbounded. Chroma issues one SQL statement whose host-parameter count grows with the limit, and once `total > 32 766` (SQLite's default `SQLITE_MAX_VARIABLE_NUMBER`) SQLite rejects it.

## Change

Paginate `col.get()` in 10 000-drawer batches and aggregate `metadatas`. No behavior change for smaller palaces.

```diff
-    # Count by wing and room
+    # Count by wing and room. Paginate col.get() to stay under SQLite's
+    # SQLITE_MAX_VARIABLE_NUMBER (default 32766). A single col.get(limit=total)
+    # raises `too many SQL variables` once a palace exceeds that many drawers.
     total = col.count()
-    r = col.get(limit=total, include=["metadatas"]) if total else {"metadatas": []}
-    metas = r["metadatas"]
+    metas: list = []
+    if total:
+        BATCH = 10000
+        for offset in range(0, total, BATCH):
+            r = col.get(limit=BATCH, offset=offset, include=["metadatas"])
+            metas.extend(r.get("metadatas", []) or [])
```

One file touched, 9 added / 3 removed.

## Reproducer

On any palace with > 32 766 drawers:

```
mempalace status    # crashes with the traceback above
```

Minimal programmatic repro:

```python
from mempalace.config import MempalaceConfig
from mempalace.palace import get_collection
col = get_collection(MempalaceConfig().palace_path)
col.get(limit=col.count(), include=["metadatas"])
# → InternalError: too many SQL variables
```

Exact inflection point:
```
limit=32766  → ok (32766 rows)
limit=33000  → FAIL: too many SQL variables
```

## Test plan

- [x] `mempalace status` succeeds on a 43 852-drawer palace after the patch (produced the normal Wing/Room breakdown)
- [x] `mempalace status` succeeds on an empty palace
- [x] No change in output format (verified by diffing against a < 32 K drawer palace before / after)
- [ ] Existing test suite (`pytest`) — not run locally; maintainers please verify in CI

## Why 10 000

`SQLITE_MAX_VARIABLE_NUMBER` is 32 766 on most SQLite ≥ 3.32 builds; some older distributions ship it as 999. 10 000 is comfortably below both and large enough that aggregation overhead stays negligible (palace would need > 100 K drawers before the per-batch overhead mattered).