### PR TITLE
fix(security): normalize MEMPALACE_PALACE_PATH env var with abspath+expanduser

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -168,7 +168,10 @@ class MempalaceConfig:
         """Path to the memory palace data directory."""
         env_val = os.environ.get("MEMPALACE_PALACE_PATH") or os.environ.get("MEMPAL_PALACE_PATH")
         if env_val:
-            return env_val
+            # Normalize: expand ~ and collapse .. to match the CLI --palace
+            # code path (mcp_server.py:62) and prevent surprise redirection
+            # when the env var contains unresolved components.
+            return os.path.abspath(os.path.expanduser(env_val))
         return self._file_config.get("palace_path", DEFAULT_PALACE_PATH)
 
     @property

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,11 +34,14 @@ def test_env_override():
 
 
 def test_env_path_expanduser():
+    # Tilde must be expanded to match the --palace CLI code path. We don't
+    # assert "~" is absent from the final string because Windows 8.3 short
+    # paths (e.g. C:\Users\RUNNER~1\...) legitimately contain tildes — the
+    # equality check is authoritative.
     raw = os.path.join("~", "mempalace-test")
     os.environ["MEMPALACE_PALACE_PATH"] = raw
     try:
         cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
-        # Tilde must be expanded to match the --palace CLI code path.
         assert cfg.palace_path == os.path.abspath(os.path.expanduser(raw))
         assert cfg.palace_path.endswith("mempalace-test")
     finally:
@@ -61,13 +64,15 @@ def test_env_path_abspath_collapses_traversal():
 
 
 def test_env_path_legacy_alias_normalized():
-    # Legacy MEMPAL_PALACE_PATH gets the same normalization treatment.
+    # Legacy MEMPAL_PALACE_PATH gets the same normalization treatment as
+    # MEMPALACE_PALACE_PATH. We don't assert "~" is absent from the final
+    # string because Windows 8.3 short paths (e.g. C:\Users\RUNNER~1\...)
+    # legitimately contain tildes — the equality check below is authoritative.
     os.environ.pop("MEMPALACE_PALACE_PATH", None)
     raw = os.path.join("~", "legacy-alias", "..", "mempalace-test")
     os.environ["MEMPAL_PALACE_PATH"] = raw
     try:
         cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
-        assert "~" not in cfg.palace_path
         assert ".." not in cfg.palace_path
         assert cfg.palace_path == os.path.abspath(os.path.expanduser(raw))
     finally:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,42 @@ def test_env_override():
     del os.environ["MEMPALACE_PALACE_PATH"]
 
 
+def test_env_path_expanduser():
+    os.environ["MEMPALACE_PALACE_PATH"] = "~/mempalace-test"
+    try:
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        # Tilde must be expanded to match the --palace CLI code path.
+        assert "~" not in cfg.palace_path
+        assert cfg.palace_path.endswith("mempalace-test")
+        assert cfg.palace_path == os.path.expanduser("~/mempalace-test")
+    finally:
+        del os.environ["MEMPALACE_PALACE_PATH"]
+
+
+def test_env_path_abspath_collapses_traversal():
+    os.environ["MEMPALACE_PALACE_PATH"] = "/tmp/palace/../mempalace-test"
+    try:
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        # .. segments must be collapsed, not preserved literally.
+        assert ".." not in cfg.palace_path
+        assert cfg.palace_path == "/tmp/mempalace-test"
+    finally:
+        del os.environ["MEMPALACE_PALACE_PATH"]
+
+
+def test_env_path_legacy_alias_normalized():
+    # Legacy MEMPAL_PALACE_PATH gets the same normalization treatment.
+    os.environ.pop("MEMPALACE_PALACE_PATH", None)
+    os.environ["MEMPAL_PALACE_PATH"] = "~/legacy-alias/../mempalace-test"
+    try:
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        assert "~" not in cfg.palace_path
+        assert ".." not in cfg.palace_path
+        assert cfg.palace_path == os.path.expanduser("~/mempalace-test")
+    finally:
+        del os.environ["MEMPAL_PALACE_PATH"]
+
+
 def test_init():
     tmpdir = tempfile.mkdtemp()
     cfg = MempalaceConfig(config_dir=tmpdir)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,31 +21,41 @@ def test_config_from_file():
 
 
 def test_env_override():
-    os.environ["MEMPALACE_PALACE_PATH"] = "/env/palace"
-    cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
-    assert cfg.palace_path == "/env/palace"
-    del os.environ["MEMPALACE_PALACE_PATH"]
+    raw = "/env/palace"
+    os.environ["MEMPALACE_PALACE_PATH"] = raw
+    try:
+        cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+        # palace_path normalizes with abspath + expanduser to match the
+        # --palace CLI code path. On Unix that's a no-op for "/env/palace";
+        # on Windows abspath prepends the current drive letter.
+        assert cfg.palace_path == os.path.abspath(os.path.expanduser(raw))
+    finally:
+        del os.environ["MEMPALACE_PALACE_PATH"]
 
 
 def test_env_path_expanduser():
-    os.environ["MEMPALACE_PALACE_PATH"] = "~/mempalace-test"
+    raw = os.path.join("~", "mempalace-test")
+    os.environ["MEMPALACE_PALACE_PATH"] = raw
     try:
         cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
         # Tilde must be expanded to match the --palace CLI code path.
-        assert "~" not in cfg.palace_path
+        assert cfg.palace_path == os.path.abspath(os.path.expanduser(raw))
         assert cfg.palace_path.endswith("mempalace-test")
-        assert cfg.palace_path == os.path.expanduser("~/mempalace-test")
     finally:
         del os.environ["MEMPALACE_PALACE_PATH"]
 
 
 def test_env_path_abspath_collapses_traversal():
-    os.environ["MEMPALACE_PALACE_PATH"] = "/tmp/palace/../mempalace-test"
+    # Build a raw path with a .. segment using the platform separator so
+    # the assertion is portable (Windows uses \, POSIX uses /).
+    raw = os.path.join(tempfile.gettempdir(), "palace", "..", "mempalace-test")
+    expected = os.path.abspath(os.path.expanduser(raw))
+    os.environ["MEMPALACE_PALACE_PATH"] = raw
     try:
         cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
         # .. segments must be collapsed, not preserved literally.
         assert ".." not in cfg.palace_path
-        assert cfg.palace_path == "/tmp/mempalace-test"
+        assert cfg.palace_path == expected
     finally:
         del os.environ["MEMPALACE_PALACE_PATH"]
 
@@ -53,12 +63,13 @@ def test_env_path_abspath_collapses_traversal():
 def test_env_path_legacy_alias_normalized():
     # Legacy MEMPAL_PALACE_PATH gets the same normalization treatment.
     os.environ.pop("MEMPALACE_PALACE_PATH", None)
-    os.environ["MEMPAL_PALACE_PATH"] = "~/legacy-alias/../mempalace-test"
+    raw = os.path.join("~", "legacy-alias", "..", "mempalace-test")
+    os.environ["MEMPAL_PALACE_PATH"] = raw
     try:
         cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
         assert "~" not in cfg.palace_path
         assert ".." not in cfg.palace_path
-        assert cfg.palace_path == os.path.expanduser("~/mempalace-test")
+        assert cfg.palace_path == os.path.abspath(os.path.expanduser(raw))
     finally:
         del os.environ["MEMPAL_PALACE_PATH"]
 

--- a/tests/test_config_extra.py
+++ b/tests/test_config_extra.py
@@ -63,10 +63,14 @@ def test_save_people_map(tmp_path):
 def test_env_mempal_palace_path(tmp_path):
     """MEMPAL_PALACE_PATH (legacy) should also work."""
     os.environ.pop("MEMPALACE_PALACE_PATH", None)
-    os.environ["MEMPAL_PALACE_PATH"] = "/legacy/path"
+    raw = "/legacy/path"
+    os.environ["MEMPAL_PALACE_PATH"] = raw
     try:
         cfg = MempalaceConfig(config_dir=str(tmp_path))
-        assert cfg.palace_path == "/legacy/path"
+        # palace_path is normalized via abspath + expanduser — compare
+        # against the normalized form so the test is portable between
+        # POSIX (no-op) and Windows (prepends current drive letter).
+        assert cfg.palace_path == os.path.abspath(os.path.expanduser(raw))
     finally:
         del os.environ["MEMPAL_PALACE_PATH"]
 


### PR DESCRIPTION
## What and Why

`MEMPALACE_PALACE_PATH` (and legacy `MEMPAL_PALACE_PATH`) read from the environment was returned as-is from `Config.palace_path`, while the sibling `--palace` CLI path gets `os.path.abspath()` applied at `mcp_server.py:62`. The inconsistency lets env-var callers end up with a literal `~` or unresolved `..` segments in the stored path, which breaks user intuition and lets a caller who can set env vars on the target user's session redirect palace storage somewhere the user didn't expect.

## Root Cause

`mempalace/config.py:167-172` — the env-var branch of the `palace_path` property short-circuits and returns `env_val` without running it through `os.path.expanduser()` / `os.path.abspath()`.

## Change Summary

- `mempalace/config.py` — expand `~` and collapse `..` on the env-var branch so both code paths converge on the same resolved absolute path. A 2-line inline comment notes the parity with the CLI code path.
- `tests/test_config.py` — three new tests covering `~` expansion, `..` collapse, and the legacy `MEMPAL_PALACE_PATH` alias getting the same treatment.

## Test Plan

- [x] `pytest tests/test_config.py -v` — 25/25 pass (3 new tests green)
- [x] `ruff check` — clean
- [x] `ruff format --check` — formatted

Closes #1163
