### PR TITLE
feat(search): expose drawer_id in mempalace_search results

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -442,9 +442,13 @@ def search_memories(
     CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
 
     scored: list = []
+    ids = _first_or_empty(drawer_results, "ids")
+    docs = _first_or_empty(drawer_results, "documents")
+    if not ids and docs:
+        ids = [None] * len(docs)
     for drawer_id, doc, meta, dist in zip(
-        _first_or_empty(drawer_results, "ids"),
-        _first_or_empty(drawer_results, "documents"),
+        ids,
+        docs,
         _first_or_empty(drawer_results, "metadatas"),
         _first_or_empty(drawer_results, "distances"),
     ):

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -442,7 +442,8 @@ def search_memories(
     CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
 
     scored: list = []
-    for doc, meta, dist in zip(
+    for drawer_id, doc, meta, dist in zip(
+        _first_or_empty(drawer_results, "ids"),
         _first_or_empty(drawer_results, "documents"),
         _first_or_empty(drawer_results, "metadatas"),
         _first_or_empty(drawer_results, "distances"),
@@ -465,6 +466,7 @@ def search_memories(
 
         effective_dist = dist - boost
         entry = {
+            "drawer_id": drawer_id,
             "text": doc,
             "wing": meta.get("wing", "unknown"),
             "room": meta.get("room", "unknown"),


### PR DESCRIPTION
Closes #1026.

## Problem
`mempalace_search` returns `text`, `wing`, `room`, `source_file`, `similarity` etc. but not `drawer_id`. Any caller that wants to follow up with `mempalace_delete_drawer`, `mempalace_get_drawer`, or `mempalace_update_drawer` (all of which require `drawer_id`) has to drop into SQLite and reverse-lookup by content/metadata. This breaks the MCP abstraction and turns simple cleanup workflows into bespoke scripts.

## Fix
Chroma's `query()` already returns `ids` on every result. Thread it through `search_memories` (`searcher.py`) into each result entry as `drawer_id`. Three lines.

## Diff
```diff
     scored: list = []
-    for doc, meta, dist in zip(
+    for drawer_id, doc, meta, dist in zip(
+        _first_or_empty(drawer_results, "ids"),
         _first_or_empty(drawer_results, "documents"),
         _first_or_empty(drawer_results, "metadatas"),
         _first_or_empty(drawer_results, "distances"),
     ):
         ...
         entry = {
+            "drawer_id": drawer_id,
             "text": doc,
             ...
```

## Test
Smoke-tested against a real palace (~1100 drawers) on `develop`-equivalent v3.3.3:
```
{"drawer_id": "drawer_wing_peter_health_2c4fb820a4186c5c", "wing": "wing_peter", "room": "health", ...}
```

## Scope
Intentionally minimal — no rename, no schema, no behavior change beyond adding the field. Re-rank / hydration / closet-boost paths preserve the new key (they only `pop` `_sort_key` / `_source_file_full` / `_chunk_index`).