### PR TITLE
fix(hooks): restore silent-save visibility on Claude Code 2.1.114

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -255,9 +255,7 @@ def hook_stop(data: dict, harness: str):
             try:
                 silent_guard = MempalaceConfig().hook_silent_save
             except AttributeError as exc:
-                _log(
-                    f"WARNING: could not read hook_silent_save: {exc}; defaulting to silent mode"
-                )
+                _log(f"WARNING: could not read hook_silent_save: {exc}; defaulting to silent mode")
         if not silent_guard:
             _output({})
             return

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -209,10 +209,19 @@ def hook_stop(data: dict, harness: str):
     stop_hook_active = parsed["stop_hook_active"]
     transcript_path = parsed["transcript_path"]
 
-    # If already in a save cycle, let through (infinite-loop prevention)
+    # If already in a block-mode save cycle, let through (infinite-loop prevention).
+    # Silent mode saves directly without returning {"decision":"block"}, so there's
+    # no loop to prevent — and Claude Code's plugin dispatch sets this flag on every
+    # fire after the first, which would otherwise suppress all subsequent auto-saves.
     if str(stop_hook_active).lower() in ("true", "1", "yes"):
-        _output({})
-        return
+        try:
+            from .config import MempalaceConfig
+            silent_guard = MempalaceConfig().hook_silent_save
+        except Exception:
+            silent_guard = True
+        if not silent_guard:
+            _output({})
+            return
 
     # Count human messages
     exchange_count = _count_human_messages(transcript_path)

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -241,19 +241,22 @@ def hook_stop(data: dict, harness: str):
     # no loop to prevent — and Claude Code's plugin dispatch sets this flag on every
     # fire after the first, which would otherwise suppress all subsequent auto-saves.
     if str(stop_hook_active).lower() in ("true", "1", "yes"):
-        silent_guard = False
+        # Safe default: assume silent mode on any config-read failure so saves
+        # proceed rather than being silently dropped. Silent mode is the default
+        # (v3.3.0+), so if we can't read config, behave as if it's still on.
+        silent_guard = True
         try:
             from .config import MempalaceConfig
         except ImportError as exc:
             _log(
-                f"WARNING: could not import MempalaceConfig for stop guard: {exc}; preserving block-mode guard"
+                f"WARNING: could not import MempalaceConfig for stop guard: {exc}; defaulting to silent mode"
             )
         else:
             try:
                 silent_guard = MempalaceConfig().hook_silent_save
             except AttributeError as exc:
                 _log(
-                    f"WARNING: could not read hook_silent_save: {exc}; preserving block-mode guard"
+                    f"WARNING: could not read hook_silent_save: {exc}; defaulting to silent mode"
                 )
         if not silent_guard:
             _output({})

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -134,24 +134,35 @@ def _log(message: str):
 
 
 def _output(data: dict):
-    """Print JSON to the real stdout, even if mcp_server has hijacked sys.stdout.
+    """Print JSON to stdout without importing modules that may redirect streams.
 
-    mempalace.mcp_server redirects stdout → stderr at module import (fd and
-    sys-level) to protect the MCP stdio protocol from ChromaDB's C-level
-    prints. Silent-save imports it transitively via _save_diary_direct, so
-    sys.stdout is stderr by the time we get here. Claude Code reads hook
-    output from fd 1, so we write there directly using the saved fd.
+    If mempalace.mcp_server is already loaded, reuse its saved real stdout fd.
+    Otherwise, write directly to fd 1 so hook responses still go to stdout even
+    if sys.stdout has been redirected elsewhere.
     """
-    payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    payload = (json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+
+    real_stdout_fd: int | None = None
+    mcp_mod = sys.modules.get("mempalace.mcp_server") or sys.modules.get(
+        f"{__package__}.mcp_server" if __package__ else "mcp_server"
+    )
+    if mcp_mod is not None:
+        real_stdout_fd = getattr(mcp_mod, "_REAL_STDOUT_FD", None)
+
+    fd = real_stdout_fd if real_stdout_fd is not None else 1
+    offset = 0
     try:
-        from .mcp_server import _REAL_STDOUT_FD
-        if _REAL_STDOUT_FD is not None:
-            os.write(_REAL_STDOUT_FD, payload.encode("utf-8"))
-            return
-    except Exception:
+        while offset < len(payload):
+            try:
+                offset += os.write(fd, payload[offset:])
+            except InterruptedError:
+                continue
+        return
+    except OSError:
         pass
-    sys.stdout.write(payload)
-    sys.stdout.flush()
+
+    sys.stdout.buffer.write(payload)
+    sys.stdout.buffer.flush()
 
 
 def _get_mine_dir(transcript_path: str = "") -> str:
@@ -230,11 +241,16 @@ def hook_stop(data: dict, harness: str):
     # no loop to prevent — and Claude Code's plugin dispatch sets this flag on every
     # fire after the first, which would otherwise suppress all subsequent auto-saves.
     if str(stop_hook_active).lower() in ("true", "1", "yes"):
+        silent_guard = False
         try:
             from .config import MempalaceConfig
-            silent_guard = MempalaceConfig().hook_silent_save
-        except Exception:
-            silent_guard = True
+        except ImportError as exc:
+            _log(f"WARNING: could not import MempalaceConfig for stop guard: {exc}; preserving block-mode guard")
+        else:
+            try:
+                silent_guard = MempalaceConfig().hook_silent_save
+            except AttributeError as exc:
+                _log(f"WARNING: could not read hook_silent_save: {exc}; preserving block-mode guard")
         if not silent_guard:
             _output({})
             return

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -245,12 +245,16 @@ def hook_stop(data: dict, harness: str):
         try:
             from .config import MempalaceConfig
         except ImportError as exc:
-            _log(f"WARNING: could not import MempalaceConfig for stop guard: {exc}; preserving block-mode guard")
+            _log(
+                f"WARNING: could not import MempalaceConfig for stop guard: {exc}; preserving block-mode guard"
+            )
         else:
             try:
                 silent_guard = MempalaceConfig().hook_silent_save
             except AttributeError as exc:
-                _log(f"WARNING: could not read hook_silent_save: {exc}; preserving block-mode guard")
+                _log(
+                    f"WARNING: could not read hook_silent_save: {exc}; preserving block-mode guard"
+                )
         if not silent_guard:
             _output({})
             return

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -134,8 +134,24 @@ def _log(message: str):
 
 
 def _output(data: dict):
-    """Print JSON to stdout with consistent formatting (pretty-printed)."""
-    print(json.dumps(data, indent=2, ensure_ascii=False))
+    """Print JSON to the real stdout, even if mcp_server has hijacked sys.stdout.
+
+    mempalace.mcp_server redirects stdout → stderr at module import (fd and
+    sys-level) to protect the MCP stdio protocol from ChromaDB's C-level
+    prints. Silent-save imports it transitively via _save_diary_direct, so
+    sys.stdout is stderr by the time we get here. Claude Code reads hook
+    output from fd 1, so we write there directly using the saved fd.
+    """
+    payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    try:
+        from .mcp_server import _REAL_STDOUT_FD
+        if _REAL_STDOUT_FD is not None:
+            os.write(_REAL_STDOUT_FD, payload.encode("utf-8"))
+            return
+    except Exception:
+        pass
+    sys.stdout.write(payload)
+    sys.stdout.flush()
 
 
 def _get_mine_dir(transcript_path: str = "") -> str:

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -218,6 +218,66 @@ def test_precompact_allows(tmp_path):
 # --- _log ---
 
 
+def test_output_writes_to_real_stdout_fd_when_mcp_server_loaded():
+    """_output() must reach fd 1 even when mcp_server has redirected sys.stdout."""
+    import types
+
+    fake_module = types.ModuleType("mempalace.mcp_server")
+
+    read_fd, write_fd = os.pipe()
+    try:
+        fake_module._REAL_STDOUT_FD = write_fd
+        with patch.dict("sys.modules", {"mempalace.mcp_server": fake_module}):
+            from mempalace.hooks_cli import _output
+
+            _output({"systemMessage": "test"})
+
+        os.close(write_fd)
+        written = b""
+        while True:
+            chunk = os.read(read_fd, 4096)
+            if not chunk:
+                break
+            written += chunk
+    finally:
+        os.close(read_fd)
+
+    data = json.loads(written.decode())
+    assert data["systemMessage"] == "test"
+
+
+def test_output_falls_back_to_fd1_when_mcp_server_absent():
+    """_output() writes to fd 1 directly when mcp_server is not loaded."""
+    read_fd, write_fd = os.pipe()
+    try:
+        orig_fd1 = os.dup(1)
+        os.dup2(write_fd, 1)
+        os.close(write_fd)
+        try:
+            modules_without_mcp = {k: v for k, v in __import__("sys").modules.items()
+                                    if "mcp_server" not in k}
+            with patch.dict("sys.modules", modules_without_mcp, clear=True):
+                from mempalace.hooks_cli import _output
+                _output({"continue": True})
+        finally:
+            os.dup2(orig_fd1, 1)
+            os.close(orig_fd1)
+    except Exception:
+        os.close(read_fd)
+        raise
+
+    written = b""
+    while True:
+        chunk = os.read(read_fd, 4096)
+        if not chunk:
+            break
+        written += chunk
+    os.close(read_fd)
+
+    data = json.loads(written.decode())
+    assert data["continue"] is True
+
+
 def test_log_writes_to_hook_log(tmp_path):
     with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
         _log("test message")

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -255,10 +255,12 @@ def test_output_falls_back_to_fd1_when_mcp_server_absent():
         os.dup2(write_fd, 1)
         os.close(write_fd)
         try:
-            modules_without_mcp = {k: v for k, v in __import__("sys").modules.items()
-                                    if "mcp_server" not in k}
+            modules_without_mcp = {
+                k: v for k, v in __import__("sys").modules.items() if "mcp_server" not in k
+            }
             with patch.dict("sys.modules", modules_without_mcp, clear=True):
                 from mempalace.hooks_cli import _output
+
                 _output({"continue": True})
         finally:
             os.dup2(orig_fd1, 1)


### PR DESCRIPTION
Two related silent-save fixes exposed by Claude Code 2.1.114's plugin-scope Stop hook dispatch. Both are producer-side — getting clean JSON with `systemMessage` onto fd 1 where Claude Code reads it. The separate UI-side regression that's preventing the `<Line>` from persisting on screen is filed at [anthropics/claude-code#50542](https://github.com/anthropics/claude-code/issues/50542).

## Fix 1 — honor `silent_save` when `stop_hook_active: true`

Claude Code 2.1.114 sets `stop_hook_active: true` on every Stop fire after the first in a session (at least for plugin-dispatched hooks). The legacy guard at the top of `hook_stop` was written for block-mode — when the hook returned `{"decision":"block"}` to ask Claude to save, a re-fire with the flag set meant "you already blocked, don't block again" so we output `{}` and bailed.

Silent-save mode (default since #673) never blocks — it saves directly and returns. The flag is meaningless in that mode, but the old guard was still suppressing every auto-save after the first one in a Claude Code session:

- First fire: `stop_hook_active: false` → saves fine, `systemMessage` output
- Every subsequent fire: `stop_hook_active: true` → legacy guard returns `{}`, silent no-op, log stays empty, marker stuck

The fix only applies the guard when the user is actually in block mode:

```python
if str(stop_hook_active).lower() in ("true", "1", "yes"):
    try:
        silent_guard = MempalaceConfig().hook_silent_save
    except Exception:
        silent_guard = True
    if not silent_guard:
        _output({})
        return
```

## Fix 2 — write hook JSON to real stdout

`mempalace.mcp_server` redirects stdout → stderr at module-level import (Python-level `sys.stdout = sys.stderr` and fd-level `os.dup2(2, 1)`) to protect the MCP JSON-RPC channel from ChromaDB's C-level noise. That redirect was added in #864 and has lived peacefully alongside silent-save for months.

Silent-save imports `mcp_server` transitively via `_save_diary_direct` → `from .mcp_server import tool_diary_write`. By the time `_output()` runs, `sys.stdout` is stderr, and `print(json.dumps(...))` lands on fd 2. Claude Code reads the hook's stdout (fd 1), finds it empty, and never sees the `systemMessage` payload.

Historically this didn't bite because… well, I'm honestly not sure. The redirect's been in place since early March, silent-save's been in place since early April, and the `systemMessage` line was rendering through at least 2026-04-17. Something in 2.1.114's dispatch path seems stricter — possibly a shift from reading both streams and parsing the first JSON-like chunk to strictly parsing stdout. Either way, writing to the real fd is the correct long-term fix.

`_output()` now writes to `_REAL_STDOUT_FD` (saved by `mcp_server` before the redirect, exported as a module attribute) via `os.write()`, falling back to `sys.stdout` only when unavailable (e.g., hooks_cli used standalone without `mcp_server`). The full schema including `continue: true, suppressOutput: false` is emitted for completeness:

```json
{
  "continue": true,
  "suppressOutput": false,
  "systemMessage": "✦ 30 memories woven into the palace — themes"
}
```

## Test

- Existing suite passes (58/58 in `tests/test_hooks_cli.py`).
- Manual verification — `bash hooks/mempal-stop-hook.sh 2>/dev/null` now shows only the JSON on stdout, `2>&1 >/dev/null` shows only the log line on stderr. Cleanly separated streams.

## UI-side status

The corresponding `<Line>` rendering regression in Claude Code 2.1.114 is tracked at [anthropics/claude-code#50542](https://github.com/anthropics/claude-code/issues/50542). That one's not fixable from our side; this PR ensures we're producing correct output once the client fix lands.

## Test plan

- [ ] `python -m pytest tests/test_hooks_cli.py -q` — 58 tests pass
- [ ] Install the plugin; run Claude Code 2.1.114; confirm `diary_*` drawers land at the 15-exchange mark
- [ ] Inspect hook script output directly: clean JSON on stdout, log noise on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)