### PR TITLE
docs: add Docker MCP deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ mempalace wake-up
 
 For Claude Code, Gemini CLI, MCP-compatible tools, and local models, see
 [mempalaceofficial.com/guide/getting-started](https://mempalaceofficial.com/guide/getting-started.html).
+For a minimal Docker/Compose deployment, see [examples/docker/README.md](examples/docker/README.md).
 
 ---
 

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+ARG MEMPALACE_VERSION=3.3.0
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir "mempalace==${MEMPALACE_VERSION}"
+
+RUN mkdir -p /data/palace /data/config
+
+ENV MEMPALACE_PALACE_PATH=/data/palace
+
+# Keep the container alive; MCP clients connect via `docker exec`.
+CMD ["tail", "-f", "/dev/null"]

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,70 @@
+# MemPalace in Docker
+
+This example runs MemPalace in a long-lived container and exposes the MCP
+server through `docker exec`. That fits stdio-based MCP clients while keeping
+the palace data in Docker volumes.
+
+## Why use Docker for MemPalace?
+
+Running MemPalace locally with `pip install mempalace` is still the simplest
+option for a single machine.
+
+Docker becomes attractive when you want one or more of these properties:
+
+- **Multiple clients, one palace** — several MCP clients can point at the same
+  remote MemPalace container instead of each machine keeping its own separate
+  local index.
+- **Operational resilience** — with `restart: unless-stopped`, the container
+  comes back after host reboots or Docker daemon restarts. This is not full HA,
+  but it is often enough for an always-on homelab or utility box.
+- **Isolation** — MemPalace and Chroma dependencies stay inside the container
+  rather than mixing with the host Python environment.
+- **Portable storage** — palace data and config live in named Docker volumes,
+  which makes backup, restore, migration, and rollback easier to reason about.
+- **Dedicated remote host** — you can keep memory on a separate always-on
+  machine and let laptops/workstations connect to it over SSH.
+
+## Start the container
+
+```bash
+cd examples/docker
+docker compose up -d
+```
+
+The example stores data in two named volumes:
+
+- `mempalace-data` → `/data`
+- `mempalace-config` → `/root/.mempalace`
+
+The active palace path inside the container is `/data/palace`.
+
+## Connect an MCP client locally
+
+```bash
+docker exec -i mempalace python -m mempalace.mcp_server --palace /data/palace
+```
+
+For Claude Code:
+
+```bash
+claude mcp add mempalace -- docker exec -i mempalace python -m mempalace.mcp_server --palace /data/palace
+```
+
+## Connect to a remote Docker host
+
+If the container runs on another machine, wrap the same command in SSH:
+
+```bash
+ssh user@host docker exec -i mempalace python -m mempalace.mcp_server --palace /data/palace
+```
+
+## Operational note
+
+`python -m mempalace.mcp_server` is a stdio MCP server. In this deployment
+model, each client connection launches its own server process inside the
+container, and that process lives for as long as the client keeps the stdio
+connection open.
+
+That is often exactly what you want for local or light remote use, but if you
+run many long-lived sessions in parallel, expect one MemPalace MCP process per
+client.

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  mempalace:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        MEMPALACE_VERSION: 3.3.0
+    container_name: mempalace
+    restart: unless-stopped
+    environment:
+      MEMPALACE_PALACE_PATH: /data/palace
+    volumes:
+      - mempalace-data:/data
+      - mempalace-config:/root/.mempalace
+    stdin_open: true
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /root/.cache
+    healthcheck:
+      test: ["CMD", "python", "-c", "import mempalace; print('ok')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  mempalace-data:
+  mempalace-config:

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -28,6 +28,16 @@ cd mempalace
 pip install -e ".[dev]"
 ```
 
+### In Docker
+
+If you want to keep MemPalace on a separate machine or inside a container, see
+the minimal Compose example in
+[`examples/docker/README.md`](https://github.com/MemPalace/mempalace/blob/develop/examples/docker/README.md).
+
+That setup is most useful when you want one shared palace for multiple clients,
+an always-on remote host, or a more isolated/portable deployment than a local
+Python install.
+
 ## Quick Start
 
 Three steps: **init**, **mine**, **search**.

--- a/website/guide/mcp-integration.md
+++ b/website/guide/mcp-integration.md
@@ -24,6 +24,36 @@ claude mcp add mempalace -- python -m mempalace.mcp_server
 claude mcp add mempalace -- python -m mempalace.mcp_server --palace /path/to/palace
 ```
 
+### Docker / Remote Docker
+
+If MemPalace runs in Docker, a simple pattern is to keep the container alive
+and start the stdio MCP server via `docker exec` for each client connection.
+
+This is especially useful when you want:
+
+- one shared palace for multiple clients
+- an always-on remote host instead of a laptop-local install
+- containerized isolation and volume-based backup/restore
+- a small amount of operational resilience via Docker restart policies
+
+It is less compelling if you only use MemPalace from one local machine and are
+happy with a normal Python install.
+
+Local Docker host:
+
+```bash
+claude mcp add mempalace -- docker exec -i mempalace python -m mempalace.mcp_server --palace /data/palace
+```
+
+Remote Docker host over SSH:
+
+```bash
+claude mcp add mempalace -- ssh user@host docker exec -i mempalace python -m mempalace.mcp_server --palace /data/palace
+```
+
+See the full example at
+[`examples/docker/README.md`](https://github.com/MemPalace/mempalace/blob/develop/examples/docker/README.md).
+
 Now your AI has all 29 tools available. Ask it anything:
 
 > *"What did we decide about auth last month?"*


### PR DESCRIPTION
## Summary
- add a minimal Docker + Compose example for running MemPalace in a long-lived container
- document the `docker exec` / `ssh ... docker exec` MCP connection pattern
- explain when Docker is useful compared with a normal local Python install

## Why
MemPalace already works well in remote/containerized MCP setups, but the repo did not ship a concrete Docker example or explain when that deployment model is actually worth choosing.

This adds a small, neutral example rather than a project-specific homelab setup.

## Included
- `examples/docker/Dockerfile`
- `examples/docker/docker-compose.yml`
- `examples/docker/README.md`
- links from the main README and getting-started guide
- a Docker/remote-Docker section in the MCP integration guide

## Notes
The example intentionally uses the current stdio MCP model via `docker exec`, and the docs call out that this means one MemPalace MCP server process per active client connection.

## Testing
- `docker compose -f examples/docker/docker-compose.yml config`
- `./.venv/bin/python -m pytest tests/test_readme_claims.py tests/test_cli.py -q`
