### PR TITLE
docs: add Codex MCP setup guidance

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -376,13 +376,15 @@ def cmd_mcp(args):
         server_cmd = base_server_cmd
 
     print("MemPalace MCP quick setup:")
-    print(f"  claude mcp add mempalace -- {server_cmd}")
+    print(f"  Claude Code: claude mcp add mempalace -- {server_cmd}")
+    print(f"  Codex:       codex mcp add mempalace -- {server_cmd}")
     print("\nRun the server directly:")
     print(f"  {server_cmd}")
 
     if not args.palace:
         print("\nOptional custom palace:")
-        print(f"  claude mcp add mempalace -- {base_server_cmd} --palace /path/to/palace")
+        print(f"  Claude Code: claude mcp add mempalace -- {base_server_cmd} --palace /path/to/palace")
+        print(f"  Codex:       codex mcp add mempalace -- {base_server_cmd} --palace /path/to/palace")
         print(f"  {base_server_cmd} --palace /path/to/palace")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -334,8 +334,10 @@ def test_mcp_command_prints_setup_guidance(monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert "MemPalace MCP quick setup:" in captured.out
-    assert "claude mcp add mempalace -- python -m mempalace.mcp_server" in captured.out
+    assert "Claude Code: claude mcp add mempalace -- python -m mempalace.mcp_server" in captured.out
+    assert "Codex:       codex mcp add mempalace -- python -m mempalace.mcp_server" in captured.out
     assert "\nOptional custom palace:\n" in captured.out
+    assert "Codex:       codex mcp add mempalace -- python -m mempalace.mcp_server --palace /path/to/palace" in captured.out
     assert "python -m mempalace.mcp_server --palace /path/to/palace" in captured.out
     assert "[--palace /path/to/palace]" not in captured.out
     assert captured.err == ""
@@ -350,6 +352,8 @@ def test_mcp_command_uses_custom_palace_path_when_provided(monkeypatch, capsys):
     expanded = str(Path("~/tmp/my palace").expanduser())
 
     assert "python -m mempalace.mcp_server --palace" in captured.out
+    assert "Claude Code: claude mcp add mempalace --" in captured.out
+    assert "Codex:       codex mcp add mempalace --" in captured.out
     assert expanded in captured.out
     assert "Optional custom palace:" not in captured.out
     assert "[--palace /path/to/palace]" not in captured.out

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -88,5 +88,5 @@ It calls `mempalace_search` automatically, gets verbatim results, and answers yo
 ## Next Steps
 
 - [Mining Your Data](/guide/mining) — deep dive into mining modes
-- [MCP Integration](/guide/mcp-integration) — connect to Claude, ChatGPT, Cursor, Gemini
+- [MCP Integration](/guide/mcp-integration) — connect to Claude, Codex, ChatGPT, Cursor, Gemini
 - [The Palace](/concepts/the-palace) — understand wings, rooms, halls, and tunnels

--- a/website/guide/mcp-integration.md
+++ b/website/guide/mcp-integration.md
@@ -14,14 +14,30 @@ mempalace mcp
 
 ### Manual Connection
 
+Claude Code:
+
 ```bash
 claude mcp add mempalace -- python -m mempalace.mcp_server
 ```
 
+Codex:
+
+```bash
+codex mcp add mempalace -- python -m mempalace.mcp_server
+```
+
 ### With Custom Palace Path
+
+Claude Code:
 
 ```bash
 claude mcp add mempalace -- python -m mempalace.mcp_server --palace /path/to/palace
+```
+
+Codex:
+
+```bash
+codex mcp add mempalace -- python -m mempalace.mcp_server --palace /path/to/palace
 ```
 
 Now your AI has all 29 tools available. Ask it anything:
@@ -35,6 +51,7 @@ Claude calls `mempalace_search` automatically, gets verbatim results, and answer
 MemPalace works with any tool that supports MCP:
 
 - **Claude Code** — native via plugin or manual MCP
+- **Codex** — native MCP support via `codex mcp add`
 - **OpenClaw** — via official skill, see [OpenClaw Skill](/guide/openclaw)
 - **ChatGPT** — via MCP bridge
 - **Cursor** — native MCP support

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -136,7 +136,7 @@ Creates a backup at `<palace_path>.backup` before rebuilding.
 
 ## `mempalace mcp`
 
-Helper command that outputs setup syntax (like `claude mcp add...`) to connect MemPalace to your AI client, automatically handling paths.
+Helper command that outputs setup syntax (like `claude mcp add...` or `codex mcp add...`) to connect MemPalace to your AI client, automatically handling paths.
 
 ```bash
 mempalace mcp


### PR DESCRIPTION
## Summary
- teach `mempalace mcp` to print both Claude Code and Codex setup commands
- document Codex manual MCP setup in the MCP integration guide
- update related CLI/getting-started docs so Codex support is discoverable

## Why
MemPalace already supports Codex hooks and Codex transcript normalization, but the `mempalace mcp` helper and the main MCP guide still only show Claude-focused setup examples. This makes Codex support harder to discover than it needs to be.

## Testing
- `./.venv/bin/python -m pytest tests -q`
