### PR TITLE
fix: remine changed conversation transcripts

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -66,7 +66,21 @@ MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB — skip files larger than this.
 # use also scales with source size.
 
 
-def _register_file(collection, source_file: str, wing: str, agent: str):
+def _source_mtime(source_file: str) -> float | None:
+    """Return the source file mtime, or None when the file is unavailable."""
+    try:
+        return os.path.getmtime(source_file)
+    except OSError:
+        return None
+
+
+def _register_file(
+    collection,
+    source_file: str,
+    wing: str,
+    agent: str,
+    source_mtime: float | None = None,
+):
     """Write a sentinel so file_already_mined() returns True for 0-chunk files.
 
     Without this, files that normalize to nothing or produce zero chunks are
@@ -74,20 +88,22 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
     ChromaDB on the first pass.
     """
     sentinel_id = f"_reg_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+    metadata = {
+        "wing": wing,
+        "room": "_registry",
+        "source_file": source_file,
+        "added_by": agent,
+        "filed_at": datetime.now().isoformat(),
+        "ingest_mode": "registry",
+        "normalize_version": NORMALIZE_VERSION,
+    }
+    if source_mtime is not None:
+        metadata["source_mtime"] = source_mtime
+
     collection.upsert(
         documents=[f"[registry] {source_file}"],
         ids=[sentinel_id],
-        metadatas=[
-            {
-                "wing": wing,
-                "room": "_registry",
-                "source_file": source_file,
-                "added_by": agent,
-                "filed_at": datetime.now().isoformat(),
-                "ingest_mode": "registry",
-                "normalize_version": NORMALIZE_VERSION,
-            }
-        ],
+        metadatas=[metadata],
     )
 
 
@@ -307,7 +323,16 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
-def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+def _file_chunks_locked(
+    collection,
+    source_file,
+    chunks,
+    wing,
+    room,
+    agent,
+    extract_mode,
+    source_mtime=None,
+):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
     Combines the per-file serialization that prevents concurrent agents from
@@ -322,7 +347,7 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
         # Re-check after lock — another agent may have just finished this file
         # at the current schema. A stale-version hit here returns False, so we
         # still fall through to the purge+rebuild path below.
-        if file_already_mined(collection, source_file):
+        if file_already_mined(collection, source_file, check_mtime=True):
             return 0, room_counts_delta, True
 
         # Purge stale drawers first. When the normalize schema bumps,
@@ -349,20 +374,21 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                 drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
                 batch_docs.append(chunk["content"])
                 batch_ids.append(drawer_id)
-                batch_metas.append(
-                    {
-                        "wing": wing,
-                        "room": chunk_room,
-                        "hall": _detect_hall_cached(chunk["content"]),
-                        "source_file": source_file,
-                        "chunk_index": chunk["chunk_index"],
-                        "added_by": agent,
-                        "filed_at": filed_at,
-                        "ingest_mode": "convos",
-                        "extract_mode": extract_mode,
-                        "normalize_version": NORMALIZE_VERSION,
-                    }
-                )
+                metadata = {
+                    "wing": wing,
+                    "room": chunk_room,
+                    "hall": _detect_hall_cached(chunk["content"]),
+                    "source_file": source_file,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": agent,
+                    "filed_at": filed_at,
+                    "ingest_mode": "convos",
+                    "extract_mode": extract_mode,
+                    "normalize_version": NORMALIZE_VERSION,
+                }
+                if source_mtime is not None:
+                    metadata["source_mtime"] = source_mtime
+                batch_metas.append(metadata)
             try:
                 collection.upsert(
                     documents=batch_docs,
@@ -423,7 +449,9 @@ def mine_convos(
         source_file = str(filepath)
 
         # Skip if already filed
-        if not dry_run and file_already_mined(collection, source_file):
+        source_mtime = _source_mtime(source_file)
+
+        if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
             files_skipped += 1
             continue
 
@@ -432,12 +460,12 @@ def mine_convos(
             content = normalize(str(filepath))
         except (OSError, ValueError):
             if not dry_run:
-                _register_file(collection, source_file, wing, agent)
+                _register_file(collection, source_file, wing, agent, source_mtime)
             continue
 
         if not content or len(content.strip()) < MIN_CHUNK_SIZE:
             if not dry_run:
-                _register_file(collection, source_file, wing, agent)
+                _register_file(collection, source_file, wing, agent, source_mtime)
             continue
 
         # Chunk — either exchange pairs or general extraction
@@ -451,7 +479,7 @@ def mine_convos(
 
         if not chunks:
             if not dry_run:
-                _register_file(collection, source_file, wing, agent)
+                _register_file(collection, source_file, wing, agent, source_mtime)
             continue
 
         # Detect room from content (general mode uses memory_type instead)
@@ -484,7 +512,7 @@ def mine_convos(
         # Lock + purge stale + file fresh chunks. Lock serializes concurrent
         # agents; purge removes pre-v2 drawers so the schema bump applies.
         drawers_added, room_delta, skipped = _file_chunks_locked(
-            collection, source_file, chunks, wing, room, agent, extract_mode
+            collection, source_file, chunks, wing, room, agent, extract_mode, source_mtime
         )
         if skipped:
             files_skipped += 1

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -401,9 +401,8 @@ def file_already_mined(collection, source_file: str, check_mtime: bool = False) 
         schema (triggers silent rebuild after a normalization upgrade)
       - `check_mtime=True` and the file's mtime differs from the stored one
 
-    When check_mtime=True (used by project miner), also re-mines on content
-    change. When check_mtime=False (used by convo miner), transcripts are
-    assumed immutable, so only the version gate triggers a rebuild.
+    When check_mtime=True, also re-mines on content change. When
+    check_mtime=False, only the version gate triggers a rebuild.
     """
     try:
         results = collection.get(where={"source_file": source_file}, limit=1)

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -77,6 +77,54 @@ def test_mine_convos_does_not_reprocess_empty_chunk_files(capsys):
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_mine_convos_reprocesses_changed_transcript_mtime(capsys):
+    """Growing transcript files must be re-mined instead of treated as immutable."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        convo_path = Path(tmpdir) / "chat.txt"
+        convo_path.write_text(
+            "> First question?\nFirst answer with enough words to create a drawer.\n"
+        )
+        palace_path = os.path.join(tmpdir, "palace")
+
+        mine_convos(tmpdir, palace_path, wing="test")
+        capsys.readouterr()
+
+        resolved = str(Path(tmpdir).resolve() / "chat.txt")
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+        initial = col.get(where={"source_file": resolved})
+        assert initial["ids"]
+        assert all("Second answer" not in doc for doc in initial["documents"])
+        first_mtime = os.path.getmtime(convo_path)
+        del col, client
+
+        convo_path.write_text(
+            "> First question?\nFirst answer with enough words to create a drawer.\n"
+            "\n> Second question?\nSecond answer that arrived later in the same transcript.\n"
+        )
+        os.utime(convo_path, (first_mtime + 10, first_mtime + 10))
+
+        mine_convos(tmpdir, palace_path, wing="test")
+        out = capsys.readouterr().out
+        assert "Files skipped (already filed): 0" in out
+
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+        rebuilt = col.get(where={"source_file": resolved})
+        assert any("Second answer" in doc for doc in rebuilt["documents"])
+        stored_mtimes = {
+            float(meta["source_mtime"])
+            for meta in rebuilt["metadatas"]
+            if meta.get("ingest_mode") == "convos"
+        }
+        assert len(stored_mtimes) == 1
+        assert abs(stored_mtimes.pop() - os.path.getmtime(convo_path)) < 0.001
+        del col, client
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
     """When stored drawers have an older normalize_version, the next mine
     silently purges them and refiles — no manual erase required.
@@ -140,9 +188,9 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         # Second mine — version gate should trigger rebuild
         mine_convos(tmpdir, palace_path, wing="test")
         out = capsys.readouterr().out
-        assert (
-            "Files skipped (already filed): 0" in out
-        ), "stale drawers should force a rebuild, not a skip"
+        assert "Files skipped (already filed): 0" in out, (
+            "stale drawers should force a rebuild, not a skip"
+        )
 
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")


### PR DESCRIPTION
## Summary
- persist `source_mtime` for conversation transcript drawers and registry sentinels
- make `convo_miner` re-mine a transcript when the source file changed
- add regression coverage for a transcript that grows between mine runs

## Problem
`convo_miner` currently skips a transcript after its first successful ingest unless the normalization schema version changes. That works for one-shot exports, but it drops new turns when the same transcript file continues to grow across later mine runs.

## Reproduction
1. Mine a conversation directory.
2. Append another exchange to the same transcript file.
3. Run `mempalace mine <dir> --mode convos` again.
4. The second run skips the file and the appended exchange never gets filed.

## Fix
Store `source_mtime` in conversation transcript metadata and reuse the existing `check_mtime=True` freshness gate from project mining. If the transcript changed, `convo_miner` purges and rebuilds drawers for that source file; unchanged transcripts are still skipped.

## Validation
- `./.venv/bin/pytest tests/test_convo_miner.py tests/test_hooks_cli.py tests/test_save_hook_mines.py -q`
- `./.venv/bin/ruff check mempalace/convo_miner.py mempalace/palace.py tests/test_convo_miner.py`
- `./.venv/bin/ruff format --check mempalace/convo_miner.py mempalace/palace.py tests/test_convo_miner.py`