### PR TITLE
fix(hooks): drop transcript-parent fallback that caused unbounded ingest

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -198,14 +198,20 @@ def _output(data: dict):
 
 
 def _get_mine_dir(transcript_path: str = "") -> str:
-    """Determine directory to mine from MEMPAL_DIR or transcript path."""
+    """Resolve MEMPAL_DIR to a directory the project miner should ingest.
+
+    Returns the value of ``MEMPAL_DIR`` if it is set and points at an
+    existing directory, otherwise the empty string. ``transcript_path``
+    is accepted for signature stability but no longer used as a fallback:
+    the previous behaviour of mining the transcript's parent directory
+    (``~/.claude/projects/-<project>/``) caused the regular project
+    miner to re-chunk every JSONL session file on every hook fire, with
+    no dedup, since :func:`_ingest_transcript` already covers transcripts
+    in conversation mode. See PR #<this> for the incident.
+    """
     mempal_dir = os.environ.get("MEMPAL_DIR", "")
     if mempal_dir and os.path.isdir(mempal_dir):
         return mempal_dir
-    if transcript_path:
-        path = Path(transcript_path).expanduser()
-        if path.is_file():
-            return str(path.parent)
     return ""
 
 

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -445,8 +445,14 @@ def test_maybe_auto_ingest_with_env(tmp_path):
                     mock_popen.assert_called_once()
 
 
-def test_maybe_auto_ingest_with_transcript(tmp_path):
-    """Falls back to transcript directory when MEMPAL_DIR is not set."""
+def test_maybe_auto_ingest_no_mempal_dir_does_not_spawn(tmp_path):
+    """Without MEMPAL_DIR set, _maybe_auto_ingest must NOT mine the transcript dir.
+
+    Regression: the previous transcript-parent fallback caused the regular
+    project miner to re-chunk Claude Code session JSONLs on every hook fire,
+    duplicating work already done by _ingest_transcript in convo mode and
+    producing unbounded palace growth.
+    """
     transcript = tmp_path / "t.jsonl"
     transcript.write_text("")
     with patch.dict("os.environ", {}, clear=True):
@@ -454,7 +460,7 @@ def test_maybe_auto_ingest_with_transcript(tmp_path):
             with patch("mempalace.hooks_cli._MINE_PID_FILE", tmp_path / "mine.pid"):
                 with patch("mempalace.hooks_cli.subprocess.Popen") as mock_popen:
                     _maybe_auto_ingest(str(transcript))
-                    mock_popen.assert_called_once()
+                    mock_popen.assert_not_called()
 
 
 def test_maybe_auto_ingest_oserror(tmp_path):
@@ -526,12 +532,17 @@ def test_get_mine_dir_mempal_dir(tmp_path):
         assert _get_mine_dir(str(transcript)) == str(mempal_dir)
 
 
-def test_get_mine_dir_transcript_fallback(tmp_path):
-    """Falls back to transcript parent dir when MEMPAL_DIR is not set."""
+def test_get_mine_dir_no_transcript_fallback(tmp_path):
+    """Without MEMPAL_DIR set, _get_mine_dir returns "" even with a transcript path.
+
+    The transcript-parent fallback was removed: it caused the project miner
+    to re-ingest Claude Code session JSONLs that _ingest_transcript already
+    handles in convo mode with dedup.
+    """
     transcript = tmp_path / "t.jsonl"
     transcript.write_text("")
     with patch.dict("os.environ", {}, clear=True):
-        assert _get_mine_dir(str(transcript)) == str(tmp_path)
+        assert _get_mine_dir(str(transcript)) == ""
 
 
 def test_get_mine_dir_empty():
@@ -609,6 +620,48 @@ def test_stop_hook_oserror_on_write(tmp_path):
     assert "systemMessage" in result
 
 
+def test_stop_hook_does_not_double_mine_transcript(tmp_path):
+    """Regression: silent stop hook must spawn exactly ONE mine subprocess
+    for the transcript, not two.
+
+    Before the fix, every save fired both:
+      1. _ingest_transcript — async `mempalace mine ... --mode convos` (good, dedups)
+      2. _maybe_auto_ingest — async `mempalace mine ...` (bug, no dedup)
+
+    Both fell back to the transcript's parent dir when MEMPAL_DIR was unset,
+    so the second call re-chunked the same Claude Code session JSONLs as
+    project files on every fire. As session JSONLs grew, each fire ingested
+    more, producing unbounded palace growth.
+    """
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(SAVE_INTERVAL)],
+    )
+    save_result = {"count": SAVE_INTERVAL, "themes": []}
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result):
+            with patch("mempalace.hooks_cli._mempalace_python", return_value="/usr/bin/python3"):
+                with patch("mempalace.hooks_cli.subprocess.Popen") as mock_popen:
+                    _capture_hook_output(
+                        hook_stop,
+                        {
+                            "session_id": "doubletest",
+                            "stop_hook_active": False,
+                            "transcript_path": str(transcript),
+                        },
+                        state_dir=tmp_path,
+                    )
+    # Exactly one Popen — the convo-mode mine via _ingest_transcript.
+    assert mock_popen.call_count == 1, (
+        f"expected one mine subprocess, got {mock_popen.call_count}: {mock_popen.call_args_list}"
+    )
+    spawned_cmd = mock_popen.call_args_list[0][0][0]
+    assert "--mode" in spawned_cmd and "convos" in spawned_cmd, (
+        f"the single mine must be the convo-mode dedup'd one, got: {spawned_cmd}"
+    )
+
+
 # --- hook_precompact with MEMPAL_DIR ---
 
 
@@ -656,8 +709,14 @@ def test_precompact_with_timeout(tmp_path):
     assert result == {}
 
 
-def test_precompact_mines_transcript_dir(tmp_path, monkeypatch):
-    """Precompact mines transcript directory when no MEMPAL_DIR."""
+def test_precompact_no_sync_project_mine_without_mempal_dir(tmp_path, monkeypatch):
+    """Precompact must NOT run the synchronous project miner against the
+    transcript's parent dir when MEMPAL_DIR is unset.
+
+    The async convo-mode mine via _ingest_transcript already covers the
+    transcript with dedup; the previous fallback re-chunked the same JSONLs
+    as project files on every fire and produced unbounded palace growth.
+    """
     transcript = tmp_path / "t.jsonl"
     transcript.write_text("")
     monkeypatch.delenv("MEMPAL_DIR", raising=False)
@@ -668,10 +727,7 @@ def test_precompact_mines_transcript_dir(tmp_path, monkeypatch):
             state_dir=tmp_path,
         )
     assert result == {}
-    mock_run.assert_called_once()
-    # Verify mine dir is the transcript's parent
-    call_args = mock_run.call_args[0][0]
-    assert str(tmp_path) in call_args[-1]
+    mock_run.assert_not_called()
 
 
 # --- run_hook ---


### PR DESCRIPTION
## Summary

The silent stop hook fires **two** mine subprocesses on every save trigger, and the second one re-ingests the entire growing Claude Code session JSONL on every fire. In a long-running project the resulting palace can balloon by orders of magnitude — observed in the wild at ~800 GB from a single project after a year of sessions, which filled a WSL VHD.

`_get_mine_dir` (used by both `_maybe_auto_ingest` and `_mine_sync`) fell back to the transcript's parent directory when `MEMPAL_DIR` was unset. For Claude Code that parent is `~/.claude/projects/-<project>/`, a folder of growing JSONL session files. Reading the hook log on a real session shows the redundancy clearly:

```
14:04 — first save  → +309 drawers (regular mine of ONE jsonl)
14:15 — second save → 0 drawers   (convo mode, correctly skipped)
14:15 — second save → +478 drawers (regular mine, RE-INGESTED same jsonl)
```

The second mine treats the JSONL as a project file, has no dedup against transcripts, and re-chunks the whole conversation history on every hook fire. As the session grows, each fire ingests more.

## Fix

`_get_mine_dir` now returns `""` unless `MEMPAL_DIR` is explicitly set to a real directory. `_maybe_auto_ingest` keeps its intended purpose — mining a separate project codebase the user has opted into via `MEMPAL_DIR`. Conversation mining still happens unchanged via `_ingest_transcript` (which uses `--mode convos` and dedups already-filed transcripts).

## Tests

- `test_get_mine_dir_no_transcript_fallback` — replaces `test_get_mine_dir_transcript_fallback`; asserts the new contract.
- `test_maybe_auto_ingest_no_mempal_dir_does_not_spawn` — replaces `test_maybe_auto_ingest_with_transcript`; asserts no subprocess spawn without `MEMPAL_DIR`.
- `test_precompact_no_sync_project_mine_without_mempal_dir` — replaces `test_precompact_mines_transcript_dir`; same fix path applied to the precompact hook.
- `test_stop_hook_does_not_double_mine_transcript` — new regression test at the `hook_stop` level. Asserts exactly one `subprocess.Popen` call (the convo-mode mine), and that the spawned command carries `--mode convos`.

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/benchmarks` — 1306 passed
- [x] `ruff check mempalace/hooks_cli.py tests/test_hooks_cli.py` — clean
- [x] `ruff format --check` — clean
- [x] Verified the failing test path exactly reproduces the original bug (two Popen calls before fix → one after)
- [ ] CI green