### PR TITLE
ci: bump Windows and macOS jobs to Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
           cache: 'pip'
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -v --ignore=tests/benchmarks --cov=mempalace --cov-report=term-missing --cov-fail-under=80 --durations=10
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
           cache: 'pip'
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -v --ignore=tests/benchmarks --cov=mempalace --cov-report=term-missing --cov-fail-under=80 --durations=10


### PR DESCRIPTION
## Summary

- Bump `test-windows` and `test-macos` jobs from Python 3.11 to 3.13.
- Aligns the single-version platform jobs with the top of the Linux matrix (which already runs 3.9 / 3.11 / 3.13).
- Leaves `requires-python = ">=3.9"` and the lint job (3.11) untouched.

This is Option A from #1192 — the reversible, low-risk scope. Option B (raising `requires-python` and dropping the `tomli` shim) is left for a future major release.

Closes #1192.

## Test plan
- [ ] CI green on `test-windows` (3.13)
- [ ] CI green on `test-macos` (3.13)
- [ ] CI green on `test-linux` matrix (unchanged)
- [ ] `lint` job still green on 3.11