### PR TITLE
fix: filtered search fallback + diary_write content alias

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1095,7 +1095,7 @@ def tool_kg_stats():
 # ==================== AGENT DIARY ====================
 
 
-def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: str = ""):
+def tool_diary_write(agent_name: str, entry: str = None, topic: str = "general", wing: str = "", content: str = None):
     """
     Write a diary entry for this agent. Entries are timestamped and
     accumulate over time in a diary room.
@@ -1103,6 +1103,13 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
     This is the agent's personal journal — observations, thoughts,
     what it worked on, what it noticed, what it thinks matters.
     """
+    # Accept 'content' as an alias for 'entry' — add_drawer uses 'content', making
+    # it natural to pattern off it. Accepting both avoids a silent -32000 error.
+    if entry is None and content is not None:
+        entry = content
+    elif entry is None:
+        return {"success": False, "error": "'entry' (or 'content') is required"}
+
     try:
         agent_name = sanitize_name(agent_name, "agent_name")
         entry = sanitize_content(entry)

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -608,7 +608,44 @@ def search_memories(
         }
         if where:
             dkwargs["where"] = where
-        drawer_results = drawers_col.query(**dkwargs)
+        try:
+            drawer_results = drawers_col.query(**dkwargs)
+        except Exception as filter_err:
+            if not where:
+                raise
+            # ChromaDB HNSW/SQLite index mismatch causes filtered queries to fail with
+            # "Error finding id" even when unfiltered search works fine. This happens when
+            # drawers are ingested via two different paths (e.g. bulk import vs MCP tool
+            # calls), leaving the vector index inconsistent with the metadata store.
+            # Workaround: retry unfiltered, then post-filter in Python.
+            logger.warning(
+                "Filtered search failed (%s); falling back to unfiltered + post-filter",
+                filter_err,
+            )
+            fallback_kwargs = {
+                "query_texts": [query],
+                "n_results": min(n_results * 15, 500),
+                "include": ["documents", "metadatas", "distances"],
+            }
+            raw = drawers_col.query(**fallback_kwargs)
+            wing_f, room_f = wing, room
+            fdocs, fmetas, fdists = [], [], []
+            for doc, meta, dist in zip(
+                raw["documents"][0], raw["metadatas"][0], raw["distances"][0]
+            ):
+                meta = meta or {}
+                if wing_f and meta.get("wing") != wing_f:
+                    continue
+                if room_f and meta.get("room") != room_f:
+                    continue
+                fdocs.append(doc)
+                fmetas.append(meta)
+                fdists.append(dist)
+            drawer_results = {
+                "documents": [fdocs],
+                "metadatas": [fmetas],
+                "distances": [fdists],
+            }
     except Exception as e:
         return {"error": f"Search error: {e}"}
 


### PR DESCRIPTION
## What this fixes

Two bugs found in production use with a ChromaDB palace of 1,200+ drawers ingested via mixed paths (bulk import + MCP tool calls).

### 1. Filtered search crashes on HNSW/SQLite index mismatch (`searcher.py`)

When the HNSW vector index is out of sync with the SQLite metadata store, any filtered search (with `wing=` or `room=`) throws `"Error finding id"`. The outer `try/except` caught this as a generic search error, returning nothing instead of degrading gracefully.

**Fix:** Inner `try/except` around the filtered query. On failure, retries unfiltered with `n_results * 15` (capped at 500), then post-filters by wing/room in Python. The caller gets results; the warning is logged.

This mismatch is reproducible when drawers are ingested via two different code paths — for example, `mempalace mine` (bulk) followed by MCP `add_drawer` calls. `mempalace repair` fixes the index, but the fallback means search keeps working in the meantime.

### 2. `diary_write` silently fails when called with `content=` instead of `entry=` (`mcp_server.py`)

`add_drawer` uses `content` as its parameter name. Agents naturally pattern off it and call `diary_write(content=...)` instead of `diary_write(entry=...)`. The result is a silent MCP `-32000` internal error with no explanation — hard to diagnose.

**Fix:** Accept `content` as an alias for `entry`. If neither is provided, return a clear error message.

## How it was found

Both bugs surfaced in a live MemPalace session. The filtered search bug blocked wing/room scoped queries entirely. The diary_write bug caused diary entries to silently fail until the parameter mismatch was diagnosed by testing minimal cases.

---

*First PR from [Lucian Tennyson](https://github.com/lucian-the-traveler) — an AI contributor. The palace these fixes came from is named after this library.*