### PR TITLE
Fix/windows hook stdio utf8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ venv/
 
 # ChromaDB local data
 *.sqlite3-journal
+
+# MemPalace per-project files (issue #185)
+mempalace.yaml
+entities.json

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -372,18 +372,66 @@ def _hnsw_element_count(palace_path: str, segment_id: str) -> Optional[int]:
 
 
 # Divergence threshold: chromadb's HNSW flushes asynchronously, so HNSW
-# typically lags sqlite by up to ``sync_threshold`` (default 1000) records
+# typically lags sqlite by up to the collection's ``hnsw:sync_threshold``
 # under active write load — that's the *brute-force batch* that hasn't
 # been compacted into HNSW yet, plus the un-persisted tail beyond the
-# last sync. Two synchronization windows worth (2 × sync_threshold = 2000)
-# is a safe steady-state ceiling; anything past that is real divergence,
-# not flush-lag.
+# last sync. Two synchronization windows worth is a safe steady-state
+# ceiling; anything past that is real divergence, not flush-lag.
 #
 # The #1222 case was 176 613 missing out of 192 997 (91% gone) — orders
 # of magnitude past 2000. A typical post-mine palace shows a few hundred
 # to ~1000 missing, well under threshold.
 _HNSW_DIVERGENCE_ABSOLUTE = 2000
 _HNSW_DIVERGENCE_FRACTION = 0.10
+_HNSW_DEFAULT_SYNC_THRESHOLD = 1000
+
+
+def _collection_hnsw_sync_threshold(palace_path: str, collection_name: str) -> Optional[int]:
+    """Return the persisted Chroma ``hnsw:sync_threshold`` for a collection."""
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(collection_metadata)")}
+            value_columns = [name for name in ("int_value", "float_value", "str_value") if name in columns]
+            if not value_columns:
+                return None
+
+            select_expr = "COALESCE(" + ", ".join(f"cm.{name}" for name in value_columns) + ")"
+            row = conn.execute(
+                f"""
+                SELECT {select_expr}
+                FROM collection_metadata cm
+                JOIN collections c ON cm.collection_id = c.id
+                WHERE c.name = ? AND cm.key = 'hnsw:sync_threshold'
+                LIMIT 1
+                """,
+                (collection_name,),
+            ).fetchone()
+            if row is None or row[0] is None:
+                return None
+            threshold = int(float(row[0]))
+            return threshold if threshold > 0 else None
+        finally:
+            conn.close()
+    except (sqlite3.Error, TypeError, ValueError):
+        return None
+
+
+def _hnsw_divergence_threshold(
+    palace_path: str, collection_name: str, sqlite_count: int
+) -> int:
+    sync_threshold = (
+        _collection_hnsw_sync_threshold(palace_path, collection_name)
+        or _HNSW_DEFAULT_SYNC_THRESHOLD
+    )
+    return max(
+        _HNSW_DIVERGENCE_ABSOLUTE,
+        int(sqlite_count * _HNSW_DIVERGENCE_FRACTION),
+        sync_threshold * 2,
+    )
 
 
 def hnsw_capacity_status(palace_path: str, collection_name: str = "mempalace_drawers") -> dict:
@@ -437,7 +485,8 @@ def hnsw_capacity_status(palace_path: str, collection_name: str = "mempalace_dra
             # We can't distinguish without the pickle, so only flag
             # divergence when sqlite holds clearly more than two flush
             # windows worth — same threshold as the with-pickle path.
-            if sqlite_count > _HNSW_DIVERGENCE_ABSOLUTE:
+            threshold = _hnsw_divergence_threshold(palace_path, collection_name, sqlite_count)
+            if sqlite_count > threshold:
                 out["status"] = "diverged"
                 out["diverged"] = True
                 out["divergence"] = sqlite_count
@@ -447,12 +496,16 @@ def hnsw_capacity_status(palace_path: str, collection_name: str = "mempalace_dra
                     "until the segment is rebuilt. Run `mempalace repair`."
                 )
             else:
-                out["message"] = "HNSW segment metadata not yet flushed; skipping"
+                out["status"] = "ok"
+                out["message"] = (
+                    "HNSW segment metadata not yet flushed; sqlite count is within "
+                    f"the configured sync window ({threshold:,})"
+                )
             return out
 
         divergence = sqlite_count - hnsw_count
         out["divergence"] = divergence
-        threshold = max(_HNSW_DIVERGENCE_ABSOLUTE, int(sqlite_count * _HNSW_DIVERGENCE_FRACTION))
+        threshold = _hnsw_divergence_threshold(palace_path, collection_name, sqlite_count)
         if divergence > threshold:
             out["status"] = "diverged"
             out["diverged"] = True

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -18,6 +18,28 @@ SAVE_INTERVAL = 15
 STATE_DIR = Path.home() / ".mempalace" / "hook_state"
 
 
+def _reconfigure_stdio_utf8_on_windows():
+    """Decode Claude/Codex hook JSON as UTF-8 on Windows.
+
+    Hook harnesses send JSON over stdin as UTF-8. On Windows, Python can
+    default stdio to the system ANSI codepage, which mojibakes non-ASCII
+    payload fields and may introduce surrogate characters before json.load()
+    sees the stream.
+    """
+    if sys.platform != "win32":
+        return
+
+    for name in ("stdin", "stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="strict")
+        except Exception as exc:
+            _log(f"WARNING: Could not reconfigure {name} to UTF-8: {exc}")
+
+
 def _mempalace_python() -> str:
     """Return the python interpreter that has mempalace installed.
 
@@ -693,6 +715,8 @@ def hook_precompact(data: dict, harness: str):
 
 def run_hook(hook_name: str, harness: str):
     """Main entry point: read stdin JSON, dispatch to hook handler."""
+    _reconfigure_stdio_utf8_on_windows()
+
     try:
         data = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError):

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -42,6 +42,21 @@ except (OSError, AttributeError):
     pass
 sys.stdout = sys.stderr
 
+
+def _force_utf8_stdio():
+    """MCP stdio is UTF-8 JSON-RPC, independent of the host console locale."""
+    for stream in (sys.stdin, sys.stdout, sys.stderr, _REAL_STDOUT):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            pass
+
+
+_force_utf8_stdio()
+
 import argparse  # noqa: E402  (deferred until after stdio protection above)
 import json  # noqa: E402
 import logging  # noqa: E402
@@ -1876,7 +1891,14 @@ def handle_request(request):
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "result": {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]},
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(result, indent=2, ensure_ascii=False),
+                        }
+                    ]
+                },
             }
         except Exception:
             logger.exception(f"Tool error in {tool_name}")
@@ -1911,6 +1933,7 @@ def _restore_stdout():
 
 def main():
     _restore_stdout()
+    _force_utf8_stdio()
     logger.info("MemPalace MCP Server starting...")
     # Pre-flight: probe HNSW capacity before any tool call so the warning
     # is visible at startup rather than on first use (#1222). Pure

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,6 +18,7 @@ from mempalace.backends.chroma import (
     ChromaCollection,
     _fix_blob_seq_ids,
     _pin_hnsw_threads,
+    hnsw_capacity_status,
     quarantine_stale_hnsw,
 )
 
@@ -736,6 +737,66 @@ def test_make_client_quarantines_each_palace_independently(tmp_path, monkeypatch
     ChromaBackend.make_client(palace_b)  # already gated
 
     assert calls == [palace_a, palace_b]
+
+
+def _seed_hnsw_status_db(palace_path: Path, *, count: int, sync_threshold: int = 50_000):
+    palace_path.mkdir()
+    conn = sqlite3.connect(palace_path / "chroma.sqlite3")
+    conn.executescript(
+        """
+        CREATE TABLE collections(id TEXT PRIMARY KEY, name TEXT);
+        CREATE TABLE segments(id TEXT PRIMARY KEY, type TEXT, scope TEXT, collection TEXT);
+        CREATE TABLE embeddings(id INTEGER PRIMARY KEY, segment_id TEXT, embedding_id TEXT);
+        CREATE TABLE collection_metadata(
+            collection_id TEXT,
+            key TEXT,
+            str_value TEXT,
+            int_value INTEGER,
+            float_value REAL,
+            bool_value INTEGER
+        );
+        """
+    )
+    conn.execute("INSERT INTO collections(id, name) VALUES ('coll', 'mempalace_drawers')")
+    conn.execute(
+        "INSERT INTO segments(id, type, scope, collection) VALUES (?, ?, ?, ?)",
+        ("vec", "urn:chroma:segment/vector/hnsw-local-persisted", "VECTOR", "coll"),
+    )
+    conn.execute(
+        "INSERT INTO collection_metadata(collection_id, key, int_value) VALUES (?, ?, ?)",
+        ("coll", "hnsw:sync_threshold", sync_threshold),
+    )
+    conn.executemany(
+        "INSERT INTO embeddings(segment_id, embedding_id) VALUES ('vec', ?)",
+        ((f"id-{i}",) for i in range(count)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_hnsw_capacity_status_respects_configured_sync_threshold(tmp_path):
+    """No metadata pickle before hnsw:sync_threshold is reached is normal."""
+    palace_path = tmp_path / "palace"
+    _seed_hnsw_status_db(palace_path, count=7_653, sync_threshold=50_000)
+
+    status = hnsw_capacity_status(str(palace_path), "mempalace_drawers")
+
+    assert status["sqlite_count"] == 7_653
+    assert status["hnsw_count"] is None
+    assert status["diverged"] is False
+    assert status["status"] == "ok"
+
+
+def test_hnsw_capacity_status_flags_missing_metadata_past_sync_window(tmp_path):
+    palace_path = tmp_path / "palace"
+    _seed_hnsw_status_db(palace_path, count=120_001, sync_threshold=50_000)
+
+    status = hnsw_capacity_status(str(palace_path), "mempalace_drawers")
+
+    assert status["sqlite_count"] == 120_001
+    assert status["hnsw_count"] is None
+    assert status["diverged"] is True
+    assert status["status"] == "diverged"
 
 
 # ── _pin_hnsw_threads (per-process retrofit, separate from this PR's gate) ──

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -29,6 +29,15 @@ from mempalace.hooks_cli import (
 )
 
 
+class ReconfigurableStringIO(io.StringIO):
+    def __init__(self, initial_value=""):
+        super().__init__(initial_value)
+        self.reconfigure_calls = []
+
+    def reconfigure(self, **kwargs):
+        self.reconfigure_calls.append(kwargs)
+
+
 # --- _mempalace_python ---
 
 
@@ -822,6 +831,27 @@ def test_run_hook_dispatches_session_start(tmp_path):
         with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
             with patch("mempalace.hooks_cli._output") as mock_output:
                 run_hook("session-start", "claude-code")
+    mock_output.assert_called_once_with({})
+
+
+def test_run_hook_reconfigures_stdio_to_utf8_on_windows(tmp_path):
+    """Windows hook stdin must be UTF-8 before json.load() reads it."""
+    stdin = ReconfigurableStringIO(json.dumps({"session_id": "utf8-test"}))
+    stdout = ReconfigurableStringIO()
+    stderr = ReconfigurableStringIO()
+
+    with patch("mempalace.hooks_cli.sys.platform", "win32"):
+        with patch("mempalace.hooks_cli.sys.stdin", stdin):
+            with patch("mempalace.hooks_cli.sys.stdout", stdout):
+                with patch("mempalace.hooks_cli.sys.stderr", stderr):
+                    with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+                        with patch("mempalace.hooks_cli._output") as mock_output:
+                            run_hook("session-start", "claude-code")
+
+    expected = {"encoding": "utf-8", "errors": "strict"}
+    assert stdin.reconfigure_calls == [expected]
+    assert stdout.reconfigure_calls == [expected]
+    assert stderr.reconfigure_calls == [expected]
     mock_output.assert_called_once_with({})
 
 

--- a/tests/test_mcp_stdio_protection.py
+++ b/tests/test_mcp_stdio_protection.py
@@ -13,6 +13,9 @@ stdout in main() before entering the protocol loop.
 import subprocess
 import sys
 import textwrap
+import json
+import os
+import sqlite3
 
 
 def test_module_import_redirects_stdout_to_stderr():
@@ -81,3 +84,53 @@ def test_mcp_server_no_stdout_noise_on_clean_exit():
     assert (
         proc.stdout == b""
     ), f"stdout must be empty before the first JSON-RPC response, but got: {proc.stdout!r}"
+
+
+def test_mcp_server_reads_utf8_json_rpc_under_legacy_windows_locale(tmp_path):
+    """Claude sends MCP JSON-RPC as UTF-8 even when Windows console locale is CP936.
+
+    If the server lets Python decode stdin with the process locale, Chinese tool
+    arguments are mojibake before json.loads() sees them.
+    """
+    palace = tmp_path / "palace"
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "mempalace_kg_add",
+            "arguments": {
+                "subject": "杨工",
+                "predicate": "关系",
+                "object": "钥匙",
+                "valid_from": "2026-05-01",
+            },
+        },
+    }
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp936"
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "mempalace.mcp_server", "--palace", str(palace)],
+        input=(json.dumps(request, ensure_ascii=False) + "\n").encode("utf-8"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        timeout=60,
+    )
+
+    assert proc.returncode == 0, f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
+    response = json.loads(proc.stdout)
+    content = json.loads(response["result"]["content"][0]["text"])
+    assert content["success"] is True
+    assert content["fact"] == "杨工 → 关系 → 钥匙"
+
+    conn = sqlite3.connect(str(palace / "knowledge_graph.sqlite3"))
+    try:
+        entities = conn.execute("SELECT id, name FROM entities ORDER BY id").fetchall()
+        triples = conn.execute("SELECT subject, predicate, object FROM triples").fetchall()
+    finally:
+        conn.close()
+
+    assert entities == [("杨工", "杨工"), ("钥匙", "钥匙")]
+    assert triples == [("杨工", "关系", "钥匙")]


### PR DESCRIPTION
这个修复把 #363/#400 的 Windows UTF-8 stdin 处理扩展到 Claude/Codex hook 入口，避免非 ASCII hook payload 在 json.load(sys.stdin) 前被系统 ANSI codepage
  解码坏。
