### PR TITLE
feat(convo_miner): auto-route AI tool sessions to wing_api

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -14,6 +14,7 @@ import hashlib
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
+from typing import Optional
 
 from .normalize import normalize
 from .palace import (
@@ -376,6 +377,60 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
     return drawers_added, room_counts_delta, False
 
 
+def _is_ai_tool_path(path: Path) -> bool:
+    """Return True when `path` lives inside a known AI-tool storage dir.
+
+    Detected paths (exact-segment match — substrings like `.gemini-backup`
+    or `.codex-archive` do NOT match):
+      - any segment ``.codex`` (Codex CLI sessions / archives)
+      - any segment ``.gemini`` (Gemini CLI sessions under ~/.gemini/tmp/...)
+      - the consecutive segment pair ``.claude/projects`` (Claude Code).
+        ``.claude`` alone is NOT matched — that is the settings/config dir,
+        not a conversation source.
+
+    Used by ``_resolve_wing`` to default the destination wing to
+    ``wing_api`` when the user hasn't passed an explicit ``--wing``.
+    """
+    try:
+        parts = path.resolve().parts
+    except (OSError, RuntimeError):
+        return False
+
+    if ".codex" in parts:
+        return True
+    if ".gemini" in parts:
+        return True
+    for i in range(len(parts) - 1):
+        if parts[i] == ".claude" and parts[i + 1] == "projects":
+            return True
+    return False
+
+
+def _resolve_wing(convo_path: Path, wing: Optional[str]) -> str:
+    """Determine the destination wing for ``mine_convos``.
+
+    Precedence (first match wins):
+
+      1. Explicit ``wing`` argument from the user — always wins, even on
+         an AI-tool path. Empty string is treated as "no wing".
+      2. AI-tool path detection — defaults to ``wing_api`` so Claude
+         Code / Codex / Gemini conversations group under a single wing
+         dedicated to API-sourced content.
+      3. Basename fallback — sanitized via ``config.normalize_wing_name``
+         (lowercase, spaces/hyphens collapsed to underscores). Shared
+         single source of truth with ``cmd_init``,
+         ``room_detector_local``, and ``miner.load_config`` so all
+         wing-slug producers stay in sync (per #1194 consolidation).
+    """
+    from .config import normalize_wing_name
+
+    if wing:
+        return wing
+    if _is_ai_tool_path(convo_path):
+        return "wing_api"
+    return normalize_wing_name(convo_path.name)
+
+
 def mine_convos(
     convo_dir: str,
     palace_path: str,
@@ -393,10 +448,7 @@ def mine_convos(
     """
 
     convo_path = Path(convo_dir).expanduser().resolve()
-    if not wing:
-        from .config import normalize_wing_name
-
-        wing = normalize_wing_name(convo_path.name)
+    wing = _resolve_wing(convo_path, wing)
 
     files = scan_convos(convo_dir)
     if limit > 0:

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import chromadb
 
-from mempalace.convo_miner import mine_convos
+from mempalace.convo_miner import (
+    _is_ai_tool_path,
+    _resolve_wing,
+    mine_convos,
+)
 from mempalace.palace import file_already_mined
 
 
@@ -158,3 +162,123 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         del col, client
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ── _is_ai_tool_path / _resolve_wing — wing_api auto-routing ───────────
+#
+# When a user runs `mempalace mine --mode convos` against a directory
+# inside a known AI-tool storage path (Claude Code's
+# ~/.claude/projects/, OpenAI Codex's ~/.codex/, Google Gemini CLI's
+# ~/.gemini/), the wing auto-defaults to "wing_api" rather than the
+# directory basename. This keeps API-sourced conversations grouped
+# under a single dedicated wing for visibility and privacy isolation.
+#
+# Explicit user-passed --wing always wins. Unrelated directories use
+# the existing basename fallback unchanged.
+
+
+def test_is_ai_tool_path_claude_projects_subdir(tmp_path):
+    """A subdirectory inside ~/.claude/projects/ is an AI tool path."""
+    target = tmp_path / ".claude" / "projects" / "-Users-test-myapp"
+    target.mkdir(parents=True)
+    assert _is_ai_tool_path(target) is True
+
+
+def test_is_ai_tool_path_claude_projects_root(tmp_path):
+    """The ~/.claude/projects/ directory itself is an AI tool path."""
+    target = tmp_path / ".claude" / "projects"
+    target.mkdir(parents=True)
+    assert _is_ai_tool_path(target) is True
+
+
+def test_is_ai_tool_path_codex_root(tmp_path):
+    target = tmp_path / ".codex"
+    target.mkdir()
+    assert _is_ai_tool_path(target) is True
+
+
+def test_is_ai_tool_path_codex_sessions(tmp_path):
+    """Codex stores sessions under ~/.codex/sessions/YYYY/MM/DD/."""
+    target = tmp_path / ".codex" / "sessions" / "2026" / "04" / "26"
+    target.mkdir(parents=True)
+    assert _is_ai_tool_path(target) is True
+
+
+def test_is_ai_tool_path_gemini_root(tmp_path):
+    target = tmp_path / ".gemini"
+    target.mkdir()
+    assert _is_ai_tool_path(target) is True
+
+
+def test_is_ai_tool_path_gemini_chats(tmp_path):
+    """Gemini stores sessions under ~/.gemini/tmp/<hash>/chats/."""
+    target = tmp_path / ".gemini" / "tmp" / "abc123" / "chats"
+    target.mkdir(parents=True)
+    assert _is_ai_tool_path(target) is True
+
+
+def test_is_ai_tool_path_dotclaude_without_projects_not_matched(tmp_path):
+    """`.claude/` alone (without `/projects`) is the settings dir, not a
+    conversation source — it MUST NOT auto-route to wing_api."""
+    target = tmp_path / ".claude"
+    target.mkdir()
+    assert _is_ai_tool_path(target) is False
+
+
+def test_is_ai_tool_path_unrelated_directory(tmp_path):
+    target = tmp_path / "Documents" / "myproject"
+    target.mkdir(parents=True)
+    assert _is_ai_tool_path(target) is False
+
+
+def test_is_ai_tool_path_substring_no_false_positive(tmp_path):
+    """A directory NAMED like `.gemini-backup` or `.codex-archive` is NOT
+    a real AI tool path. We use exact-segment match, not substring."""
+    a = tmp_path / ".gemini-backup"
+    a.mkdir()
+    b = tmp_path / ".codex-archive"
+    b.mkdir()
+    assert _is_ai_tool_path(a) is False
+    assert _is_ai_tool_path(b) is False
+
+
+def test_resolve_wing_explicit_wins_over_auto_detection(tmp_path):
+    """User-passed --wing always wins, even on an AI tool path."""
+    target = tmp_path / ".claude" / "projects" / "-Users-x"
+    target.mkdir(parents=True)
+    assert _resolve_wing(target, wing="my_custom_wing") == "my_custom_wing"
+
+
+def test_resolve_wing_claude_projects_auto_routes_to_wing_api(tmp_path):
+    target = tmp_path / ".claude" / "projects" / "-Users-test-myapp"
+    target.mkdir(parents=True)
+    assert _resolve_wing(target, wing=None) == "wing_api"
+
+
+def test_resolve_wing_codex_auto_routes_to_wing_api(tmp_path):
+    target = tmp_path / ".codex" / "sessions" / "2026"
+    target.mkdir(parents=True)
+    assert _resolve_wing(target, wing=None) == "wing_api"
+
+
+def test_resolve_wing_gemini_auto_routes_to_wing_api(tmp_path):
+    target = tmp_path / ".gemini" / "tmp" / "abc" / "chats"
+    target.mkdir(parents=True)
+    assert _resolve_wing(target, wing=None) == "wing_api"
+
+
+def test_resolve_wing_unrelated_dir_uses_basename_fallback(tmp_path):
+    """Existing behavior preserved: arbitrary directories use the
+    sanitized basename as the wing."""
+    target = tmp_path / "MyProject Folder"
+    target.mkdir()
+    # Spaces become underscores, hyphens become underscores, lowercased.
+    assert _resolve_wing(target, wing=None) == "myproject_folder"
+
+
+def test_resolve_wing_empty_string_treated_as_no_wing(tmp_path):
+    """An empty string for wing should behave like None — fall through to
+    auto-detection / basename. Mirrors the original `if not wing:` guard."""
+    target = tmp_path / ".gemini" / "tmp"
+    target.mkdir(parents=True)
+    assert _resolve_wing(target, wing="") == "wing_api"


### PR DESCRIPTION
When mempalace mine --mode convos is invoked against a directory inside a known AI-tool storage path (Claude Code, Codex CLI, Gemini CLI), the destination wing now auto-defaults to wing_api rather than the directory basename. Conversations from external API-keyed tools land grouped under a single dedicated wing for visibility.

Detected paths (exact-segment match — substrings like .gemini-backup or .codex-archive do NOT match):

  - any segment .codex (Codex CLI sessions / archives)
  - any segment .gemini (Gemini CLI sessions under ~/.gemini/tmp/...)
  - the consecutive segment pair .claude/projects (Claude Code). .claude alone is NOT matched - that is the settings/config dir, not a conversation source.

Wing-resolution precedence (first match wins):

  1. Explicit --wing argument from the user - always wins
  2. AI-tool path detection -> wing_api
  3. Basename fallback (existing behavior, unchanged)

Two new helpers split out of mine_convos for unit-test coverage:

  - _is_ai_tool_path(path: Path) -> bool
  - _resolve_wing(convo_path: Path, wing: Optional[str]) -> str

mine_convos now calls _resolve_wing in place of its inline basename logic. No other call sites or downstream consumers change.

Test coverage:

  - 15 unit tests covering positive matches (Claude Code subdir + root, Codex root + sessions, Gemini root + chats), negative cases (.claude alone is settings dir, unrelated paths, substring no-match on .gemini-backup / .codex-archive), explicit --wing override, auto-route trio, basename fallback, empty-string-as-no-wing.
  - End-to-end smoke test (manual): real-shape Claude Code JSONL fixture mined via the actual CLI; sqlite read-back of /tmp palace confirms drawers landed with wing='wing_api' and verbatim content preserved; mempalace search --wing wing_api returns expected content ranked.
  - Full pytest sweep: 1388 baseline + 15 new = 1403 passed, zero regressions.

Closes part of #59 for the auto-routing UX.
