### PR TITLE
feat(searcher): expose two-stage sort + _debug observability (Phase 5)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -7,11 +7,28 @@ drawer query is the floor — always runs — and closet hits add a rank-based
 boost when they agree. Closets are a ranking *signal*, never a gate, so
 weak closets (regex extraction on narrative content) can only help, never
 hide drawers the direct path would have found.
+
+## Final-order note (two-stage sort) ##
+``search_memories`` applies **two** sort passes — if you expected the output
+to be monotonic in ``effective_distance``, here is why it isn't:
+
+  1. **Stage 1** (``scored.sort(_sort_key)``) — orders candidates by
+     ``effective_distance = vector_distance - closet_boost`` ascending,
+     then takes the top ``n_results`` for hydration.
+  2. **Stage 2** (``_hybrid_rank``) — re-orders the final slice by a convex
+     combination of vector similarity and min-max-normalised BM25 over the
+     candidate corpus (``0.6 * vec_sim + 0.4 * bm25_norm`` descending).
+
+The list the caller sees is Stage 2's output. ``_sort_key`` is therefore an
+internal / intermediate ranking signal, not the final one; pass
+``_debug=True`` to ``search_memories`` to see it preserved in the result
+dicts alongside timings.
 """
 
 import logging
 import math
 import re
+import time
 from pathlib import Path
 
 from .palace import get_closets_collection, get_collection
@@ -301,13 +318,15 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     print()
 
 
-def search_memories(
+def search_memories(  # noqa: C901 — end-to-end search pipeline; splitting hurts readability
     query: str,
     palace_path: str,
     wing: str = None,
     room: str = None,
     n_results: int = 5,
     max_distance: float = 0.0,
+    *,
+    _debug: bool = False,
 ) -> dict:
     """Programmatic search — returns a dict instead of printing.
 
@@ -323,7 +342,22 @@ def search_memories(
             cosine distance (hnsw:space=cosine) — 0 = identical, 2 = opposite.
             Results with distance > this value are filtered out. A value of
             0.0 disables filtering. Typical useful range: 0.3–1.0.
+        _debug: When True, preserve intermediate ranking keys
+            (``_sort_key``, ``_drawer_rank``) in each result dict and attach
+            per-stage timings to the top-level response under the ``timings``
+            key (ms): ``drawer_query_ms``, ``closet_query_ms``,
+            ``hydrate_ms``, ``hybrid_rerank_ms``, ``total_ms``. Intended for
+            tuning + regression tests; leave False in production.
+
+    Note on final order:
+        The returned ``results`` list is sorted by the BM25+vector hybrid
+        (see module docstring), *not* by ``effective_distance``. See the
+        "two-stage sort" block in ``searcher.py``'s module docstring for
+        the full rationale.
     """
+    _t_total_start = time.perf_counter()
+    timings: dict = {}
+
     try:
         drawers_col = get_collection(palace_path, create=False)
     except Exception as e:
@@ -350,7 +384,9 @@ def search_memories(
         }
         if where:
             dkwargs["where"] = where
+        _t0 = time.perf_counter()
         drawer_results = drawers_col.query(**dkwargs)
+        timings["drawer_query_ms"] = round((time.perf_counter() - _t0) * 1000, 2)
     except Exception as e:
         return {"error": f"Search error: {e}"}
 
@@ -365,7 +401,9 @@ def search_memories(
         }
         if where:
             ckwargs["where"] = where
+        _t0 = time.perf_counter()
         closet_results = closets_col.query(**ckwargs)
+        timings["closet_query_ms"] = round((time.perf_counter() - _t0) * 1000, 2)
         for rank, (cdoc, cmeta, cdist) in enumerate(
             zip(
                 _first_or_empty(closet_results, "documents"),
@@ -387,10 +425,12 @@ def search_memories(
     CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
 
     scored: list = []
-    for doc, meta, dist in zip(
-        _first_or_empty(drawer_results, "documents"),
-        _first_or_empty(drawer_results, "metadatas"),
-        _first_or_empty(drawer_results, "distances"),
+    for drawer_rank, (doc, meta, dist) in enumerate(
+        zip(
+            _first_or_empty(drawer_results, "documents"),
+            _first_or_empty(drawer_results, "metadatas"),
+            _first_or_empty(drawer_results, "distances"),
+        )
     ):
         # Filter on raw distance before rounding to avoid precision loss.
         if max_distance > 0.0 and dist > max_distance:
@@ -427,6 +467,10 @@ def search_memories(
             "_sort_key": effective_dist,
             "_source_file_full": source,
             "_chunk_index": meta.get("chunk_index"),
+            # Drawer ordinal in the raw vector query (pre-boost, pre-hybrid).
+            # Preserved only when ``_debug=True``; useful to correlate the
+            # final hybrid order against the pure vector order.
+            "_drawer_rank": drawer_rank,
         }
         if closet_preview:
             entry["closet_preview"] = closet_preview
@@ -441,6 +485,7 @@ def search_memories(
     # closet said "this source is relevant"; vector may have picked the
     # wrong chunk within it; grep picks the right one.
     MAX_HYDRATION_CHARS = 10000
+    _t0 = time.perf_counter()
     for h in hits:
         if h["matched_via"] == "drawer":
             continue
@@ -489,17 +534,33 @@ def search_memories(
         h["text"] = expanded
         h["drawer_index"] = best_idx
         h["total_drawers"] = len(ordered_docs)
+    timings["hydrate_ms"] = round((time.perf_counter() - _t0) * 1000, 2)
 
-    # BM25 hybrid re-rank within the final candidate set.
+    # Stage 2 of the two-stage sort: BM25+vector hybrid re-rank within the
+    # final candidate set. This is the ordering the caller sees, not the
+    # ``effective_distance`` order from Stage 1. See module docstring.
+    _t0 = time.perf_counter()
     hits = _hybrid_rank(hits, query)
+    timings["hybrid_rerank_ms"] = round((time.perf_counter() - _t0) * 1000, 2)
+
+    # Internal keys are always popped from non-debug responses to keep the
+    # public contract tight; in debug mode ``_sort_key`` and ``_drawer_rank``
+    # survive for inspection.
     for h in hits:
-        h.pop("_sort_key", None)
         h.pop("_source_file_full", None)
         h.pop("_chunk_index", None)
+        if not _debug:
+            h.pop("_sort_key", None)
+            h.pop("_drawer_rank", None)
 
-    return {
+    timings["total_ms"] = round((time.perf_counter() - _t_total_start) * 1000, 2)
+
+    response = {
         "query": query,
         "filters": {"wing": wing, "room": room},
         "total_before_filter": len(_first_or_empty(drawer_results, "documents")),
         "results": hits,
     }
+    if _debug:
+        response["timings"] = timings
+    return response

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -131,3 +131,135 @@ class TestClosetMetadata:
             assert h["matched_via"] == "drawer"
             assert "closet_preview" not in h
             assert h["closet_boost"] == 0.0
+
+
+# ── observability: _debug flag + final-sort invariant (Phase 5 / V1) ─────────
+
+
+class TestDebugMode:
+    """Guards the public contract of ``search_memories(..., _debug=...)``.
+
+    This flag is the operator-facing hook for diagnosing ranking anomalies.
+    If the keys or timings go missing, tuning work downstream breaks silently.
+    """
+
+    def test_debug_false_is_clean(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        result = search_memories("JWT", palace, n_results=3)
+        # Internal keys and timings must not leak into non-debug responses.
+        assert "timings" not in result
+        for h in result["results"]:
+            assert "_sort_key" not in h
+            assert "_drawer_rank" not in h
+            assert "_source_file_full" not in h
+            assert "_chunk_index" not in h
+
+    def test_debug_true_preserves_keys_and_timings(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        result = search_memories("JWT", palace, n_results=3, _debug=True)
+        assert "timings" in result, "debug response must include the timings block"
+        for key in ("drawer_query_ms", "hydrate_ms", "hybrid_rerank_ms", "total_ms"):
+            assert key in result["timings"], f"missing timing key {key!r}"
+            assert isinstance(result["timings"][key], (int, float))
+            assert result["timings"][key] >= 0
+        assert result["results"], "expected at least one hit"
+        for h in result["results"]:
+            assert "_sort_key" in h
+            assert "_drawer_rank" in h
+            assert isinstance(h["_drawer_rank"], int)
+            # _source_file_full / _chunk_index are still stripped in debug — they
+            # are implementation plumbing, not ranking signals.
+            assert "_source_file_full" not in h
+            assert "_chunk_index" not in h
+
+    def test_timings_include_closet_when_closets_exist(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D1",
+            source_file="fixture_D1.md",
+            topics=["JWT auth", "token expiry"],
+        )
+        result = search_memories("JWT", palace, n_results=3, _debug=True)
+        assert "closet_query_ms" in result["timings"]
+
+
+class TestFinalSortInvariant:
+    """Regression guard for V1 (search ordering anomaly documented during
+    verification). The final order is Stage 2 — ``_hybrid_rank``'s convex
+    combination of vector similarity and min-max-normalised BM25 — not the
+    Stage 1 ``effective_distance`` ascending order.
+
+    If someone swaps the two stages or drops ``_hybrid_rank``, this test fails.
+    """
+
+    @staticmethod
+    def _expected_hybrid_scores(hits, vector_weight=0.6, bm25_weight=0.4):
+        """Re-derive the hybrid score from the hit dicts using the same
+        formula as ``_hybrid_rank``. Returns a list aligned with ``hits``.
+        """
+        bm25_raws = [h.get("bm25_score", 0.0) for h in hits]
+        max_bm25 = max(bm25_raws) if bm25_raws else 0.0
+        bm25_norm = (
+            [s / max_bm25 for s in bm25_raws] if max_bm25 > 0 else [0.0] * len(bm25_raws)
+        )
+        scores = []
+        for h, norm in zip(hits, bm25_norm):
+            vec_sim = max(0.0, 1.0 - h.get("distance", 1.0))
+            scores.append(vector_weight * vec_sim + bm25_weight * norm)
+        return scores
+
+    def test_final_order_matches_hybrid_rank_not_effective_distance(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        # Include a closet so the two stages can diverge.
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D3",
+            source_file="fixture_D3.md",
+            topics=["database migration tooling", "schema upgrades"],
+        )
+        result = search_memories(
+            "database migration PostgreSQL schema", palace, n_results=4, _debug=True
+        )
+        hits = result["results"]
+        assert len(hits) >= 2, "need at least 2 hits to check ordering"
+
+        scores = self._expected_hybrid_scores(hits)
+        # Assert the returned order is non-increasing in the reconstructed
+        # hybrid score — i.e. ``_hybrid_rank`` was the last ranking step.
+        for a, b in zip(scores, scores[1:]):
+            assert a + 1e-9 >= b, (
+                "final results must be sorted descending by hybrid "
+                "(0.6*vec_sim + 0.4*bm25_norm); drift here means Stage 2 "
+                "(_hybrid_rank) was skipped or a third sort sneaked in "
+                f"after it. Got scores: {scores}"
+            )
+
+    def test_effective_distance_is_not_guaranteed_monotonic(self, tmp_path):
+        """Documents V1 as design: when hybrid rerank kicks in, the output
+        order is allowed to diverge from ``effective_distance`` ascending.
+        This test is informational — it simply confirms the old intuition
+        ("must be sorted by effective_distance") is not a load-bearing
+        invariant, so future readers don't re-file V1.
+        """
+        palace = str(tmp_path / "palace")
+        _seed_drawers(palace)
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D3",
+            source_file="fixture_D3.md",
+            topics=["database migration tooling", "schema upgrades"],
+        )
+        result = search_memories(
+            "database migration PostgreSQL schema", palace, n_results=4
+        )
+        effs = [h["effective_distance"] for h in result["results"]]
+        # Not an assertion that effs are unsorted — on a particular corpus
+        # they might coincide with the hybrid order. The guarantee we make
+        # is the *other* one (hybrid in TestFinalSortInvariant above).
+        # Here we just assert the field is still present for observability.
+        assert all(isinstance(e, float) for e in effs)


### PR DESCRIPTION
## Summary

Phase 5 of the MemPalace Closets Gap Remediation Plan. Resolves **V1** (search ordering anomaly surfaced during docs verification) and addresses the observability gap flagged in the approved plan.

**Independent of Phase 1 (#1039)** — branched off `develop`; no shared code path. Either PR can merge first.

## The V1 anomaly (and why it wasn't a bug)
`search_memories()` applies a **two-stage sort**:

1. **Stage 1** — `scored.sort(_sort_key)` orders candidates by `effective_distance = vector_distance - closet_boost` ascending, takes top `n_results` for hydration.
2. **Stage 2** — `_hybrid_rank()` re-orders the final slice by a convex combination of vector similarity and min-max-normalised BM25 (`0.6 * vec_sim + 0.4 * bm25_norm` descending).

The list callers see is Stage 2's output, not Stage 1's. This was working as designed, just undocumented. Now it's explicit in both the module docstring and `search_memories()`'s docstring, with a regression test that catches drift if the stages are swapped or `_hybrid_rank` is dropped.

## New `_debug` flag
Keyword-only, default False. Zero behavioural change when unset.

When `_debug=True`:
- `_sort_key` (Stage-1 effective_distance) preserved per hit
- `_drawer_rank` (ordinal in the raw vector query) preserved per hit
- `timings` block attached to the top-level response:
  - `drawer_query_ms`, `closet_query_ms`, `hydrate_ms`, `hybrid_rerank_ms`, `total_ms`

Useful for tuning + regression tests; intended to leave disabled in production. Instrumentation cost is microseconds, well under the 500ms hook budget in CLAUDE.md.

## Tests
- **1038 passed, 0 failures, ruff clean** (full suite, ignoring benchmarks).
- **New test groups** in `tests/test_hybrid_search.py`:
  - `TestDebugMode` (3 tests) — guards the `_debug=True` / `_debug=False` contract; asserts all internal keys + timings are preserved or stripped correctly.
  - `TestFinalSortInvariant` (2 tests) — regression guards the two-stage sort. Reconstructs the hybrid score from returned `distance` + `bm25_score` fields and asserts the final order is non-increasing. Documents `effective_distance` as explicitly NOT load-bearing so V1 doesn't get re-filed.

## Trade-off: C901 noqa
`search_memories` now trips ruff's `C901` (complexity 26 > 25) due to timing instrumentation. Added `# noqa: C901` with justification in-line rather than extracting helpers — the search pipeline is inherently sequential (query drawers → query closets → score → hydrate → rerank) and cutting it up would obscure the end-to-end flow. Flag for future cleanup if Phase 2+ grows it further.

## Commits
- `ee81f99` — feat(searcher): expose two-stage sort + _debug observability

## Links
- 📎 [Reference — Closets Collection documentation](https://www.notion.so/347ed1cc33488153a02bc7292a5429aa)
- ✅ [Approved Gap Remediation Plan (HITL)](https://www.notion.so/347ed1cc3348810e9773dd2514bf3a7e)
- 🔄 [Session Handoff](https://www.notion.so/347ed1cc334881cc8862d2623ab07289)
- 🔗 Related: #1039 (Phase 1 \u2014 config surface, independent)
- 💬 [Conversation](https://app.warp.dev/conversation/34637b1e-afee-444a-a9f2-c3457ceec6e4)
- 📋 [Plan artifact](https://app.warp.dev/drive/notebook/EvtnTsepCyV5lLVvZ5mTQK)

Co-Authored-By: Oz <oz-agent@warp.dev>