### PR TITLE
fix(normalize): handle UTF-8 BOM in transcript files

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -122,7 +122,7 @@ def normalize(filepath: str) -> str:
     if file_size > 500 * 1024 * 1024:  # 500 MB safety limit
         raise IOError(f"File too large ({file_size // (1024 * 1024)} MB): {filepath}")
     try:
-        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+        with open(filepath, "r", encoding="utf-8-sig", errors="replace") as f:
             content = f.read()
     except OSError as e:
         raise IOError(f"Could not read {filepath}: {e}") from e


### PR DESCRIPTION
## What and Why

`normalize()` opens transcript files with `encoding='utf-8'`. When a file has a UTF-8 BOM prefix (`\xef\xbb\xbf`) — common from Windows exports of Claude Code JSONL sessions — `json.loads()` raises `JSONDecodeError` on every line because the first line starts with `﻿{`. `_try_claude_code_jsonl` silently skips all lines and the file falls through as raw unstructured text, discarding all message content.

## Root Cause

`normalize.py:124` — `encoding="utf-8"` does not strip the BOM; `encoding="utf-8-sig"` does.

## Fix

```python
# Before
with open(filepath, "r", encoding="utf-8", errors="replace") as f:

# After
with open(filepath, "r", encoding="utf-8-sig", errors="replace") as f:
```

Python's `utf-8-sig` codec strips the BOM on read and is fully backward-compatible with BOM-free files. No behavioral change on Linux/macOS files.

## Reproduction

```python
import tempfile, os
from mempalace.normalize import normalize

# BOM-prefixed JSONL (Windows Claude Code export)
bom_file = tempfile.mktemp(suffix=".jsonl")
with open(bom_file, "wb") as f:
    f.write(b"\xef\xbb\xbf")  # UTF-8 BOM
    f.write(b'{"type":"human","message":{"content":"hello"}}\n')

result_before = normalize(bom_file)  # returns raw JSON lines, not a transcript
# After fix: returns properly formatted transcript with "hello"
```

## Tests

All 107 `test_normalize.py` tests pass. All 1066 tests pass.

Closes #1034 (partial — encoding fix for `normalize.py`; other files addressed in separate PRs)