### PR TITLE
fix(search): wire CLI mempalace search through BM25 hybrid rerank — blocks 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Broaden `_wing_from_transcript_path` to handle Claude Code project folders without a `-Projects-` segment (e.g. `~/dev/<parent>/<project>`, `~/code/<project>`). The project name is now derived from the final dash-separated token of the encoded folder, so Linux users with code outside `~/Projects/` get per-project diary scoping instead of falling through to `wing_sessions`. (#1145, follow-up to #659)
 - `mempalace_diary_read(wing="")` now returns diary entries from every wing this agent has written to, matching the #1097 "empty-string as no filter" pattern. Previously defaulted to `wing_<agent>`, siloing entries that hooks wrote to project-derived wings. (#1145)
 - `mempalace mine` now skips the generated `entities.json` file so its contents aren't re-ingested as project content. (#1175)
+- **CLI `mempalace search` retrieval quality.** The CLI path was using pure ChromaDB cosine distance with no BM25 rerank, so drawers containing every query term but embedding as noise (directory listings, diff output, shell logs) scored `Match: 0.0` alongside genuinely irrelevant results — with no way for the user to tell them apart. Wired the CLI through the same `_hybrid_rank` the `mempalace_search` MCP tool already used, and surfaced both `cosine=` and `bm25=` scores in the output so the user sees which component of the match is firing. Agent search via MCP was unaffected; this fixes the human-facing CLI parity gap.
 
 ### Improvements
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -273,6 +273,24 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print(f'\n  No results found for: "{query}"')
         return
 
+    # Pure-cosine retrieval on the CLI path was missing lexical matches:
+    # a drawer whose text contains every query term can still score distance
+    # >= 1.0 against the natural-language query when the drawer is a
+    # mechanical artifact (directory listing, diff, log fragment) that
+    # embeds as file-tree noise rather than as prose about its subject.
+    # The MCP tool path already hybridizes BM25 with vector sim via
+    # `_hybrid_rank`; do the same here so CLI results match what agents
+    # see via `mempalace_search`.
+    hits = [
+        {
+            "text": doc,
+            "distance": float(dist),
+            "metadata": meta or {},
+        }
+        for doc, meta, dist in zip(docs, metas, dists)
+    ]
+    hits = _hybrid_rank(hits, query)
+
     print(f"\n{'=' * 60}")
     print(f'  Results for: "{query}"')
     if wing:
@@ -281,19 +299,20 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print(f"  Room: {room}")
     print(f"{'=' * 60}\n")
 
-    for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
-        similarity = round(max(0.0, 1 - dist), 3)
-        meta = meta or {}
+    for i, hit in enumerate(hits, 1):
+        vec_sim = round(max(0.0, 1 - hit["distance"]), 3)
+        bm25 = hit.get("bm25_score", 0.0)
+        meta = hit["metadata"]
         source = Path(meta.get("source_file", "?")).name
         wing_name = meta.get("wing", "?")
         room_name = meta.get("room", "?")
 
         print(f"  [{i}] {wing_name} / {room_name}")
         print(f"      Source: {source}")
-        print(f"      Match:  {similarity}")
+        print(f"      Match:  cosine={vec_sim}  bm25={bm25}")
         print()
         # Print the verbatim text, indented
-        for line in doc.strip().split("\n"):
+        for line in hit["text"].strip().split("\n"):
             print(f"      {line}")
         print()
         print(f"  {'─' * 56}")

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -191,3 +191,49 @@ class TestSearchCLI:
         assert "[2]" in captured.out
         # Second result renders with fallback '?' values instead of crashing
         assert "second doc" in captured.out
+
+    def test_search_applies_bm25_hybrid_rerank(self, capsys):
+        """CLI search must call the same hybrid rerank that the MCP path uses.
+
+        Regression for a shipping bug where the CLI only consulted ChromaDB
+        cosine distance: a drawer whose body contained every query term still
+        scored Match 0.0 if its embedding happened to be far from the query
+        (e.g. the drawer was a shell-output fragment that embeds as "file
+        tree noise"). Hybrid rerank fixes this by combining BM25 with cosine
+        — lexical matches rise above pure vector noise.
+
+        Simulates: three candidates, all with distance >= 1.0 (cosine = 0);
+        candidate 2 contains every query term. After the fix, candidate 2
+        should rank first and display a non-zero bm25 score.
+        """
+        mock_col = MagicMock()
+        mock_col.query.return_value = {
+            "documents": [
+                [
+                    "unrelated directory listing -rw-rw-r-- file.txt",
+                    "foo bar baz is a multi-word project",
+                    "another unrelated chunk about colors",
+                ]
+            ],
+            "metadatas": [
+                [
+                    {"source_file": "a.md", "wing": "w", "room": "r"},
+                    {"source_file": "b.md", "wing": "w", "room": "r"},
+                    {"source_file": "c.md", "wing": "w", "room": "r"},
+                ]
+            ],
+            "distances": [[1.5, 1.5, 1.5]],
+        }
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search("foo bar baz", "/fake/path")
+        captured = capsys.readouterr()
+        # The lexical match must rank first
+        first_block, _, rest = captured.out.partition("[2]")
+        assert (
+            "b.md" in first_block
+        ), f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        # And its bm25 score must be > 0, visible to the user
+        assert "bm25=" in first_block
+        assert "bm25=0.0" not in first_block
+        # Cosine reporting still present for transparency
+        assert "cosine=" in first_block


### PR DESCRIPTION
## Summary

Blocking fix for v3.3.3. The CLI `mempalace search` path was using pure ChromaDB cosine distance with no BM25 rerank, producing embarrassing results where drawers containing every query term still scored `Match: 0.0` indistinguishable from completely unrelated matches. The MCP path (`mempalace_search`, used by agents) was already hybrid and unaffected — this fixes the CLI parity gap.

## The failure mode

A drawer whose text contains every query term can still embed as semantic noise when the drawer is a mechanical artifact — a directory listing, a diff, a log tail — rather than prose about the subject. Its cosine distance to a natural-language query crosses 1.0, so `max(0, 1-dist)` floors to 0.0.

Before this fix, that drawer showed `Match: 0.0` in the CLI output. So did completely unrelated drawers. Users had no way to tell a lexical-match-but-vector-miss apart from a total miss — every result looked equally bad.

```
  [1] Match: 0.0   <drawer contains every query term>
  [2] Match: 0.0   <unrelated noise>
  [3] Match: 0.0   <unrelated noise>
```

After: both scores surface separately, and BM25 reorders when cosine can't discriminate.

```
  [1] Match: cosine=0.0  bm25=5.5   <drawer contains every query term>
  [2] Match: cosine=0.0  bm25=0.0   <unrelated noise>
  [3] Match: cosine=0.0  bm25=0.0   <unrelated noise>
```

## Root cause

`_hybrid_rank` ([searcher.py:112](mempalace/searcher.py#L112)) existed and worked. It was called from `search_memories` (MCP path, [searcher.py:494](mempalace/searcher.py#L494)) but **not** from `search` (CLI path, [searcher.py:262](mempalace/searcher.py#L262)). Two consumers of the same retrieval code with opposite ranking quality.

## Fix

After `col.query(...)` in the CLI path, reshape ChromaDB's columnar result into the row-dict shape `_hybrid_rank` expects, call it, and emit from the reordered list. Displays `cosine=` and `bm25=` separately so both signals are visible to the user.

## Test plan

- [x] Full test suite: all passing
- [x] Ruff + format clean
- [x] New regression test: three candidates at distance 1.5 (cosine = 0), one containing query terms — must rank first with non-zero bm25
- [x] No changes to MCP search path — agents unaffected

## Risk

Low. The rerank function is already production-proven on the MCP path. This PR only wires a second consumer through it. Output format changes from `Match: 0.0` to `Match: cosine=0.0 bm25=0.0` — a superset that would break any downstream parser of CLI output, but this is human-facing text, not a machine-readable format.