### PR TITLE
fix: skip _fix_blob_seq_ids sqlite open on already-migrated palaces (#1090)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -4,6 +4,7 @@ import datetime as _dt
 import logging
 import os
 import sqlite3
+from pathlib import Path
 from typing import Any, Optional
 
 import chromadb
@@ -206,7 +207,7 @@ def _fix_blob_seq_ids(palace_path: str) -> None:
     # confirmed to be in the INTEGER-seq_id state and future opens can skip the
     # sqlite3.connect() entirely.
     try:
-        open(marker, "a").close()
+        Path(marker).touch()
     except OSError:
         logger.exception("Could not write migration marker %s", marker)
 

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -159,6 +159,9 @@ def _pin_hnsw_threads(collection) -> None:
         logger.debug("_pin_hnsw_threads modify failed", exc_info=True)
 
 
+_BLOB_FIX_MARKER = ".blob_seq_ids_migrated"
+
+
 def _fix_blob_seq_ids(palace_path: str) -> None:
     """Fix ChromaDB 0.6.x -> 1.5.x migration bug: BLOB seq_ids -> INTEGER.
 
@@ -168,9 +171,18 @@ def _fix_blob_seq_ids(palace_path: str) -> None:
     type INTEGER) is not compatible with SQL type BLOB".
 
     Must run BEFORE PersistentClient is created (the compactor fires on init).
+
+    Opening a Python sqlite3 connection against a ChromaDB 1.5.x WAL-mode
+    database leaves state that segfaults the next PersistentClient call. After
+    the migration has run once successfully, a marker file is written so
+    subsequent opens skip the sqlite connection entirely. Already-migrated
+    palaces can touch the marker manually to opt into the fast path.
     """
     db_path = os.path.join(palace_path, "chroma.sqlite3")
     if not os.path.isfile(db_path):
+        return
+    marker = os.path.join(palace_path, _BLOB_FIX_MARKER)
+    if os.path.isfile(marker):
         return
     try:
         with sqlite3.connect(db_path) as conn:
@@ -189,6 +201,14 @@ def _fix_blob_seq_ids(palace_path: str) -> None:
             conn.commit()
     except Exception:
         logger.exception("Could not fix BLOB seq_ids in %s", db_path)
+        return
+    # Write marker whether or not rows needed migration — the palace is now
+    # confirmed to be in the INTEGER-seq_id state and future opens can skip the
+    # sqlite3.connect() entirely.
+    try:
+        open(marker, "a").close()
+    except OSError:
+        logger.exception("Could not write migration marker %s", marker)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -383,7 +383,6 @@ def test_fix_blob_seq_ids_noop_without_database(tmp_path):
 
 def test_fix_blob_seq_ids_writes_marker_after_blob_path(tmp_path):
     """The .blob_seq_ids_migrated marker is written after a successful BLOB → INTEGER conversion."""
-    from pathlib import Path
     from mempalace.backends.chroma import _BLOB_FIX_MARKER
 
     db_path = tmp_path / "chroma.sqlite3"
@@ -409,7 +408,6 @@ def test_fix_blob_seq_ids_writes_marker_when_already_integer(tmp_path):
     marker on first run too — next ``_fix_blob_seq_ids`` call short-circuits
     before touching the sqlite3 file.
     """
-    from pathlib import Path
     from mempalace.backends.chroma import _BLOB_FIX_MARKER
 
     db_path = tmp_path / "chroma.sqlite3"
@@ -435,7 +433,6 @@ def test_fix_blob_seq_ids_skips_sqlite_when_marker_present(tmp_path):
     PersistentClient call (#1090). Once a palace has been migrated, we
     never want to open it again, even read-only.
     """
-    from pathlib import Path
     from unittest.mock import patch
     from mempalace.backends.chroma import _BLOB_FIX_MARKER
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -381,6 +381,75 @@ def test_fix_blob_seq_ids_noop_without_database(tmp_path):
     _fix_blob_seq_ids(str(tmp_path))  # should not raise
 
 
+def test_fix_blob_seq_ids_writes_marker_after_blob_path(tmp_path):
+    """The .blob_seq_ids_migrated marker is written after a successful BLOB → INTEGER conversion."""
+    from pathlib import Path
+    from mempalace.backends.chroma import _BLOB_FIX_MARKER
+
+    db_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE embeddings (rowid INTEGER PRIMARY KEY, seq_id)")
+    conn.execute("INSERT INTO embeddings (seq_id) VALUES (?)", ((42).to_bytes(8, "big"),))
+    conn.commit()
+    conn.close()
+
+    marker = tmp_path / _BLOB_FIX_MARKER
+    assert not marker.exists()
+
+    _fix_blob_seq_ids(str(tmp_path))
+
+    assert marker.is_file(), "marker must be written after a successful migration"
+
+
+def test_fix_blob_seq_ids_writes_marker_when_already_integer(tmp_path):
+    """The marker is written even when the migration is a no-op (already INTEGER).
+
+    The point of the marker is to skip the sqlite3 open on subsequent calls,
+    not to record that a conversion happened. So a clean palace gets the
+    marker on first run too — next ``_fix_blob_seq_ids`` call short-circuits
+    before touching the sqlite3 file.
+    """
+    from pathlib import Path
+    from mempalace.backends.chroma import _BLOB_FIX_MARKER
+
+    db_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE embeddings (rowid INTEGER PRIMARY KEY, seq_id INTEGER)")
+    conn.execute("INSERT INTO embeddings (seq_id) VALUES (42)")
+    conn.commit()
+    conn.close()
+
+    marker = tmp_path / _BLOB_FIX_MARKER
+    assert not marker.exists()
+
+    _fix_blob_seq_ids(str(tmp_path))
+
+    assert marker.is_file(), "marker must be written even when no BLOBs found"
+
+
+def test_fix_blob_seq_ids_skips_sqlite_when_marker_present(tmp_path):
+    """When the marker exists, ``_fix_blob_seq_ids`` does not open sqlite3.
+
+    This is the load-bearing property of the marker — opening Python's
+    sqlite3 against a live ChromaDB 1.5.x WAL DB corrupts the next
+    PersistentClient call (#1090). Once a palace has been migrated, we
+    never want to open it again, even read-only.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+    from mempalace.backends.chroma import _BLOB_FIX_MARKER
+
+    # Pre-create the marker so the function should short-circuit.
+    db_path = tmp_path / "chroma.sqlite3"
+    db_path.write_bytes(b"sentinel")  # presence required for the function to proceed
+    (tmp_path / _BLOB_FIX_MARKER).touch()
+
+    with patch("mempalace.backends.chroma.sqlite3.connect") as mock_connect:
+        _fix_blob_seq_ids(str(tmp_path))
+
+    mock_connect.assert_not_called()
+
+
 # ── quarantine_stale_hnsw ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #1090.

Opening `chroma.sqlite3` via Python's `sqlite3.connect()` against a live ChromaDB 1.5.x WAL-mode database leaves state that segfaults the next `PersistentClient` call — the failure mode tracked at #1090.

`_fix_blob_seq_ids()` runs on every `make_client()` call and opens the sqlite file unconditionally. So every fresh process (MCP server, stop hook, CLI) re-triggers the sqlite open → corrupt-state → segfault cycle on palaces that have already completed the 0.6.x → 1.5.x `seq_id` migration.

**Guard:** a `.blob_seq_ids_migrated` marker file in the palace directory.

- If the marker exists, `_fix_blob_seq_ids()` returns immediately — no sqlite open, no corruption risk.
- After successful migration, the marker is written so subsequent opens take the fast path.
- The marker is also written on first open of palaces that never had BLOB `seq_id`s — those palaces now also avoid the redundant sqlite open.
- Existing already-migrated palaces can `touch .mempalace/palace/.blob_seq_ids_migrated` manually to opt in immediately.

## Why the sqlite open is unsafe

ChromaDB 1.5.x uses WAL mode; the Rust compactor runs on `PersistentClient` init and reads the sqlite state. Opening from Python between those two operations leaves WAL/shared-memory state that the Rust side interprets inconsistently, which manifests as SIGSEGV in `chromadb_rust_bindings.abi3.so`. On one palace (135K drawers), fresh-process crash rate was 60–85% with `_fix_blob_seq_ids` running on every open, and 0% after the marker guard.

This is one of three known segfault triggers in the 1.5.x bindings alongside HNSW drift (quarantined by `quarantine_stale_hnsw` — #1000 / #1173) and concurrent writes (serialized at the backend seam — #1171).

## Test plan

- [x] Local: after marker exists, `_fix_blob_seq_ids` returns before any `sqlite3.connect()` call
- [x] 1094 existing tests pass
- [ ] Production: fresh MCP server + stop hook + `mempalace mine` subprocess all run against a post-migration palace without segfaults

Generated with [Claude Code](https://claude.com/claude-code)