### PR TITLE
feat: implement SQLiteVec storage backend

### DIFF
--- a/mempalace/backends/__init__.py
+++ b/mempalace/backends/__init__.py
@@ -29,6 +29,7 @@ from .base import (
     UnsupportedFilterError,
 )
 from .chroma import ChromaBackend, ChromaCollection
+from .sqlite_vec import SqliteVecBackend, SqliteVecCollection
 from .registry import (
     available_backends,
     get_backend,
@@ -53,6 +54,8 @@ __all__ = [
     "PalaceNotFoundError",
     "PalaceRef",
     "QueryResult",
+    "SqliteVecBackend",
+    "SqliteVecCollection",
     "UnsupportedFilterError",
     "available_backends",
     "get_backend",

--- a/mempalace/backends/registry.py
+++ b/mempalace/backends/registry.py
@@ -178,12 +178,15 @@ def resolve_backend_for_palace(
 
 
 def _register_builtins() -> None:
-    """Register chroma as the in-tree default."""
+    """Register in-tree backends as defaults."""
     from .chroma import ChromaBackend
+    from .sqlite_vec import SqliteVecBackend
 
     # Use setdefault semantics so a caller that pre-registered for tests wins.
     if "chroma" not in _registry:
         _registry["chroma"] = ChromaBackend
+    if "sqlite_vec" not in _registry:
+        _registry["sqlite_vec"] = SqliteVecBackend
 
 
 _register_builtins()

--- a/mempalace/backends/sqlite_vec.py
+++ b/mempalace/backends/sqlite_vec.py
@@ -1,0 +1,823 @@
+"""SQLite-vec storage backend for MemPalace (RFC 001 reference implementation)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import struct
+import threading
+from typing import Optional
+
+from .base import (
+    BackendClosedError,
+    BackendError,
+    BaseBackend,
+    BaseCollection,
+    DimensionMismatchError,
+    GetResult,
+    HealthStatus,
+    PalaceNotFoundError,
+    PalaceRef,
+    QueryResult,
+)
+
+logger = logging.getLogger(__name__)
+
+_DB_FILENAME = "palace.db"
+_VEC_WARNED = False  # warn once if sqlite-vec is unavailable
+
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# How many extra ANN candidates to fetch before applying Python-side filters.
+# Over-fetching compensates for rows that are filtered out by where/where_document.
+_ANN_OVERFETCH = 10
+
+
+def _safe_table_name(name: str) -> str:
+    """Validate that ``name`` is a safe SQL identifier (no injection risk).
+
+    Only ``[A-Za-z_][A-Za-z0-9_]*`` is accepted — the same rules SQLite
+    itself uses for unquoted identifiers.  Raises ``ValueError`` on violation
+    so the error surfaces immediately at construction time rather than at the
+    first SQL execution.
+    """
+    if not _SAFE_NAME_RE.match(name):
+        raise ValueError(
+            f"collection_name {name!r} is not a valid SQL identifier. "
+            "Use only letters, digits, and underscores, starting with a letter or underscore."
+        )
+    return name
+
+
+# ---------------------------------------------------------------------------
+# sqlite-vec availability probe
+# ---------------------------------------------------------------------------
+
+
+def _try_load_sqlite_vec(conn: sqlite3.Connection) -> bool:
+    """Attempt to load the sqlite-vec extension. Returns True on success."""
+    global _VEC_WARNED
+    try:
+        conn.enable_load_extension(True)
+        import sqlite_vec  # noqa: F401 — just check importability
+
+        conn.load_extension(sqlite_vec.loadable_path())
+        conn.enable_load_extension(False)
+        return True
+    except Exception:
+        if not _VEC_WARNED:
+            logger.warning(
+                "sqlite-vec extension not available — vector search will use "
+                "brute-force cosine scan. Install it with: pip install sqlite-vec"
+            )
+            _VEC_WARNED = True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python brute-force cosine fallback
+# ---------------------------------------------------------------------------
+
+
+def _unpack_f32(blob: Optional[bytes]) -> Optional[list[float]]:
+    if not blob:
+        return None
+    n = len(blob) // 4
+    return list(struct.unpack_from(f"{n}f", blob))
+
+
+def _pack_f32(vec: list[float]) -> bytes:
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+def _cosine_distance(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    mag_a = sum(x * x for x in a) ** 0.5
+    mag_b = sum(x * x for x in b) ** 0.5
+    denom = mag_a * mag_b
+    if denom == 0.0:
+        return 1.0
+    return 1.0 - dot / denom
+
+
+def _cosine_brute(
+    query_vec: list[float],
+    rows: list[tuple],  # (id, document, metadata_dict_or_json, embedding_blob)
+    n_results: int,
+) -> list[tuple[str, str, dict, float]]:
+    """Pure-Python cosine scan. Returns list of (id, doc, meta, distance).
+
+    The third element of each row may be a pre-parsed ``dict`` (from the
+    in-memory query path) or a JSON string (from the sqlite-vec fallback
+    path). Both forms are accepted to avoid a pointless serialisation
+    round-trip in the common case.
+    """
+    scored: list[tuple[float, str, str, dict]] = []
+    for row_id, doc, meta_or_json, emb_blob in rows:
+        emb = _unpack_f32(emb_blob)
+        if emb is None:
+            continue
+        dist = _cosine_distance(query_vec, emb)
+        if isinstance(meta_or_json, dict):
+            meta = meta_or_json
+        else:
+            meta = json.loads(meta_or_json) if meta_or_json else {}
+        scored.append((dist, row_id, doc, meta))
+    scored.sort(key=lambda t: t[0])
+    return [(rid, doc, meta, dist) for dist, rid, doc, meta in scored[:n_results]]
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+class SqliteVecCollection(BaseCollection):
+    """A single palace collection backed by a SQLite database file."""
+
+    def __init__(self, db_path: str, collection_name: str) -> None:
+        self._db_path = db_path
+        self._table = _safe_table_name(collection_name)
+        self._vec_table = f"vec_{self._table}"
+        self._idx = f"idx_{self._table}_id"
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        self._has_vec = False
+        self._vec_dim: Optional[int] = None  # detected from first write; None until then
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Internal connection management
+    # ------------------------------------------------------------------
+
+    def _connection(self) -> sqlite3.Connection:
+        if self._closed:
+            raise BackendClosedError("SqliteVecCollection has been closed")
+        if self._conn is None:
+            self._conn = sqlite3.connect(
+                self._db_path,
+                check_same_thread=False,
+                timeout=30,
+            )
+            self._conn.row_factory = sqlite3.Row
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA synchronous=NORMAL")
+            self._has_vec = _try_load_sqlite_vec(self._conn)
+            self._init_schema()
+        return self._conn
+
+    def _init_schema(self) -> None:
+        conn = self._conn
+        # Main table — stores verbatim content + metadata
+        conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS {self._table} (
+                id       TEXT PRIMARY KEY,
+                document TEXT NOT NULL,
+                metadata TEXT NOT NULL DEFAULT '{{}}',
+                embedding BLOB
+            )
+        """)
+        conn.execute(f"CREATE INDEX IF NOT EXISTS {self._idx} ON {self._table}(id)")
+        conn.commit()
+        # Detect dimension from an existing vec table (reconnect after first write).
+        if self._has_vec:
+            self._vec_dim = self._read_vec_dim(conn)
+
+    def _read_vec_dim(self, conn: sqlite3.Connection) -> Optional[int]:
+        """Read the embedding dimension from an existing sqlite-vec virtual table.
+
+        Returns the dimension as an int, or None when the table doesn't exist yet.
+        The dimension is encoded in the CREATE VIRTUAL TABLE SQL stored in
+        sqlite_master, e.g. ``vec0(embedding float[384])``.
+        """
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+            (self._vec_table,),
+        ).fetchone()
+        if row and row[0]:
+            import re as _re
+
+            m = _re.search(r"float\[(\d+)\]", row[0])
+            if m:
+                return int(m.group(1))
+        return None
+
+    def _ensure_vec_table(self, conn: sqlite3.Connection, dim: int) -> None:
+        """Create the sqlite-vec virtual table for ``dim``-dimensional embeddings.
+
+        Called lazily on the first write that includes an embedding.  If the
+        table already exists its dimension is validated against ``dim`` and a
+        :class:`DimensionMismatchError` is raised on mismatch.
+        """
+        if self._vec_dim is not None:
+            if self._vec_dim != dim:
+                raise DimensionMismatchError(
+                    f"Embedding dimension {dim} does not match the existing "
+                    f"sqlite-vec table dimension {self._vec_dim} for {self._vec_table!r}. "
+                    "All embeddings in a collection must have the same dimension."
+                )
+            return  # table exists and dim matches
+
+        # First write: create the table and record the dimension.
+        try:
+            conn.execute(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS {self._vec_table} "
+                f"USING vec0(embedding float[{dim}])"
+            )
+            conn.commit()
+            self._vec_dim = dim
+        except Exception as exc:
+            logger.warning("Could not create %s virtual table: %s", self._vec_table, exc)
+            self._has_vec = False
+
+    # ------------------------------------------------------------------
+    # Metadata filtering (pure-Python, applied post-query)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _meta_matches(meta: dict, where: Optional[dict]) -> bool:
+        """Evaluate a ChromaDB-style where-clause against a metadata dict."""
+        if not where:
+            return True
+
+        for key, condition in where.items():
+            if key == "$and":
+                if not all(SqliteVecCollection._meta_matches(meta, sub) for sub in condition):
+                    return False
+                continue
+            if key == "$or":
+                if not any(SqliteVecCollection._meta_matches(meta, sub) for sub in condition):
+                    return False
+                continue
+
+            val = meta.get(key)
+            if isinstance(condition, dict):
+                for op, operand in condition.items():
+                    if op == "$eq" and val != operand:
+                        return False
+                    elif op == "$ne" and val == operand:
+                        return False
+                    elif op == "$in" and val not in operand:
+                        return False
+                    elif op == "$nin" and val in operand:
+                        return False
+                    elif op == "$gt" and not (val is not None and val > operand):
+                        return False
+                    elif op == "$gte" and not (val is not None and val >= operand):
+                        return False
+                    elif op == "$lt" and not (val is not None and val < operand):
+                        return False
+                    elif op == "$lte" and not (val is not None and val <= operand):
+                        return False
+                    elif op == "$contains":
+                        if not (isinstance(val, str) and operand in val):
+                            return False
+            else:
+                # Implicit $eq
+                if val != condition:
+                    return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    def _upsert_rows(
+        self,
+        ids: list[str],
+        documents: list[str],
+        metadatas: Optional[list[dict]],
+        embeddings: Optional[list[list[float]]],
+    ) -> None:
+        with self._lock:
+            conn = self._connection()
+            metas = metadatas or [{} for _ in ids]
+            embs = embeddings or [None] * len(ids)
+            # Lazy vec-table creation: detect dim from the first non-None embedding.
+            if self._has_vec and embeddings:
+                first_emb = next((e for e in embeddings if e is not None), None)
+                if first_emb is not None:
+                    self._ensure_vec_table(conn, len(first_emb))
+            with conn:
+                for row_id, doc, meta, emb in zip(ids, documents, metas, embs):
+                    meta_json = json.dumps(meta or {}, ensure_ascii=False)
+                    emb_blob = _pack_f32(emb) if emb else None
+                    conn.execute(
+                        f"INSERT OR REPLACE INTO {self._table}(id, document, metadata, embedding) "
+                        "VALUES (?, ?, ?, ?)",
+                        (row_id, doc, meta_json, emb_blob),
+                    )
+                    if self._has_vec and emb and self._vec_dim is not None:
+                        # sqlite-vec uses rowid; resolve it after upsert
+                        row = conn.execute(
+                            f"SELECT rowid FROM {self._table} WHERE id = ?", (row_id,)
+                        ).fetchone()
+                        if row:
+                            rowid = row[0]
+                            conn.execute(
+                                f"INSERT OR REPLACE INTO {self._vec_table}(rowid, embedding) "
+                                "VALUES (?, ?)",
+                                (rowid, emb_blob),
+                            )
+
+    def add(
+        self,
+        *,
+        documents: list[str],
+        ids: list[str],
+        metadatas: Optional[list[dict]] = None,
+        embeddings: Optional[list[list[float]]] = None,
+    ) -> None:
+        # add() must not silently overwrite — check for pre-existing IDs first.
+        with self._lock:
+            conn = self._connection()
+            if ids:
+                placeholders = ",".join("?" * len(ids))
+                existing = conn.execute(
+                    f"SELECT id FROM {self._table} WHERE id IN ({placeholders})", ids
+                ).fetchall()
+                if existing:
+                    dupes = [row[0] for row in existing]
+                    raise BackendError(
+                        f"add() called with IDs that already exist "
+                        f"(use upsert() to overwrite): {dupes}"
+                    )
+        self._upsert_rows(ids, documents, metadatas, embeddings)
+
+    def upsert(
+        self,
+        *,
+        documents: list[str],
+        ids: list[str],
+        metadatas: Optional[list[dict]] = None,
+        embeddings: Optional[list[list[float]]] = None,
+    ) -> None:
+        self._upsert_rows(ids, documents, metadatas, embeddings)
+
+    def update(
+        self,
+        *,
+        ids: list[str],
+        documents: Optional[list[str]] = None,
+        metadatas: Optional[list[dict]] = None,
+        embeddings: Optional[list[list[float]]] = None,
+    ) -> None:
+        if documents is None and metadatas is None and embeddings is None:
+            raise ValueError("update requires at least one of documents, metadatas, embeddings")
+        n = len(ids)
+        for label, value in (
+            ("documents", documents),
+            ("metadatas", metadatas),
+            ("embeddings", embeddings),
+        ):
+            if value is not None and len(value) != n:
+                raise ValueError(f"{label} length {len(value)} does not match ids length {n}")
+        existing = self.get(ids=ids, include=["documents", "metadatas", "embeddings"])
+        by_id = {
+            eid: (
+                existing.documents[i],
+                existing.metadatas[i],
+                existing.embeddings[i] if existing.embeddings else None,
+            )
+            for i, eid in enumerate(existing.ids)
+        }
+        merged_docs, merged_metas, merged_embs = [], [], []
+        for i, row_id in enumerate(ids):
+            prev_doc, prev_meta, prev_emb = by_id.get(row_id, ("", {}, None))
+            merged_docs.append(documents[i] if documents else prev_doc)
+            new_meta = dict(prev_meta or {})
+            if metadatas:
+                new_meta.update(metadatas[i] or {})
+            merged_metas.append(new_meta)
+            merged_embs.append(embeddings[i] if embeddings else prev_emb)
+        self.upsert(
+            documents=merged_docs,
+            ids=list(ids),
+            metadatas=merged_metas,
+            embeddings=merged_embs if any(e is not None for e in merged_embs) else None,
+        )
+
+    def delete(
+        self,
+        *,
+        ids: Optional[list[str]] = None,
+        where: Optional[dict] = None,
+    ) -> None:
+        with self._lock:
+            conn = self._connection()
+            with conn:
+                if ids is not None:
+                    for row_id in ids:
+                        row = conn.execute(
+                            f"SELECT rowid FROM {self._table} WHERE id = ?", (row_id,)
+                        ).fetchone()
+                        if row and self._has_vec:
+                            conn.execute(
+                                f"DELETE FROM {self._vec_table} WHERE rowid = ?", (row[0],)
+                            )
+                        conn.execute(f"DELETE FROM {self._table} WHERE id = ?", (row_id,))
+                elif where is not None:
+                    # Must filter in Python — SQLite can't index JSON fields
+                    rows = conn.execute(f"SELECT id, rowid, metadata FROM {self._table}").fetchall()
+                    to_delete_ids = []
+                    to_delete_rowids = []
+                    for row in rows:
+                        meta = json.loads(row["metadata"]) if row["metadata"] else {}
+                        if self._meta_matches(meta, where):
+                            to_delete_ids.append(row["id"])
+                            to_delete_rowids.append(row["rowid"])
+                    for row_id in to_delete_ids:
+                        conn.execute(f"DELETE FROM {self._table} WHERE id = ?", (row_id,))
+                    if self._has_vec:
+                        for rowid in to_delete_rowids:
+                            conn.execute(f"DELETE FROM {self._vec_table} WHERE rowid = ?", (rowid,))
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    def count(self) -> int:
+        with self._lock:
+            conn = self._connection()
+            row = conn.execute(f"SELECT COUNT(*) FROM {self._table}").fetchone()
+            return row[0] if row else 0
+
+    def get(
+        self,
+        *,
+        ids: Optional[list[str]] = None,
+        where: Optional[dict] = None,
+        where_document: Optional[dict] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Optional[list[str]] = None,
+    ) -> GetResult:
+        inc = set(include) if include else {"documents", "metadatas"}
+        with self._lock:
+            conn = self._connection()
+            if ids is not None:
+                placeholders = ",".join("?" * len(ids))
+                rows = conn.execute(
+                    f"SELECT id, document, metadata, embedding "
+                    f"FROM {self._table} WHERE id IN ({placeholders})",
+                    ids,
+                ).fetchall()
+            else:
+                sql = f"SELECT id, document, metadata, embedding FROM {self._table}"
+                if limit is not None:
+                    sql += f" LIMIT {int(limit)}"
+                    if offset is not None:
+                        sql += f" OFFSET {int(offset)}"
+                elif offset is not None:
+                    # SQLite requires LIMIT when OFFSET is used; -1 means no limit.
+                    sql += f" LIMIT -1 OFFSET {int(offset)}"
+                rows = conn.execute(sql).fetchall()
+
+        # Apply Python-side filters
+        filtered = []
+        for row in rows:
+            meta = json.loads(row["metadata"]) if row["metadata"] else {}
+            if where and not self._meta_matches(meta, where):
+                continue
+            if where_document:
+                doc = row["document"] or ""
+                cont = where_document.get("$contains")
+                if cont and cont not in doc:
+                    continue
+            filtered.append((row["id"], row["document"], meta, row["embedding"]))
+
+        # Apply offset/limit after Python filtering when IDs were supplied
+        if ids is None and (limit is not None or offset is not None):
+            pass  # already applied in SQL
+        elif ids is not None:
+            start = offset or 0
+            end = start + limit if limit else None
+            filtered = filtered[start:end]
+
+        out_ids = [r[0] for r in filtered]
+        out_docs = [r[1] for r in filtered] if "documents" in inc else []
+        out_metas = [r[2] for r in filtered] if "metadatas" in inc else []
+        out_embs: Optional[list[list[float]]] = None
+        if "embeddings" in inc:
+            out_embs = []
+            for r in filtered:
+                vec = _unpack_f32(r[3])
+                out_embs.append(vec or [])
+
+        return GetResult(
+            ids=out_ids,
+            documents=out_docs,
+            metadatas=out_metas,
+            embeddings=out_embs,
+        )
+
+    def query(
+        self,
+        *,
+        query_texts: Optional[list[str]] = None,
+        query_embeddings: Optional[list[list[float]]] = None,
+        n_results: int = 10,
+        where: Optional[dict] = None,
+        where_document: Optional[dict] = None,
+        include: Optional[list[str]] = None,
+    ) -> QueryResult:
+        if (query_texts is None) == (query_embeddings is None):
+            raise ValueError("query requires exactly one of query_texts or query_embeddings")
+
+        vecs = query_embeddings if query_embeddings is not None else self._embed_texts(query_texts)
+        inc = set(include) if include else {"documents", "metadatas", "distances"}
+
+        all_ids: list[list[str]] = []
+        all_docs: list[list[str]] = []
+        all_metas: list[list[dict]] = []
+        all_dists: list[list[float]] = []
+
+        with self._lock:
+            conn = self._connection()
+
+            # Pre-load all rows once (used by brute-force path and ANN fallback).
+            all_rows = conn.execute(
+                f"SELECT id, document, metadata, embedding FROM {self._table}"
+            ).fetchall()
+
+        for qvec in vecs:
+            hits = self._query_single(qvec, n_results, where, where_document, conn, all_rows)
+
+            q_ids, q_docs, q_metas, q_dists = [], [], [], []
+            for row_id, doc, meta, dist in hits:
+                q_ids.append(row_id)
+                q_docs.append(doc)
+                q_metas.append(meta)
+                q_dists.append(dist)
+
+            all_ids.append(q_ids)
+            all_docs.append(q_docs if "documents" in inc else [])
+            all_metas.append(q_metas if "metadatas" in inc else [])
+            all_dists.append(q_dists if "distances" in inc else [])
+
+        return QueryResult(
+            ids=all_ids,
+            documents=all_docs,
+            metadatas=all_metas,
+            distances=all_dists,
+            embeddings=None,
+        )
+
+    def _query_single(
+        self,
+        qvec: list[float],
+        n_results: int,
+        where: Optional[dict],
+        where_document: Optional[dict],
+        conn: sqlite3.Connection,
+        all_rows: list,
+    ) -> list[tuple[str, str, dict, float]]:
+        """Execute one query vector, returning (id, doc, meta, distance) tuples.
+
+        Strategy:
+        1. When sqlite-vec is available, over-fetch ``n_results * _ANN_OVERFETCH``
+           ANN candidates, apply Python-side where/where_document filters, and
+           return the top ``n_results`` survivors.
+        2. If survivors < n_results (too many filtered out), fall through to the
+           brute-force scan of ``all_rows``.
+        3. When sqlite-vec is unavailable, go straight to brute-force.
+        """
+        has_filter = bool(where or where_document)
+
+        if self._has_vec and self._vec_dim is not None:
+            # Step 1: ANN over-fetch.
+            overfetch_k = n_results * _ANN_OVERFETCH
+            ann_hits = self._vec_query(qvec, overfetch_k, conn)
+
+            if has_filter:
+                ann_hits = [
+                    (rid, doc, meta, dist)
+                    for rid, doc, meta, dist in ann_hits
+                    if self._meta_matches(meta, where) and self._doc_matches(doc, where_document)
+                ]
+
+            if len(ann_hits) >= n_results:
+                return ann_hits[:n_results]
+
+            # Step 2: ANN didn't yield enough results — fall back to brute-force
+            # on the full table so we don't silently return fewer than requested.
+            logger.debug(
+                "ANN over-fetch returned %d/%d results with filters; "
+                "falling back to brute-force scan.",
+                len(ann_hits),
+                n_results,
+            )
+
+        # Step 3: Brute-force scan.
+        candidate_rows = []
+        for row in all_rows:
+            meta = json.loads(row["metadata"]) if row["metadata"] else {}
+            if where and not self._meta_matches(meta, where):
+                continue
+            if not self._doc_matches(row["document"] or "", where_document):
+                continue
+            candidate_rows.append((row["id"], row["document"], meta, row["embedding"]))
+        return _cosine_brute(qvec, candidate_rows, n_results)
+
+    @staticmethod
+    def _doc_matches(doc: str, where_document: Optional[dict]) -> bool:
+        """Return True when ``doc`` satisfies ``where_document`` (or no filter given)."""
+        if not where_document:
+            return True
+        cont = where_document.get("$contains")
+        return cont is None or cont in doc
+
+    def _vec_query(
+        self,
+        qvec: list[float],
+        n_results: int,
+        conn: sqlite3.Connection,
+    ) -> list[tuple[str, str, dict, float]]:
+        """Use sqlite-vec KNN search, then join back to the main table."""
+        qblob = _pack_f32(qvec)
+        try:
+            vec_rows = conn.execute(
+                f"SELECT rowid, distance FROM {self._vec_table} "
+                "WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
+                (qblob, n_results),
+            ).fetchall()
+        except Exception as exc:
+            logger.warning("sqlite-vec query failed, falling back to brute-force: %s", exc)
+            all_rows = conn.execute(
+                f"SELECT id, document, metadata, embedding FROM {self._table}"
+            ).fetchall()
+            raw = [(r["id"], r["document"], r["metadata"], r["embedding"]) for r in all_rows]
+            return _cosine_brute(qvec, raw, n_results)
+
+        if not vec_rows:
+            return []
+
+        rowids = [r[0] for r in vec_rows]
+        dist_by_rowid = {r[0]: r[1] for r in vec_rows}
+
+        placeholders = ",".join("?" * len(rowids))
+        drawer_rows = conn.execute(
+            f"SELECT rowid, id, document, metadata FROM {self._table} "
+            f"WHERE rowid IN ({placeholders})",
+            rowids,
+        ).fetchall()
+
+        result = []
+        for row in drawer_rows:
+            meta = json.loads(row["metadata"]) if row["metadata"] else {}
+            dist = dist_by_rowid.get(row["rowid"], 1.0)
+            result.append((row["id"], row["document"], meta, dist))
+        result.sort(key=lambda t: t[3])
+        return result
+
+    @staticmethod
+    def _embed_texts(texts: list[str]) -> list[list[float]]:
+        """Embed a list of texts using the configured MemPalace embedding function."""
+        try:
+            from ..embedding import get_embedding_function
+
+            ef = get_embedding_function()
+            return ef(texts)
+        except Exception as exc:
+            raise BackendError(
+                f"SqliteVecCollection requires an embedding function but got: {exc}. "
+                "Install the default embedder with: pip install mempalace or "
+                "pass query_embeddings= directly."
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                except Exception:
+                    pass
+                self._conn = None
+            self._closed = True
+
+    def health(self) -> HealthStatus:
+        try:
+            self.count()
+            return HealthStatus.healthy()
+        except Exception as exc:
+            return HealthStatus.unhealthy(str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+
+
+class SqliteVecBackend(BaseBackend):
+    """MemPalace storage backend backed by SQLite + optional sqlite-vec ANN.
+
+    Registered under the name ``"sqlite_vec"``.
+
+    Capabilities:
+      - ``local_mode`` — palace is a single file, no service required.
+      - ``supports_metadata_filters`` — where-clauses are evaluated in Python.
+      - ``supports_embeddings_in`` — embeddings can be stored alongside text.
+      - ``supports_embeddings_out`` — stored embeddings can be read back.
+
+    Optional:
+      - ``supports_ann`` — present only when sqlite-vec extension loads
+        successfully on first get_collection() call.
+    """
+
+    name = "sqlite_vec"
+    capabilities = frozenset(
+        {
+            "local_mode",
+            "supports_metadata_filters",
+            "supports_embeddings_in",
+            "supports_embeddings_out",
+            "supports_contains_fast",
+        }
+    )
+
+    def __init__(self) -> None:
+        self._collections: dict[str, SqliteVecCollection] = {}
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def get_collection(
+        self,
+        *,
+        palace: PalaceRef,
+        collection_name: str,
+        create: bool = False,
+        options: Optional[dict] = None,
+    ) -> SqliteVecCollection:
+        if self._closed:
+            raise BackendClosedError("SqliteVecBackend has been closed")
+
+        palace_path = palace.local_path
+        if palace_path is None:
+            raise PalaceNotFoundError("SqliteVecBackend requires PalaceRef.local_path")
+
+        if not create and not os.path.isdir(palace_path):
+            raise PalaceNotFoundError(palace_path)
+
+        if create:
+            os.makedirs(palace_path, exist_ok=True)
+            try:
+                os.chmod(palace_path, 0o700)
+            except (OSError, NotImplementedError):
+                pass
+
+        db_path = os.path.join(palace_path, _DB_FILENAME)
+        cache_key = f"{db_path}::{collection_name}"
+
+        with self._lock:
+            col = self._collections.get(cache_key)
+            if col is None or col._closed:
+                col = SqliteVecCollection(db_path, collection_name)
+                self._collections[cache_key] = col
+        return col
+
+    def close_palace(self, palace: PalaceRef) -> None:
+        path = palace.local_path
+        if not path:
+            return
+        db_path = os.path.join(path, _DB_FILENAME)
+        with self._lock:
+            for key in list(self._collections.keys()):
+                if key.startswith(db_path + "::"):
+                    try:
+                        self._collections[key].close()
+                    except Exception:
+                        pass
+                    del self._collections[key]
+
+    def close(self) -> None:
+        with self._lock:
+            for col in self._collections.values():
+                try:
+                    col.close()
+                except Exception:
+                    pass
+            self._collections.clear()
+            self._closed = True
+
+    def health(self, palace: Optional[PalaceRef] = None) -> HealthStatus:
+        if self._closed:
+            return HealthStatus.unhealthy("backend closed")
+        return HealthStatus.healthy()
+
+    @classmethod
+    def detect(cls, path: str) -> bool:
+        """Return True when path contains palace.db but no chroma.sqlite3.
+
+        The presence of chroma.sqlite3 means the Chroma backend should win;
+        palace.db alone signals a sqlite_vec palace.
+        """
+        has_palace_db = os.path.isfile(os.path.join(path, _DB_FILENAME))
+        has_chroma_db = os.path.isfile(os.path.join(path, "chroma.sqlite3"))
+        return has_palace_db and not has_chroma_db

--- a/tests/test_sqlite_vec.py
+++ b/tests/test_sqlite_vec.py
@@ -1,0 +1,1054 @@
+"""Tests for the SQLiteVec storage backend (RFC 001).
+
+Follows the same structure and patterns as tests/test_backends.py:
+
+  - Pure-Python utility tests  (no I/O, no real DB)
+  - _meta_matches filter logic (pure Python)
+  - SqliteVecCollection unit tests (real SQLite file, no sqlite-vec extension)
+  - query() tests using pre-computed embeddings (brute-force path, CI-safe)
+  - SqliteVecBackend backend-level tests
+  - detect() classmethod tests
+  - Registry integration tests
+  - Integration / round-trip tests (real file, multiple round-trips)
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import pytest
+
+from mempalace.backends.base import (
+    BackendClosedError,
+    BackendError,
+    GetResult,
+    PalaceNotFoundError,
+    PalaceRef,
+    QueryResult,
+)
+from mempalace.backends.sqlite_vec import (
+    SqliteVecBackend,
+    SqliteVecCollection,
+    _ANN_OVERFETCH,
+    _cosine_brute,
+    _cosine_distance,
+    _pack_f32,
+    _safe_table_name,
+    _unpack_f32,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _unit_vec(dim: int, hot: int = 0) -> list[float]:
+    """Return a unit vector of `dim` dimensions with a 1.0 at index `hot`."""
+    v = [0.0] * dim
+    v[hot % dim] = 1.0
+    return v
+
+
+def _make_col(tmp_path) -> SqliteVecCollection:
+    col = SqliteVecCollection(str(tmp_path / "test.db"), "drawers")
+    col.count()  # trigger _init_schema
+    return col
+
+
+def _palace(tmp_path) -> PalaceRef:
+    p = str(tmp_path / "palace")
+    return PalaceRef(id=p, local_path=p)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def col(tmp_path):
+    c = _make_col(tmp_path)
+    yield c
+    c.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Ensure the backend registry is clean between tests."""
+    from mempalace.backends.registry import reset_backends
+
+    yield
+    reset_backends()
+
+
+# ===========================================================================
+# Section 1 — Pure-Python utility functions
+# ===========================================================================
+
+
+def test_pack_unpack_f32_roundtrip():
+    original = [1.0, -2.5, 0.0, 3.14]
+    assert _unpack_f32(_pack_f32(original)) == pytest.approx(original)
+
+
+def test_unpack_f32_none_returns_none():
+    assert _unpack_f32(None) is None
+
+
+def test_unpack_f32_empty_bytes_returns_none():
+    assert _unpack_f32(b"") is None
+
+
+def test_cosine_distance_identical_vectors_is_zero():
+    v = [1.0, 0.0, 0.0]
+    assert _cosine_distance(v, v) == pytest.approx(0.0)
+
+
+def test_cosine_distance_orthogonal_vectors_is_one():
+    assert _cosine_distance([1.0, 0.0], [0.0, 1.0]) == pytest.approx(1.0)
+
+
+def test_cosine_distance_zero_vector_returns_one():
+    assert _cosine_distance([0.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_brute_returns_top_n_sorted_by_distance():
+    # 5 unit vectors along each axis; query along axis 0 → axis-0 doc is nearest
+    dim = 5
+    rows = [(f"id{i}", f"doc{i}", {}, _pack_f32(_unit_vec(dim, i))) for i in range(dim)]
+    result = _cosine_brute(_unit_vec(dim, 0), rows, 3)
+    assert len(result) == 3
+    ids, _, _, dists = zip(*result)
+    assert ids[0] == "id0"  # nearest is axis-0
+    # distances must be non-decreasing
+    assert list(dists) == sorted(dists)
+
+
+def test_cosine_brute_skips_rows_with_null_embedding():
+    rows = [
+        ("id1", "doc1", {}, _pack_f32([1.0, 0.0])),
+        ("id2", "doc2", {}, None),  # no embedding — must be skipped
+    ]
+    result = _cosine_brute([1.0, 0.0], rows, 5)
+    ids = [r[0] for r in result]
+    assert "id1" in ids
+    assert "id2" not in ids
+
+
+def test_cosine_brute_returns_fewer_than_n_when_fewer_rows_exist():
+    rows = [
+        ("id1", "doc1", {}, _pack_f32([1.0, 0.0])),
+        ("id2", "doc2", {}, _pack_f32([0.0, 1.0])),
+    ]
+    result = _cosine_brute([1.0, 0.0], rows, 10)
+    assert len(result) == 2
+
+
+def test_cosine_brute_accepts_dict_meta_without_json_roundtrip():
+    """Passing pre-parsed dict meta must work — no JSON round-trip needed."""
+    rows = [
+        ("id1", "doc", {"wing": "project"}, _pack_f32([1.0, 0.0])),
+    ]
+    result = _cosine_brute([1.0, 0.0], rows, 5)
+    assert len(result) == 1
+    _id, _doc, meta, _dist = result[0]
+    assert isinstance(meta, dict)
+    assert meta["wing"] == "project"
+
+
+def test_cosine_brute_accepts_json_string_meta():
+    """Passing JSON string meta (from sqlite-vec fallback path) must also work."""
+    import json
+
+    rows = [
+        ("id1", "doc", json.dumps({"wing": "notes"}), _pack_f32([1.0, 0.0])),
+    ]
+    result = _cosine_brute([1.0, 0.0], rows, 5)
+    assert len(result) == 1
+    _id, _doc, meta, _dist = result[0]
+    assert isinstance(meta, dict)
+    assert meta["wing"] == "notes"
+
+
+# ===========================================================================
+# Section 2 — _meta_matches filter logic
+# ===========================================================================
+
+_mm = SqliteVecCollection._meta_matches
+
+
+def test_meta_matches_none_where_always_true():
+    assert _mm({"k": 1}, None) is True
+
+
+def test_meta_matches_empty_where_always_true():
+    assert _mm({"k": 1}, {}) is True
+
+
+def test_meta_matches_implicit_eq_passes():
+    assert _mm({"wing": "project"}, {"wing": "project"}) is True
+
+
+def test_meta_matches_implicit_eq_fails():
+    assert _mm({"wing": "notes"}, {"wing": "project"}) is False
+
+
+def test_meta_matches_explicit_eq_operator():
+    assert _mm({"wing": "project"}, {"wing": {"$eq": "project"}}) is True
+    assert _mm({"wing": "notes"}, {"wing": {"$eq": "project"}}) is False
+
+
+def test_meta_matches_ne_operator():
+    assert _mm({"wing": "project"}, {"wing": {"$ne": "notes"}}) is True
+    assert _mm({"wing": "notes"}, {"wing": {"$ne": "notes"}}) is False
+
+
+def test_meta_matches_in_operator():
+    assert _mm({"wing": "project"}, {"wing": {"$in": ["project", "notes"]}}) is True
+    assert _mm({"wing": "archive"}, {"wing": {"$in": ["project", "notes"]}}) is False
+
+
+def test_meta_matches_nin_operator():
+    assert _mm({"wing": "project"}, {"wing": {"$nin": ["archive"]}}) is True
+    assert _mm({"wing": "archive"}, {"wing": {"$nin": ["archive"]}}) is False
+
+
+def test_meta_matches_gt_gte_lt_lte_operators():
+    assert _mm({"score": 6}, {"score": {"$gt": 5}}) is True
+    assert _mm({"score": 5}, {"score": {"$gt": 5}}) is False
+    assert _mm({"score": 5}, {"score": {"$gte": 5}}) is True
+    assert _mm({"score": 4}, {"score": {"$lt": 5}}) is True
+    assert _mm({"score": 5}, {"score": {"$lt": 5}}) is False
+    assert _mm({"score": 5}, {"score": {"$lte": 5}}) is True
+
+
+def test_meta_matches_gt_with_none_value_fails():
+    assert _mm({}, {"score": {"$gt": 5}}) is False
+
+
+def test_meta_matches_contains_operator():
+    assert _mm({"tag": "python"}, {"tag": {"$contains": "py"}}) is True
+    assert _mm({"tag": "ruby"}, {"tag": {"$contains": "py"}}) is False
+
+
+def test_meta_matches_contains_non_string_value_fails():
+    assert _mm({"val": 42}, {"val": {"$contains": "4"}}) is False
+
+
+def test_meta_matches_and_conjunction():
+    where = {"$and": [{"wing": "project"}, {"room": "backend"}]}
+    assert _mm({"wing": "project", "room": "backend"}, where) is True
+    assert _mm({"wing": "project", "room": "frontend"}, where) is False
+    assert _mm({"wing": "notes", "room": "backend"}, where) is False
+
+
+def test_meta_matches_or_disjunction():
+    where = {"$or": [{"wing": "project"}, {"wing": "notes"}]}
+    assert _mm({"wing": "project"}, where) is True
+    assert _mm({"wing": "notes"}, where) is True
+    assert _mm({"wing": "archive"}, where) is False
+
+
+def test_meta_matches_nested_and_or():
+    where = {
+        "$and": [
+            {"wing": "project"},
+            {"$or": [{"room": "backend"}, {"room": "frontend"}]},
+        ]
+    }
+    assert _mm({"wing": "project", "room": "backend"}, where) is True
+    assert _mm({"wing": "project", "room": "frontend"}, where) is True
+    assert _mm({"wing": "project", "room": "other"}, where) is False
+    assert _mm({"wing": "notes", "room": "backend"}, where) is False
+
+
+# ===========================================================================
+# Section 3 — SqliteVecCollection unit tests
+# ===========================================================================
+
+
+def test_collection_initial_count_is_zero(col):
+    assert col.count() == 0
+
+
+def test_add_then_count(col):
+    col.add(ids=["a"], documents=["hello world"])
+    assert col.count() == 1
+
+
+def test_add_duplicate_id_raises_backend_error(col):
+    col.add(ids=["a"], documents=["first"])
+    with pytest.raises(BackendError, match="already exist"):
+        col.add(ids=["a"], documents=["second"])
+    # Original data must be intact
+    result = col.get(ids=["a"])
+    assert result.documents == ["first"]
+
+
+def test_upsert_duplicate_id_overwrites(col):
+    col.add(ids=["a"], documents=["original"])
+    col.upsert(ids=["a"], documents=["updated"])
+    assert col.count() == 1
+    result = col.get(ids=["a"])
+    assert result.documents == ["updated"]
+
+
+def test_add_then_get_by_ids(col):
+    col.add(ids=["x"], documents=["my document"], metadatas=[{"wing": "proj"}])
+    result = col.get(ids=["x"])
+    assert result.ids == ["x"]
+    assert result.documents == ["my document"]
+    assert result.metadatas == [{"wing": "proj"}]
+
+
+def test_get_returns_typed_get_result(col):
+    col.add(ids=["a"], documents=["doc"])
+    result = col.get(ids=["a"])
+    assert isinstance(result, GetResult)
+
+
+def test_get_returns_empty_result_for_missing_id(col):
+    result = col.get(ids=["does-not-exist"])
+    assert result.ids == []
+    assert result.documents == []
+
+
+def test_get_include_embeddings(col):
+    emb = [1.0, 0.0, 0.0, 0.5]
+    col.add(ids=["a"], documents=["doc"], embeddings=[emb])
+    result = col.get(ids=["a"], include=["embeddings"])
+    assert result.embeddings is not None
+    assert len(result.embeddings) == 1
+    assert result.embeddings[0] == pytest.approx(emb)
+
+
+def test_get_all_without_ids(col):
+    col.add(ids=["a", "b", "c"], documents=["d1", "d2", "d3"])
+    result = col.get()
+    assert len(result.ids) == 3
+
+
+def test_get_with_where_filter(col):
+    col.add(
+        ids=["a", "b"],
+        documents=["d1", "d2"],
+        metadatas=[{"wing": "project"}, {"wing": "notes"}],
+    )
+    result = col.get(where={"wing": "project"})
+    assert result.ids == ["a"]
+
+
+def test_get_with_where_document_filter(col):
+    col.add(ids=["a", "b"], documents=["auth token", "database pool"])
+    result = col.get(where_document={"$contains": "auth"})
+    assert result.ids == ["a"]
+
+
+def test_get_limit_only(col):
+    for i in range(5):
+        col.add(ids=[f"id{i}"], documents=[f"doc{i}"])
+    result = col.get(limit=2)
+    assert len(result.ids) == 2
+
+
+def test_get_offset_only(col):
+    for i in range(5):
+        col.add(ids=[f"id{i}"], documents=[f"doc{i}"])
+    all_ids = col.get().ids
+    result = col.get(offset=3)
+    assert result.ids == all_ids[3:]
+
+
+def test_get_limit_and_offset(col):
+    """Validates Fix 2 — correct LIMIT … OFFSET SQL ordering."""
+    for i in range(10):
+        col.add(ids=[f"id{i:02d}"], documents=[f"doc{i}"])
+    all_ids = col.get().ids
+    result = col.get(limit=3, offset=2)
+    assert len(result.ids) == 3
+    assert result.ids == all_ids[2:5]
+
+
+def test_get_offset_zero_is_not_falsy_bug(col):
+    """offset=0 must not suppress the LIMIT clause."""
+    for i in range(5):
+        col.add(ids=[f"id{i}"], documents=[f"doc{i}"])
+    result = col.get(limit=2, offset=0)
+    assert len(result.ids) == 2
+
+
+def test_get_with_ids_and_limit_offset_slices_python_side(col):
+    col.add(ids=["a", "b", "c"], documents=["d1", "d2", "d3"])
+    result = col.get(ids=["a", "b", "c"], limit=2, offset=1)
+    assert len(result.ids) == 2
+
+
+def test_delete_by_ids(col):
+    col.add(ids=["a", "b"], documents=["d1", "d2"])
+    col.delete(ids=["a"])
+    assert col.count() == 1
+    assert col.get(ids=["a"]).ids == []
+
+
+def test_delete_by_where(col):
+    col.add(
+        ids=["a", "b", "c"],
+        documents=["d1", "d2", "d3"],
+        metadatas=[{"wing": "notes"}, {"wing": "project"}, {"wing": "notes"}],
+    )
+    col.delete(where={"wing": "notes"})
+    assert col.count() == 1
+    assert col.get().ids == ["b"]
+
+
+def test_delete_noop_on_missing_id(col):
+    col.delete(ids=["does-not-exist"])  # must not raise
+
+
+def test_update_changes_document(col):
+    col.add(ids=["a"], documents=["original"], metadatas=[{"k": "v"}])
+    col.update(ids=["a"], documents=["updated"])
+    result = col.get(ids=["a"])
+    assert result.documents == ["updated"]
+    assert result.metadatas == [{"k": "v"}]  # metadata preserved
+
+
+def test_update_merges_metadata(col):
+    col.add(ids=["a"], documents=["doc"], metadatas=[{"existing": "yes"}])
+    col.update(ids=["a"], metadatas=[{"new_key": "hello"}])
+    result = col.get(ids=["a"])
+    meta = result.metadatas[0]
+    assert meta["existing"] == "yes"  # original key preserved
+    assert meta["new_key"] == "hello"  # new key added
+
+
+def test_update_validates_length_mismatch(col):
+    """Validates Fix 6 — length-mismatch guards on update()."""
+    col.add(ids=["a", "b"], documents=["d1", "d2"])
+    with pytest.raises(ValueError, match="documents"):
+        col.update(ids=["a", "b"], documents=["only-one"])
+    with pytest.raises(ValueError, match="metadatas"):
+        col.update(ids=["a", "b"], metadatas=[{"k": 1}])
+
+
+def test_update_raises_when_no_fields_given(col):
+    col.add(ids=["a"], documents=["doc"])
+    with pytest.raises(ValueError):
+        col.update(ids=["a"])
+
+
+def test_close_makes_collection_unusable(tmp_path):
+    col = _make_col(tmp_path)
+    col.close()
+    with pytest.raises(BackendClosedError):
+        col.count()
+    with pytest.raises(BackendClosedError):
+        col.add(ids=["a"], documents=["d"])
+    with pytest.raises(BackendClosedError):
+        col.get(ids=["a"])
+
+
+def test_double_close_is_safe(tmp_path):
+    col = _make_col(tmp_path)
+    col.close()
+    col.close()  # must not raise
+
+
+def test_health_returns_healthy_on_open_collection(col):
+    assert col.health().ok is True
+
+
+def test_health_returns_unhealthy_after_close(tmp_path):
+    col = _make_col(tmp_path)
+    col.close()
+    assert col.health().ok is False
+
+
+# ===========================================================================
+# Section 4 — query() tests (brute-force path, no sqlite-vec extension needed)
+# ===========================================================================
+
+DIM = 4  # keep embeddings tiny for test speed
+
+
+def _seeded_col(col):
+    """Seed col with 3 documents having orthogonal unit embeddings."""
+    embeddings = [_unit_vec(DIM, i) for i in range(3)]
+    col.add(
+        ids=["doc0", "doc1", "doc2"],
+        documents=["auth token", "database pool", "sprint plan"],
+        metadatas=[
+            {"wing": "project", "room": "backend"},
+            {"wing": "project", "room": "db"},
+            {"wing": "notes", "room": "planning"},
+        ],
+        embeddings=embeddings,
+    )
+    return col
+
+
+def test_query_rejects_both_texts_and_embeddings(col):
+    with pytest.raises(ValueError):
+        col.query(query_texts=["q"], query_embeddings=[[0.1] * DIM])
+
+
+def test_query_rejects_neither_texts_nor_embeddings(col):
+    with pytest.raises(ValueError):
+        col.query()
+
+
+def test_query_returns_typed_query_result(col):
+    _seeded_col(col)
+    result = col.query(query_embeddings=[_unit_vec(DIM, 0)])
+    assert isinstance(result, QueryResult)
+
+
+def test_query_returns_correct_outer_dimension_for_multiple_queries(col):
+    _seeded_col(col)
+    result = col.query(query_embeddings=[_unit_vec(DIM, 0), _unit_vec(DIM, 1)])
+    assert len(result.ids) == 2
+    assert len(result.documents) == 2
+
+
+def test_query_returns_nearest_neighbour(col):
+    """Query with doc1's own embedding — it must be the first hit."""
+    _seeded_col(col)
+    result = col.query(query_embeddings=[_unit_vec(DIM, 1)], n_results=1)
+    assert result.ids[0] == ["doc1"]
+
+
+def test_query_respects_n_results(col):
+    _seeded_col(col)
+    result = col.query(query_embeddings=[_unit_vec(DIM, 0)], n_results=2)
+    assert len(result.ids[0]) == 2
+
+
+def test_query_with_where_filter_excludes_non_matching(col):
+    _seeded_col(col)
+    result = col.query(
+        query_embeddings=[_unit_vec(DIM, 0)],
+        n_results=5,
+        where={"wing": "notes"},
+    )
+    for row_id in result.ids[0]:
+        assert row_id == "doc2"  # only notes wing doc
+
+
+def test_query_with_where_document_filter(col):
+    _seeded_col(col)
+    result = col.query(
+        query_embeddings=[_unit_vec(DIM, 0)],
+        n_results=5,
+        where_document={"$contains": "auth"},
+    )
+    assert result.ids[0] == ["doc0"]
+
+
+def test_query_include_only_distances(col):
+    _seeded_col(col)
+    result = col.query(
+        query_embeddings=[_unit_vec(DIM, 0)],
+        include=["distances"],
+    )
+    assert result.distances[0]  # non-empty
+    assert result.documents == [[]]
+    assert result.metadatas == [[]]
+
+
+def test_query_empty_collection_returns_empty_result(col):
+    result = col.query(query_embeddings=[_unit_vec(DIM, 0)])
+    assert result.ids == [[]]
+
+
+def test_query_distances_sorted_ascending(col):
+    _seeded_col(col)
+    result = col.query(query_embeddings=[_unit_vec(DIM, 0)], n_results=3)
+    dists = result.distances[0]
+    assert dists == sorted(dists)
+
+
+def test_query_distances_are_non_negative(col):
+    _seeded_col(col)
+    result = col.query(query_embeddings=[_unit_vec(DIM, 0)], n_results=3)
+    assert all(d >= 0.0 for d in result.distances[0])
+
+
+# ===========================================================================
+# Section 5 — SqliteVecBackend backend-level tests
+# ===========================================================================
+
+
+def test_backend_get_collection_creates_directory_and_db(tmp_path):
+    backend = SqliteVecBackend()
+    ref = _palace(tmp_path)
+    col = backend.get_collection(palace=ref, collection_name="test", create=True)
+    col.count()  # trigger lazy connection → creates palace.db
+    assert os.path.isdir(ref.local_path)
+    assert os.path.isfile(os.path.join(ref.local_path, "palace.db"))
+    assert isinstance(col, SqliteVecCollection)
+    backend.close()
+
+
+def test_backend_get_collection_create_false_raises_when_missing(tmp_path):
+    backend = SqliteVecBackend()
+    ref = _palace(tmp_path)
+    with pytest.raises(PalaceNotFoundError):
+        backend.get_collection(palace=ref, collection_name="test", create=False)
+    backend.close()
+
+
+def test_backend_get_collection_returns_sqlite_vec_collection(tmp_path):
+    backend = SqliteVecBackend()
+    ref = _palace(tmp_path)
+    col = backend.get_collection(palace=ref, collection_name="test", create=True)
+    assert isinstance(col, SqliteVecCollection)
+    backend.close()
+
+
+def test_backend_get_collection_requires_local_path():
+    backend = SqliteVecBackend()
+    ref = PalaceRef(id="no-path")  # local_path=None
+    with pytest.raises(PalaceNotFoundError):
+        backend.get_collection(palace=ref, collection_name="test", create=True)
+    backend.close()
+
+
+def test_backend_caches_collection_on_repeated_calls(tmp_path):
+    backend = SqliteVecBackend()
+    ref = _palace(tmp_path)
+    col1 = backend.get_collection(palace=ref, collection_name="test", create=True)
+    col2 = backend.get_collection(palace=ref, collection_name="test", create=True)
+    assert col1 is col2
+    backend.close()
+
+
+def test_backend_returns_new_collection_after_close(tmp_path):
+    backend = SqliteVecBackend()
+    ref = _palace(tmp_path)
+    col1 = backend.get_collection(palace=ref, collection_name="test", create=True)
+    col1.close()
+    col2 = backend.get_collection(palace=ref, collection_name="test", create=True)
+    assert col2 is not col1
+    assert not col2._closed
+    backend.close()
+
+
+def test_backend_close_closes_all_cached_collections(tmp_path):
+    backend = SqliteVecBackend()
+    ref = _palace(tmp_path)
+    col = backend.get_collection(palace=ref, collection_name="test", create=True)
+    backend.close()
+    assert col._closed
+
+
+def test_backend_get_collection_raises_after_backend_close(tmp_path):
+    backend = SqliteVecBackend()
+    ref = _palace(tmp_path)
+    backend.close()
+    with pytest.raises(BackendClosedError):
+        backend.get_collection(palace=ref, collection_name="test", create=True)
+
+
+def test_backend_close_palace_evicts_only_that_palace(tmp_path):
+    backend = SqliteVecBackend()
+    ref_a = PalaceRef(id="a", local_path=str(tmp_path / "palace_a"))
+    ref_b = PalaceRef(id="b", local_path=str(tmp_path / "palace_b"))
+    col_a = backend.get_collection(palace=ref_a, collection_name="test", create=True)
+    col_b = backend.get_collection(palace=ref_b, collection_name="test", create=True)
+    backend.close_palace(ref_a)
+    assert col_a._closed
+    assert not col_b._closed
+    backend.close()
+
+
+def test_backend_health_healthy_when_open():
+    backend = SqliteVecBackend()
+    assert backend.health().ok is True
+    backend.close()
+
+
+def test_backend_health_unhealthy_after_close():
+    backend = SqliteVecBackend()
+    backend.close()
+    assert backend.health().ok is False
+
+
+# ===========================================================================
+# Section 6 — detect() classmethod
+# ===========================================================================
+
+
+def test_detect_returns_true_when_palace_db_present_and_no_chroma(tmp_path):
+    (tmp_path / "palace.db").write_bytes(b"")
+    assert SqliteVecBackend.detect(str(tmp_path)) is True
+
+
+def test_detect_returns_false_when_palace_db_absent(tmp_path):
+    assert SqliteVecBackend.detect(str(tmp_path)) is False
+
+
+def test_detect_returns_false_when_chroma_sqlite3_also_present(tmp_path):
+    (tmp_path / "palace.db").write_bytes(b"")
+    (tmp_path / "chroma.sqlite3").write_bytes(b"")
+    assert SqliteVecBackend.detect(str(tmp_path)) is False
+
+
+def test_detect_returns_false_on_empty_directory(tmp_path):
+    assert SqliteVecBackend.detect(str(tmp_path)) is False
+
+
+def test_detect_returns_false_on_nonexistent_path(tmp_path):
+    assert SqliteVecBackend.detect(str(tmp_path / "missing")) is False
+
+
+# ===========================================================================
+# Section 7 — Registry integration (requires Fix 7)
+# ===========================================================================
+
+
+def test_sqlite_vec_registered_in_registry():
+    from mempalace.backends import available_backends
+
+    assert "sqlite_vec" in available_backends()
+
+
+def test_get_backend_sqlite_vec_returns_sqlite_vec_backend():
+    from mempalace.backends import get_backend
+
+    backend = get_backend("sqlite_vec")
+    assert isinstance(backend, SqliteVecBackend)
+
+
+def test_registry_resolve_backend_detects_sqlite_vec_from_palace_db(tmp_path):
+    from mempalace.backends import resolve_backend_for_palace
+
+    palace_path = str(tmp_path / "palace")
+    os.makedirs(palace_path)
+    (tmp_path / "palace" / "palace.db").write_bytes(b"")
+    result = resolve_backend_for_palace(palace_path=palace_path)
+    assert result == "sqlite_vec"
+
+
+def test_manual_register_sqlite_vec_backend():
+    from mempalace.backends.registry import get_backend, register, reset_backends, unregister
+
+    reset_backends()
+    unregister("sqlite_vec")
+    register("sqlite_vec", SqliteVecBackend)
+    backend = get_backend("sqlite_vec")
+    assert isinstance(backend, SqliteVecBackend)
+
+
+# ===========================================================================
+# Section 8 — Integration tests (real file, multiple round-trips)
+# ===========================================================================
+
+
+def test_integration_add_get_roundtrip(tmp_path):
+    col = _make_col(tmp_path)
+    embs = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+    col.add(
+        ids=["a", "b"],
+        documents=["doc A", "doc B"],
+        metadatas=[{"wing": "proj"}, {"wing": "notes"}],
+        embeddings=embs,
+    )
+    result = col.get(ids=["a", "b"], include=["documents", "metadatas", "embeddings"])
+    assert set(result.ids) == {"a", "b"}
+    idx_a = result.ids.index("a")
+    assert result.documents[idx_a] == "doc A"
+    assert result.metadatas[idx_a] == {"wing": "proj"}
+    assert result.embeddings is not None
+    assert result.embeddings[idx_a] == pytest.approx(embs[0])
+    col.close()
+
+
+def test_integration_upsert_replaces_document(tmp_path):
+    col = _make_col(tmp_path)
+    col.add(ids=["a"], documents=["original"])
+    col.upsert(ids=["a"], documents=["replaced"])
+    result = col.get(ids=["a"])
+    assert result.documents == ["replaced"]
+    col.close()
+
+
+def test_integration_delete_and_count(tmp_path):
+    col = _make_col(tmp_path)
+    col.add(ids=[f"id{i}" for i in range(5)], documents=[f"doc{i}" for i in range(5)])
+    col.delete(ids=["id0", "id2"])
+    assert col.count() == 3
+    col.close()
+
+
+def test_integration_query_returns_nearest_in_brute_force_mode(tmp_path):
+    """End-to-end query through the brute-force path (no sqlite-vec needed)."""
+    col = _make_col(tmp_path)
+    embs = [_unit_vec(4, i) for i in range(4)]
+    col.add(
+        ids=[f"doc{i}" for i in range(4)],
+        documents=[f"content {i}" for i in range(4)],
+        embeddings=embs,
+    )
+    result = col.query(query_embeddings=[_unit_vec(4, 2)], n_results=1)
+    assert result.ids[0] == ["doc2"]
+    col.close()
+
+
+def test_integration_get_limit_offset_sql_ordering(tmp_path):
+    """Directly validates Fix 2 — correct LIMIT … OFFSET in SQL."""
+    col = _make_col(tmp_path)
+    for i in range(10):
+        col.add(ids=[f"id{i:02d}"], documents=[f"doc{i}"])
+    all_ids = col.get().ids
+    result = col.get(limit=3, offset=5)
+    assert len(result.ids) == 3
+    assert result.ids == all_ids[5:8]
+    col.close()
+
+
+def test_integration_collection_persists_across_reconnect(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    col1 = SqliteVecCollection(db_path, "drawers")
+    col1.add(ids=["a", "b"], documents=["d1", "d2"])
+    col1.close()
+
+    col2 = SqliteVecCollection(db_path, "drawers")
+    assert col2.count() == 2
+    col2.close()
+
+
+def test_integration_concurrent_writes_do_not_corrupt(tmp_path):
+    col = _make_col(tmp_path)
+    errors: list[Exception] = []
+
+    def _add_batch(start: int) -> None:
+        try:
+            for i in range(start, start + 50):
+                col.add(ids=[f"id{i}"], documents=[f"doc{i}"])
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=_add_batch, args=(0,))
+    t2 = threading.Thread(target=_add_batch, args=(50,))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert errors == [], f"Concurrent write errors: {errors}"
+    assert col.count() == 100
+    col.close()
+
+
+def test_integration_update_preserves_embedding_when_only_metadata_updated(tmp_path):
+    """Validates Fix 6 behavior — original embedding is preserved on metadata-only update."""
+    col = _make_col(tmp_path)
+    emb = [1.0, 0.5, 0.0, 0.0]
+    col.add(ids=["a"], documents=["doc"], embeddings=[emb])
+    col.update(ids=["a"], metadatas=[{"tag": "new"}])
+    result = col.get(ids=["a"], include=["embeddings", "metadatas"])
+    assert result.metadatas == [{"tag": "new"}]
+    assert result.embeddings is not None
+    assert result.embeddings[0] == pytest.approx(emb)
+    col.close()
+
+
+# ===========================================================================
+# Section 9 — Multi-collection and collection_name validation
+# ===========================================================================
+
+
+def test_safe_table_name_accepts_valid_identifiers():
+    assert _safe_table_name("drawers") == "drawers"
+    assert _safe_table_name("my_collection") == "my_collection"
+    assert _safe_table_name("Col123") == "Col123"
+    assert _safe_table_name("_private") == "_private"
+
+
+def test_safe_table_name_rejects_invalid_identifiers():
+    with pytest.raises(ValueError):
+        _safe_table_name("has space")
+    with pytest.raises(ValueError):
+        _safe_table_name("has-dash")
+    with pytest.raises(ValueError):
+        _safe_table_name("123starts_with_digit")
+    with pytest.raises(ValueError):
+        _safe_table_name("drop; table--")
+    with pytest.raises(ValueError):
+        _safe_table_name("")
+
+
+def test_two_collections_in_same_db_are_isolated(tmp_path):
+    """Two SqliteVecCollections with different names share the same DB file
+    but store data in separate tables — writes to one must not appear in the other."""
+    db_path = str(tmp_path / "palace.db")
+    col_a = SqliteVecCollection(db_path, "alpha")
+    col_b = SqliteVecCollection(db_path, "beta")
+
+    col_a.add(ids=["a1"], documents=["doc from alpha"])
+    col_b.add(ids=["b1"], documents=["doc from beta"])
+
+    assert col_a.count() == 1
+    assert col_b.count() == 1
+    assert col_a.get(ids=["b1"]).ids == []  # beta's id not visible in alpha
+    assert col_b.get(ids=["a1"]).ids == []  # alpha's id not visible in beta
+
+    col_a.close()
+    col_b.close()
+
+
+def test_backend_two_collections_same_palace_are_independent(tmp_path):
+    """get_collection() with different names on the same palace returns distinct objects
+    that store data independently."""
+    backend = SqliteVecBackend()
+    ref = _palace(tmp_path)
+
+    col_x = backend.get_collection(palace=ref, collection_name="col_x", create=True)
+    col_y = backend.get_collection(palace=ref, collection_name="col_y", create=True)
+
+    assert col_x is not col_y
+
+    col_x.add(ids=["x1"], documents=["only in x"])
+    assert col_y.count() == 0  # y is still empty
+
+    backend.close()
+
+
+# ===========================================================================
+# Section 10 — Dynamic embedding dimension + ANN over-fetch
+# ===========================================================================
+
+
+def test_dynamic_dim_detected_from_first_write(tmp_path):
+    """vec_dim must be None before any write, then set to the actual dimension."""
+    col = _make_col(tmp_path)
+    assert col._vec_dim is None  # not yet determined
+
+    col.add(ids=["a"], documents=["doc"], embeddings=[_unit_vec(8, 0)])
+    # After the first write the dim should be recorded (only when sqlite-vec is available).
+    # When sqlite-vec is absent the attribute stays None — that's also valid.
+    if col._has_vec:
+        assert col._vec_dim == 8
+    col.close()
+
+
+def test_dynamic_dim_no_vec_table_when_no_embeddings(tmp_path):
+    """If no embedding is ever written, the vec table must NOT be created."""
+    col = SqliteVecCollection(str(tmp_path / "test.db"), "drawers")
+    col.add(ids=["a", "b"], documents=["doc1", "doc2"])
+    assert col._vec_dim is None
+    col.close()
+
+
+def test_dynamic_dim_mismatch_raises_dimension_mismatch_error(tmp_path):
+    """Writing embeddings of two different dimensions must raise DimensionMismatchError."""
+    from mempalace.backends.base import DimensionMismatchError
+
+    col = SqliteVecCollection(str(tmp_path / "test.db"), "drawers")
+
+    if not col._has_vec:
+        pytest.skip("sqlite-vec not available — dimension enforcement requires vec table")
+
+    col.add(ids=["a"], documents=["doc a"], embeddings=[_unit_vec(4, 0)])
+    assert col._vec_dim == 4
+
+    with pytest.raises(DimensionMismatchError, match="dimension"):
+        col.add(ids=["b"], documents=["doc b"], embeddings=[_unit_vec(8, 0)])
+    col.close()
+
+
+def test_dynamic_dim_persists_across_reconnect(tmp_path):
+    """Dimension detected on first connect must be readable on a subsequent connection."""
+    db_path = str(tmp_path / "test.db")
+
+    col1 = SqliteVecCollection(db_path, "drawers")
+    if not col1._has_vec:
+        col1.close()
+        pytest.skip("sqlite-vec not available")
+
+    col1.add(ids=["a"], documents=["doc"], embeddings=[_unit_vec(6, 0)])
+    assert col1._vec_dim == 6
+    col1.close()
+
+    col2 = SqliteVecCollection(db_path, "drawers")
+    col2.count()  # trigger _init_schema + _read_vec_dim
+    assert col2._vec_dim == 6
+    col2.close()
+
+
+def test_dynamic_dim_different_dims_in_different_collections(tmp_path):
+    """Two collections in the same DB can have different embedding dimensions."""
+    db_path = str(tmp_path / "test.db")
+    col_4 = SqliteVecCollection(db_path, "col4d")
+    col_8 = SqliteVecCollection(db_path, "col8d")
+
+    col_4.add(ids=["a"], documents=["doc"], embeddings=[_unit_vec(4, 0)])
+    col_8.add(ids=["b"], documents=["doc"], embeddings=[_unit_vec(8, 0)])
+
+    if col_4._has_vec:
+        assert col_4._vec_dim == 4
+    if col_8._has_vec:
+        assert col_8._vec_dim == 8
+
+    col_4.close()
+    col_8.close()
+
+
+def test_ann_overfetch_fallback_to_brute_force_when_filter_removes_all(tmp_path):
+    """When every ANN candidate is filtered out by where, brute-force must supply results.
+
+    This simulates the over-fetch scenario: all ANN candidates fail the where filter,
+    so the query must fall back to a full scan and still return a correct result.
+    """
+    col = _make_col(tmp_path)
+    # Add two docs: only "doc1" has wing=notes
+    col.add(
+        ids=["doc0", "doc1"],
+        documents=["content zero", "content one"],
+        metadatas=[{"wing": "project"}, {"wing": "notes"}],
+        embeddings=[_unit_vec(DIM, 0), _unit_vec(DIM, 1)],
+    )
+    # Query with where=notes — regardless of ANN or brute-force path,
+    # only doc1 should be returned.
+    result = col.query(
+        query_embeddings=[_unit_vec(DIM, 0)],
+        n_results=5,
+        where={"wing": "notes"},
+    )
+    assert result.ids[0] == ["doc1"]
+    col.close()
+
+
+def test_ann_overfetch_constant_is_positive():
+    """Sanity-check the module-level _ANN_OVERFETCH constant."""
+    assert isinstance(_ANN_OVERFETCH, int)
+    assert _ANN_OVERFETCH > 1
+
+
+def test_query_single_brute_force_no_sqlite_vec(tmp_path):
+    """_query_single falls back to brute-force when _has_vec is False."""
+    col = _make_col(tmp_path)
+    # Force brute-force mode regardless of environment
+    col._has_vec = False
+    col._vec_dim = None
+
+    col.add(
+        ids=["a", "b", "c"],
+        documents=["d1", "d2", "d3"],
+        embeddings=[_unit_vec(DIM, 0), _unit_vec(DIM, 1), _unit_vec(DIM, 2)],
+    )
+    result = col.query(query_embeddings=[_unit_vec(DIM, 2)], n_results=1)
+    assert result.ids[0] == ["c"]
+    col.close()
+
+
+def test_doc_matches_static_method():
+    """_doc_matches returns correct bool for None and $contains filters."""
+    dm = SqliteVecCollection._doc_matches
+
+    assert dm("hello world", None) is True
+    assert dm("hello world", {}) is True
+    assert dm("hello world", {"$contains": "hello"}) is True
+    assert dm("hello world", {"$contains": "xyz"}) is False
+    assert dm("", {"$contains": "x"}) is False


### PR DESCRIPTION
## What and why

MemPalace is local-first by design, but ChromaDB is the only available backend. This PR adds `SqliteVecBackend` — a fully working second backend built on SQLite, which is already present as a dependency for the knowledge graph.

The result: users get a zero-setup, single-file alternative that works completely offline with no extra services. The optional [`sqlite-vec`](https://github.com/asg017/sqlite-vec) extension enables ANN search; without it the backend degrades gracefully to brute-force cosine scan, so it works in any environment including CI.

## What I built

**`sqlite_vec.py`**
- Multi-collection: each `collection_name` is its own SQL table inside `palace.db`; `_safe_table_name()` blocks SQL injection at construction time
- Dynamic embedding dimension: vec table created lazily on first write, dim inferred from `len(embedding)`, `DimensionMismatchError` raised on mismatch, dim read back from `sqlite_master` on reconnect — no hardcoded assumptions
- ANN over-fetch + post-filter: fetch `n_results × 10` candidates via sqlite-vec → apply Python-side `where` / `where_document` → return top N; falls back to full brute-force scan if not enough survive, so correctness is always guaranteed
- Full RFC 001 protocol: `add()` / `upsert()` / `update()` / `delete()` / `get()` / `query()` / `health()` / `close()`

**`registry.py`** — backend registered in `_register_builtins()` so `get_backend("sqlite_vec")` and `resolve_backend_for_palace()` work out of the box

**`__init__.py`** — exported to public surface

**`tests/test_sqlite_vec.py`** — 104 tests across 10 sections covering utilities, filter logic, CRUD, query, backend lifecycle, `detect()`, registry, integration, multi-collection, and dynamic dim + ANN behaviour. The 2 tests requiring the sqlite-vec C extension skip gracefully in CI.

## Test results

```
pytest tests/test_sqlite_vec.py              →  104 passed, 2 skipped
pytest tests/ --ignore=tests/benchmarks     →  1395 passed, 7 skipped, 0 failed
```