### PR TITLE
perf: paginate miner.status() — fixes SQLITE_MAX_VARIABLE_NUMBER crash past ~32K drawers

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -847,22 +847,32 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
+    # Count by wing and room. Paginate col.get() in 10K-drawer batches:
+    # a single col.get(limit=total) hits SQLite's SQLITE_MAX_VARIABLE_NUMBER
+    # (default 32,766) on palaces with many thousands of drawers — see #802,
+    # #1015. Pagination keeps each query under the variable cap.
     total = col.count()
-    r = col.get(limit=total, include=["metadatas"]) if total else {"metadatas": []}
-    metas = r["metadatas"]
-
     wing_rooms = defaultdict(lambda: defaultdict(int))
-    for m in metas:
-        m = m or {}
-        wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
+    scanned = 0
+    batch = 10000
+    offset = 0
+    while offset < total:
+        r = col.get(limit=batch, offset=offset, include=["metadatas"])
+        metas = r.get("metadatas") or []
+        if not metas:
+            break
+        for m in metas:
+            m = m or {}
+            wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
+        scanned += len(metas)
+        offset += len(metas)
 
     print(f"\n{'=' * 55}")
-    print(f"  MemPalace Status — {len(metas)} drawers")
+    print(f"  MemPalace Status — {scanned:,} drawers")
     print(f"{'=' * 55}\n")
     for wing, rooms in sorted(wing_rooms.items()):
         print(f"  WING: {wing}")
         for room, count in sorted(rooms.items(), key=lambda x: x[1], reverse=True):
-            print(f"    ROOM: {room:20} {count:5} drawers")
+            print(f"    ROOM: {room:20} {count:>8,} drawers")
         print()
     print(f"{'=' * 55}\n")


### PR DESCRIPTION
Closes #802 (reported 1 week ago) and #1015 (filed today — same crash, same stack location, filed after you merged #999).

## The bug

```python
total = col.count()
r = col.get(limit=total, include=["metadatas"])
```

On palaces with more than ~32,766 drawers, ChromaDB's underlying SQLite query binds `total` variables and exceeds `SQLITE_MAX_VARIABLE_NUMBER` (default 32,766), raising:

```
sqlite3.OperationalError: too many SQL variables
```

`mempalace status` crashes before printing anything on any palace over the limit. The fork has been running this paginated version for 9 days (landed on jphein/mempalace main on 2026-04-10) against a 152,682-drawer palace, so I haven't re-triggered the crash directly in that window — but the unpatched code path is reproducible by reverting this patch.

## The fix

```python
offset = 0
while offset < total:
    r = col.get(limit=10000, offset=offset, include=["metadatas"])
    metas = r.get("metadatas") or []
    if not metas:
        break
    ...
    offset += len(metas)
```

Each page stays well under the variable cap. Loop terminates when ChromaDB returns fewer than the requested batch (final page).

Also switches printed counts to thousand-separated decimals (`152,682` vs `152682`) — easier to read on large palaces.

## Test plan

- [x] `pytest tests/test_miner.py tests/test_cli.py -q` — 62 passed
- [x] Paginated code path exercised on a 152,682-drawer palace in the fork since 2026-04-10 — `status` completes and prints correct per-wing/per-room counts

## Notes

- This is a targeted fix for `miner.py::status()` only. Same underlying issue may exist in other `col.get(limit=total)` call sites; happy to file follow-ups if you confirm you want this scope.
- The fork (jphein/mempalace) has been running this patch since 2026-04-10. Filing now because #1015 duplicates #802 and the fix is simple enough to merge independently.

