### PR TITLE
fix(searcher): tolerate None documents in BM25 reranker

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -46,7 +46,14 @@ def _first_or_empty(results, key: str) -> list:
 
 
 def _tokenize(text: str) -> list:
-    """Lowercase + strip to alphanumeric tokens of length ≥ 2."""
+    """Lowercase + strip to alphanumeric tokens of length ≥ 2.
+
+    Tolerates ``None`` documents — Chroma can return ``None`` in the
+    ``documents`` field for drawers without text content, which would
+    otherwise raise ``AttributeError`` mid-rerank.
+    """
+    if not text:
+        return []
     return _TOKEN_RE.findall(text.lower())
 
 

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -121,6 +121,39 @@ class TestSearchMemories:
         assert none_hit["room"] == "unknown"
 
 
+# ── BM25 internals: None / empty document safety ─────────────────────
+
+
+class TestBM25NoneSafety:
+    """Regression tests for the AttributeError observed in production when
+    Chroma returned ``None`` documents inside a hybrid-rerank pass.
+
+    Trace from the daemon log (2026-04-24 21:07:05):
+        File "mempalace/searcher.py", line 81, in _bm25_scores
+            tokenized = [_tokenize(d) for d in documents]
+        File "mempalace/searcher.py", line 52, in _tokenize
+            return _TOKEN_RE.findall(text.lower())
+        AttributeError: 'NoneType' object has no attribute 'lower'
+    """
+
+    def test_tokenize_handles_none(self):
+        from mempalace.searcher import _tokenize
+        assert _tokenize(None) == []
+
+    def test_tokenize_handles_empty_string(self):
+        from mempalace.searcher import _tokenize
+        assert _tokenize("") == []
+
+    def test_bm25_scores_does_not_crash_on_none_documents(self):
+        """A ``None`` mixed into the corpus must yield score 0.0 for that doc
+        and finite scores for the rest, not raise AttributeError."""
+        from mempalace.searcher import _bm25_scores
+        scores = _bm25_scores("postgres migration", ["postgres migration done", None, "kafka rebalance"])
+        assert len(scores) == 3
+        assert scores[1] == 0.0
+        assert scores[0] > 0.0
+
+
 # ── search() (CLI print function) ─────────────────────────────────────
 
 

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -138,17 +138,22 @@ class TestBM25NoneSafety:
 
     def test_tokenize_handles_none(self):
         from mempalace.searcher import _tokenize
+
         assert _tokenize(None) == []
 
     def test_tokenize_handles_empty_string(self):
         from mempalace.searcher import _tokenize
+
         assert _tokenize("") == []
 
     def test_bm25_scores_does_not_crash_on_none_documents(self):
         """A ``None`` mixed into the corpus must yield score 0.0 for that doc
         and finite scores for the rest, not raise AttributeError."""
         from mempalace.searcher import _bm25_scores
-        scores = _bm25_scores("postgres migration", ["postgres migration done", None, "kafka rebalance"])
+
+        scores = _bm25_scores(
+            "postgres migration", ["postgres migration done", None, "kafka rebalance"]
+        )
         assert len(scores) == 3
         assert scores[1] == 0.0
         assert scores[0] > 0.0


### PR DESCRIPTION
## Problem

`searcher._tokenize` calls `text.lower()` unconditionally. When ChromaDB returns a drawer with `documents` containing `None`, the hybrid-rerank path raises `AttributeError` mid-search, dropping the entire query response.

Observed in production on 2026-04-24 21:07:05:

```
File "mempalace/searcher.py", line 81, in _bm25_scores
    tokenized = [_tokenize(d) for d in documents]
File "mempalace/searcher.py", line 52, in _tokenize
    return _TOKEN_RE.findall(text.lower())
AttributeError: 'NoneType' object has no attribute 'lower'
```

This closes the gap left by #999's None-metadata audit, which fixed metadata read loops but did not extend to BM25 reranker helpers.

## Fix

`_tokenize` short-circuits to `[]` when `text` is falsy (`None` or `""`). A `None` doc gets BM25 score 0.0; the rest of the corpus reranks normally.

## Tests

Three regression tests in `TestBM25NoneSafety`:

1. `test_tokenize_handles_none` — direct unit guard
2. `test_tokenize_handles_empty_string` — covers the empty-string case at the same boundary
3. `test_bm25_scores_does_not_crash_on_none_documents` — load-bearing: mixed corpus with a `None` mid-list, asserts score 0.0 for that doc and finite scores for the rest. This is the exact production failure shape.

All existing searcher and hybrid_search tests still pass (`pytest tests/test_searcher.py tests/test_hybrid_search.py` → 30/30 against develop after cherry-pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)