### PR TITLE
fix: lifecycle hardening for MCP-driven shutdowns and convo_miner signal safety

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -605,14 +605,28 @@ class ChromaBackend(BaseBackend):
         return ChromaCollection(collection)
 
     def close_palace(self, palace) -> None:
-        """Drop cached handles for ``palace``. Accepts ``PalaceRef`` or legacy path str."""
+        """Drop cached handles for ``palace``. Accepts ``PalaceRef`` or legacy path str.
+
+        Calls ``client.close()`` first to flush ChromaDB's background
+        compactor — failing to do so corrupts the HNSW index on exit.
+        """
         path = palace.local_path if isinstance(palace, PalaceRef) else palace
         if path is None:
             return
-        self._clients.pop(path, None)
+        client = self._clients.pop(path, None)
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                logger.warning("Failed to close ChromaDB client for %s", path, exc_info=True)
         self._freshness.pop(path, None)
 
     def close(self) -> None:
+        for client in self._clients.values():
+            try:
+                client.close()
+            except Exception:
+                logger.warning("Failed to close ChromaDB client", exc_info=True)
         self._clients.clear()
         self._freshness.clear()
         self._closed = True

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -477,6 +477,18 @@ class ChromaBackend(BaseBackend):
         except OSError:
             return (0, 0.0)
 
+    @staticmethod
+    def _cache_key(path: str) -> str:
+        """Normalize a palace path for consistent cache-dict key lookup.
+
+        Resolves relative paths, symlinks, and trailing slashes so that
+        ``get_collection("./palace")`` and ``close_palace("/abs/palace")``
+        always hit the same cache entry.
+        """
+        from pathlib import Path
+
+        return str(Path(path).resolve())
+
     def _client(self, palace_path: str):
         """Return a cached ``PersistentClient``, rebuilding on inode/mtime change.
 
@@ -499,6 +511,7 @@ class ChromaBackend(BaseBackend):
 
             raise BackendClosedError("ChromaBackend has been closed")
 
+        palace_path = self._cache_key(palace_path)
         cached = self._clients.get(palace_path)
         cached_inode, cached_mtime = self._freshness.get(palace_path, (0, 0.0))
         current_inode, current_mtime = self._db_stat(palace_path)
@@ -613,6 +626,7 @@ class ChromaBackend(BaseBackend):
         path = palace.local_path if isinstance(palace, PalaceRef) else palace
         if path is None:
             return
+        path = self._cache_key(path)
         client = self._clients.pop(path, None)
         if client is not None:
             try:

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -22,6 +22,7 @@ from .palace import (
     file_already_mined,
     get_collection,
     mine_lock,
+    safe_mine_session,
 )
 
 
@@ -417,81 +418,86 @@ def mine_convos(
     files_skipped = 0
     room_counts = defaultdict(int)
 
-    for i, filepath in enumerate(files, 1):
-        source_file = str(filepath)
+    with safe_mine_session(palace_path, dry_run=dry_run) as session:
+        for i, filepath in enumerate(files, 1):
+            source_file = str(filepath)
 
-        # Skip if already filed
-        if not dry_run and file_already_mined(collection, source_file):
-            files_skipped += 1
-            continue
+            # Skip if already filed
+            if not dry_run and file_already_mined(collection, source_file):
+                files_skipped += 1
+                continue
 
-        # Normalize format
-        try:
-            content = normalize(str(filepath))
-        except (OSError, ValueError):
-            if not dry_run:
-                _register_file(collection, source_file, wing, agent)
-            continue
+            # Normalize format
+            try:
+                content = normalize(str(filepath))
+            except (OSError, ValueError):
+                if not dry_run:
+                    _register_file(collection, source_file, wing, agent)
+                continue
 
-        if not content or len(content.strip()) < MIN_CHUNK_SIZE:
-            if not dry_run:
-                _register_file(collection, source_file, wing, agent)
-            continue
+            if not content or len(content.strip()) < MIN_CHUNK_SIZE:
+                if not dry_run:
+                    _register_file(collection, source_file, wing, agent)
+                continue
 
-        # Chunk — either exchange pairs or general extraction
-        if extract_mode == "general":
-            from .general_extractor import extract_memories
-
-            chunks = extract_memories(content)
-            # Each chunk already has memory_type; use it as the room name
-        else:
-            chunks = chunk_exchanges(content)
-
-        if not chunks:
-            if not dry_run:
-                _register_file(collection, source_file, wing, agent)
-            continue
-
-        # Detect room from content (general mode uses memory_type instead)
-        if extract_mode != "general":
-            room = detect_convo_room(content)
-        else:
-            room = None  # set per-chunk below
-
-        if dry_run:
+            # Chunk — either exchange pairs or general extraction
             if extract_mode == "general":
-                from collections import Counter
+                from .general_extractor import extract_memories
 
-                type_counts = Counter(c.get("memory_type", "general") for c in chunks)
-                types_str = ", ".join(f"{t}:{n}" for t, n in type_counts.most_common())
-                print(f"    [DRY RUN] {filepath.name} → {len(chunks)} memories ({types_str})")
+                chunks = extract_memories(content)
+                # Each chunk already has memory_type; use it as the room name
             else:
-                print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-            total_drawers += len(chunks)
-            # Track room counts
-            if extract_mode == "general":
-                for c in chunks:
-                    room_counts[c.get("memory_type", "general")] += 1
+                chunks = chunk_exchanges(content)
+
+            if not chunks:
+                if not dry_run:
+                    _register_file(collection, source_file, wing, agent)
+                continue
+
+            # Detect room from content (general mode uses memory_type instead)
+            if extract_mode != "general":
+                room = detect_convo_room(content)
             else:
+                room = None  # set per-chunk below
+
+            if dry_run:
+                if extract_mode == "general":
+                    from collections import Counter
+
+                    type_counts = Counter(c.get("memory_type", "general") for c in chunks)
+                    types_str = ", ".join(f"{t}:{n}" for t, n in type_counts.most_common())
+                    print(f"    [DRY RUN] {filepath.name} → {len(chunks)} memories ({types_str})")
+                else:
+                    print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
+                total_drawers += len(chunks)
+                # Track room counts
+                if extract_mode == "general":
+                    for c in chunks:
+                        room_counts[c.get("memory_type", "general")] += 1
+                else:
+                    room_counts[room] += 1
+                continue
+
+            if extract_mode != "general":
                 room_counts[room] += 1
-            continue
 
-        if extract_mode != "general":
-            room_counts[room] += 1
+            # Lock + purge stale + file fresh chunks. Lock serializes concurrent
+            # agents; purge removes pre-v2 drawers so the schema bump applies.
+            drawers_added, room_delta, skipped = _file_chunks_locked(
+                collection, source_file, chunks, wing, room, agent, extract_mode
+            )
+            if skipped:
+                files_skipped += 1
+                continue
+            for r, n in room_delta.items():
+                room_counts[r] += n
 
-        # Lock + purge stale + file fresh chunks. Lock serializes concurrent
-        # agents; purge removes pre-v2 drawers so the schema bump applies.
-        drawers_added, room_delta, skipped = _file_chunks_locked(
-            collection, source_file, chunks, wing, room, agent, extract_mode
-        )
-        if skipped:
-            files_skipped += 1
-            continue
-        for r, n in room_delta.items():
-            room_counts[r] += n
+            total_drawers += drawers_added
+            print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
 
-        total_drawers += drawers_added
-        print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+            if session.interrupted:
+                print(f"\n  Stopped gracefully after {i}/{len(files)} files.")
+                break
 
     print(f"\n{'=' * 55}")
     print("  Done.")

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -4,10 +4,13 @@ palace.py — Shared palace operations.
 Consolidates collection access patterns used by both miners and the MCP server.
 """
 
+import atexit
 import contextlib
 import hashlib
 import os
 import re
+import signal
+import sys
 
 from .backends.chroma import ChromaBackend
 
@@ -38,6 +41,14 @@ SKIP_DIRS = {
 }
 
 _DEFAULT_BACKEND = ChromaBackend()
+atexit.register(_DEFAULT_BACKEND.close)
+
+# Convert SIGTERM → sys.exit(0) so atexit handlers fire when an MCP
+# server, systemd, or IDE kills this process.  Without this bridge,
+# SIGTERM terminates immediately — atexit never runs, ChromaDB's
+# compactor never flushes, and HNSW segments can be left corrupt.
+if hasattr(signal, "SIGTERM"):
+    signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
 
 # Schema version for drawer normalization. Bump when the normalization
 # pipeline changes in a way that existing drawers should be rebuilt to pick up

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -68,6 +68,70 @@ def get_closets_collection(palace_path: str, create: bool = True):
     return get_collection(palace_path, collection_name="mempalace_closets", create=create)
 
 
+def close_palace(palace_path: str) -> None:
+    """Flush ChromaDB's compactor and release cached handles for a palace.
+
+    Must be called before process exit when the mine loop finishes
+    (normally or via SIGINT) to prevent HNSW index corruption.
+    """
+    _DEFAULT_BACKEND.close_palace(palace_path)
+
+
+class safe_mine_session:
+    """Context manager that protects a mine loop from SIGINT corruption.
+
+    Usage::
+
+        with safe_mine_session(palace_path, dry_run=dry_run) as session:
+            for filepath in files:
+                process_file(filepath, ...)
+                if session.interrupted:
+                    break
+
+    On ``__exit__``, the session flushes ChromaDB's compactor via
+    ``close_palace()`` *before* restoring the original signal handler —
+    closing the window where a Ctrl+C during flush could corrupt the
+    HNSW index.
+    """
+
+    def __init__(self, palace_path: str, *, dry_run: bool = False):
+        self.palace_path = palace_path
+        self.dry_run = dry_run
+        self.interrupted = False
+        self._prev_handler = None
+
+    def __enter__(self):
+        import signal
+
+        self._prev_handler = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, self._handle_sigint)
+        return self
+
+    def _handle_sigint(self, signum, frame):
+        if not self.interrupted:
+            self.interrupted = True
+            print("\n  ⏸ Ctrl+C received — finishing current file before stopping...")
+        else:
+            print("\n  ⏸ Stopping after this file — interrupting mid-write corrupts the index.")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        import signal
+
+        # Flush the compactor BEFORE restoring the signal handler.
+        # This closes the window where Ctrl+C during flush could
+        # corrupt the HNSW index.
+        if not self.dry_run:
+            try:
+                close_palace(self.palace_path)
+            except Exception as e:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Failed to close palace cleanly: %s", e,
+                )
+        signal.signal(signal.SIGINT, self._prev_handler)
+        return False
+
+
 CLOSET_CHAR_LIMIT = 1500  # fill closet until ~1500 chars, then start a new one
 CLOSET_EXTRACT_WINDOW = 5000  # how many chars of source content to scan for entities/topics
 

--- a/tests/test_atexit_and_cache_key.py
+++ b/tests/test_atexit_and_cache_key.py
@@ -1,0 +1,168 @@
+"""Tests for atexit hook registration, SIGTERM bridge, and ChromaBackend cache key normalization.
+
+Covers:
+  - atexit.register is called with _DEFAULT_BACKEND.close at import time
+  - SIGTERM handler bridges to sys.exit(0) so atexit hooks fire on MCP kill
+  - _DEFAULT_BACKEND.close() is idempotent (safe to call multiple times)
+  - _cache_key() normalizes relative, absolute, and trailing-slash paths
+  - close_palace() finds the cached client even when path formats diverge
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mempalace.backends.chroma import ChromaBackend
+
+
+# ── atexit hook registration ──────────────────────────────────────────────
+
+
+class TestAtexitRegistration:
+    """Verify atexit.register is called for _DEFAULT_BACKEND.close."""
+
+    def test_atexit_registered_at_import(self):
+        """The palace module registers _DEFAULT_BACKEND.close via atexit."""
+        import atexit
+
+        # atexit._run_exitfuncs is CPython internal, but atexit callbacks
+        # are visible via the _ncallbacks() count. Instead, we verify that
+        # the _DEFAULT_BACKEND singleton's close method is registered by
+        # checking that importing palace doesn't crash and the backend
+        # has the expected close method that atexit would call.
+        from mempalace.palace import _DEFAULT_BACKEND
+
+        assert callable(_DEFAULT_BACKEND.close)
+        assert isinstance(_DEFAULT_BACKEND, ChromaBackend)
+        # Verify close is safe to call (what atexit will do)
+        # We can't inspect atexit's internal list portably, but we can
+        # verify the registration line exists in source as a structural test.
+        import inspect
+
+        source = inspect.getsource(
+            __import__("mempalace.palace", fromlist=["_DEFAULT_BACKEND"])
+        )
+        assert "atexit.register(_DEFAULT_BACKEND.close)" in source
+
+
+class TestCloseIdempotent:
+    """Verify _DEFAULT_BACKEND.close() can be called multiple times safely."""
+
+    def test_close_twice_does_not_raise(self):
+        backend = ChromaBackend()
+        backend.close()
+        backend.close()  # Should not raise
+
+    def test_close_clears_state(self):
+        backend = ChromaBackend()
+        backend.close()
+        assert backend._closed is True
+        assert len(backend._clients) == 0
+        assert len(backend._freshness) == 0
+
+
+# ── _cache_key normalization ──────────────────────────────────────────────
+
+
+class TestCacheKey:
+    """Verify _cache_key produces consistent keys for equivalent paths."""
+
+    def test_relative_and_absolute_resolve_to_same_key(self, tmp_path):
+        """./subdir and /abs/subdir resolve to the same cache key."""
+        subdir = tmp_path / "palace"
+        subdir.mkdir()
+        absolute = str(subdir)
+        # Build a relative path from cwd
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            relative = "./palace"
+            assert ChromaBackend._cache_key(relative) == ChromaBackend._cache_key(absolute)
+        finally:
+            os.chdir(original_cwd)
+
+    def test_trailing_slash_normalized(self, tmp_path):
+        """Trailing slash doesn't create a different cache key."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        without_slash = str(palace)
+        with_slash = str(palace) + "/"
+        assert ChromaBackend._cache_key(without_slash) == ChromaBackend._cache_key(with_slash)
+
+    def test_absolute_path_unchanged(self, tmp_path):
+        """An absolute path resolves to itself (no trailing slash)."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        key = ChromaBackend._cache_key(str(palace))
+        assert key == str(palace.resolve())
+
+
+class TestClosePalaceCacheKeyMatch:
+    """Verify close_palace finds the cached client even with path divergence."""
+
+    def test_close_palace_finds_client_with_different_path_format(self, tmp_path):
+        """get_collection with relative path, close_palace with absolute — client.close() fires."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+
+        backend = ChromaBackend()
+        mock_client = MagicMock()
+
+        # Inject a cached client under the normalized key
+        normalized = backend._cache_key(str(palace))
+        backend._clients[normalized] = mock_client
+        backend._freshness[normalized] = (12345, 1000.0)
+
+        # close_palace with a different format (trailing slash)
+        backend.close_palace(str(palace) + "/")
+
+        mock_client.close.assert_called_once()
+        assert normalized not in backend._clients
+        assert normalized not in backend._freshness
+
+    def test_close_palace_noop_when_no_client_cached(self, tmp_path):
+        """close_palace on an uncached path is a silent no-op."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        backend = ChromaBackend()
+        # Should not raise
+        backend.close_palace(str(palace))
+
+
+# ── SIGTERM → sys.exit bridge ─────────────────────────────────────────────
+
+
+class TestSigtermBridge:
+    """Verify SIGTERM handler is installed to trigger atexit on MCP kill."""
+
+    def test_sigterm_handler_installed(self):
+        """palace module installs a SIGTERM handler at import time."""
+        import signal
+
+        handler = signal.getsignal(signal.SIGTERM)
+        # Should not be SIG_DFL (default) — our handler replaces it.
+        assert handler is not signal.SIG_DFL, (
+            "SIGTERM handler is still SIG_DFL — palace module's "
+            "signal.signal(SIGTERM, ...) did not execute"
+        )
+
+    def test_sigterm_handler_raises_systemexit(self):
+        """The SIGTERM handler calls sys.exit(0), which raises SystemExit."""
+        import signal
+
+        handler = signal.getsignal(signal.SIGTERM)
+        with pytest.raises(SystemExit) as exc_info:
+            handler(signal.SIGTERM, None)
+        assert exc_info.value.code == 0
+
+    def test_sigterm_source_has_bridge(self):
+        """Structural test: palace.py source contains the SIGTERM bridge."""
+        import inspect
+
+        source = inspect.getsource(
+            __import__("mempalace.palace", fromlist=["_DEFAULT_BACKEND"])
+        )
+        assert "signal.signal(signal.SIGTERM" in source

--- a/tests/test_safe_mine_session.py
+++ b/tests/test_safe_mine_session.py
@@ -1,0 +1,276 @@
+"""Tests for safe_mine_session context manager and close_palace lifecycle.
+
+Covers the SIGINT handler, signal restoration order, close_palace flush,
+and the ChromaBackend.close_palace / close warning paths.
+"""
+
+import logging
+import signal
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mempalace.palace import close_palace, safe_mine_session
+
+
+# ── safe_mine_session: basic lifecycle ──────────────────────────────────
+
+
+class TestSafeMineSessionLifecycle:
+    """Core context manager behaviour without actual SIGINT delivery."""
+
+    def test_enters_and_exits_cleanly(self, tmp_path):
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        with safe_mine_session(str(palace), dry_run=True) as session:
+            assert session.interrupted is False
+
+    def test_interrupted_flag_starts_false(self, tmp_path):
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        with safe_mine_session(str(palace), dry_run=True) as session:
+            assert session.interrupted is False
+            # Manually simulate what the handler does
+            session.interrupted = True
+        assert session.interrupted is True
+
+    def test_dry_run_skips_close_palace(self, tmp_path):
+        """In dry_run mode, close_palace should NOT be called."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        with patch("mempalace.palace.close_palace") as mock_close:
+            with safe_mine_session(str(palace), dry_run=True):
+                pass
+        mock_close.assert_not_called()
+
+    def test_non_dry_run_calls_close_palace(self, tmp_path):
+        """Normal mode MUST call close_palace on exit."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        with patch("mempalace.palace.close_palace") as mock_close:
+            with safe_mine_session(str(palace), dry_run=False):
+                pass
+        mock_close.assert_called_once_with(str(palace))
+
+    def test_close_palace_called_even_on_exception(self, tmp_path):
+        """close_palace fires even when the body raises."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        with patch("mempalace.palace.close_palace") as mock_close:
+            with pytest.raises(RuntimeError):
+                with safe_mine_session(str(palace), dry_run=False):
+                    raise RuntimeError("boom")
+        mock_close.assert_called_once_with(str(palace))
+
+
+# ── safe_mine_session: signal handling ──────────────────────────────────
+
+
+class TestSafeMineSessionSignal:
+    """Signal installation and restoration behaviour."""
+
+    def test_installs_custom_handler_on_enter(self, tmp_path):
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        original = signal.getsignal(signal.SIGINT)
+        with safe_mine_session(str(palace), dry_run=True) as session:
+            current = signal.getsignal(signal.SIGINT)
+            assert current is not original
+            assert current == session._handle_sigint
+        # After exit, original is restored
+        assert signal.getsignal(signal.SIGINT) is original
+
+    def test_restores_original_handler_on_exit(self, tmp_path):
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        original = signal.getsignal(signal.SIGINT)
+        with safe_mine_session(str(palace), dry_run=True):
+            pass
+        assert signal.getsignal(signal.SIGINT) is original
+
+    def test_restores_handler_after_close_palace_not_before(self, tmp_path):
+        """Signal must stay deferred during close_palace() — the whole point
+        of the fix.  We verify by checking what signal handler is active at
+        the moment close_palace is called."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        handler_during_close = []
+
+        def spy_close(path):
+            handler_during_close.append(signal.getsignal(signal.SIGINT))
+
+        original = signal.getsignal(signal.SIGINT)
+        with patch("mempalace.palace.close_palace", side_effect=spy_close):
+            with safe_mine_session(str(palace), dry_run=False):
+                pass
+
+        # During close_palace, the handler should NOT have been the original
+        assert len(handler_during_close) == 1
+        assert handler_during_close[0] is not original
+
+    def test_handler_sets_interrupted_on_first_call(self, tmp_path, capsys):
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        with safe_mine_session(str(palace), dry_run=True) as session:
+            assert session.interrupted is False
+            # Simulate SIGINT delivery
+            session._handle_sigint(signal.SIGINT, None)
+            assert session.interrupted is True
+            captured = capsys.readouterr()
+            assert "Ctrl+C received" in captured.out
+
+    def test_handler_second_call_stays_interrupted(self, tmp_path, capsys):
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        with safe_mine_session(str(palace), dry_run=True) as session:
+            session._handle_sigint(signal.SIGINT, None)
+            session._handle_sigint(signal.SIGINT, None)
+            assert session.interrupted is True
+            captured = capsys.readouterr()
+            assert "corrupts the index" in captured.out
+
+
+# ── close_palace: backend integration ───────────────────────────────────
+
+
+class TestClosePalace:
+    """Tests for the close_palace function and backend close methods."""
+
+    def test_close_palace_calls_client_close(self, tmp_path):
+        """close_palace must trigger client.close() on the cached client."""
+        from mempalace.backends.chroma import ChromaBackend
+
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        backend = ChromaBackend()
+
+        # Open a real client so it gets cached
+        backend.get_collection(str(palace), collection_name="mempalace_drawers", create=True)
+        assert str(palace) in backend._clients
+
+        # Now close it
+        backend.close_palace(str(palace))
+
+        # Client should be removed from cache
+        assert str(palace) not in backend._clients
+        assert str(palace) not in backend._freshness
+
+    def test_close_palace_noop_for_uncached_path(self, tmp_path):
+        """close_palace on a path never opened should not raise."""
+        from mempalace.backends.chroma import ChromaBackend
+
+        backend = ChromaBackend()
+        # Should not raise
+        backend.close_palace(str(tmp_path / "nonexistent"))
+
+    def test_close_palace_none_path_is_noop(self):
+        """close_palace(None) should return immediately."""
+        from mempalace.backends.chroma import ChromaBackend
+        from mempalace.backends import PalaceRef
+
+        backend = ChromaBackend()
+        # PalaceRef with None local_path
+        ref = PalaceRef(id="test", local_path=None)
+        backend.close_palace(ref)  # should not raise
+
+    def test_close_all_clears_all_clients(self, tmp_path):
+        """close() must close all cached clients and clear state."""
+        from mempalace.backends.chroma import ChromaBackend
+
+        backend = ChromaBackend()
+
+        # Open two palaces
+        p1 = tmp_path / "palace1"
+        p2 = tmp_path / "palace2"
+        p1.mkdir()
+        p2.mkdir()
+        backend.get_collection(str(p1), collection_name="mempalace_drawers", create=True)
+        backend.get_collection(str(p2), collection_name="mempalace_drawers", create=True)
+        assert len(backend._clients) == 2
+
+        backend.close()
+
+        assert len(backend._clients) == 0
+        assert len(backend._freshness) == 0
+        assert backend._closed is True
+
+    def test_close_palace_logs_warning_on_client_close_failure(self, tmp_path, caplog):
+        """When client.close() raises, the exception must be logged as a warning."""
+        from mempalace.backends.chroma import ChromaBackend
+
+        backend = ChromaBackend()
+        palace_str = str(tmp_path / "palace")
+
+        # Inject a mock client that raises on close()
+        mock_client = MagicMock()
+        mock_client.close.side_effect = RuntimeError("disk full")
+        backend._clients[palace_str] = mock_client
+        backend._freshness[palace_str] = (0, 0.0)
+
+        with caplog.at_level(logging.WARNING, logger="mempalace.backends.chroma"):
+            backend.close_palace(palace_str)
+
+        assert "Failed to close ChromaDB client" in caplog.text
+        assert "disk full" in caplog.text
+        # Client should still be removed from cache
+        assert palace_str not in backend._clients
+
+    def test_close_logs_warning_on_client_close_failure(self, tmp_path, caplog):
+        """close() must log warnings for individual client failures
+        but continue closing remaining clients."""
+        from mempalace.backends.chroma import ChromaBackend
+
+        backend = ChromaBackend()
+
+        # Two clients: one raises, one succeeds
+        mock_bad = MagicMock()
+        mock_bad.close.side_effect = RuntimeError("io error")
+        mock_good = MagicMock()
+
+        backend._clients["bad"] = mock_bad
+        backend._clients["good"] = mock_good
+        backend._freshness["bad"] = (0, 0.0)
+        backend._freshness["good"] = (0, 0.0)
+
+        with caplog.at_level(logging.WARNING, logger="mempalace.backends.chroma"):
+            backend.close()
+
+        # Both clients should have had close() called
+        mock_bad.close.assert_called_once()
+        mock_good.close.assert_called_once()
+        # Warning logged for the failing one
+        assert "Failed to close ChromaDB client" in caplog.text
+        # State fully cleared
+        assert len(backend._clients) == 0
+        assert backend._closed is True
+
+
+# ── Integration: convo_miner uses safe_mine_session ─────────────────────
+#
+# NOTE: miner.mine() no longer uses safe_mine_session — upstream PR #1183
+# added try/except KeyboardInterrupt directly in the mine loop. Our
+# safe_mine_session is still used by convo_miner.mine_convos() and
+# provides signal-deferral during the convo mining path (which upstream
+# did not harden).
+
+
+class TestConvoMinerIntegration:
+    """Verify that mine_convos() still uses safe_mine_session."""
+
+    def test_convo_miner_imports_safe_mine_session(self):
+        """convo_miner must import safe_mine_session from palace."""
+        from mempalace import convo_miner
+
+        # Verify the import exists (would ImportError if removed)
+        assert hasattr(convo_miner, "mine_convos")
+
+    def test_safe_mine_session_referenced_in_convo_miner_source(self):
+        """Ensure convo_miner.py actually calls safe_mine_session."""
+        import inspect
+        from mempalace import convo_miner
+
+        source = inspect.getsource(convo_miner)
+        assert "safe_mine_session" in source, (
+            "convo_miner must use safe_mine_session for signal-safe mining"
+        )


### PR DESCRIPTION
## fix: lifecycle hardening for MCP-driven shutdowns and `convo_miner` signal safety

### Context

PR #1183 added graceful `KeyboardInterrupt` handling to `mine()` for Ctrl+C — great UX improvement. However, as noted in [#1113 (comment)](https://github.com/MemPalace/mempalace/pull/1113#issuecomment-4321513719), two lifecycle scenarios remain unprotected:

1. **MCP server termination** — When an IDE, `systemd`, or MCP proxy kills the mempalace process, it sends `SIGTERM`, not `SIGINT`. Python's default `SIGTERM` handler terminates the process immediately — no `except`, no `finally`, no `atexit`. ChromaDB's HNSW compactor never flushes.

2. **`convo_miner` has no signal handling** — `mine_convos()` was not hardened by #1183. A Ctrl+C during a `collection.upsert()` call can corrupt the HNSW index.

This PR provides defense-in-depth for both scenarios without modifying `miner.py` or conflicting with #1183.

---

### How this complements #1183

| Signal | Handler | Location | Who |
|---|---|---|---|
| **SIGINT** (Ctrl+C) in `mine()` | `try/except KeyboardInterrupt` | `miner.py` | ✅ Upstream #1183 |
| **SIGINT** (Ctrl+C) in `mine_convos()` | `safe_mine_session` — defers signal until current upsert completes | `palace.py` → `convo_miner.py` | 🆕 This PR |
| **SIGTERM** (MCP/IDE/systemd kill) | `signal.signal(SIGTERM, → sys.exit(0))` — converts to `SystemExit` so `atexit` + `finally` blocks run | `palace.py` | 🆕 This PR |
| **Normal exit** / stdin EOF | `atexit.register(_DEFAULT_BACKEND.close)` | `palace.py` | 🆕 This PR |
| **Path mismatch** in cache cleanup | `_cache_key()` normalization via `Path.resolve()` | `chroma.py` | 🆕 This PR |

**Key difference:** #1183's `try/except KeyboardInterrupt` catches Ctrl+C (SIGINT → `KeyboardInterrupt`). It does **not** catch SIGTERM, which is what MCP hosts send when shutting down server subprocesses. Our SIGTERM bridge also makes #1183's `finally: _cleanup_mine_pid_file()` block more reliable — without it, SIGTERM kills the process before `finally` executes.

---

### Changes

#### `mempalace/palace.py`
- **`atexit.register(_DEFAULT_BACKEND.close)`** — Ensures ChromaDB handles are flushed on normal interpreter shutdown (stdin EOF from MCP, clean exit).
- **`signal.signal(SIGTERM, lambda: sys.exit(0))`** — Bridges SIGTERM → `SystemExit`, triggering `atexit` handlers and `finally` blocks. Guarded by `hasattr(signal, "SIGTERM")` for Windows portability.
- **`close_palace(palace_path)`** — Flushes and releases a specific palace's ChromaDB client.
- **`safe_mine_session`** — Context manager that replaces the SIGINT handler during mining, deferring interruption until the current file's upsert completes, then calling `close_palace()` before restoring the original handler.

#### `mempalace/convo_miner.py`
- Wraps `mine_convos()` loop in `safe_mine_session` for atomic upsert protection.

#### `mempalace/backends/chroma.py`
- **`close_palace(palace_path)`** — Backend method to flush a specific client by palace path.
- **`_cache_key(path)`** — Normalizes paths via `Path(path).resolve()` so `close_palace("/foo/bar/")` finds the client cached under `"/foo/bar"`. Fixes a bug where trailing slashes or relative paths caused cleanup misses.

#### `tests/test_safe_mine_session.py` (new, 18 tests)
- Lifecycle: enter/exit, dry-run skip, close-on-exception
- Signal: handler installation, restoration order, interrupted flag
- `close_palace`: cache hit/miss, idempotency, error logging
- Integration: verifies `convo_miner` imports and calls `safe_mine_session`

#### `tests/test_atexit_and_cache_key.py` (new, 11 tests)
- Atexit registration verification
- SIGTERM bridge: handler installed, raises `SystemExit(0)`, source structural test
- Cache key normalization: relative/absolute equivalence, trailing slash, identity
- `close_palace` path divergence: finds client despite format mismatch

---

### What this does NOT change

- **`mempalace/miner.py`** — Zero modifications. We fully defer to #1183's `KeyboardInterrupt` handling for the main mine loop.
- No new dependencies.
- No CLI interface changes.

### Test results

All existing tests pass. 29 new tests added across 2 test files.
