### PR TITLE
fix(searcher): clamp effective_distance to valid cosine range [0, 2]

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -825,7 +825,12 @@ def search_memories(
                 matched_via = "drawer+closet"
                 closet_preview = c_preview
 
-        effective_dist = dist - boost
+        # Clamp to the valid cosine-distance range [0, 2]. When a strong
+        # closet boost (up to 0.40) exceeds the raw distance, the subtraction
+        # can go negative — which (a) yields ``similarity > 1.0`` downstream
+        # and (b) makes the sort key land *below* ordinary positive distances,
+        # inverting the ranking so the best hybrid matches sort last.
+        effective_dist = max(0.0, min(2.0, dist - boost))
         entry = {
             "text": doc,
             "wing": meta.get("wing", "unknown"),

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -120,6 +120,63 @@ class TestSearchMemories:
         assert none_hit["wing"] == "unknown"
         assert none_hit["room"] == "unknown"
 
+    def test_effective_distance_clamped_to_valid_cosine_range(self):
+        """A strong closet boost (up to 0.40) applied to a low-distance drawer
+        can drive ``dist - boost`` negative. That violates the cosine-distance
+        invariant ``[0, 2]``: the API returns ``similarity > 1.0`` and the
+        internal ``_sort_key`` sinks below ordinary positive distances,
+        inverting the ranking so the best hybrid matches sort last.
+
+        With the clamp, ``effective_distance`` stays in ``[0, 2]``,
+        ``similarity`` stays in ``[0, 1]``, and the sort order is stable.
+        """
+        # Drawer a.md gets a tiny base distance (0.08) — nearly exact match.
+        # Drawer b.md gets a larger base distance (0.35).
+        drawers_col = MagicMock()
+        drawers_col.query.return_value = {
+            "documents": [["doc-a", "doc-b"]],
+            "metadatas": [[
+                {"source_file": "a.md", "wing": "w", "room": "r", "chunk_index": 0},
+                {"source_file": "b.md", "wing": "w", "room": "r", "chunk_index": 0},
+            ]],
+            "distances": [[0.08, 0.35]],
+            "ids": [["d-a", "d-b"]],
+        }
+        # A strong closet at rank 0 points at a.md → boost = 0.40,
+        # which exceeds a.md's base distance and would go negative without
+        # the clamp. No closet for b.md.
+        closets_col = MagicMock()
+        closets_col.query.return_value = {
+            "documents": [["closet-preview-a"]],
+            "metadatas": [[{"source_file": "a.md"}]],
+            "distances": [[0.2]],  # within CLOSET_DISTANCE_CAP (1.5)
+            "ids": [["c-a"]],
+        }
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=drawers_col),
+            patch("mempalace.searcher.get_closets_collection", return_value=closets_col),
+        ):
+            result = search_memories("query", "/fake/path", n_results=5)
+
+        hits = result["results"]
+        assert hits, "should return results"
+
+        # Invariants on every hit.
+        for h in hits:
+            assert 0.0 <= h["similarity"] <= 1.0, (
+                f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            )
+            assert 0.0 <= h["effective_distance"] <= 2.0, (
+                f"effective_distance out of range: {h['effective_distance']} "
+                f"for {h['source_file']}"
+            )
+
+        # With the clamp, the closet-boosted a.md still ranks ahead of b.md —
+        # the boost still wins, but it no longer flips the ranking.
+        assert hits[0]["source_file"] == "a.md"
+        assert hits[0]["matched_via"] == "drawer+closet"
+
 
 # ── BM25 internals: None / empty document safety ─────────────────────
 

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -135,10 +135,12 @@ class TestSearchMemories:
         drawers_col = MagicMock()
         drawers_col.query.return_value = {
             "documents": [["doc-a", "doc-b"]],
-            "metadatas": [[
-                {"source_file": "a.md", "wing": "w", "room": "r", "chunk_index": 0},
-                {"source_file": "b.md", "wing": "w", "room": "r", "chunk_index": 0},
-            ]],
+            "metadatas": [
+                [
+                    {"source_file": "a.md", "wing": "w", "room": "r", "chunk_index": 0},
+                    {"source_file": "b.md", "wing": "w", "room": "r", "chunk_index": 0},
+                ]
+            ],
             "distances": [[0.08, 0.35]],
             "ids": [["d-a", "d-b"]],
         }
@@ -164,9 +166,9 @@ class TestSearchMemories:
 
         # Invariants on every hit.
         for h in hits:
-            assert 0.0 <= h["similarity"] <= 1.0, (
-                f"similarity out of range: {h['similarity']} for {h['source_file']}"
-            )
+            assert (
+                0.0 <= h["similarity"] <= 1.0
+            ), f"similarity out of range: {h['similarity']} for {h['source_file']}"
             assert 0.0 <= h["effective_distance"] <= 2.0, (
                 f"effective_distance out of range: {h['effective_distance']} "
                 f"for {h['source_file']}"


### PR DESCRIPTION
## Summary

``search_memories`` in ``mempalace/searcher.py`` computes
``effective_dist = dist - boost`` at line 411. The ``boost`` can be as
large as ``CLOSET_RANK_BOOSTS[0] == 0.40`` when a closet hits at rank 0.
When the raw drawer distance is small (any near-exact match — typical
on short queries with strong semantic overlap), the subtraction goes
negative, violating the cosine-distance invariant ``[0, 2]``.

Two downstream effects, observed in the wild:

1. **`similarity` > 1.0.** Line 418:

   ```python
   \"similarity\": round(max(0.0, 1 - effective_dist), 3),
   ```

   With ``effective_dist = -0.30`` this returns ``1.30``. The
   ``max(0.0, ...)`` only prevents *negative* similarities; it does not
   cap above 1. API consumers see nonsensical similarity values.

2. **Inverted ranking.** Line 427 stores ``_sort_key = effective_dist``;
   line 435 sorts ``scored`` ascending. A negative ``_sort_key`` drops
   *below* ordinary positive distances, so the strongest hybrid hit
   lands last — the opposite of what hybrid retrieval is supposed to
   deliver.

## Change

One-line clamp to the valid cosine-distance range:

\`\`\`diff
-        effective_dist = dist - boost
+        # Clamp to the valid cosine-distance range [0, 2]. When a strong
+        # closet boost (up to 0.40) exceeds the raw distance, the subtraction
+        # can go negative — which (a) yields \`\`similarity > 1.0\`\` downstream
+        # and (b) makes the sort key land *below* ordinary positive distances,
+        # inverting the ranking so the best hybrid matches sort last.
+        effective_dist = max(0.0, min(2.0, dist - boost))
\`\`\`

The boost still wins (closet-backed hits still rank first); it just no
longer flips the order or returns out-of-range values.

## Test plan

New test ``TestSearchMemories::test_effective_distance_clamped_to_valid_cosine_range`` —
mocks ``get_collection`` + ``get_closets_collection`` to return a
low-distance drawer (``0.08``) with a strong closet match (rank 0,
boost 0.40). Asserts:

- every hit has ``0.0 <= similarity <= 1.0``
- every hit has ``0.0 <= effective_distance <= 2.0``
- the closet-boosted source still ranks first

Full searcher + hybrid suite: ``27 passed in 102.24s``.

## Relationship to other open PRs

- **Complements #988.** #988 clamps the output ``similarity`` to
  ``[0, 1]``, which is a partial mitigation: it hides the nonsensical
  similarity number but leaves ``effective_distance`` (returned in the
  result dict) and the sort key in the invalid range. This PR clamps at
  the arithmetic source, so both downstream users stay in range and
  ranking is correct. The two PRs can merge in either order; if #988
  lands first, the ``max(0.0, ...)`` guard there becomes redundant but
  harmless.
- Orthogonal to **#979** (``tool_check_duplicate`` guards).

## Why it doesn't introduce new issues

| Plausible regression | Prevention |
|---|---|
| Clamping to ``[0, 2]`` caps the boost effect at ``dist``. | Deliberate: the boost was over-tuned (0.40 vs typical distances 0.3–0.7). A cap still gives the boosted hit the *best* position without flipping the order. |
| Downstream consumers might expect ``effective_distance`` in the old range. | Old range was ``(-∞, 2]``; new range is ``[0, 2]`` — strict subset. No downstream consumer is broken by narrower bounds. |