### PR TITLE
fix: add total count to tool_list_drawers pagination response

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -746,6 +746,13 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
             kwargs["where"] = where
         result = col.get(**kwargs)
 
+        # Compute total matching drawers for pagination.
+        if where:
+            total_result = col.get(where=where, include=[])
+            total = len(total_result["ids"])
+        else:
+            total = col.count()
+
         drawers = []
         for i, did in enumerate(result["ids"]):
             meta = result["metadatas"][i]
@@ -760,6 +767,7 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
             )
         return {
             "drawers": drawers,
+            "total": total,
             "count": len(drawers),
             "offset": offset,
             "limit": limit,
@@ -1436,7 +1444,7 @@ TOOLS = {
         "handler": tool_get_drawer,
     },
     "mempalace_list_drawers": {
-        "description": "List drawers with pagination. Optional wing/room filter. Returns IDs, wings, rooms, and content previews.",
+        "description": "List drawers with pagination. Optional wing/room filter. Returns IDs, wings, rooms, content previews, and total matching count for pagination.",
         "input_schema": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Problem

`mempalace_list_drawers` returns `count` (current page size) but no `total` field, making reliable pagination impossible.

When `count == limit`, the caller cannot distinguish between:
- The last page happening to be exactly full (no more results)
- A page with more results remaining

This forces callers to make an extra request to discover there are no more drawers, or stop early and miss data.

**Before:**
```json
{"drawers": [...], "count": 20, "offset": 0, "limit": 20}
```
No way to know if there are 20 total or 200.

**After:**
```json
{"drawers": [...], "total": 47, "count": 20, "offset": 0, "limit": 20}
```
Caller knows to request offset=20, then offset=40, then stop.

## Changes

- **mempalace/mcp_server.py** — `tool_list_drawers()`:
  - Added `total` field to response dict
  - For unfiltered requests: uses `col.count()` (zero-cost)
  - For filtered requests (wing/room): uses `col.get(where=..., include=[])` to count matching IDs without fetching documents
  - Updated tool description to mention total count

## How to test

```bash
python -m pytest tests/ -v --ignore=tests/benchmarks
```

All 1066 existing tests pass. The change is additive — a new field in the response dict. No existing fields are modified or removed.

Manual verification:
```python
from mempalace.mcp_server import tool_list_drawers
result = tool_list_drawers(limit=5, offset=0)
assert "total" in result  # new field
assert result["total"] >= result["count"]
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] Linter passes (`ruff check .`)
- [x] Formatter passes (`ruff format --check .`)
- [x] No new dependencies
- [x] Backward compatible (additive field only)
