### PR TITLE
docs: fix hook paths and config keys in HOOKS_TUTORIAL.md

### DIFF
--- a/examples/HOOKS_TUTORIAL.md
+++ b/examples/HOOKS_TUTORIAL.md
@@ -7,21 +7,22 @@ MemPalace hooks act as an "Auto-Save" feature. They help your AI keep a permanen
 * **PreCompact Hook** (`mempal_precompact_hook.sh`): Saves your context right before the AI's memory window fills up.
 
 ### 2. Setup for Claude Code
-Add this to your configuration file to enable automatic background saving:
+Add this to `~/.claude/settings.local.json` to enable automatic background saving globally, or to `.claude/settings.local.json` inside a specific project for project-scoped hooks.
+
+**Important:** Use absolute paths — relative paths like `./hooks/...` will not work because Claude Code resolves hook commands from the working directory at hook fire time, not from the mempalace repo root.
 
 ```json
 {
   "hooks": {
     "Stop": [
       {
-        "matcher": "", 
-        "hooks": [{"type": "command", "command": "./hooks/mempal_save_hook.sh"}]
+        "matcher": "*",
+        "hooks": [{"type": "command", "command": "/absolute/path/to/mempalace/hooks/mempal_save_hook.sh", "timeout": 30}]
       }
     ],
     "PreCompact": [
       {
-        "matcher": "", 
-        "hooks": [{"type": "command", "command": "./hooks/mempal_precompact_hook.sh"}]
+        "hooks": [{"type": "command", "command": "/absolute/path/to/mempalace/hooks/mempal_precompact_hook.sh", "timeout": 30}]
       }
     ]
   }


### PR DESCRIPTION
Closes #1037

## What does this PR do?

Fixes `examples/HOOKS_TUTORIAL.md`:

- **Absolute paths**: replaces `./hooks/...` with `/absolute/path/to/mempalace/hooks/...` — relative paths fail because Claude Code resolves hook commands from the working directory at fire time, not the mempalace repo root. Matches the existing `hooks/README.md` reference config.
- **`PreCompact` matcher removed**: `matcher` is only valid for `Stop` hooks, not `PreCompact`.
- **`timeout: 30` added**: consistent with `hooks/README.md`.
- **Target file clarified**: specifies `~/.claude/settings.local.json` for global or `.claude/settings.local.json` for project-scoped setup.

## How to test

Follow the updated tutorial on a fresh install and verify hooks fire correctly.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)