### PR TITLE
fix(search): hint at `mempalace repair` when filtered query hits HNSW index mismatch (#1035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Sync `version.py` to match `pyproject.toml` (#820)
 - Remove unused `main` import from `mempalace/__init__.py` (#827)
 - README audit — fix 7 stale claims (tool count, version badge, wake-up token cost, `dialect.py` lossless disclaimer, `pyproject.toml` version) with 42 regression-guard tests (#835)
+- Surface a `mempalace repair` hint when a filtered search hits an HNSW index from a pre-1.0 palace, instead of raising an opaque ChromaDB `Error finding id` (#1035)
 
 ### Improvements
 - Optimize entity detection with regex caching and pre-compilation (#828)

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -262,6 +262,11 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         results = col.query(**kwargs)
 
     except Exception as e:
+        if where and "Error finding id" in str(e):
+            print(
+                "\n  Hint: this palace's HNSW index predates 1.0 and fails on "
+                "filtered queries.\n  Run: mempalace repair <palace_path>"
+            )
         print(f"\n  Search error: {e}")
         raise SearchError(f"Search error: {e}") from e
 
@@ -352,6 +357,11 @@ def search_memories(
             dkwargs["where"] = where
         drawer_results = drawers_col.query(**dkwargs)
     except Exception as e:
+        if where and "Error finding id" in str(e):
+            return {
+                "error": f"Search error: {e}",
+                "hint": "This palace's HNSW index predates 1.0. Run: mempalace repair <palace_path>",
+            }
         return {"error": f"Search error: {e}"}
 
     # Gather closet hits (best-per-source) to build a boost lookup.

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -265,7 +265,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         if where and "Error finding id" in str(e):
             print(
                 "\n  Hint: this palace's HNSW index predates 1.0 and fails on "
-                "filtered queries.\n  Run: mempalace repair <palace_path>"
+                f"filtered queries.\n  Run: mempalace repair {palace_path}"
             )
         print(f"\n  Search error: {e}")
         raise SearchError(f"Search error: {e}") from e
@@ -360,7 +360,7 @@ def search_memories(
         if where and "Error finding id" in str(e):
             return {
                 "error": f"Search error: {e}",
-                "hint": "This palace's HNSW index predates 1.0. Run: mempalace repair <palace_path>",
+                "hint": f"This palace's HNSW index predates 1.0. Run: mempalace repair {palace_path}",
             }
         return {"error": f"Search error: {e}"}
 

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -191,3 +191,51 @@ class TestSearchCLI:
         assert "[2]" in captured.out
         # Second result renders with fallback '?' values instead of crashing
         assert "second doc" in captured.out
+
+
+# ── HNSW / pre-1.0 index-mismatch repair hint (#1035) ─────────────────
+
+
+class TestHNSWRepairHint:
+    """When a filtered query hits a pre-1.0 palace, ChromaDB raises
+    `Error finding id ...`. Surface a `mempalace repair` hint instead
+    of leaking the opaque error alone.
+    """
+
+    def test_cli_filtered_query_hints_repair(self, capsys):
+        """CLI path: filtered search + 'Error finding id' → hint printed."""
+        mock_col = MagicMock()
+        mock_col.query.side_effect = RuntimeError("Error finding id 1234")
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            with pytest.raises(SearchError, match="Search error"):
+                search("test", "/fake/path", wing="project")
+
+        captured = capsys.readouterr()
+        assert "mempalace repair" in captured.out
+
+    def test_api_filtered_query_returns_hint(self):
+        """API path: filtered search + 'Error finding id' → dict has hint."""
+        mock_col = MagicMock()
+        mock_col.query.side_effect = RuntimeError("Error finding id 1234")
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("test", "/fake/path", wing="project")
+
+        assert "error" in result
+        assert "hint" in result
+        assert "mempalace repair" in result["hint"]
+
+    def test_unfiltered_query_does_not_hint(self):
+        """Guard check: without a wing/room filter the hint must NOT fire,
+        even if the error text contains 'Error finding id'. Unrelated
+        failures should not get a misleading repair suggestion.
+        """
+        mock_col = MagicMock()
+        mock_col.query.side_effect = RuntimeError("Error finding id 1234")
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("test", "/fake/path")
+
+        assert "error" in result
+        assert "hint" not in result

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -203,7 +203,9 @@ class TestHNSWRepairHint:
     """
 
     def test_cli_filtered_query_hints_repair(self, capsys):
-        """CLI path: filtered search + 'Error finding id' → hint printed."""
+        """CLI path: filtered search + 'Error finding id' → hint printed
+        with the actual palace_path interpolated so it's copy-pasteable.
+        """
         mock_col = MagicMock()
         mock_col.query.side_effect = RuntimeError("Error finding id 1234")
 
@@ -212,10 +214,14 @@ class TestHNSWRepairHint:
                 search("test", "/fake/path", wing="project")
 
         captured = capsys.readouterr()
-        assert "mempalace repair" in captured.out
+        assert "mempalace repair /fake/path" in captured.out
+        # Placeholder must not leak through.
+        assert "<palace_path>" not in captured.out
 
     def test_api_filtered_query_returns_hint(self):
-        """API path: filtered search + 'Error finding id' → dict has hint."""
+        """API path: filtered search + 'Error finding id' → dict has hint
+        with the actual palace_path interpolated.
+        """
         mock_col = MagicMock()
         mock_col.query.side_effect = RuntimeError("Error finding id 1234")
 
@@ -224,7 +230,8 @@ class TestHNSWRepairHint:
 
         assert "error" in result
         assert "hint" in result
-        assert "mempalace repair" in result["hint"]
+        assert "mempalace repair /fake/path" in result["hint"]
+        assert "<palace_path>" not in result["hint"]
 
     def test_unfiltered_query_does_not_hint(self):
         """Guard check: without a wing/room filter the hint must NOT fire,


### PR DESCRIPTION
## Summary

Fixes #1035. When a palace's HNSW index predates 1.0 (i.e. built under
`chromadb` 0.6.x), a filtered search on 1.5.x raises an opaque
`ValueError: Error finding id ...`. The repair command already handles
the actual upgrade (`mempalace repair`), but users upgrading in place
have no way to discover that from the error alone.

This PR catches the exception in both query paths in `searcher.py`,
detects the specific signature (a `where` filter was in play **and**
the exception message contains `"Error finding id"`), and surfaces a
hint pointing at `mempalace repair` before re-raising (CLI) or
returning the error dict (API / MCP). The no-palace path already pairs
`error` + `hint` in the returned dict, so the API branch mirrors that
shape.

## Changes

- `mempalace/searcher.py` — detect-and-hint inside the existing
  `except` blocks in `search()` (CLI) and `search_memories()` (API),
  guarded by `where and "Error finding id" in str(e)`
- `CHANGELOG.md` — one-line entry under `### Bug Fixes` in the
  `[Unreleased] — v3.3.0` section
- `tests/test_searcher.py::TestHNSWRepairHint` — three focused tests:
  CLI positive, API positive, and a negative-guard test to ensure
  unrelated failures don't get a misleading repair suggestion

All 1060 tests in the full suite pass. `ruff check` and
`ruff format --check` both clean on the touched files.

## Scope note for the maintainer

In the issue thread, #851 and #1016 were mentioned as related —
happy to be corrected, but my read is those address SQLite parameter
limits in `col.get()` pagination, which is a different code path from
the HNSW `col.query()` failure this PR addresses. If you'd like this
to also cover the pagination path, I'm glad to extend the PR; I kept
it narrow since your earlier reply greenlit a ~5-line detect-and-hint
specifically against the 0.6.x→1.5.x HNSW failure.

## Known related gap

The `mempalace repair` command this hint points at currently
segfaults on a sufficiently corrupt HNSW index — `repair` calls
`col.count()` before doing any repair work, and that's the call that
crashes on drift. That's tracked separately in #1108 (wiring
`quarantine_stale_hnsw()` from #1000 into the backend open path). On
palaces where the index is merely stale (not corrupt enough to crash
`count()`), `repair` works as intended and this hint is actionable;
#1108 closes the remaining case.

## Test plan

- [x] `pytest tests/test_searcher.py -v` — 24 passed (3 new)
- [x] `pytest -x` — 1060 passed
- [x] `ruff check mempalace/searcher.py tests/test_searcher.py`
- [x] `ruff format --check mempalace/searcher.py tests/test_searcher.py`
