### PR TITLE
fix: reject non-http(s) LLM endpoints + clear ruff bugbear/silent-except findings

### DIFF
--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -40,6 +40,7 @@ import json
 import os
 import re
 import time
+import urllib.parse
 import urllib.request
 import urllib.error
 from datetime import datetime
@@ -101,6 +102,14 @@ class LLMConfig:
         self.endpoint = (endpoint or os.environ.get("LLM_ENDPOINT", "")).rstrip("/")
         self.key = key or os.environ.get("LLM_KEY", "")
         self.model = model or os.environ.get("LLM_MODEL", "")
+        if self.endpoint:
+            # Privacy-by-architecture: reject file:// and other non-HTTP schemes
+            # so a misconfigured endpoint cannot exfiltrate local files.
+            scheme = urllib.parse.urlparse(self.endpoint).scheme.lower()
+            if scheme not in ("http", "https"):
+                raise ValueError(
+                    f"LLM_ENDPOINT must use http:// or https:// (got scheme {scheme!r})"
+                )
 
     def missing(self) -> list:
         missing = []

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -11,6 +11,7 @@ Same palace as project mining. Different ingest strategy.
 import os
 import sys
 import hashlib
+import logging
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
@@ -23,6 +24,8 @@ from .palace import (
     get_collection,
     mine_lock,
 )
+
+logger = logging.getLogger("mempalace_mcp")
 
 
 # Cached hall keywords — avoids re-reading config per drawer
@@ -331,7 +334,7 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
         try:
             collection.delete(where={"source_file": source_file})
         except Exception:
-            pass
+            logger.debug("Stale-drawer purge failed for %s", source_file, exc_info=True)
 
         # Batch chunks into bounded upserts so large transcripts keep most of
         # the embedding speedup without one huge Chroma/SQLite request. Keep

--- a/mempalace/dedup.py
+++ b/mempalace/dedup.py
@@ -89,7 +89,7 @@ def dedup_source_group(col, drawer_ids, threshold=DEFAULT_THRESHOLD, dry_run=Tru
     kept = []
     to_delete = []
 
-    for did, doc, meta in items:
+    for did, doc, _meta in items:
         if not doc or len(doc) < 20:
             to_delete.append(did)
             continue

--- a/mempalace/dialect.py
+++ b/mempalace/dialect.py
@@ -873,7 +873,7 @@ class Dialect:
 
         for date_key in sorted(by_date.keys()):
             lines.append(f"=MOMENTS[{date_key}]=")
-            for z, fnum in by_date[date_key]:
+            for z, _fnum in by_date[date_key]:
                 entities = []
                 for p in z.get("people", []):
                     code = self.encode_entity(p)

--- a/mempalace/fact_checker.py
+++ b/mempalace/fact_checker.py
@@ -27,6 +27,7 @@ Usage:
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from datetime import datetime, timezone
@@ -34,6 +35,8 @@ from datetime import datetime, timezone
 # Share miner's mtime-cached registry loader so we don't double-read
 # ~/.mempalace/known_entities.json on every check_text call.
 from .miner import _load_known_entities_raw
+
+logger = logging.getLogger("mempalace_mcp")
 
 
 # Narrow detection patterns — parse "X is Y's Z" and "X's Z is Y".
@@ -214,6 +217,7 @@ def _check_kg_contradictions(text: str, palace_path: str) -> list:
         try:
             facts = kg.query_entity(subject, direction="outgoing")
         except Exception:
+            logger.debug("KG lookup failed for subject %r", subject, exc_info=True)
             continue
         if not facts:
             continue

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -157,7 +157,7 @@ class Layer1:
             lines.append(room_line)
             total_len += len(room_line)
 
-            for imp, meta, doc in entries:
+            for _imp, meta, doc in entries:
                 source = Path(meta.get("source_file", "")).name if meta.get("source_file") else ""
 
                 # Truncate doc to keep L1 compact

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -900,7 +900,7 @@ def tool_add_drawer(
         if existing and existing["ids"]:
             return {"success": True, "reason": "already_exists", "drawer_id": drawer_id}
     except Exception:
-        pass
+        logger.debug("Idempotency pre-check failed for %s", drawer_id, exc_info=True)
 
     try:
         col.upsert(
@@ -1418,7 +1418,7 @@ def tool_hook_settings(silent_save: bool = None, desktop_toast: bool = None):
     try:
         config = MempalaceConfig()
     except Exception:
-        pass
+        logger.debug("Could not re-read config after update", exc_info=True)
 
     result = {
         "success": True,

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -12,6 +12,7 @@ import sys
 import shlex
 import hashlib
 import fnmatch
+import logging
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
@@ -30,6 +31,8 @@ from .palace import (
     purge_file_closets,
     upsert_closet_lines,
 )
+
+logger = logging.getLogger("mempalace_mcp")
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -842,7 +845,7 @@ def process_file(
         try:
             collection.delete(where={"source_file": source_file})
         except Exception:
-            pass
+            logger.debug("Stale-drawer purge failed for %s", source_file, exc_info=True)
 
         # Batch chunks into bounded upserts so the embedding model sees many
         # chunks per forward pass without building one huge Chroma/SQLite

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -118,14 +118,14 @@ def normalize(filepath: str) -> str:
     try:
         file_size = os.path.getsize(filepath)
     except OSError as e:
-        raise IOError(f"Could not read {filepath}: {e}")
+        raise IOError(f"Could not read {filepath}: {e}") from e
     if file_size > 500 * 1024 * 1024:  # 500 MB safety limit
         raise IOError(f"File too large ({file_size // (1024 * 1024)} MB): {filepath}")
     try:
         with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             content = f.read()
     except OSError as e:
-        raise IOError(f"Could not read {filepath}: {e}")
+        raise IOError(f"Could not read {filepath}: {e}") from e
 
     if not content.strip():
         return content

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -6,11 +6,14 @@ Consolidates collection access patterns used by both miners and the MCP server.
 
 import contextlib
 import hashlib
+import logging
 import os
 import re
 import threading
 
 from .backends.chroma import ChromaBackend
+
+logger = logging.getLogger("mempalace_mcp")
 
 SKIP_DIRS = {
     ".git",
@@ -229,7 +232,7 @@ def purge_file_closets(closets_col, source_file: str) -> None:
     try:
         closets_col.delete(where={"source_file": source_file})
     except Exception:
-        pass
+        logger.debug("Closet purge failed for %s", source_file, exc_info=True)
 
 
 def upsert_closet_lines(closets_col, closet_id_base, lines, metadata):
@@ -307,7 +310,7 @@ def mine_lock(source_file: str):
 
                 fcntl.flock(lf, fcntl.LOCK_UN)
         except Exception:
-            pass
+            logger.debug("Mine-lock release failed", exc_info=True)
         lf.close()
 
 

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -575,7 +575,7 @@ def follow_tunnels(wing: str, room: str, col=None, config=None):
                     if did and did in drawer_map:
                         c["drawer_preview"] = drawer_map[did][:300]
             except Exception:
-                pass
+                logger.debug("Drawer preview hydration failed", exc_info=True)
 
     return connections
 

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -202,7 +202,7 @@ def detect_rooms_from_files(project_dir: str) -> list:
 
     SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv", "dist", "build"}
 
-    for root, dirs, filenames in os.walk(project_path):
+    for _root, dirs, filenames in os.walk(project_path):
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
         for filename in filenames:
             name_lower = filename.lower().replace("-", "_").replace(" ", "_")

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -245,7 +245,7 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
         all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
         total_drawers = len(all_meta.ids) if all_meta.ids else None
     except Exception:
-        pass
+        logger.debug("total_drawers lookup failed for %s", src, exc_info=True)
 
     return {
         "text": combined_text,
@@ -297,10 +297,10 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     """
     try:
         col = get_collection(palace_path, create=False)
-    except Exception:
+    except Exception as e:
         print(f"\n  No palace found at {palace_path}")
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
-        raise SearchError(f"No palace found at {palace_path}")
+        raise SearchError(f"No palace found at {palace_path}") from e
 
     # Alert the user if this palace predates hnsw:space=cosine being set on
     # creation — their similarity scores will be junk until they run repair.
@@ -795,7 +795,8 @@ def search_memories(
             if source and source not in closet_boost_by_source:
                 closet_boost_by_source[source] = (rank, cdist, cdoc[:200])
     except Exception:
-        pass  # no closets yet — hybrid degrades to pure drawer search
+        # No closets yet — hybrid degrades to pure drawer search.
+        logger.debug("Closet collection unavailable; using drawer-only search", exc_info=True)
 
     # Rank-based boost. The ordinal signal ("which closet matched best") is
     # more reliable than absolute distance on narrative content, where
@@ -877,6 +878,7 @@ def search_memories(
                 include=["documents", "metadatas"],
             )
         except Exception:
+            logger.debug("Neighbor fetch failed for %s", full_source, exc_info=True)
             continue
         docs = source_drawers.documents
         metas_ = source_drawers.metadatas


### PR DESCRIPTION
## Summary

Two unrelated but small cleanup items surfaced by a ruff audit against the current codebase:

1. **Privacy hardening in `closet_llm.py`** — `LLMConfig` passes `LLM_ENDPOINT` straight to `urllib.request.urlopen` with no scheme check, so a misconfigured endpoint such as `file:///etc/passwd` would be read and forwarded as a \"Chat Completions\" request. Given the project's *privacy by architecture* guarantee, the constructor now validates the scheme and raises `ValueError` for anything other than `http`/`https`. All existing `LLMConfig` tests use `http://` endpoints, so they still pass.
2. **Ruff bugbear + silent-except cleanup** — fixes every finding under `ruff --select B,S110,S112` inside the `mempalace/` package:
   - `B904` exception chaining in `normalize.py` (2×) and `searcher.py` (1×).
   - `B007` unused loop variables renamed to `_name` in `dedup`, `dialect`, `layers`, `room_detector_local`.
   - `S110`/`S112` bare `try/except/pass` and `try/except/continue` replaced with `logger.debug(..., exc_info=True)` in `mcp_server`, `searcher`, `palace`, `palace_graph`, `miner`, `convo_miner`, `fact_checker`. Five of those files didn't previously have a module-level logger, so one was added using the existing `\"mempalace_mcp\"` logger name that `mcp_server.py` and `searcher.py` already use.

No behaviour change — failures that were already silent still don't propagate; they're just visible at `DEBUG` level now. Configured `ruff check` (E/F/W/C901) continues to pass.

## Test plan

- [x] `ruff check .` — all checks pass.
- [x] `ruff check --select B,S110,S112 mempalace/` — all checks pass.
- [x] `python -c \"import ast, pathlib; [ast.parse(p.read_text()) for p in pathlib.Path('mempalace').rglob('*.py')]\"` — every file parses.
- [ ] `pytest tests/` — not run locally (env without chromadb). CI will cover.

## Notes for reviewers

- Happy to split the endpoint-scheme commit into its own PR if that's preferred for release-note hygiene — it's the only functional change.
- Did **not** run `ruff format` because the local ruff is `0.15.11` and `.pre-commit-config.yaml` pins `0.4.10`; formatter output differs between those versions.
- Did **not** touch the `UP*` findings — `target-version = \"py39\"` in `pyproject.toml` blocks the `X | None` rewrites anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)