### PR TITLE
security: pentest fixes — input validation, ID collision, arg injection, regex hardening

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -16,7 +16,13 @@ from pathlib import Path
 # in file paths, SQLite, or ChromaDB metadata.
 
 MAX_NAME_LENGTH = 128
-_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_ .'-]{0,126}[a-zA-Z0-9]?$")
+# Names must start with an alphanumeric character.
+# Single-character names are valid (only the first group matches).
+# Multi-character names must also END with an alphanumeric character so that
+# trailing hyphens, dots, or spaces are rejected (e.g. "wing-" is invalid).
+# Inner characters may include: letters, digits, underscore, space, dot,
+# single-quote, and hyphen.
+_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9_ .'-]{0,125}[a-zA-Z0-9])?$")
 
 
 def sanitize_name(value: str, field_name: str = "name") -> str:

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -88,19 +88,34 @@ def _output(data: dict):
 
 
 def _maybe_auto_ingest():
-    """If MEMPAL_DIR is set and exists, run mempalace mine in background."""
+    """If MEMPAL_DIR is set and exists, run mempalace mine in background.
+
+    The path is resolved to an absolute path and passed as a positional
+    argument (not interpolated into a shell string) so tainted env-var values
+    cannot inject shell metacharacters or extra arguments.
+    """
     mempal_dir = os.environ.get("MEMPAL_DIR", "")
-    if mempal_dir and os.path.isdir(mempal_dir):
-        try:
-            log_path = STATE_DIR / "hook.log"
-            with open(log_path, "a") as log_f:
-                subprocess.Popen(
-                    [sys.executable, "-m", "mempalace", "mine", mempal_dir],
-                    stdout=log_f,
-                    stderr=log_f,
-                )
-        except OSError:
-            pass
+    if not mempal_dir:
+        return
+    # Resolve to an absolute path before use to prevent path traversal via
+    # relative components. Also reject values that look like option flags
+    # (starting with '-') to avoid argument injection into the subprocess.
+    try:
+        resolved = str(Path(mempal_dir).resolve())
+    except (OSError, ValueError):
+        return
+    if not os.path.isdir(resolved) or resolved.startswith("-"):
+        return
+    try:
+        log_path = STATE_DIR / "hook.log"
+        with open(log_path, "a") as log_f:
+            subprocess.Popen(
+                [sys.executable, "-m", "mempalace", "mine", resolved],
+                stdout=log_f,
+                stderr=log_f,
+            )
+    except OSError:
+        pass
 
 
 SUPPORTED_HARNESSES = {"claude-code", "codex"}
@@ -186,8 +201,14 @@ def hook_precompact(data: dict, harness: str):
     _log(f"PRE-COMPACT triggered for session {session_id}")
 
     # Optional: auto-ingest synchronously before compaction (so memories land first)
+    # Resolve MEMPAL_DIR to an absolute path (same hardening as _maybe_auto_ingest).
     mempal_dir = os.environ.get("MEMPAL_DIR", "")
-    if mempal_dir and os.path.isdir(mempal_dir):
+    if mempal_dir:
+        try:
+            mempal_dir = str(Path(mempal_dir).resolve())
+        except (OSError, ValueError):
+            mempal_dir = ""
+    if mempal_dir and os.path.isdir(mempal_dir) and not mempal_dir.startswith("-"):
         try:
             log_path = STATE_DIR / "hook.log"
             with open(log_path, "a") as log_f:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -100,8 +100,8 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         logger.error(f"WAL write failed: {e}")
 
 
-_client_cache = None
-_collection_cache = None
+# NOTE: _client_cache and _collection_cache are declared once above (lines 66-67).
+# The duplicate declarations that previously appeared here have been removed.
 
 
 def _get_client():
@@ -246,7 +246,13 @@ def tool_get_taxonomy():
     return {"taxonomy": taxonomy}
 
 
+_MAX_SEARCH_RESULTS = 100
+
+
 def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+    # Clamp limit to [1, _MAX_SEARCH_RESULTS] to prevent resource exhaustion
+    # from arbitrarily large or nonsensical values.
+    limit = max(1, min(int(limit), _MAX_SEARCH_RESULTS))
     return search_memories(
         query,
         palace_path=_config.palace_path,
@@ -338,7 +344,9 @@ def tool_add_drawer(
     if not col:
         return _no_palace()
 
-    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content[:100]).encode()).hexdigest()[:24]}"
+    # Hash the full content (not just the first 100 chars) so that two
+    # different documents in the same wing/room always get distinct IDs.
+    drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content).encode()).hexdigest()[:24]}"
 
     _wal_log(
         "add_drawer",
@@ -448,6 +456,14 @@ def tool_kg_add(
 
 def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = None):
     """Mark a fact as no longer true (set end date)."""
+    # Apply the same sanitization as tool_kg_add to keep the two consistent.
+    try:
+        subject = sanitize_name(subject, "subject")
+        predicate = sanitize_name(predicate, "predicate")
+        object = sanitize_name(object, "object")
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+
     _wal_log(
         "kg_invalidate",
         {"subject": subject, "predicate": predicate, "object": object, "ended": ended},
@@ -485,6 +501,9 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
     try:
         agent_name = sanitize_name(agent_name, "agent_name")
         entry = sanitize_content(entry)
+        # Sanitize topic: allow None/empty (default to "general"), otherwise validate.
+        if topic and topic != "general":
+            topic = sanitize_name(topic, "topic")
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
@@ -545,6 +564,12 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
     Read an agent's recent diary entries. Returns the last N entries
     in chronological order — the agent's personal journal.
     """
+    try:
+        agent_name = sanitize_name(agent_name, "agent_name")
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+    # Clamp last_n to [1, 1000] to prevent nonsensical slicing.
+    last_n = max(1, min(int(last_n), 1000))
     wing = f"wing_{agent_name.lower().replace(' ', '_')}"
     col = _get_collection()
     if not col:


### PR DESCRIPTION
## Summary

Security pentest performed by **Crew Leo Agile dev team** (Axon, Tech Lead). 9 vulnerabilities identified and fixed across `mcp_server.py`, `config.py`, and `hooks_cli.py`.

### Findings & Fixes

| # | Severity | File | Finding | Fix |
|---|---|---|---|---|
| 1 | Medium | `mcp_server.py` | Drawer ID hashes only first 100 chars — silent collision risk | Hash full content |
| 2 | Medium | `mcp_server.py` | `tool_diary_read` doesn't sanitize `agent_name` (inconsistent with write) | Add `sanitize_name()` |
| 3 | Medium | `mcp_server.py` | `tool_diary_write` stores `topic` without validation | Add `sanitize_name()` |
| 4 | Medium | `mcp_server.py` | `tool_kg_invalidate` doesn't sanitize (inconsistent with `tool_kg_add`) | Add `sanitize_name()` guards |
| 5 | Low | `mcp_server.py` | `tool_search` accepts unbounded `limit` | Clamp to `[1, 100]` |
| 6 | Low | `mcp_server.py` | `tool_diary_read` `last_n` negative values cause wrong results | Clamp to `[1, 1000]` |
| 7 | Low | `mcp_server.py` | Duplicate `_client_cache`/`_collection_cache` declarations | Remove duplicates |
| 8 | Low | `config.py` | `_SAFE_NAME_RE` allows names ending with special chars | Rewrite regex |
| 9 | Low | `hooks_cli.py` | `MEMPAL_DIR` without path resolution — argument injection | Resolve to absolute path, reject `-` prefixes |

### What was NOT found
- No hardcoded secrets or API keys
- No `eval()` / `exec()` usage
- No SQL injection vectors
- No unsafe deserialization
- Dependencies pinned appropriately

🤖 Generated by Crew Leo Agile dev team