### PR TITLE
fix(db): paginate collection fetches to avoid SQL variable limit

### DIFF
--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -221,7 +221,18 @@ def regenerate_closets(
         print("No drawers in palace.")
         return {"processed": 0}
 
-    all_data = drawers_col.get(limit=total, include=["documents", "metadatas"])
+    # Paginate: one-shot get(limit=total) exceeds chroma's SQLite bound-variable
+    # cap at large palace sizes (reproduced at ~12k drawers on chroma 1.5.8).
+    all_data: dict = {"ids": [], "documents": [], "metadatas": []}
+    offset = 0
+    while offset < total:
+        batch = drawers_col.get(limit=1000, offset=offset, include=["documents", "metadatas"])
+        if not batch["ids"]:
+            break
+        all_data["ids"].extend(batch["ids"])
+        all_data["documents"].extend(batch["documents"])
+        all_data["metadatas"].extend(batch["metadatas"])
+        offset += len(batch["ids"])
     by_source = {}
     for doc_id, doc, meta in zip(all_data["ids"], all_data["documents"], all_data["metadatas"]):
         source = meta.get("source_file", "unknown")

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -847,10 +847,18 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
+    # Count by wing and room.
+    # Paginate: one-shot get(limit=total) exceeds chroma's SQLite bound-variable
+    # cap at large palace sizes (reproduced at ~12k drawers on chroma 1.5.8).
     total = col.count()
-    r = col.get(limit=total, include=["metadatas"]) if total else {"metadatas": []}
-    metas = r["metadatas"]
+    metas: list = []
+    offset = 0
+    while offset < total:
+        batch = col.get(limit=1000, offset=offset, include=["metadatas"])
+        if not batch["ids"]:
+            break
+        metas.extend(batch["metadatas"])
+        offset += len(batch["ids"])
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -373,6 +373,52 @@ def test_status_handles_none_metadata_without_crash(tmp_path, capsys):
     assert "WING: proj" in out
 
 
+def test_status_paginates_instead_of_one_shot_fetch(tmp_path, capsys):
+    """status() must paginate col.get() instead of fetching all drawers at once.
+
+    At large palace sizes (~12k drawers on chroma 1.5.8) a single
+    ``col.get(limit=total)`` exceeds chroma's SQLite bound-variable cap and
+    raises ``chromadb.errors.InternalError: too many SQL variables``. The fix
+    is to fetch in pages. This test reproduces the failure mode with a fake
+    collection that rejects any oversized single-fetch call."""
+    from unittest.mock import patch
+
+    class PaginatingFakeCol:
+        def __init__(self, total: int):
+            self._total = total
+            self.get_calls: list[tuple[int, int]] = []
+
+        def count(self):
+            return self._total
+
+        def get(self, *args, **kwargs):
+            limit = kwargs.get("limit", self._total)
+            offset = kwargs.get("offset", 0)
+            # Simulate chroma's SQL-variable cap: any single fetch that
+            # asks for the whole palace at once blows up. Matches the
+            # real-world error seen at ~12k drawers.
+            if limit > 5000:
+                raise RuntimeError("too many SQL variables")
+            self.get_calls.append((limit, offset))
+            end = min(offset + limit, self._total)
+            return {
+                "ids": [f"d{i}" for i in range(offset, end)],
+                "metadatas": [{"wing": "w", "room": "r"} for _ in range(offset, end)],
+            }
+
+    fake = PaginatingFakeCol(total=12_000)
+    with patch("mempalace.miner.get_collection", return_value=fake):
+        status(str(tmp_path))
+
+    # Must have paginated — more than one call, each under the cap.
+    assert len(fake.get_calls) > 1
+    assert all(limit <= 5000 for (limit, _offset) in fake.get_calls)
+    # Every drawer must have been counted.
+    out = capsys.readouterr().out
+    assert "12000 drawers" in out
+    assert "WING: w" in out
+
+
 # ── normalize_version schema gate ───────────────────────────────────────
 #
 # When the normalization pipeline changes shape (e.g., strip_noise lands),


### PR DESCRIPTION
- Replace single-shot col.get(limit=total) calls with paginated requests
- Batch size is set to 1000 to stay safely below ChromaDB's SQLite bound-variable cap
- Add unit test to verify pagination logic and ensure complete data retrieval at scale

## What does this PR do?

## How to test

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)
