### PR TITLE
fix(palace_graph): skip None metadata in build_graph

### DIFF
--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -92,6 +92,16 @@ def build_graph(col=None, config=None):
     while offset < total:
         batch = col.get(limit=1000, offset=offset, include=["metadatas"])
         for meta in batch["metadatas"]:
+            # ChromaDB can return ``None`` for drawers without metadata
+            # (legacy data, partial writes — upstream #1020 territory).
+            # Skip these silently rather than crash the whole graph
+            # build — a single None drawer shouldn't take down /stats
+            # or any caller of build_graph for the entire palace. Caught
+            # 2026-04-25 by palace-daemon's verify-routes.sh smoke test
+            # against the canonical 151K palace. Closes the same gap as
+            # upstream #999 / fork PR #1094 in a different read path.
+            if meta is None:
+                continue
             room = meta.get("room", "")
             wing = meta.get("wing", "")
             hall = meta.get("hall", "")

--- a/tests/test_palace_graph.py
+++ b/tests/test_palace_graph.py
@@ -54,6 +54,27 @@ class TestBuildGraph:
         assert nodes == {}
         assert edges == []
 
+    def test_none_metadata_does_not_crash(self):
+        """ChromaDB can return None for drawers without metadata (legacy
+        data, partial writes — upstream #1020 territory). build_graph
+        must skip None entries silently rather than crash the whole
+        graph build with AttributeError. Caught 2026-04-25 by
+        palace-daemon's verify-routes.sh smoke test against the
+        canonical 151K palace; /stats was 500-ing on a single None
+        drawer and taking out every consumer of build_graph for the
+        whole call path."""
+        col = _make_fake_collection(
+            [
+                {"room": "auth", "wing": "wing_code", "hall": "security", "date": "2026-01-01"},
+                None,  # legacy / partial-write drawer with no metadata
+                {"room": "auth", "wing": "wing_code", "hall": "security", "date": "2026-01-02"},
+            ]
+        )
+        nodes, edges = build_graph(col=col)
+        # The two real drawers were processed; the None one was skipped.
+        assert "auth" in nodes
+        assert nodes["auth"]["count"] == 2
+
     def test_single_wing_no_edges(self):
         col = _make_fake_collection(
             [


### PR DESCRIPTION
## Problem

`palace_graph.build_graph` at line 95 calls `meta.get("room", "")` unconditionally on every entry in `batch["metadatas"]`. ChromaDB returns `None` for drawers without metadata (legacy data, partial writes — same root cause as the entries fixed in #999 and #1094 in different files), and a single `None` drawer crashes the entire graph build with `AttributeError: 'NoneType' object has no attribute 'get'`.

This takes out every consumer of `build_graph`: `graph_stats`, `find_tunnels`, `traverse`, and any palace-daemon-style HTTP endpoint that calls them. Caught 2026-04-25 by a smoke-test script against a 151K-drawer production palace — `/stats` was 500-ing on a single bad drawer.

## Fix

Skip `None` entries with a `continue` early-return inside the loop. The graph build is recoverable: `build_graph` already filters `room and room != "general" and wing` immediately downstream, so a missing-metadata drawer was never going to participate in the result anyway. The skip is silent because logging every legacy-data drawer would be log spam on palaces that have many of them.

```python
for meta in batch["metadatas"]:
    if meta is None:
        continue
    room = meta.get("room", "")
    ...
```

## Closes the same gap as

- #999 (None-metadata audit in searcher.py / mcp_server.py / miner.status, merged 2026-04-18)
- #1094 (coerce None metadatas to `{}` at ChromaCollection boundary, MERGEABLE)

`palace_graph.py` is a separate read path that the #999 audit didn't reach, and #1094 (when it merges) handles this at the backend layer for *new* writes — but legacy drawers already in the palace need this defensive check.

## Tests

`TestBuildGraph::test_none_metadata_does_not_crash` constructs a fixture with a `None` entry mixed between two real drawers and asserts the build completes with the two real drawers processed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)