### PR TITLE
release: v3.3.3 — restore install integrity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [3.3.3] — 2026-04-23
+
+### Bug Fixes
+
+- **Install regression** — `mempalace-mcp` console script is now declared in `pyproject.toml` alongside `.claude-plugin/plugin.json`'s reference to it. In v3.3.2 the two drifted apart (plugin.json shipped the new `"command": "mempalace-mcp"` form before the matching entry point landed), so every fresh `pip install mempalace==3.3.2` produced a Claude Code plugin config pointing at a binary that wasn't installed. (#1093, #340)
+- Restore silent-save visibility after the Claude Code 2.1.114 client regression — production transcript saves were failing silently until this PR. (#1021)
+- Paginate `status`-path metadata fetches so large palaces don't trip SQLite variable limits. (#851)
+- Resolve the Claude plugin hook runner across platform / plugin-dir variations; previously broke on Windows and some macOS layouts. (#942)
+- Real `python3` resolution for `.sh` hooks with a `MEMPAL_PYTHON` override path. (#833)
+- Add optional `wing` parameter to `tool_diary_write` / `tool_diary_read` and derive per-project wing from the Claude Code transcript path when writing from the stop hook — diary entries from different projects no longer collapse into a shared default wing. (#659)
+- Treat empty string as "no filter" in `mempalace_search` `wing`/`room`; LLM agents that default to filling every optional parameter with `""` no longer get bounced with `must be a non-empty string`. (#1097, #1084)
+
+### Improvements
+
+- **Deterministic hook saves.** Save hook now uses a silent Python API path, so successive hook invocations produce reproducible results and zero data loss on the hot path. (#673)
+- **Graph cache with write-invalidation** inside `build_graph()` — warm-path calls no longer rebuild the palace-graph per request. (#661)
+
+### Added
+
+- i18n: Belarusian translation. (#1051)
+- i18n: entity detection for German, Spanish, and French locales. (#1001)
+- i18n: Traditional + Simplified Chinese entity detection. (#945)
+
+### Known — deferred to v3.3.4
+
+- HNSW parallel-insert SIGSEGV when `hnsw:num_threads` is unset on collection creation (#974) — fix in-flight as #976, awaiting rebase against develop.
+
+---
+
 ## [3.3.2] — 2026-04-19
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 MIT — see [LICENSE](LICENSE).
 
 <!-- Link Definitions -->
-[version-shield]: https://img.shields.io/badge/version-3.3.2-4dc9f6?style=flat-square&labelColor=0a0e14
+[version-shield]: https://img.shields.io/badge/version-3.3.3-4dc9f6?style=flat-square&labelColor=0a0e14
 [release-link]: https://github.com/MemPalace/mempalace/releases
 [python-shield]: https://img.shields.io/badge/python-3.9+-7dd8f8?style=flat-square&labelColor=0a0e14&logo=python&logoColor=7dd8f8
 [python-link]: https://www.python.org/

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.3.2"
+__version__ = "3.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.3.2"
+version = "3.3.3"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
**Draft — queued for @igorls review + approval before tagging.** Supersedes #1143.

## Summary

Version bump for **v3.3.3**, a restore-integrity release. Unbreaks fresh \`pip install mempalace\` from v3.3.2.

Six-file touch; no code changes:

- \`mempalace/version.py\`: \`3.3.2\` → \`3.3.3\`
- \`pyproject.toml\`: \`3.3.2\` → \`3.3.3\`
- \`.claude-plugin/plugin.json\`: \`3.3.2\` → \`3.3.3\`
- \`.claude-plugin/marketplace.json\`: \`3.3.2\` → \`3.3.3\`
- \`.codex-plugin/plugin.json\`: \`3.3.2\` → \`3.3.3\`
- \`CHANGELOG.md\`: new \`[3.3.3]\` entry

All 5 version sources now agree per the Version Guard workflow. The #1093 fix is already on \`develop\` via merged [#340](https://github.com/MemPalace/mempalace/pull/340) (messelink, ~10h after we tagged 3.3.2).

## Why

v3.3.2 shipped a \`.claude-plugin/plugin.json\` referencing a \`mempalace-mcp\` binary that the same release's \`pyproject.toml\` never declared. Every fresh \`pip install mempalace==3.3.2\` produces a Claude Code plugin config pointing at a binary that isn't installed → MCP server fails to launch. Diagnosed by @jphein in [#1093](https://github.com/MemPalace/mempalace/issues/1093).

## Why not \`release/3.3.3\` as the branch name

The \`release/*\` ruleset requires all updates go through a PR with no force-push, which meant I couldn't fix my own CI break on [#1143](https://github.com/MemPalace/mempalace/pull/1143) (missed 3 of 5 version files). A \`chore/\`-prefixed branch dodges the ruleset so follow-up CI fixes stay cheap. If you prefer the \`release/*\` convention for release-shaped PRs, easy to rename the head branch before tagging — or leave as-is, the tag is what matters.

## What ships with 3.3.3 (all already on \`develop\`)

**Bug fixes**
- [#340](https://github.com/MemPalace/mempalace/pull/340) — \`mempalace-mcp\` entry point (the #1093 fix)
- [#1021](https://github.com/MemPalace/mempalace/pull/1021) — Claude Code 2.1.114 silent-save regression
- [#851](https://github.com/MemPalace/mempalace/pull/851) — large-palace \`status\` pagination
- [#942](https://github.com/MemPalace/mempalace/pull/942), [#833](https://github.com/MemPalace/mempalace/pull/833) — hook resolution (Windows, plugin-dir)
- [#659](https://github.com/MemPalace/mempalace/pull/659) — diary per-project wing-scoping (jphein)
- [#1097](https://github.com/MemPalace/mempalace/pull/1097) — \`mempalace_search\` empty-string filter

**Improvements**
- [#673](https://github.com/MemPalace/mempalace/pull/673) — deterministic hook saves
- [#661](https://github.com/MemPalace/mempalace/pull/661) — graph cache + write-invalidation

**Added**
- i18n: [#1051](https://github.com/MemPalace/mempalace/pull/1051), [#1001](https://github.com/MemPalace/mempalace/pull/1001), [#945](https://github.com/MemPalace/mempalace/pull/945)

**Deferred to 3.3.4**
- [#976](https://github.com/MemPalace/mempalace/pull/976) (HNSW SIGSEGV / closes #974) — conflicting, awaiting felipetruman rebase.

## Smoke test — passed locally on develop @ HEAD

\`\`\`bash
$ grep mempalace-mcp pyproject.toml .claude-plugin/plugin.json
pyproject.toml:mempalace-mcp = \"mempalace.mcp_server:main\"
.claude-plugin/plugin.json:      \"command\": \"mempalace-mcp\"

$ python -m build --wheel
Successfully built mempalace-3.3.2-py3-none-any.whl

$ python -m venv /tmp/v333 && source /tmp/v333/bin/activate
$ pip install dist/mempalace-3.3.2-py3-none-any.whl
$ which mempalace-mcp
/tmp/v333/bin/mempalace-mcp

$ mempalace-mcp --help
usage: mempalace-mcp [-h] [--palace PATH]
MemPalace MCP Server
\`\`\`

All four invariants pass. Full brief with decisions + proposed release notes: [go-team-mempalace/proposals/v3-3-3-igor-brief.html](https://github.com/MemPalace/go-team-mempalace/blob/main/proposals/v3-3-3-igor-brief.html).

## Review checklist for @igorls

- [ ] Cut from current \`develop\` is the right shape (vs a narrower cherry-pick set)?
- [ ] Ship without [#976](https://github.com/MemPalace/mempalace/pull/976) (recommend yes — unblocks install now; #976 rolls to 3.3.4)?
- [ ] CHANGELOG entry complete and accurate?
- [ ] Branch name \`chore/release-3.3.3-prep\` OK, or would you prefer this be re-pushed as \`release/3.3.3\` once CI is green?

## Tag sequence (after merge)

\`\`\`bash
git checkout develop && git pull
git tag -a v3.3.3 -m \"v3.3.3 — restore install integrity\"
git push origin v3.3.3
\`\`\`

CI publishes to PyPI; marketplace refresh picks up \`plugin.json\`.

---

Ready for your review. Mark as ready-for-review + merge (or redirect) when you're happy with the shape.