### PR TITLE
docs(changelog): document init entity-detection overhaul in 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Treat empty string as "no filter" in `mempalace_search` `wing`/`room`; LLM agents that default to filling every optional parameter with `""` no longer get bounced with `must be a non-empty string`. (#1097, #1084)
 - Broaden `_wing_from_transcript_path` to handle Claude Code project folders without a `-Projects-` segment (e.g. `~/dev/<parent>/<project>`, `~/code/<project>`). The project name is now derived from the final dash-separated token of the encoded folder, so Linux users with code outside `~/Projects/` get per-project diary scoping instead of falling through to `wing_sessions`. (#1145, follow-up to #659)
 - `mempalace_diary_read(wing="")` now returns diary entries from every wing this agent has written to, matching the #1097 "empty-string as no filter" pattern. Previously defaulted to `wing_<agent>`, siloing entries that hooks wrote to project-derived wings. (#1145)
-- `mempalace mine` now skips the generated `entities.json` file so its contents aren't re-ingested as project content.
+- `mempalace mine` now skips the generated `entities.json` file so its contents aren't re-ingested as project content. (#1175)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Treat empty string as "no filter" in `mempalace_search` `wing`/`room`; LLM agents that default to filling every optional parameter with `""` no longer get bounced with `must be a non-empty string`. (#1097, #1084)
 - Broaden `_wing_from_transcript_path` to handle Claude Code project folders without a `-Projects-` segment (e.g. `~/dev/<parent>/<project>`, `~/code/<project>`). The project name is now derived from the final dash-separated token of the encoded folder, so Linux users with code outside `~/Projects/` get per-project diary scoping instead of falling through to `wing_sessions`. (#1145, follow-up to #659)
 - `mempalace_diary_read(wing="")` now returns diary entries from every wing this agent has written to, matching the #1097 "empty-string as no filter" pattern. Previously defaulted to `wing_<agent>`, siloing entries that hooks wrote to project-derived wings. (#1145)
+- `mempalace mine` now skips the generated `entities.json` file so its contents aren't re-ingested as project content.
 
 ### Improvements
 
 - **Deterministic hook saves.** Save hook now uses a silent Python API path, so successive hook invocations produce reproducible results and zero data loss on the hot path. (#673)
 - **Graph cache with write-invalidation** inside `build_graph()` — warm-path calls no longer rebuild the palace-graph per request. (#661)
+- **`mempalace init` entity detection overhaul.** Canonical project names now come from package manifests (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`) and real people come from git commit authors, rather than being inferred from prose. Includes union-find dedup across name/email aliases, bot filtering that keeps `@users.noreply.github.com` humans, and automatic "mine" flagging by contribution share. (#1148)
+- **Regex detector accuracy.** CamelCase extraction so `MemPalace`, `ChromaDB`, `OpenAI` aren't fragmented; tighter versioned/hyphenated pattern kills `context-manager` / `multi-word` false positives; dialogue `^NAME:\s` requires ≥2 hits so `Created: <date>` metadata stops classifying field names as people; expanded stopwords for common English participles and descriptors; high-pronoun signal classifies as person rather than dumping to uncertain. (#1148)
+- **Init → miner wire-up.** Confirmed entities merge into `~/.mempalace/known_entities.json` on init, which the miner reads to tag drawer metadata for entity-filtered search. Previously init's output was not consumed by the miner; the per-project `entities.json` is kept as an audit trail. (#1157)
+- **Case-insensitive project dedup** across manifest, git, and convo sources so casing variants of the same project name collapse into one review entry. (#1175)
 
 ### Added
 
 - i18n: Belarusian translation. (#1051)
 - i18n: entity detection for German, Spanish, and French locales. (#1001)
 - i18n: Traditional + Simplified Chinese entity detection. (#945)
+- **`mempalace init --llm`**: optional LLM-assisted entity classification. Defaults to local Ollama (zero-API); also supports any OpenAI-compatible endpoint (LM Studio, llama.cpp server, vLLM, OpenRouter, etc.) and the Anthropic Messages API. Runs interactively with a progress indicator; Ctrl-C cancels cleanly and returns partial results. Useful for prose-heavy folders where the regex detector struggles (diaries, transcripts, research notes). Opt-in only — default init path remains zero-API. (#1150)
+- **Claude Code conversation scanner.** `~/.claude/projects/<slug>/` directories now contribute project entities using each session's authoritative `cwd` metadata, avoiding slug-decoding ambiguity. (#1150)
 
 ### Known — deferred to v3.3.4
 


### PR DESCRIPTION
## Context

The 3.3.3 section of `CHANGELOG.md` on develop was written before #1148, #1150, #1157, and #1175 landed (the last three were rescued from stacked feature branches via #1175 yesterday). Merging #1159 to `main` without this update would advertise only the hook/diary/search fixes that made it to develop through the first direct merge — the entity-detection overhaul, the LLM refinement, the Claude Code convo scanner, and the miner wire-up would all ship silently.

This PR adds the missing entries so the release notes reflect what actually shipped. Should merge into develop before #1159 cuts the tag.

## Entries added

**Bug Fixes**
- `mempalace mine` now skips the generated `entities.json` file so its contents aren't re-ingested as project content

**Improvements**
- Entity detection overhaul — manifest + git-author signal replaces prose inference (#1148)
- Regex detector accuracy — CamelCase, tighter versioned/hyphenated, dialogue-metadata filter, stopwords, high-pronoun classification (#1148)
- Init → miner wire-up via `~/.mempalace/known_entities.json` (#1157)
- Case-insensitive project dedup across all sources (#1175)

**Added**
- `mempalace init --llm` with Ollama / openai-compat / Anthropic providers, interactive progress, Ctrl-C cancellation (#1150)
- Claude Code conversation-directory scanner (#1150)

## Note on section date

The 3.3.3 section is dated `2026-04-23` — from before the release. If the tag is cut `2026-04-24`, consider updating the section header to match. Not changed here; it's a judgement call on whether the date marks "intended release" or "actual tag cut."

## Test plan

- [x] Doc-only change; no code modified
- [x] Renders correctly in the existing Keep-a-Changelog layout
- [ ] Reviewer confirms entries match what PRs #1148, #1150, #1157, #1175 actually delivered before #1159 cuts the tag