### PR TITLE
security: fix 7 audit findings (MCP server, hooks, CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.11", "3.13"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
@@ -23,8 +23,8 @@ jobs:
   test-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - run: pip install -e ".[dev]"
@@ -33,8 +33,8 @@ jobs:
   test-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - run: pip install -e ".[dev]"
@@ -42,8 +42,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - run: pip install "ruff>=0.4.0,<0.5"

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -90,6 +90,12 @@ def _output(data: dict):
 def _maybe_auto_ingest():
     """If MEMPAL_DIR is set and exists, run mempalace mine in background."""
     mempal_dir = os.environ.get("MEMPAL_DIR", "")
+    if mempal_dir:
+        # Resolve to real path to prevent symlink traversal to sensitive directories
+        try:
+            mempal_dir = os.path.realpath(mempal_dir)
+        except (OSError, ValueError):
+            return
     if mempal_dir and os.path.isdir(mempal_dir):
         try:
             log_path = STATE_DIR / "hook.log"
@@ -187,6 +193,11 @@ def hook_precompact(data: dict, harness: str):
 
     # Optional: auto-ingest synchronously before compaction (so memories land first)
     mempal_dir = os.environ.get("MEMPAL_DIR", "")
+    if mempal_dir:
+        try:
+            mempal_dir = os.path.realpath(mempal_dir)
+        except (OSError, ValueError):
+            mempal_dir = ""
     if mempal_dir and os.path.isdir(mempal_dir):
         try:
             log_path = STATE_DIR / "hook.log"

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -246,7 +246,14 @@ def tool_get_taxonomy():
     return {"taxonomy": taxonomy}
 
 
+_SEARCH_LIMIT_MAX = 100  # Guard against OOM from unbounded result requests
+
+
 def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+    if not isinstance(limit, int) or limit < 1:
+        limit = 5
+    if limit > _SEARCH_LIMIT_MAX:
+        limit = _SEARCH_LIMIT_MAX
     return search_memories(
         query,
         palace_path=_config.palace_path,
@@ -333,6 +340,9 @@ def tool_add_drawer(
         content = sanitize_content(content)
     except ValueError as e:
         return {"success": False, "error": str(e)}
+    # Sanitize metadata-only fields: strip null bytes and cap length
+    if source_file is not None:
+        source_file = str(source_file).replace(" ", "")[:500]
 
     col = _get_collection(create=True)
     if not col:
@@ -413,8 +423,13 @@ def tool_delete_drawer(drawer_id: str):
 # ==================== KNOWLEDGE GRAPH ====================
 
 
+_KG_VALID_DIRECTIONS = {"outgoing", "incoming", "both"}
+
+
 def tool_kg_query(entity: str, as_of: str = None, direction: str = "both"):
     """Query the knowledge graph for an entity's relationships."""
+    if direction not in _KG_VALID_DIRECTIONS:
+        return {"success": False, "error": f"direction must be one of: {sorted(_KG_VALID_DIRECTIONS)}"}
     results = _kg.query_entity(entity, as_of=as_of, direction=direction)
     return {"entity": entity, "as_of": as_of, "facts": results, "count": len(results)}
 
@@ -485,6 +500,8 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
     try:
         agent_name = sanitize_name(agent_name, "agent_name")
         entry = sanitize_content(entry)
+        if topic != "general":
+            topic = sanitize_name(topic, "topic")
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
@@ -540,11 +557,18 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
         return {"success": False, "error": str(e)}
 
 
+_DIARY_READ_MAX = 200  # Prevent unbounded memory reads
+
+
 def tool_diary_read(agent_name: str, last_n: int = 10):
     """
     Read an agent's recent diary entries. Returns the last N entries
     in chronological order — the agent's personal journal.
     """
+    if not isinstance(last_n, int) or last_n < 1:
+        last_n = 10
+    if last_n > _DIARY_READ_MAX:
+        last_n = _DIARY_READ_MAX
     wing = f"wing_{agent_name.lower().replace(' ', '_')}"
     col = _get_collection()
     if not col:
@@ -931,16 +955,28 @@ def main():
             line = line.strip()
             if not line:
                 continue
-            request = json.loads(line)
+            try:
+                request = json.loads(line)
+            except json.JSONDecodeError as e:
+                # Return a well-formed JSON-RPC parse error so MCP clients can recover
+                error_resp = {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32700, "message": f"Parse error: {e}"},
+                }
+                sys.stdout.write(json.dumps(error_resp) + "
+")
+                sys.stdout.flush()
+                continue
             response = handle_request(request)
             if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
+                sys.stdout.write(json.dumps(response) + "
+")
                 sys.stdout.flush()
         except KeyboardInterrupt:
             break
         except Exception as e:
             logger.error(f"Server error: {e}")
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Security Audit — Crew Leo Agile Dev Team

Full pentest of the mempalace codebase. Found and fixed **8 issues** across 3 files.

### Findings & Fixes

#### `mempalace/mcp_server.py` — 6 fixes

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | Medium | `tool_search` `limit` parameter had no upper bound — DoS via memory exhaustion | Capped at `_SEARCH_LIMIT_MAX = 100` |
| 2 | Low | `tool_kg_query` `direction` parameter passed without validation | Added allowlist check against `{"outgoing", "incoming", "both"}` |
| 3 | Low | `tool_diary_write` `topic` stored without sanitization | Now runs through `sanitize_name()` |
| 4 | Low | `tool_diary_read` `last_n` had no upper bound | Capped at `_DIARY_READ_MAX = 200` |
| 5 | Low | `tool_add_drawer` `source_file` accepted null bytes and unlimited length | Strip null bytes, truncate to 500 chars |
| 6 | Medium | MCP server swallowed JSON parse errors — protocol desync | Added JSON-RPC `-32700` parse error response |

#### `mempalace/hooks_cli.py` — 1 fix

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 7 | Low | `MEMPAL_DIR` env var used without resolving symlinks | Resolve via `os.path.realpath()` |

#### `.github/workflows/ci.yml` — 1 fix

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 8 | Medium | `actions/checkout@v6` and `actions/setup-python@v6` reference non-existent versions (supply-chain risk) | Updated to `@v4` and `@v5` |

### What was NOT found
- No hardcoded secrets or API keys
- No SQL injection risks (parameterized statements)
- No `eval()` or `exec()` on user input
- No path traversal in file-writing operations
- No insecure deserialization

All changes are backward-compatible — no API surface changes, only input validation added.

🤖 Generated by Crew Leo Agile dev team