### PR TITLE
feat: split hooks.auto_save and hooks.auto_mine for independent control of diary vs mine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Improvements
 - Optimize entity detection with regex caching and pre-compilation (#828)
 - Extract locked filing block into helper to keep `mine_convos` under C901 complexity
+- `hooks.auto_mine` config flag decouples the background mine from the diary save in stop/precompact hooks — set `false` (via `mempalace_hook_settings` MCP tool, `config.json`, or `MEMPALACE_HOOKS_AUTO_MINE` env var) to keep fast diary writes without the recursive `~/.claude/projects/<cwd>/` walk that can peg CPU on large archives; defaults to `true` to preserve existing behavior
 
 ### Documentation
 - Add `docs/CLOSETS.md` — closet layer overview

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -602,14 +602,18 @@ class MempalaceConfig:
 
         Env var ``MEMPALACE_HOOKS_AUTO_MINE`` (or legacy ``MEMPAL_HOOKS_AUTO_MINE``)
         overrides the config file. Accepts ``0``/``false``/``no``/``off`` as
-        falsey; anything else is truthy. Default: ``True`` (preserves existing
+        falsey; anything else (including ``true``/``1``/``yes``/``on``) is
+        truthy. Empty / whitespace-only values are treated as unset and fall
+        back to the config file. Default: ``True`` (preserves existing
         behavior for users who don't opt out).
         """
-        env_val = os.environ.get("MEMPALACE_HOOKS_AUTO_MINE") or os.environ.get(
-            "MEMPAL_HOOKS_AUTO_MINE"
-        )
-        if env_val:
-            return env_val.strip().lower() not in ("0", "false", "no", "off")
+        env_val = os.environ.get("MEMPALACE_HOOKS_AUTO_MINE")
+        if env_val is None:
+            env_val = os.environ.get("MEMPAL_HOOKS_AUTO_MINE")
+        if env_val is not None:
+            stripped = env_val.strip().lower()
+            if stripped:
+                return stripped not in ("0", "false", "no", "off")
         return self._file_config.get("hooks", {}).get("auto_mine", True)
 
     @property

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -592,6 +592,27 @@ class MempalaceConfig:
         return self._file_config.get("hooks", {}).get("silent_save", True)
 
     @property
+    def hook_auto_mine(self):
+        """Whether the stop/precompact hooks run the background mine after the diary save.
+
+        Set to ``False`` to keep the fast diary write but skip the
+        ``_ingest_transcript`` + ``_maybe_auto_ingest`` calls that walk the
+        ``~/.claude/projects/<cwd>/`` tree and can peg a CPU core for hours on
+        large archives. Diary writes (``_save_diary_direct``) still fire.
+
+        Env var ``MEMPALACE_HOOKS_AUTO_MINE`` (or legacy ``MEMPAL_HOOKS_AUTO_MINE``)
+        overrides the config file. Accepts ``0``/``false``/``no``/``off`` as
+        falsey; anything else is truthy. Default: ``True`` (preserves existing
+        behavior for users who don't opt out).
+        """
+        env_val = os.environ.get("MEMPALACE_HOOKS_AUTO_MINE") or os.environ.get(
+            "MEMPAL_HOOKS_AUTO_MINE"
+        )
+        if env_val:
+            return env_val.strip().lower() not in ("0", "false", "no", "off")
+        return self._file_config.get("hooks", {}).get("auto_mine", True)
+
+    @property
     def hook_desktop_toast(self):
         """Whether the stop hook shows a desktop notification via notify-send."""
         return self._file_config.get("hooks", {}).get("desktop_toast", False)

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -1026,8 +1026,6 @@ def hook_precompact(data: dict, harness: str):
 
     # Respect hooks.auto_mine — users who disabled background mining don't
     # want the pre-compaction mine either. Compaction still proceeds.
-    from .config import MempalaceConfig
-
     try:
         auto_mine = MempalaceConfig().hook_auto_mine
     except Exception:

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -931,9 +931,11 @@ def hook_stop(data: dict, harness: str):
             config = MempalaceConfig()
             silent = config.hook_silent_save
             toast = config.hook_desktop_toast
+            auto_mine = config.hook_auto_mine
         except Exception:
             silent = True
             toast = False
+            auto_mine = True
 
         project_wing = _wing_from_transcript_path(transcript_path)
 
@@ -944,8 +946,10 @@ def hook_stop(data: dict, harness: str):
                 result = _save_diary_direct(
                     transcript_path, session_id, wing=project_wing, toast=toast
                 )
-                _ingest_transcript(transcript_path)
-            _maybe_auto_ingest()
+                if auto_mine:
+                    _ingest_transcript(transcript_path)
+            if auto_mine:
+                _maybe_auto_ingest()
             # Only advance save marker after successful save
             count = result.get("count", 0)
             if count > 0:
@@ -973,9 +977,10 @@ def hook_stop(data: dict, harness: str):
                 last_save_file.write_text(str(exchange_count), encoding="utf-8")
             except OSError:
                 pass
-            if transcript_path:
+            if transcript_path and auto_mine:
                 _ingest_transcript(transcript_path)
-            _maybe_auto_ingest()
+            if auto_mine:
+                _maybe_auto_ingest()
             reason = STOP_BLOCK_REASON + f" Write diary entry to wing={project_wing}."
             _output({"decision": "block", "reason": reason})
     else:
@@ -1018,6 +1023,20 @@ def hook_precompact(data: dict, harness: str):
         return
 
     _log(f"PRE-COMPACT triggered for session {session_id}")
+
+    # Respect hooks.auto_mine — users who disabled background mining don't
+    # want the pre-compaction mine either. Compaction still proceeds.
+    from .config import MempalaceConfig
+
+    try:
+        auto_mine = MempalaceConfig().hook_auto_mine
+    except Exception:
+        auto_mine = True
+
+    if not auto_mine:
+        _log("auto_mine disabled; skipping pre-compaction mine")
+        _output({})
+        return
 
     # Capture tool output via our normalize path before compaction loses it
     if transcript_path:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1796,7 +1796,9 @@ def tool_diary_read(agent_name: str, last_n: int = 10, wing: str = ""):
         return {"error": "Failed to read diary entries"}
 
 
-def tool_hook_settings(silent_save: bool = None, desktop_toast: bool = None):
+def tool_hook_settings(
+    silent_save: bool = None, desktop_toast: bool = None, auto_mine: bool = None
+):
     """
     Get or set hook behavior settings.
 
@@ -1804,6 +1806,10 @@ def tool_hook_settings(silent_save: bool = None, desktop_toast: bool = None):
       False = legacy blocking MCP calls. Default: True.
     - desktop_toast: True = show notify-send desktop toast on save,
       False = terminal-only notification. Default: False.
+    - auto_mine: True = run background mine after diary save in stop/precompact
+      hooks (full behavior). False = write diary only, skip the recursive
+      ``~/.claude/projects/<cwd>/`` mine that can peg CPU for hours on large
+      archives. Default: True.
 
     Call with no arguments to see current settings.
     """
@@ -1821,6 +1827,9 @@ def tool_hook_settings(silent_save: bool = None, desktop_toast: bool = None):
     if desktop_toast is not None:
         config.set_hook_setting("desktop_toast", desktop_toast)
         changed.append(f"desktop_toast → {desktop_toast}")
+    if auto_mine is not None:
+        config.set_hook_setting("auto_mine", auto_mine)
+        changed.append(f"auto_mine → {auto_mine}")
 
     # Re-read to return current state
     try:
@@ -1833,6 +1842,7 @@ def tool_hook_settings(silent_save: bool = None, desktop_toast: bool = None):
         "settings": {
             "silent_save": config.hook_silent_save,
             "desktop_toast": config.hook_desktop_toast,
+            "auto_mine": config.hook_auto_mine,
         },
     }
     if changed:
@@ -2385,7 +2395,9 @@ TOOLS = {
         "description": (
             "Get or set hook behavior. silent_save: True = save directly "
             "(no MCP clutter), False = legacy blocking. desktop_toast: "
-            "True = show desktop notification. Call with no args to view."
+            "True = show desktop notification. auto_mine: True = run the "
+            "background mine after diary save (default), False = diary "
+            "only. Call with no args to view."
         ),
         "input_schema": {
             "type": "object",
@@ -2397,6 +2409,10 @@ TOOLS = {
                 "desktop_toast": {
                     "type": "boolean",
                     "description": "True = show desktop toast via notify-send",
+                },
+                "auto_mine": {
+                    "type": "boolean",
+                    "description": "True = run background mine in hooks, False = diary only",
                 },
             },
         },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,6 +136,53 @@ def test_normalize_wing_name_mixed():
     assert normalize_wing_name("My-Cool App") == "my_cool_app"
 
 
+# --- hooks.auto_mine ---
+
+
+def test_hook_auto_mine_default_true():
+    cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+    assert cfg.hook_auto_mine is True
+
+
+def test_hook_auto_mine_file_override_false():
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "config.json"), "w") as f:
+        json.dump({"hooks": {"auto_mine": False}}, f)
+    cfg = MempalaceConfig(config_dir=tmpdir)
+    assert cfg.hook_auto_mine is False
+
+
+@pytest.mark.parametrize("falsey", ["0", "false", "False", "no", "NO", "off", "Off"])
+def test_hook_auto_mine_env_override_false(falsey):
+    os.environ["MEMPALACE_HOOKS_AUTO_MINE"] = falsey
+    try:
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        assert cfg.hook_auto_mine is False
+    finally:
+        del os.environ["MEMPALACE_HOOKS_AUTO_MINE"]
+
+
+def test_hook_auto_mine_env_override_true():
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "config.json"), "w") as f:
+        json.dump({"hooks": {"auto_mine": False}}, f)
+    os.environ["MEMPALACE_HOOKS_AUTO_MINE"] = "true"
+    try:
+        cfg = MempalaceConfig(config_dir=tmpdir)
+        assert cfg.hook_auto_mine is True
+    finally:
+        del os.environ["MEMPALACE_HOOKS_AUTO_MINE"]
+
+
+def test_hook_auto_mine_legacy_env_prefix():
+    os.environ["MEMPAL_HOOKS_AUTO_MINE"] = "false"
+    try:
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        assert cfg.hook_auto_mine is False
+    finally:
+        del os.environ["MEMPAL_HOOKS_AUTO_MINE"]
+
+
 # --- sanitize_name ---
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,6 +183,36 @@ def test_hook_auto_mine_legacy_env_prefix():
         del os.environ["MEMPAL_HOOKS_AUTO_MINE"]
 
 
+@pytest.mark.parametrize("empty", ["", "   ", "\t", "\n"])
+def test_hook_auto_mine_empty_env_falls_back_to_config(empty):
+    """Empty / whitespace-only env values must fall back to config, not flip to True."""
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "config.json"), "w") as f:
+        json.dump({"hooks": {"auto_mine": False}}, f)
+    os.environ["MEMPALACE_HOOKS_AUTO_MINE"] = empty
+    try:
+        cfg = MempalaceConfig(config_dir=tmpdir)
+        assert cfg.hook_auto_mine is False
+    finally:
+        del os.environ["MEMPALACE_HOOKS_AUTO_MINE"]
+
+
+def test_hook_auto_mine_empty_primary_does_not_leak_to_legacy():
+    """An empty primary env var must not silently fall through to the legacy var."""
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "config.json"), "w") as f:
+        json.dump({"hooks": {"auto_mine": False}}, f)
+    os.environ["MEMPALACE_HOOKS_AUTO_MINE"] = ""
+    os.environ["MEMPAL_HOOKS_AUTO_MINE"] = "true"
+    try:
+        cfg = MempalaceConfig(config_dir=tmpdir)
+        # Primary is set (to ""), so legacy must be ignored; empty -> fall back to config.
+        assert cfg.hook_auto_mine is False
+    finally:
+        del os.environ["MEMPALACE_HOOKS_AUTO_MINE"]
+        del os.environ["MEMPAL_HOOKS_AUTO_MINE"]
+
+
 # --- sanitize_name ---
 
 

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -255,7 +255,7 @@ def test_extract_recent_messages_missing_file():
 # --- hook_stop ---
 
 
-def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
+def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None, auto_mine=True):
     """Run a hook and capture its JSON stdout output."""
     import io
     from unittest.mock import PropertyMock
@@ -273,6 +273,7 @@ def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
     mock_config = MagicMock()
     type(mock_config).hook_silent_save = PropertyMock(return_value=True)
     type(mock_config).hook_desktop_toast = PropertyMock(return_value=False)
+    type(mock_config).hook_auto_mine = PropertyMock(return_value=auto_mine)
     patches.append(patch("mempalace.config.MempalaceConfig", return_value=mock_config))
     with contextlib.ExitStack() as stack:
         for p in patches:
@@ -595,6 +596,76 @@ def test_wing_from_transcript_path_cwd_handles_non_string_cwd(tmp_path):
         encoding="utf-8",
     )
     assert _wing_from_transcript_path(str(transcript)) == "wing_proper_name"
+
+
+# --- hooks.auto_mine gating ---
+
+
+def test_stop_hook_auto_mine_disabled_skips_ingest(tmp_path):
+    """auto_mine=False: diary still saves, but ingest + auto-ingest are skipped."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(SAVE_INTERVAL)],
+    )
+    save_result = {"count": 15, "themes": ["hooks"]}
+    with (
+        patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result) as mock_save,
+        patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+        patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto_ingest,
+    ):
+        result = _capture_hook_output(
+            hook_stop,
+            {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
+            state_dir=tmp_path,
+            auto_mine=False,
+        )
+    assert "systemMessage" in result
+    mock_save.assert_called_once()
+    mock_ingest.assert_not_called()
+    mock_auto_ingest.assert_not_called()
+
+
+def test_stop_hook_auto_mine_enabled_default(tmp_path):
+    """auto_mine=True (default): diary saves AND both ingest paths fire."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(SAVE_INTERVAL)],
+    )
+    save_result = {"count": 15, "themes": ["hooks"]}
+    with (
+        patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result) as mock_save,
+        patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+        patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto_ingest,
+    ):
+        result = _capture_hook_output(
+            hook_stop,
+            {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
+            state_dir=tmp_path,
+            auto_mine=True,
+        )
+    assert "systemMessage" in result
+    mock_save.assert_called_once()
+    mock_ingest.assert_called_once_with(str(transcript))
+    mock_auto_ingest.assert_called_once_with()
+
+
+def test_precompact_auto_mine_disabled(tmp_path):
+    """auto_mine=False: precompact returns empty output without ingesting or mining."""
+    with (
+        patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+        patch("mempalace.hooks_cli._mine_sync") as mock_mine,
+    ):
+        result = _capture_hook_output(
+            hook_precompact,
+            {"session_id": "test", "transcript_path": str(tmp_path / "t.jsonl")},
+            state_dir=tmp_path,
+            auto_mine=False,
+        )
+    assert result == {}
+    mock_ingest.assert_not_called()
+    mock_mine.assert_not_called()
 
 
 # --- _log ---

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -610,15 +610,19 @@ def test_stop_hook_auto_mine_disabled_skips_ingest(tmp_path):
     )
     save_result = {"count": 15, "themes": ["hooks"]}
     with (
+        patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls,
         patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result) as mock_save,
         patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
         patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto_ingest,
     ):
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_silent_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        mock_cfg_cls.return_value.hook_auto_mine = False
         result = _capture_hook_output(
             hook_stop,
             {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
             state_dir=tmp_path,
-            auto_mine=False,
         )
     assert "systemMessage" in result
     mock_save.assert_called_once()
@@ -635,15 +639,19 @@ def test_stop_hook_auto_mine_enabled_default(tmp_path):
     )
     save_result = {"count": 15, "themes": ["hooks"]}
     with (
+        patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls,
         patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result) as mock_save,
         patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
         patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto_ingest,
     ):
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_silent_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        mock_cfg_cls.return_value.hook_auto_mine = True
         result = _capture_hook_output(
             hook_stop,
             {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
             state_dir=tmp_path,
-            auto_mine=True,
         )
     assert "systemMessage" in result
     mock_save.assert_called_once()
@@ -654,14 +662,16 @@ def test_stop_hook_auto_mine_enabled_default(tmp_path):
 def test_precompact_auto_mine_disabled(tmp_path):
     """auto_mine=False: precompact returns empty output without ingesting or mining."""
     with (
+        patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls,
         patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
         patch("mempalace.hooks_cli._mine_sync") as mock_mine,
     ):
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_auto_mine = False
         result = _capture_hook_output(
             hook_precompact,
             {"session_id": "test", "transcript_path": str(tmp_path / "t.jsonl")},
             state_dir=tmp_path,
-            auto_mine=False,
         )
     assert result == {}
     mock_ingest.assert_not_called()

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -365,14 +365,15 @@ Read recent diary entries.
 
 ### `mempalace_hook_settings`
 
-Get or set auto-save hook behaviour. `silent_save=true` saves directly without MCP-level clutter; `silent_save=false` uses the legacy blocking path. `desktop_toast=true` surfaces a desktop notification when a save completes. Call with no arguments to view the current settings.
+Get or set auto-save hook behaviour. `silent_save=true` saves directly without MCP-level clutter; `silent_save=false` uses the legacy blocking path. `desktop_toast=true` surfaces a desktop notification when a save completes. `auto_mine=true` (default) runs the background mine after the diary save; set `false` to keep the fast diary write but skip the recursive `~/.claude/projects/<cwd>/` walk that can peg CPU on large archives. Call with no arguments to view the current settings.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `silent_save` | boolean | No | `true` = silent direct save, `false` = blocking MCP calls |
 | `desktop_toast` | boolean | No | `true` = show desktop toast via `notify-send` |
+| `auto_mine` | boolean | No | `true` = run background mine in hooks, `false` = diary only |
 
-**Returns:** `{ silent_save, desktop_toast }`
+**Returns:** `{ silent_save, desktop_toast, auto_mine }`
 
 ---
 


### PR DESCRIPTION
## Problem

The Stop and PreCompact hooks currently do three things with no way to enable them independently:

1. `_save_diary_direct` is cheap, a few hundred ms. Writes the distilled memory entry.
2. `_ingest_transcript` is medium cost. Syncs the current session's `.jsonl`.
3. `_maybe_auto_ingest` / `_mine_sync` is expensive. Walks the whole `~/.claude/projects/<cwd>/` tree and can peg a CPU core for hours on large archives.

So users are stuck picking between "no hook-driven memory" and "burn a core every 15 exchanges." Some people want the fast diary write but not the recursive mine, especially on machines with thousands of accumulated transcripts. #1068 and #1069 have context.

## Solution

Adds a new config flag `hooks.auto_mine` (default `true`) that gates the two mine paths in both hooks. The diary save stays unconditional because it's cheap and it's the thing users actually want.

With `auto_mine: false`, hook-driven diary writes keep working but the recursive mine is skipped. "Combined mode" is just leaving both `silent_save` and `auto_mine` on.

### Flags

| Flag | Default | Gates |
|---|---|---|
| `hooks.silent_save` | `true` | Silent Python diary write vs legacy `{"decision": "block"}` AI-driven save |
| **`hooks.auto_mine` *(new)*** | `true` | Single-file ingest + recursive mine after the diary save |

Override precedence follows the existing pattern in `config.py`: env var (`MEMPALACE_HOOKS_AUTO_MINE`, legacy alias `MEMPAL_HOOKS_AUTO_MINE`) > `~/.mempalace/config.json` > default `True`.

### Usage

Via the existing MCP tool:

```
mempalace_hook_settings(auto_mine=False)
```

Via config file:

```json
{
  "hooks": {
    "auto_mine": false
  }
}
```

Via env var:

```bash
export MEMPALACE_HOOKS_AUTO_MINE=false
```

Falsey values: `0`, `false`, `no`, `off` (case-insensitive). Anything else is truthy. Empty-string env var falls through to the config file, matching the pattern used by `MEMPALACE_PALACE_PATH` and `MEMPALACE_ENTITY_LANGUAGES`.

## Scope note

This PR doesn't touch `hooks.silent_save` or any other existing flag. It's independent of #711 (`hooks.auto_save`, the outer hook enable/disable). Either can land first; the other rebases cleanly. I kept them as separate PRs.

## Test plan

- [x] `tests/test_config.py`: 5 new tests plus 7 parametrize cases covering default, file override, env override, and the legacy env prefix.
- [x] `tests/test_hooks_cli.py`: 3 new tests for the stop-hook silent branch (auto_mine on and off) and precompact with auto_mine off.
- [x] Full non-benchmark suite 1080/1080 locally on Python 3.14.
- [x] `ruff check .` passes.
- [x] `ruff format --check` passes on touched files under both current ruff and CI-pinned `ruff>=0.4.0,<0.5`.
- [x] CI: 6/6 green (lint, test-linux 3.9/3.11/3.13, test-macos, test-windows).

## Backwards compatibility

`hook_auto_mine` defaults to `True`. Users who don't set the flag see no behavior change.

## Files touched

- `mempalace/config.py`: new `hook_auto_mine` property
- `mempalace/hooks_cli.py`: gate mine calls in `hook_stop` (both branches) and `hook_precompact`
- `mempalace/mcp_server.py`: `auto_mine` parameter on `mempalace_hook_settings`
- `tests/test_config.py`: config coverage
- `tests/test_hooks_cli.py`: hook coverage (helper `_capture_hook_output` gains an `auto_mine=True` default)
- `website/reference/mcp-tools.md`: doc update
- `CHANGELOG.md`: `[Unreleased]` entry

## Related

- Informed by #1068 (ORT CPU pin diagnosis) and #1069 (hooks consolidation refactor)
- Independent of #711 (`hooks.auto_save`)
