### PR TITLE
fix(hooks): quote plugin-root paths with spaces (#1076)

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh\""
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-precompact-hook.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mempal-precompact-hook.sh\""
           }
         ]
       }

--- a/.codex-plugin/hooks.json
+++ b/.codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh session-start"
+            "command": "\"${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh\" session-start"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh stop"
+            "command": "\"${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh\" stop"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh precompact"
+            "command": "\"${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh\" precompact"
           }
         ]
       }


### PR DESCRIPTION
## Problem

Hook commands in `.claude-plugin/hooks/hooks.json` and `.codex-plugin/hooks.json` expand `${CLAUDE_PLUGIN_ROOT}` / `${CODEX_PLUGIN_ROOT}` without quoting. When the user profile path contains a space (e.g. `C:\Users\Richard M` on Windows), the shell splits the command on the space and the hook fails:

```
Stop hook error: Failed with non-blocking status code: bash: /c/Users/Richard: No such file or directory
```

## Fix

Wrap the path variable in double quotes so shell word-splitting preserves the token boundary.

**`.claude-plugin/hooks/hooks.json`** (Stop + PreCompact):
```
"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh\""
```

**`.codex-plugin/hooks.json`** (SessionStart + Stop + PreCompact):
```
"command": "\"${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh\" session-start"
```

On the Codex variant the argument stays outside the quotes so it remains a separate token after shell parsing. Same pattern used by the superpowers plugin reference in issue #1076.

## Scope check

- `plugin.json` / `.mcp.json`: MCP command is the `mempalace-mcp` entry point with no path arg, not affected.
- `hooks/*.sh` (legacy): standalone scripts whose path the user writes into `settings.local.json`, out of scope for the plugin-shipped configs.
- Internal `.sh` bodies already quote all path variables.

## Test plan

- [x] Both JSON files remain valid (`jq empty` passes on both).
- [x] Local reproduction on Linux with a space-containing plugin path confirms the pre-fix vs post-fix delta:
  ```
  # path: /tmp/memp smoke <pid>
  # unquoted:  bash: /tmp/memp: No such file or directory
  # quoted:    {}   (hook ran to completion, empty decision)
  ```
  Matches the `bash: /c/Users/Richard: No such file or directory` shape reported on Windows.
- [ ] Windows smoke with a space-containing profile path: unable to verify locally, would appreciate a sanity check from @dogskool on 3.3.1 once the fix is in.

Fixes #1076.
