### PR TITLE
fix: harden Chroma status path and Windows CLI output

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -466,6 +466,7 @@ class ChromaBackend(BaseBackend):
 
         if cached is None or inode_changed or mtime_changed or mtime_appeared:
             _fix_blob_seq_ids(palace_path)
+            quarantine_stale_hnsw(palace_path)
             cached = chromadb.PersistentClient(path=palace_path)
             self._clients[palace_path] = cached
             # Re-stat after the client constructor runs: chromadb creates

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-MemPalace — Give your AI a memory. No API key required.
+MemPalace - Give your AI a memory. No API key required.
 
 Two ways to ingest:
   Projects:      mempalace mine ~/projects/my_app          (code, docs, notes)
@@ -103,7 +103,7 @@ def cmd_init(args):
                     json.dump(confirmed, f, indent=2)
                 print(f"  Entities saved: {entities_path}")
         else:
-            print("  No entities detected — proceeding with directory-based rooms.")
+            print("  No entities detected - proceeding with directory-based rooms.")
 
     # Pass 2: detect rooms from folder structure
     detect_rooms_local(project_dir=args.dir, yes=getattr(args, "yes", False))
@@ -151,7 +151,7 @@ def cmd_sweep(args):
 
     The sweeper deduplicates against its own prior writes via
     deterministic drawer IDs + a timestamp cursor. It does NOT currently
-    coordinate with the file-level miners (miner.py / convo_miner.py) —
+    coordinate with the file-level miners (miner.py / convo_miner.py) -
     those produce char-chunked drawers without compatible message
     metadata, so running both miners may store overlapping content under
     different IDs.
@@ -205,7 +205,7 @@ def cmd_search(args):
 
 
 def cmd_wakeup(args):
-    """Show L0 (identity) + L1 (essential story) — the wake-up context."""
+    """Show L0 (identity) + L1 (essential story) - the wake-up context."""
     from .layers import MemoryStack
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
@@ -292,7 +292,7 @@ def cmd_repair(args):
         print(f"  Drawers found: {total}")
     except Exception as e:
         print(f"  Error reading palace: {e}")
-        print("  Cannot recover — palace may need to be re-mined from source files.")
+        print("  Cannot recover - palace may need to be re-mined from source files.")
         return
 
     if total == 0:
@@ -515,7 +515,7 @@ def cmd_compress(args):
 def main():
     version_label = f"MemPalace {__version__}"
     parser = argparse.ArgumentParser(
-        description="MemPalace — Give your AI a memory. No API key required.",
+        description="MemPalace - Give your AI a memory. No API key required.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=f"{version_label}\n\n{__doc__}",
     )
@@ -576,7 +576,7 @@ def main():
     p_mine.add_argument(
         "--agent",
         default="mempalace",
-        help="Your name — recorded on every drawer (default: mempalace)",
+        help="Your name - recorded on every drawer (default: mempalace)",
     )
     p_mine.add_argument("--limit", type=int, default=0, help="Max files to process (0 = all)")
     p_mine.add_argument(
@@ -691,7 +691,7 @@ def main():
     # migrate
     p_migrate = sub.add_parser(
         "migrate",
-        help="Migrate palace from a different ChromaDB version (fixes 3.0.0 → 3.1.0 upgrade)",
+        help="Migrate palace from a different ChromaDB version (fixes 3.0.0 -> 3.1.0 upgrade)",
     )
     p_migrate.add_argument(
         "--dry-run",

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -784,7 +784,7 @@ def mine(
     print(f"  Files:   {len(files)}")
     print(f"  Palace:  {palace_path}")
     if dry_run:
-        print("  DRY RUN — nothing will be filed")
+        print("  DRY RUN - nothing will be filed")
     if not respect_gitignore:
         print("  .gitignore: DISABLED")
     if include_ignored:
@@ -849,8 +849,19 @@ def status(palace_path: str):
 
     # Count by wing and room
     total = col.count()
-    r = col.get(limit=total, include=["metadatas"]) if total else {"metadatas": []}
-    metas = r["metadatas"]
+    metas = []
+    if total:
+        batch_size = 500  # stay under Chroma/SQLite variable limits on large palaces
+        offset = 0
+        while True:
+            batch = col.get(limit=batch_size, offset=offset, include=["metadatas"])
+            batch_metas = batch["metadatas"]
+            if not batch_metas:
+                break
+            metas.extend(batch_metas)
+            offset += len(batch_metas)
+            if len(batch_metas) < batch_size:
+                break
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:
@@ -858,7 +869,7 @@ def status(palace_path: str):
         wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
 
     print(f"\n{'=' * 55}")
-    print(f"  MemPalace Status — {len(metas)} drawers")
+    print(f"  MemPalace Status - {len(metas)} drawers")
     print(f"{'=' * 55}\n")
     for wing, rooms in sorted(wing_rooms.items()):
         print(f"  WING: {wing}")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -266,6 +266,44 @@ def test_chroma_cache_picks_up_db_created_after_first_open(tmp_path):
     assert backend._freshness[str(palace_path)] != (0, 0.0)
 
 
+def test_chroma_client_quarantines_stale_hnsw_before_open(monkeypatch, tmp_path):
+    """Backend should quarantine drifted HNSW dirs before constructing the client.
+
+    This guards the real-world crash path where chroma.sqlite3 is much newer
+    than on-disk segment indexes and Chroma can abort the process during the
+    next open/count/query.
+    """
+    now = 1_700_000_000.0
+    palace_path, seg = _make_palace_with_segment(
+        tmp_path, hnsw_mtime=now - 7200, sqlite_mtime=now
+    )
+
+    class _FakeClient:
+        def get_or_create_collection(self, name, metadata=None):
+            return _FakeCollection()
+
+    seen = {}
+
+    def _fake_persistent_client(*, path):
+        seen["path"] = path
+        seen["seg_exists_at_open"] = seg.exists()
+        return _FakeClient()
+
+    monkeypatch.setattr(chromadb, "PersistentClient", _fake_persistent_client)
+
+    collection = ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=True,
+    )
+
+    assert isinstance(collection, ChromaCollection)
+    assert seen["path"] == str(palace_path)
+    assert seen["seg_exists_at_open"] is False
+    drift_dirs = [p for p in palace_path.iterdir() if ".drift-" in p.name]
+    assert len(drift_dirs) == 1
+
+
 def test_base_collection_update_default_rejects_mismatched_lengths():
     """The ABC default update() raises ValueError rather than silently misaligning."""
     from mempalace.backends.base import BaseCollection

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -373,6 +373,32 @@ def test_status_handles_none_metadata_without_crash(tmp_path, capsys):
     assert "WING: proj" in out
 
 
+def test_status_paginates_large_palaces(tmp_path, capsys):
+    """status should page metadata reads instead of fetching every drawer at once."""
+    from unittest.mock import patch
+
+    class FakeCol:
+        def count(self):
+            return 1200
+
+        def get(self, *args, **kwargs):
+            limit = kwargs["limit"]
+            offset = kwargs["offset"]
+            metas = []
+            end = min(offset + limit, 1200)
+            for idx in range(offset, end):
+                metas.append({"wing": "proj", "room": f"room-{idx // 600}"})
+            return {"metadatas": metas}
+
+    with patch("mempalace.miner.get_collection", return_value=FakeCol()):
+        status(str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert "MemPalace Status" in out
+    assert "1200 drawers" in out
+    assert "WING: proj" in out
+
+
 # ── normalize_version schema gate ───────────────────────────────────────
 #
 # When the normalization pipeline changes shape (e.g., strip_noise lands),


### PR DESCRIPTION
## Summary
This PR fixes three user-facing failures I hit while verifying a local MemPalace install on Windows:

- quarantine stale Chroma HNSW segment directories before opening a refreshed client
- paginate mempalace status metadata reads so large palaces do not hit SQLite variable limits
- make CLI help/status text ASCII-safe so default Windows cp1252 consoles do not crash on --help

## Validation
- python -m pytest tests/test_backends.py tests/test_cli.py tests/test_miner.py -q
- python -m mempalace.cli --help
- python -m mempalace.cli init --help
- python -m mempalace.cli status

Fixes #1121
Fixes #1122
Fixes #1123