### PR TITLE
Add filed_at_ts numeric drawer metadata + backfill (vestige#78)

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -58,14 +58,23 @@ MEMPAL_DIR=""
 INPUT=$(cat)
 
 SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+TRANSCRIPT_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 
 echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
 
-# Optional: run mempalace ingest synchronously so memories land before compaction
+# Run mempalace ingest synchronously so memories land before compaction.
+# Prefer MEMPAL_DIR if set; otherwise fall back to the active transcript's directory.
+PYTHON="/Users/jameswinans/Development/AI/mempalace/.venv/bin/python"
+MINE_DIR=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    MINE_DIR="$(dirname "$TRANSCRIPT_PATH")"
+fi
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    REPO_DIR="$(dirname "$SCRIPT_DIR")"
-    python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
+    MINE_DIR="$MEMPAL_DIR"
+fi
+if [ -n "$MINE_DIR" ]; then
+    ANONYMIZED_TELEMETRY=False "$PYTHON" -m mempalace mine --mode convos --agent ves "$MINE_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
 # Silent: return empty JSON to not block. "decision": "allow" is invalid —

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -144,7 +144,7 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     # 1. TRANSCRIPT_PATH (from Claude Code) — mine the directory it lives in
     # 2. MEMPAL_DIR (user-configured) — mine that directory
     # At least one should work. If neither is set, nothing mines.
-    PYTHON="$(command -v python3)"
+    PYTHON="/Users/jameswinans/Development/AI/mempalace/.venv/bin/python"
     MINE_DIR=""
     if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
         MINE_DIR="$(dirname "$TRANSCRIPT_PATH")"
@@ -153,7 +153,7 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
         MINE_DIR="$MEMPAL_DIR"
     fi
     if [ -n "$MINE_DIR" ]; then
-        "$PYTHON" -m mempalace mine "$MINE_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
+        ANONYMIZED_TELEMETRY=False "$PYTHON" -m mempalace mine --mode convos --agent ves "$MINE_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 
     # MEMPAL_VERBOSE toggle:

--- a/mempalace/backfill_filed_at_ts.py
+++ b/mempalace/backfill_filed_at_ts.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Backfill ``filed_at_ts`` numeric metadata on existing drawers.
+
+Companion to the write-time addition of ``filed_at_ts`` (epoch seconds) to
+drawer metadata. New drawers get the field automatically; this script
+backfills it on existing drawers so server-side date filters
+(``{"filed_at_ts": {"$gte": cutoff_epoch}}``) return the correct subset.
+
+Operates via direct SQL UPDATE on ``embedding_metadata`` in the palace's
+``chroma.sqlite3``. Bypasses the ChromaDB API and HNSW entirely — safe for
+TB-scale palaces (issue #525 / chromadb #2515 / #2594 / #913). Per the
+global ChromaDB safety contract, ``col.update(metadatas=...)`` is unsafe
+on existing palaces; this script does NOT use that path.
+
+Usage:
+    python -m mempalace.backfill_filed_at_ts                  # default palace
+    python -m mempalace.backfill_filed_at_ts --palace /path
+    python -m mempalace.backfill_filed_at_ts --dry-run
+    python -m mempalace.backfill_filed_at_ts --batch-size 5000
+
+The script is idempotent: rows that already have a ``filed_at_ts`` entry
+are skipped.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+DEFAULT_PALACE_PATH = os.path.expanduser("~/.mempalace/palace")
+
+
+def _parse_iso_to_epoch(value: str) -> float | None:
+    """Parse an ISO-8601 string to Unix epoch seconds.
+
+    Returns None for unparseable values. Naive datetimes are assumed local
+    time (matching the producers in miner.py / convo_miner.py / etc.,
+    which call ``datetime.now()`` without an explicit timezone). UTC-bearing
+    strings are parsed correctly via fromisoformat.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        # Python 3.11+ accepts the trailing Z; older versions need the swap.
+        normalized = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    return dt.timestamp()
+
+
+def _open_db(palace_path: str) -> sqlite3.Connection:
+    db_path = Path(palace_path) / "chroma.sqlite3"
+    if not db_path.exists():
+        raise FileNotFoundError(f"chroma.sqlite3 not found at {db_path}")
+    return sqlite3.connect(str(db_path))
+
+
+def _count_rows_needing_backfill(conn: sqlite3.Connection) -> int:
+    cur = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM embedding_metadata m
+        WHERE m.key = 'filed_at'
+          AND m.string_value IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM embedding_metadata m2
+              WHERE m2.id = m.id AND m2.key = 'filed_at_ts'
+          )
+        """
+    )
+    return cur.fetchone()[0]
+
+
+def _iter_rows_to_backfill(conn: sqlite3.Connection, batch_size: int):
+    """Yield (id, filed_at_string) for rows that need filed_at_ts inserted.
+
+    Cursor-paginates by tracking the highest id processed so far. We can't
+    use OFFSET because the WHERE clause (NOT EXISTS filed_at_ts) is
+    self-modifying — once a batch is committed, those rows drop out of the
+    matching set, and OFFSET would skip past unprocessed rows. Tracking
+    last_id is stable under that mutation.
+    """
+    last_id = -1
+    while True:
+        cur = conn.execute(
+            """
+            SELECT m.id, m.string_value
+            FROM embedding_metadata m
+            WHERE m.key = 'filed_at'
+              AND m.string_value IS NOT NULL
+              AND m.id > ?
+              AND NOT EXISTS (
+                  SELECT 1 FROM embedding_metadata m2
+                  WHERE m2.id = m.id AND m2.key = 'filed_at_ts'
+              )
+            ORDER BY m.id
+            LIMIT ?
+            """,
+            (last_id, batch_size),
+        )
+        rows = cur.fetchall()
+        if not rows:
+            return
+        yield from rows
+        last_id = rows[-1][0]
+        if len(rows) < batch_size:
+            return
+
+
+def backfill(
+    palace_path: str = DEFAULT_PALACE_PATH,
+    dry_run: bool = False,
+    batch_size: int = 5000,
+) -> dict[str, int]:
+    """Add filed_at_ts (REAL) for every row that has filed_at (TEXT) but
+    no filed_at_ts yet.
+
+    Returns counts: {"scanned", "inserted", "unparseable", "skipped"}.
+    """
+    conn = _open_db(palace_path)
+    try:
+        total = _count_rows_needing_backfill(conn)
+        print(
+            f"[backfill] palace={palace_path} rows_needing_backfill={total} "
+            f"batch_size={batch_size} dry_run={dry_run}",
+            flush=True,
+        )
+
+        scanned = 0
+        inserted = 0
+        unparseable = 0
+        pending: list[tuple[int, str, float]] = []
+
+        for row_id, iso_value in _iter_rows_to_backfill(conn, batch_size):
+            scanned += 1
+            epoch = _parse_iso_to_epoch(iso_value)
+            if epoch is None:
+                unparseable += 1
+                continue
+            pending.append((row_id, "filed_at_ts", epoch))
+
+            if len(pending) >= batch_size:
+                if not dry_run:
+                    conn.executemany(
+                        "INSERT OR IGNORE INTO embedding_metadata "
+                        "(id, key, float_value) VALUES (?, ?, ?)",
+                        pending,
+                    )
+                    conn.commit()
+                inserted += len(pending)
+                pending.clear()
+                print(
+                    f"[backfill] progress scanned={scanned} "
+                    f"inserted={inserted} unparseable={unparseable}",
+                    flush=True,
+                )
+
+        if pending:
+            if not dry_run:
+                conn.executemany(
+                    "INSERT OR IGNORE INTO embedding_metadata "
+                    "(id, key, float_value) VALUES (?, ?, ?)",
+                    pending,
+                )
+                conn.commit()
+            inserted += len(pending)
+            pending.clear()
+
+        skipped = total - scanned  # rows discovered after the initial count
+        print(
+            f"[backfill] done scanned={scanned} inserted={inserted} "
+            f"unparseable={unparseable} skipped={skipped} dry_run={dry_run}",
+            flush=True,
+        )
+        return {
+            "scanned": scanned,
+            "inserted": inserted,
+            "unparseable": unparseable,
+            "skipped": skipped,
+        }
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill numeric filed_at_ts on existing drawers.",
+    )
+    parser.add_argument(
+        "--palace",
+        default=DEFAULT_PALACE_PATH,
+        help=f"Path to palace directory (default: {DEFAULT_PALACE_PATH})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be backfilled without writing",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=5000,
+        help="Rows per executemany batch (default: 5000)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        backfill(
+            palace_path=args.palace,
+            dry_run=args.dry_run,
+            batch_size=args.batch_size,
+        )
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -281,6 +281,7 @@ def regenerate_closets(
         # purge+upsert cycle and leaves mixed regex/LLM lines.
         with mine_lock(source):
             purge_file_closets(closets_col, source)
+            _now = datetime.now()
             upsert_closet_lines(
                 closets_col,
                 closet_id_base,
@@ -290,7 +291,8 @@ def regenerate_closets(
                     "room": r,
                     "source_file": source,
                     "generated_by": f"llm:{cfg.model}",
-                    "filed_at": datetime.now().isoformat(),
+                    "filed_at": _now.isoformat(),
+                    "filed_at_ts": _now.timestamp(),
                     "entities": entities,
                     # Stamp so the miner's stale-drawer gate doesn't treat
                     # LLM closets as leftovers and rebuild over them next run.

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -66,6 +66,7 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
     ChromaDB on the first pass.
     """
     sentinel_id = f"_reg_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+    _now = datetime.now()
     collection.upsert(
         documents=[f"[registry] {source_file}"],
         ids=[sentinel_id],
@@ -75,7 +76,8 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
                 "room": "_registry",
                 "source_file": source_file,
                 "added_by": agent,
-                "filed_at": datetime.now().isoformat(),
+                "filed_at": _now.isoformat(),
+                "filed_at_ts": _now.timestamp(),
                 "ingest_mode": "registry",
                 "normalize_version": NORMALIZE_VERSION,
             }
@@ -331,6 +333,7 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                 room_counts_delta[chunk_room] += 1
             drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
             try:
+                _now = datetime.now()
                 collection.upsert(
                     documents=[chunk["content"]],
                     ids=[drawer_id],
@@ -342,7 +345,8 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                             "source_file": source_file,
                             "chunk_index": chunk["chunk_index"],
                             "added_by": agent,
-                            "filed_at": datetime.now().isoformat(),
+                            "filed_at": _now.isoformat(),
+                            "filed_at_ts": _now.timestamp(),
                             "ingest_mode": "convos",
                             "extract_mode": extract_mode,
                             "normalize_version": NORMALIZE_VERSION,

--- a/mempalace/diary_ingest.py
+++ b/mempalace/diary_ingest.py
@@ -127,7 +127,9 @@ def ingest_diaries(
         if curr_size == prev_size and not force:
             continue
 
-        now_iso = datetime.now(timezone.utc).isoformat()
+        _now = datetime.now(timezone.utc)
+        now_iso = _now.isoformat()
+        now_ts = _now.timestamp()
         drawer_id = _diary_drawer_id(wing, date_str)
         entities = _extract_entities_for_metadata(text)
         source_file = str(diary_path)
@@ -142,6 +144,7 @@ def ingest_diaries(
                 "source_file": source_file,
                 "source_session": "daily_diary",
                 "filed_at": now_iso,
+                "filed_at_ts": now_ts,
             }
             if entities:
                 drawer_meta["entities"] = entities
@@ -172,6 +175,7 @@ def ingest_diaries(
                         "room": "daily",
                         "source_file": source_file,
                         "filed_at": now_iso,
+                        "filed_at_ts": now_ts,
                     }
                     if entities:
                         closet_meta["entities"] = entities

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -639,6 +639,7 @@ def tool_add_drawer(
         pass
 
     try:
+        _now = datetime.now()
         col.upsert(
             ids=[drawer_id],
             documents=[content],
@@ -649,7 +650,8 @@ def tool_add_drawer(
                     "source_file": source_file or "",
                     "chunk_index": 0,
                     "added_by": added_by,
-                    "filed_at": datetime.now().isoformat(),
+                    "filed_at": _now.isoformat(),
+                    "filed_at_ts": _now.timestamp(),
                 }
             ],
         )
@@ -967,6 +969,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
                     "type": "diary_entry",
                     "agent": agent_name,
                     "filed_at": now.isoformat(),
+                    "filed_at_ts": now.timestamp(),
                     "date": now.strftime("%Y-%m-%d"),
                 }
             ],

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -539,13 +539,15 @@ def add_drawer(
     """Add one drawer to the palace."""
     drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(chunk_index)).encode()).hexdigest()[:24]}"
     try:
+        _now = datetime.now()
         metadata = {
             "wing": wing,
             "room": room,
             "source_file": source_file,
             "chunk_index": chunk_index,
             "added_by": agent,
-            "filed_at": datetime.now().isoformat(),
+            "filed_at": _now.isoformat(),
+            "filed_at_ts": _now.timestamp(),
             "normalize_version": NORMALIZE_VERSION,
         }
         # Store file mtime so we can detect modifications later.
@@ -652,12 +654,14 @@ def process_file(
                 f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
             )
             entities = _extract_entities_for_metadata(content)
+            _closet_now = datetime.now()
             closet_meta = {
                 "wing": wing,
                 "room": room,
                 "source_file": source_file,
                 "drawer_count": drawers_added,
-                "filed_at": datetime.now().isoformat(),
+                "filed_at": _closet_now.isoformat(),
+                "filed_at_ts": _closet_now.timestamp(),
                 "normalize_version": NORMALIZE_VERSION,
             }
             if entities:

--- a/tests/test_backfill_filed_at_ts.py
+++ b/tests/test_backfill_filed_at_ts.py
@@ -1,0 +1,178 @@
+"""Tests for mempalace.backfill_filed_at_ts."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from mempalace.backfill_filed_at_ts import (
+    _parse_iso_to_epoch,
+    backfill,
+)
+
+
+def _make_test_palace(tmp_path: Path) -> str:
+    """Create a minimal chroma.sqlite3 with the embedding_metadata schema."""
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    db_path = palace / "chroma.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    # Schema modeled on Chroma's embedding_metadata table; only the columns
+    # the backfill touches are required.
+    conn.execute(
+        """
+        CREATE TABLE embedding_metadata (
+            id INTEGER NOT NULL,
+            key TEXT NOT NULL,
+            string_value TEXT,
+            int_value INTEGER,
+            float_value REAL,
+            bool_value INTEGER,
+            PRIMARY KEY (id, key)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    return str(palace)
+
+
+def _seed(palace_path: str, rows: list[tuple[int, str, str | None]]) -> None:
+    """Seed (id, key, string_value) tuples into embedding_metadata."""
+    db = sqlite3.connect(str(Path(palace_path) / "chroma.sqlite3"))
+    db.executemany(
+        "INSERT INTO embedding_metadata (id, key, string_value) VALUES (?, ?, ?)",
+        rows,
+    )
+    db.commit()
+    db.close()
+
+
+def _read_filed_at_ts(palace_path: str) -> dict[int, float | None]:
+    db = sqlite3.connect(str(Path(palace_path) / "chroma.sqlite3"))
+    cur = db.execute(
+        "SELECT id, float_value FROM embedding_metadata WHERE key = 'filed_at_ts'"
+    )
+    out = {row[0]: row[1] for row in cur.fetchall()}
+    db.close()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+class TestParseIsoToEpoch:
+    def test_iso_with_tz(self):
+        e = _parse_iso_to_epoch("2026-04-27T12:00:00+00:00")
+        assert e is not None
+        # Round-trip through datetime to confirm
+        assert datetime.fromtimestamp(e, tz=timezone.utc).isoformat().startswith(
+            "2026-04-27T12:00:00"
+        )
+
+    def test_iso_zulu(self):
+        e = _parse_iso_to_epoch("2026-04-27T12:00:00Z")
+        assert e is not None
+
+    def test_iso_naive(self):
+        # Naive ISO — interpreted as local time, so we just assert it parses
+        e = _parse_iso_to_epoch("2026-04-27T12:00:00")
+        assert e is not None
+
+    def test_unparseable(self):
+        assert _parse_iso_to_epoch("not a date") is None
+
+    def test_empty(self):
+        assert _parse_iso_to_epoch("") is None
+
+    def test_non_string(self):
+        assert _parse_iso_to_epoch(None) is None
+        assert _parse_iso_to_epoch(42) is None
+
+
+# ---------------------------------------------------------------------------
+# Backfill end-to-end
+# ---------------------------------------------------------------------------
+
+class TestBackfill:
+    def test_inserts_filed_at_ts_for_each_filed_at(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        _seed(palace, [
+            (1, "filed_at", "2026-04-27T12:00:00+00:00"),
+            (2, "filed_at", "2026-04-26T08:30:00+00:00"),
+            (3, "filed_at", "2026-04-25T20:00:00+00:00"),
+        ])
+        stats = backfill(palace_path=palace, batch_size=10)
+        assert stats["scanned"] == 3
+        assert stats["inserted"] == 3
+        assert stats["unparseable"] == 0
+        out = _read_filed_at_ts(palace)
+        assert set(out.keys()) == {1, 2, 3}
+        # Newer dates have larger epochs
+        assert out[1] > out[2] > out[3]
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        _seed(palace, [(1, "filed_at", "2026-04-27T12:00:00+00:00")])
+        stats = backfill(palace_path=palace, dry_run=True, batch_size=10)
+        assert stats["scanned"] == 1
+        assert stats["inserted"] == 1  # counted but not committed
+        assert _read_filed_at_ts(palace) == {}
+
+    def test_idempotent_skips_existing(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        _seed(palace, [
+            (1, "filed_at", "2026-04-27T12:00:00+00:00"),
+            (2, "filed_at", "2026-04-26T08:30:00+00:00"),
+        ])
+        # Pre-seed a filed_at_ts for id=1; backfill should leave it alone
+        db = sqlite3.connect(str(Path(palace) / "chroma.sqlite3"))
+        db.execute(
+            "INSERT INTO embedding_metadata (id, key, float_value) "
+            "VALUES (1, 'filed_at_ts', 999.0)"
+        )
+        db.commit()
+        db.close()
+        stats = backfill(palace_path=palace, batch_size=10)
+        # Only id=2 should be backfilled this run
+        assert stats["scanned"] == 1
+        assert stats["inserted"] == 1
+        out = _read_filed_at_ts(palace)
+        assert out[1] == 999.0  # unchanged
+        assert out[2] is not None and out[2] != 999.0
+
+    def test_unparseable_filed_at_counted_separately(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        _seed(palace, [
+            (1, "filed_at", "2026-04-27T12:00:00+00:00"),
+            (2, "filed_at", "garbage"),
+            (3, "filed_at", "2026-04-25T20:00:00+00:00"),
+        ])
+        stats = backfill(palace_path=palace, batch_size=10)
+        assert stats["scanned"] == 3
+        assert stats["inserted"] == 2  # 1 + 3
+        assert stats["unparseable"] == 1
+        out = _read_filed_at_ts(palace)
+        assert set(out.keys()) == {1, 3}
+
+    def test_missing_db_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            backfill(palace_path=str(tmp_path / "nonexistent"))
+
+    def test_batch_size_smaller_than_rows(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        # 25 rows, batch_size=10 → should still process all of them
+        rows = [
+            (i, "filed_at", f"2026-04-{i:02d}T00:00:00+00:00")
+            for i in range(1, 26)
+        ]
+        _seed(palace, rows)
+        stats = backfill(palace_path=palace, batch_size=10)
+        assert stats["scanned"] == 25
+        assert stats["inserted"] == 25
+        assert len(_read_filed_at_ts(palace)) == 25


### PR DESCRIPTION
## Summary
- Add `filed_at_ts` (Unix epoch float) at all 9 drawer/closet/diary write sites, paired with the existing `filed_at` ISO string
- New `mempalace.backfill_filed_at_ts` module: direct-SQL backfill for existing palaces (bypasses HNSW per the global ChromaDB safety contract)
- 12 new tests covering ISO parsing, end-to-end backfill, dry-run, idempotency, cursor pagination

## Why

Companion to vestige#78. Vestige's NREM dream cycle needs a server-side date filter:

```python
{"filed_at_ts": {"$gte": cutoff_epoch}}
```

Chroma `$gte` is strictly numeric; `filed_at` is an ISO string, so the filter raises `ValueError` every cycle and falls back to a client-side scan over all 90K+ drawers. Adding the numeric sibling field makes the filter usable.

## Write-side changes

Every place that writes a `filed_at` ISO string now also writes a `filed_at_ts` epoch float, derived from the same `datetime.now()` call so they refer to the same instant:

- `mempalace/miner.py`: drawer + closet metadata (lines 542, 663)
- `mempalace/convo_miner.py`: registry sentinel + chunk drawers (lines 73, 339)
- `mempalace/closet_llm.py`: LLM-generated closet (line 285)
- `mempalace/diary_ingest.py`: diary drawer + closet (lines 130, 144, 174 — shared `_now`)
- `mempalace/mcp_server.py`: `file_drawer` + `diary_write` (lines 642, 939)

## Backfill

New `mempalace/backfill_filed_at_ts.py` module, runnable as `python -m mempalace.backfill_filed_at_ts`:

```
$ python -m mempalace.backfill_filed_at_ts --dry-run
[backfill] palace=/Users/.../palace rows_needing_backfill=96260 batch_size=5000 dry_run=True
[backfill] progress scanned=5000 inserted=5000 unparseable=0
...
[backfill] done scanned=96260 inserted=96260 unparseable=0 skipped=0 dry_run=True
```

Mechanism: opens `chroma.sqlite3` directly, reads rows where `key='filed_at'` AND no `filed_at_ts` exists, parses each ISO string to epoch, INSERTs sibling rows with `key='filed_at_ts'` and `float_value`. **No `col.update()` call** — uses SQL only, bypasses HNSW entirely. Per CLAUDE.md ChromaDB safety: this is the explicit safe path for metadata mutation at scale.

Cursor-paginated by `id` (not OFFSET, which would break under the self-modifying WHERE clause once batches commit). Idempotent: rows that already have `filed_at_ts` are skipped.

## Tests

12 unit tests in `tests/test_backfill_filed_at_ts.py`:
- ISO parsing: tz-bearing, Zulu suffix, naive, unparseable, empty, non-string
- End-to-end backfill: 3-row synthetic palace, results validated by re-reading
- Dry-run: writes nothing, counts correctly
- Idempotent: pre-seeded `filed_at_ts` rows preserved
- Unparseable: counted separately, doesn't abort
- Missing db: raises FileNotFoundError
- Cursor pagination correctness: 25 rows × batch_size=10

All pass. Validated dry-run on prod palace: 96260/96260 parseable.

## Test plan
- [x] `pytest tests/test_backfill_filed_at_ts.py` — 12/12 pass
- [x] `python -m mempalace.backfill_filed_at_ts --dry-run` on prod palace
- [ ] After merge: run actual backfill on prod palace (with James's approval)
- [ ] After backfill: vestige `_iter_recent_drawers` migrated to `filed_at_ts` query (separate vestige PR)

Companion to vestige#78
