### PR TITLE
fix(compress): drop and recreate mempalace_compressed to avoid HNSW link_lists.bin inflation

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -902,6 +902,15 @@ def cmd_compress(args):
     # Store compressed versions (unless dry-run)
     if not args.dry_run:
         try:
+            # Drop and recreate the compressed collection on each run.
+            # Repeated upserts in chromadb 1.5.8 cause the HNSW link_lists.bin
+            # sparse file to grow without GC; rebuilding the index from scratch
+            # each compress run keeps disk size proportional to entry count.
+            # See #1092 for the broader concurrent-writer report.
+            try:
+                backend.delete_collection(palace_path, "mempalace_compressed")
+            except Exception:
+                pass
             comp_col = backend.get_or_create_collection(palace_path, "mempalace_compressed")
             for doc_id, compressed, meta, stats in compressed_entries:
                 comp_meta = dict(meta)


### PR DESCRIPTION
## Context

Adds a localized fix for one disk-fill vector reported in #1092 (and reproduced in my #1272, now closed as duplicate): the `mempalace compress` code path.

In my case the `mempalace_compressed` collection's `link_lists.bin` grew to **1.7 TB physical / 17 TB logical (sparse)** for ~13K entries on a 1.8 TB disk, after running `mempalace compress` twice in one day with the MCP server and Stop/PreCompact hooks active in parallel. This PR doesn't address the underlying chromadb 1.5.8 concurrent-writer issue (that's broader — see #1092 for the full picture), but it removes one practical way the disk fills.

## Fix

Drop and recreate the `mempalace_compressed` collection at the start of each compress run, before the upsert loop. Each run starts with a fresh HNSW index, so accumulation in `link_lists.bin` cannot happen.

Diff is small (~5 lines added) in `cmd_compress` (`mempalace/cli.py`).

## Trade-off

Re-vectorizing all compressed entries on every compress run. With the local ONNX embedder and ~10K entries this is on the order of minutes, well within the budget for a weekly cron job. The alternative (silent disk fill) is much worse.

This is consistent with what the miner already does: `miner.py:718-726` deletes by `source_file` before re-inserting to bypass hnswlib's `updatePoint` path that triggers the same kind of behavior. The compress path was the missing parallel.

## Testing

Patched a local pipx install with this change and re-ran `mempalace compress` against the same palace several times in a row. `du -sh ~/.mempalace/palace/<compressed_uuid>` stayed proportional to the actual entry count across runs — no growth.

## Notes

- Doesn't fix the underlying chromadb 1.x sparse-file behavior. A separate upstream report in `chroma-core/chroma` would be the right path for that.
- `verbatim always` is preserved: the user-facing data lives in `mempalace_drawers`, untouched. `mempalace_compressed` is a derived index of AAAK summaries, regenerated from those originals on each compress.

Related: #1092
