### PR TITLE
feat(miner): add .cs to READABLE_EXTENSIONS for C# project support

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -53,6 +53,7 @@ READABLE_EXTENSIONS = {
     ".csv",
     ".sql",
     ".toml",
+    ".cs"
 }
 
 SKIP_FILENAMES = {

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -761,3 +761,16 @@ def test_mine_does_not_remove_other_processes_pid_file(tmp_path):
 
     assert pid_file.exists(), "Foreign PID entries must not be removed"
     assert pid_file.read_text().strip() == str(other_pid)
+
+
+def test_scan_project_picks_up_cs_files():
+    """C# source files (.cs) should be included in READABLE_EXTENSIONS and scanned."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / "Program.cs", "namespace App { class Program {} }\n" * 20)
+
+        assert scanned_files(project_root, respect_gitignore=False) == ["Program.cs"]
+    finally:
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
# feat(miner): add `.cs` to `READABLE_EXTENSIONS` for C# project support

## Summary

Adds `.cs` (C#) to the `READABLE_EXTENSIONS` set in `miner.py` so that C# source
files are picked up and indexed when mining a .NET / C# project.

## Motivation

Users working on C# codebases were finding that their source files were silently
skipped during `mempalace mine` because `.cs` was absent from the readable-
extensions allow-list. This change brings C# to parity with the other supported
languages (Python, JavaScript, TypeScript, Go, Rust, etc.).

## Changes

| File | Change |
|------|--------|
| `mempalace/miner.py` | Added `".cs"` to `READABLE_EXTENSIONS` |
| `tests/test_miner.py` | Added `test_scan_project_picks_up_cs_files` to verify the extension is scanned |

## Diff

```diff
# mempalace/miner.py
 READABLE_EXTENSIONS = {
     ...
     ".csv",
     ".sql",
     ".toml",
+    ".cs"
 }
```

## Testing

```bash
# Run the full miner test suite (all 32 tests must pass)
python -m pytest tests/test_miner.py -v
```

All 32 tests pass, including the new `test_scan_project_picks_up_cs_files` test.

## Checklist

- [x] Feature branch: `feat/miner-add-cs-extension` → target `develop`
- [x] Code follows project style (ruff, snake_case, no new dependencies)
- [x] New test added (`test_scan_project_picks_up_cs_files`)
- [x] All existing tests pass (`32 passed`)
- [x] No API keys or external services required
- [x] Verbatim storage unaffected — change is index-layer only (which files get picked up)
- [x] Conventional commit message used: `feat(miner): add .cs to READABLE_EXTENSIONS for C# project support`

## PR Target

Base branch: `develop`  
Head branch: `feat/miner-add-cs-extension`
