### PR TITLE
fix: treat empty string as no filter in mempalace_search wing/room

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -285,7 +285,7 @@ def _get_cached_metadata(col, where=None):
 
 def _sanitize_optional_name(value: str = None, field_name: str = "name") -> str:
     """Validate optional wing/room-style filters."""
-    if value is None:
+    if value is None or value == "":
         return None
     return sanitize_name(value, field_name)
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -285,7 +285,7 @@ def _get_cached_metadata(col, where=None):
 
 def _sanitize_optional_name(value: str = None, field_name: str = "name") -> str:
     """Validate optional wing/room-style filters."""
-    if value is None or value == "":
+    if value is None or not value.strip():
         return None
     return sanitize_name(value, field_name)
 


### PR DESCRIPTION
Fixes #1084

## What does this PR do?
Treats empty string as `None` (no filter) in `_sanitize_optional_name`. 
Previously, `mempalace_search` rejected empty-string `wing`/`room` values 
with "must be a non-empty string" even though the schema marks them optional.
This broke LLM agents that default to filling every declared parameter with "".

## How to test
Call `mempalace_search` with `wing: ""` and `room: ""` - should return 
results instead of an error. Quick unit check:

from mempalace.mcp_server import _sanitize_optional_name
assert _sanitize_optional_name("") is None
assert _sanitize_optional_name(None) is None
assert _sanitize_optional_name("main") == "main"

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)