### PR TITLE
docs: fix HOOKS_TUTORIAL.md paths, matcher, and missing timeout (#1037)

### DIFF
--- a/examples/HOOKS_TUTORIAL.md
+++ b/examples/HOOKS_TUTORIAL.md
@@ -7,26 +7,41 @@ MemPalace hooks act as an "Auto-Save" feature. They help your AI keep a permanen
 * **PreCompact Hook** (`mempal_precompact_hook.sh`): Saves your context right before the AI's memory window fills up.
 
 ### 2. Setup for Claude Code
-Add this to your configuration file to enable automatic background saving:
+Add this to `~/.claude/settings.local.json` (global) or `.claude/settings.local.json` (project-scoped) to enable automatic background saving:
 
 ```json
 {
   "hooks": {
     "Stop": [
       {
-        "matcher": "", 
-        "hooks": [{"type": "command", "command": "./hooks/mempal_save_hook.sh"}]
+        "matcher": "*", 
+        "hooks": [{
+          "type": "command",
+          "command": "/absolute/path/to/hooks/mempal_save_hook.sh",
+          "timeout": 30
+        }]
       }
     ],
     "PreCompact": [
       {
-        "matcher": "", 
-        "hooks": [{"type": "command", "command": "./hooks/mempal_precompact_hook.sh"}]
+        "hooks": [{
+          "type": "command",
+          "command": "/absolute/path/to/hooks/mempal_precompact_hook.sh",
+          "timeout": 30
+        }]
       }
     ]
   }
 }
 ```
+
+Make the hooks executable:
+```bash
+chmod +x /absolute/path/to/hooks/mempal_save_hook.sh
+chmod +x /absolute/path/to/hooks/mempal_precompact_hook.sh
+```
+
+**Note:** Replace `/absolute/path/to/hooks/` with the actual path where you cloned the MemPalace repository (e.g., `~/projects/mempalace/hooks/`).
 
 ### 3. What changed (v3.1.0+)
 


### PR DESCRIPTION
Fixes four issues in `examples/HOOKS_TUTORIAL.md` that cause silent hook failures:

**Problems fixed:**
1. **Relative paths** → Absolute paths (`/absolute/path/to/hooks/...`)
   Claude Code resolves hooks from working directory at fire time, not repo root.

2. **Wrong matcher** → `Stop` uses `"*"`, `PreCompact` has no matcher
   `PreCompact` hooks don't use matchers (only `Stop` hooks do per hooks/README.md).

3. **Missing timeout** → Added `"timeout": 30` to both hooks
   Matches the specification in hooks/README.md.

4. **Ambiguous target** → Specified `~/.claude/settings.local.json`
   Clarified global vs project-scoped config paths.

**Also added:**
- `chmod +x` instructions for hook scripts
- Note to replace `/absolute/path/to/hooks/` with actual path
- Proper JSON formatting with newlines

This aligns the tutorial with the correct examples already documented in `hooks/README.md`.

Fixes #1037

**Disclosure:** This contribution was generated with AI assistance and reviewed before submission.