### PR TITLE
fix(palace): honour MEMPALACE_BACKEND env var so entry-point backends are actually used

### DIFF
--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -10,6 +10,7 @@ import os
 import re
 
 from .backends.chroma import ChromaBackend
+from .backends.registry import get_backend, resolve_backend_for_palace
 
 SKIP_DIRS = {
     ".git",
@@ -37,7 +38,22 @@ SKIP_DIRS = {
     "target",
 }
 
-_DEFAULT_BACKEND = ChromaBackend()
+def _resolve_default_backend():
+    """Resolve the default backend per RFC 001 §3.3 priority order.
+
+    Honours the ``MEMPALACE_BACKEND`` environment variable so entry-point
+    backends (e.g. ``mempalace-postgres``) are selected automatically. Falls
+    back to the in-tree ChromaBackend when no override is set.
+    """
+    name = resolve_backend_for_palace(
+        env_value=os.environ.get("MEMPALACE_BACKEND"),
+    )
+    if name == "chroma":
+        return ChromaBackend()
+    return get_backend(name)
+
+
+_DEFAULT_BACKEND = _resolve_default_backend()
 
 # Schema version for drawer normalization. Bump when the normalization
 # pipeline changes in a way that existing drawers should be rebuilt to pick up


### PR DESCRIPTION
## Summary

`palace._DEFAULT_BACKEND` is hard-coded to `ChromaBackend()`, so the `MEMPALACE_BACKEND` environment variable that `backends.registry.resolve_backend_for_palace` is documented to honour (RFC 001 §3.3 priority 3) has no effect on the miner, search, or the MCP server.

As a result, third-party backends declared via the `mempalace.backends` entry point are discoverable via `available_backends()` but never actually used in practice.

This PR wires `palace._DEFAULT_BACKEND` through the registry so an opt-in env var selects the backend, and falls back to `ChromaBackend` when no override is set — existing installs behave exactly as before.

## Change

```python
def _resolve_default_backend():
    name = resolve_backend_for_palace(
        env_value=os.environ.get("MEMPALACE_BACKEND"),
    )
    if name == "chroma":
        return ChromaBackend()
    return get_backend(name)


_DEFAULT_BACKEND = _resolve_default_backend()
```

+17 / -1 in one file.

## Why this matters

With this single hook in place, a backend distributed as a separate package (e.g. the in-development [`mempalace-postgres`](https://github.com/malakhov-dmitrii/mempalace-postgres)) can be selected simply with:

```bash
pip install mempalace-postgres
export MEMPALACE_BACKEND=postgres
export MEMPALACE_PG_DSN=postgres://…
mempalace mine ./my-project
```

No fork, no monkey-patch, no touching the Chroma default.

This unlocks the contract already described in `backends/registry.py` and aligns the default-selection path with the RFC 001 priority order.

## Scope

Deliberately minimal:

- No behavioural change for existing Chroma users (when `MEMPALACE_BACKEND` is unset the resolution lands on `"chroma"` and we still instantiate `ChromaBackend()` directly).
- No new dependencies.
- No changes to the `get_collection` call site — only the resolution of `_DEFAULT_BACKEND`.

## Test plan

- [ ] Unset `MEMPALACE_BACKEND` → `mempalace mine` still uses Chroma (no regression).
- [ ] Export `MEMPALACE_BACKEND=chroma` → identical behaviour.
- [ ] Export `MEMPALACE_BACKEND=<bogus>` → early `KeyError: unknown backend` from the registry (fail fast, same as existing `get_backend` behaviour).
- [ ] With an entry-point backend installed (e.g. `mempalace-postgres`) and `MEMPALACE_BACKEND=postgres` → miner writes to that backend.