### PR TITLE
fix(convo_miner): preserve blank lines and indentation in AI responses

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -192,11 +192,15 @@ def _chunk_by_exchange(lines: list, chunk_size: int, min_chunk_size: int) -> lis
                 next_line = lines[i]
                 if next_line.strip().startswith(">") or next_line.strip().startswith("---"):
                     break
-                if next_line.strip():
-                    ai_lines.append(next_line.strip())
+                # Preserve the line as-is — blank lines and indentation carry meaning
+                # (paragraph breaks, list/code structure) and must survive verbatim.
+                ai_lines.append(next_line)
                 i += 1
 
-            ai_response = " ".join(ai_lines)
+            # Join on newline (not space) so line structure, blank lines, and
+            # indentation reach the drawer unchanged. Trim only trailing blank
+            # lines produced by the loop stopping at the next `>` turn.
+            ai_response = "\n".join(ai_lines).rstrip("\n")
             content = f"{user_turn}\n{ai_response}" if ai_response else user_turn
 
             _emit_bounded(chunks, content, chunk_size, min_chunk_size)

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -186,6 +186,64 @@ class TestChunkExchanges:
         assert chunks[1]["content"] == "b" * CHUNK_SIZE
         assert chunks[2]["content"] == "c" * CHUNK_SIZE
 
+    def test_ai_response_preserves_blank_lines(self):
+        """Blank lines inside an AI response must survive ingestion (verbatim principle).
+
+        A response with paragraph breaks separates distinct ideas; collapsing the
+        blank lines loses that boundary and fuses unrelated content.
+        """
+        # Three `>` turns route through _chunk_by_exchange (the exchange-pair path).
+        content = (
+            "> explain the architecture\n"
+            "First paragraph introducing the system.\n"
+            "\n"
+            "Second paragraph about the data layer.\n"
+            "\n"
+            "Third paragraph about retrieval.\n"
+            "\n"
+            "> what about caching?\n"
+            "Cache lives in memory and is invalidated on write.\n"
+            "\n"
+            "> and persistence?\n"
+            "Persistence lives on disk via SQLite and Chroma.\n"
+        )
+        chunks = chunk_exchanges(content)
+        assert len(chunks) >= 1
+        stored = "\n".join(c["content"] for c in chunks)
+        # Paragraph break between the three bodies must survive as `\n\n`.
+        assert "First paragraph introducing the system.\n\nSecond paragraph" in stored
+        assert "Second paragraph about the data layer.\n\nThird paragraph" in stored
+
+    def test_ai_response_preserves_line_structure(self):
+        """Line-oriented content (lists, code fences, tables) must keep newlines.
+
+        Joining lines with a single space fuses structurally distinct tokens,
+        breaks downstream search, and destroys code blocks.
+        """
+        content = (
+            "> show me the steps\n"
+            "1. First step\n"
+            "2. Second step\n"
+            "3. Third step\n"
+            "```python\n"
+            "def hello():\n"
+            "    return 'world'\n"
+            "```\n"
+            "\n"
+            "> what next?\n"
+            "Run the test suite.\n"
+            "\n"
+            "> anything else?\n"
+            "Ship the feature.\n"
+        )
+        chunks = chunk_exchanges(content)
+        assert len(chunks) >= 1
+        stored = "\n".join(c["content"] for c in chunks)
+        # Each list item keeps its own line (not "1. First step 2. Second step").
+        assert "1. First step\n2. Second step\n3. Third step" in stored
+        # Code fence survives intact, with indentation preserved.
+        assert "```python\ndef hello():\n    return 'world'\n```" in stored
+
 
 class TestEmitBounded:
     """Direct unit tests for the chunk-size-enforcement helper."""


### PR DESCRIPTION
## What and Why

`_chunk_by_exchange` collapses every AI response during ingest:
- `.strip()` on each line destroys indentation (breaks code fences and nested lists)
- blank lines are skipped, fusing paragraphs
- `" ".join(ai_lines)` replaces every newline with a space

This violates the **verbatim-always** design principle stated in [CLAUDE.md](https://github.com/MemPalace/mempalace/blob/develop/CLAUDE.md#design-principles) and contradicts the function's own docstring, which claims *"The full AI response is preserved verbatim."*

Related prior fix [#708](https://github.com/MemPalace/mempalace/pull/708) removed the 8-line truncation in the same function but did not touch the line-collapse path.

## Root Cause

[`mempalace/convo_miner.py:133-137`](https://github.com/MemPalace/mempalace/blob/develop/mempalace/convo_miner.py#L133):

```python
if next_line.strip():
    ai_lines.append(next_line.strip())  # strips indentation, drops blanks
i += 1

ai_response = " ".join(ai_lines)      # joins with space, not newline
```

## Reproduction

```python
from mempalace.convo_miner import chunk_exchanges

content = (
    "> show me the steps\n"
    "1. First step\n"
    "2. Second step\n"
    "3. Third step\n"
    "```python\n"
    "def hello():\n"
    "    return 'world'\n"
    "```\n"
    "\n"
    "> what next?\nRun the suite.\n\n"
    "> anything else?\nShip it.\n"
)
chunks = chunk_exchanges(content)
print(chunks[0]['content'])
```

**Before this PR:**
```
> show me the steps
1. First step 2. Second step 3. Third step ```python def hello(): return 'world' ```
```

**After this PR:**
```
> show me the steps
1. First step
2. Second step
3. Third step
```python
def hello():
    return 'world'
```
```

## Change Summary

- [`mempalace/convo_miner.py:128-140`](https://github.com/MemPalace/mempalace/blob/develop/mempalace/convo_miner.py#L128) — keep each line as-is, join on `\n`, trim only trailing blank lines produced by the outer loop stopping at the next `>` turn.
- [`tests/test_convo_miner_unit.py`](https://github.com/MemPalace/mempalace/blob/develop/tests/test_convo_miner_unit.py) — two regression tests: blank-line preservation and list/code-fence preservation.

## Test Plan

- [x] `pytest tests/test_convo_miner_unit.py` — 17/17 pass
- [x] `pytest tests/test_convo_miner.py tests/test_convo_miner_size_cap.py` — 5/5 pass
- [x] `pytest tests/ --ignore=tests/benchmarks` — 1068/1068 pass (zero downstream regressions)
- [x] `ruff check` / `ruff format --check` — clean

## Follow-up (out of scope)

The fallback path `_chunk_by_paragraph` ([`convo_miner.py:169`](https://github.com/MemPalace/mempalace/blob/develop/mempalace/convo_miner.py#L169)) has a narrower version of the same bug — it calls `.strip()` on each paragraph, dropping leading/trailing whitespace within the paragraph. Happy to send a second PR for that if this approach is welcome.