### PR TITLE
chore(gitignore): ignore local MemPalace runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ venv/
 
 # ChromaDB local data
 *.sqlite3-journal
+
+# MemPalace per-project files (issue #185)
+mempalace.yaml
+entities.json


### PR DESCRIPTION
## Summary
- ignore local runtime files `mempalace.yaml` and `entities.json`
- prevent accidental commits of per-project MemPalace configuration

## Test plan
- [x] run `git status` and confirm no additional tracked changes

Made with [Cursor](https://cursor.com)