### PR TITLE
fix(cli, fact-checker): reconfigure stdio to UTF-8 on Windows

### DIFF
--- a/mempalace/_stdio.py
+++ b/mempalace/_stdio.py
@@ -1,0 +1,71 @@
+"""Stdio UTF-8 reconfiguration helper for Windows entry points.
+
+Python on Windows defaults stdio to the system ANSI codepage
+(cp1252/cp1251/cp950 depending on locale), which mojibakes UTF-8 input
+or output the moment a non-Latin character shows up. Every console
+entry point that touches stdio needs to fix this on Windows -- the MCP
+server, the CLI, the fact_checker `--stdin` mode -- so the
+reconfigure code lives here in one place to keep the per-stream
+errors policies aligned across them.
+
+Per-stream errors policy is caller-chosen:
+
+* MCP server uses ``strict`` on stdout/stderr because everything written
+  there is server-controlled JSON-RPC; any encode failure is a real bug
+  the operator wants loud.
+* CLI / fact_checker use ``replace`` on stdout/stderr because they print
+  verbatim drawer text that may contain surrogate halves round-tripped
+  from filenames -- ``strict`` would crash mid-print.
+* All callers use ``surrogateescape`` on stdin so a malformed byte from
+  a redirected file or a misbehaving client survives as a lone surrogate
+  the consumer's parser surfaces, instead of ``UnicodeDecodeError``
+  killing the read loop on the first bad byte.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Callable, Optional
+
+
+def reconfigure_stdio_utf8_on_windows(
+    *,
+    stdin_errors: str = "surrogateescape",
+    stdout_errors: str = "strict",
+    stderr_errors: str = "strict",
+    on_failure: Optional[Callable[[str, BaseException], None]] = None,
+) -> None:
+    """Reconfigure stdio to UTF-8 on Windows. No-op elsewhere.
+
+    Args:
+        stdin_errors: errors= policy for stdin.reconfigure().
+        stdout_errors: errors= policy for stdout.reconfigure().
+        stderr_errors: errors= policy for stderr.reconfigure().
+        on_failure: optional ``(stream_name, exc) -> None`` callback for
+            streams whose ``reconfigure`` raises (e.g. Jupyter-replaced
+            streams that lack the method-shape we expect). Defaults to a
+            ``WARNING:`` line on the original sys.stderr.
+    """
+    if sys.platform != "win32":
+        return
+
+    policies = (
+        ("stdin", stdin_errors),
+        ("stdout", stdout_errors),
+        ("stderr", stderr_errors),
+    )
+    for name, errors in policies:
+        stream = getattr(sys, name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors=errors)
+        except Exception as exc:  # noqa: BLE001 -- last-resort guard
+            if on_failure is not None:
+                on_failure(name, exc)
+            else:
+                print(
+                    f"WARNING: Could not reconfigure {name} to UTF-8: {exc}",
+                    file=sys.stderr,
+                )

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -943,16 +943,32 @@ def _reconfigure_stdio_utf8_on_windows():
     content piped in (`mempalace search ... < query.txt`) or piped out
     (`mempalace search "..." > out.txt`) when verbatim drawer text or
     wing/room names contain non-Latin characters.
+
+    Per-stream errors policy:
+      stdin  -- surrogateescape: malformed bytes from a redirected file
+                survive as lone surrogates instead of crashing the read.
+      stdout -- replace: ``mempalace search`` prints verbatim drawer
+                text. A drawer that round-tripped a filename through
+                surrogateescape can hold a lone surrogate, which would
+                otherwise raise ``UnicodeEncodeError`` mid-print and
+                lose the rest of the search result block.
+      stderr -- replace: same hazard for logger output that quotes
+                user-supplied path or content.
     """
     if sys.platform != "win32":
         return
-    for name in ("stdin", "stdout", "stderr"):
+    policies = (
+        ("stdin", "surrogateescape"),
+        ("stdout", "replace"),
+        ("stderr", "replace"),
+    )
+    for name, errors in policies:
         stream = getattr(sys, name, None)
         reconfigure = getattr(stream, "reconfigure", None)
         if reconfigure is None:
             continue
         try:
-            reconfigure(encoding="utf-8", errors="strict")
+            reconfigure(encoding="utf-8", errors=errors)
         except Exception as exc:
             print(
                 f"WARNING: Could not reconfigure {name} to UTF-8: {exc}",

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -938,42 +938,17 @@ def cmd_compress(args):
 def _reconfigure_stdio_utf8_on_windows():
     """Decode stdio as UTF-8 on Windows for the primary `mempalace` CLI.
 
-    Without this, Python defaults stdio to the system ANSI codepage
-    (cp1252/cp1251/cp950 depending on locale). That mojibakes non-ASCII
-    content piped in (`mempalace search ... < query.txt`) or piped out
-    (`mempalace search "..." > out.txt`) when verbatim drawer text or
-    wing/room names contain non-Latin characters.
-
-    Per-stream errors policy:
-      stdin  -- surrogateescape: malformed bytes from a redirected file
-                survive as lone surrogates instead of crashing the read.
-      stdout -- replace: ``mempalace search`` prints verbatim drawer
-                text. A drawer that round-tripped a filename through
-                surrogateescape can hold a lone surrogate, which would
-                otherwise raise ``UnicodeEncodeError`` mid-print and
-                lose the rest of the search result block.
-      stderr -- replace: same hazard for logger output that quotes
-                user-supplied path or content.
+    Thin wrapper around the shared helper in ``mempalace._stdio``. The CLI
+    overrides stdout/stderr to ``replace`` because ``mempalace search``
+    prints verbatim drawer text that may carry surrogate halves
+    round-tripped from filenames -- ``strict`` would crash mid-print and
+    lose the rest of the search result block. stdin keeps the default
+    ``surrogateescape`` so a redirected non-UTF-8 file does not kill the
+    read on the first bad byte.
     """
-    if sys.platform != "win32":
-        return
-    policies = (
-        ("stdin", "surrogateescape"),
-        ("stdout", "replace"),
-        ("stderr", "replace"),
-    )
-    for name, errors in policies:
-        stream = getattr(sys, name, None)
-        reconfigure = getattr(stream, "reconfigure", None)
-        if reconfigure is None:
-            continue
-        try:
-            reconfigure(encoding="utf-8", errors=errors)
-        except Exception as exc:
-            print(
-                f"WARNING: Could not reconfigure {name} to UTF-8: {exc}",
-                file=sys.stderr,
-            )
+    from ._stdio import reconfigure_stdio_utf8_on_windows
+
+    reconfigure_stdio_utf8_on_windows(stdout_errors="replace", stderr_errors="replace")
 
 
 def main():

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -935,7 +935,34 @@ def cmd_compress(args):
         print("  (dry run -- nothing stored)")
 
 
+def _reconfigure_stdio_utf8_on_windows():
+    """Decode stdio as UTF-8 on Windows for the primary `mempalace` CLI.
+
+    Without this, Python defaults stdio to the system ANSI codepage
+    (cp1252/cp1251/cp950 depending on locale). That mojibakes non-ASCII
+    content piped in (`mempalace search ... < query.txt`) or piped out
+    (`mempalace search "..." > out.txt`) when verbatim drawer text or
+    wing/room names contain non-Latin characters.
+    """
+    if sys.platform != "win32":
+        return
+    for name in ("stdin", "stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="strict")
+        except Exception as exc:
+            print(
+                f"WARNING: Could not reconfigure {name} to UTF-8: {exc}",
+                file=sys.stderr,
+            )
+
+
 def main():
+    _reconfigure_stdio_utf8_on_windows()
+
     version_label = f"MemPalace {__version__}"
     parser = argparse.ArgumentParser(
         description="MemPalace — Give your AI a memory. No API key required.",

--- a/mempalace/fact_checker.py
+++ b/mempalace/fact_checker.py
@@ -303,10 +303,37 @@ def _edit_distance(s1: str, s2: str) -> int:
     return prev[-1]
 
 
+def _reconfigure_stdio_utf8_on_windows():
+    """Decode --stdin payload as UTF-8 on Windows.
+
+    Without this, Python defaults stdio to the system ANSI codepage
+    (cp1252/cp1251/cp950 depending on locale), which mojibakes
+    non-ASCII fact text before pattern parsing sees it.
+    """
+    import sys
+
+    if sys.platform != "win32":
+        return
+    for name in ("stdin", "stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="strict")
+        except Exception as exc:
+            print(
+                f"WARNING: Could not reconfigure {name} to UTF-8: {exc}",
+                file=sys.stderr,
+            )
+
+
 if __name__ == "__main__":
     import argparse
     import json
     import sys
+
+    _reconfigure_stdio_utf8_on_windows()
 
     parser = argparse.ArgumentParser(
         description="Check text against known facts in the MemPalace palace.",

--- a/mempalace/fact_checker.py
+++ b/mempalace/fact_checker.py
@@ -309,18 +309,32 @@ def _reconfigure_stdio_utf8_on_windows():
     Without this, Python defaults stdio to the system ANSI codepage
     (cp1252/cp1251/cp950 depending on locale), which mojibakes
     non-ASCII fact text before pattern parsing sees it.
+
+    Per-stream errors policy mirrors the primary CLI helper in
+    ``mempalace/cli.py``:
+      stdin  -- surrogateescape: malformed input bytes survive as lone
+                surrogates instead of crashing the read.
+      stdout -- replace: extracted fact text can include surrogate
+                halves round-tripped from filenames; replace prevents
+                a UnicodeEncodeError mid-print.
+      stderr -- replace: same protection for warning lines.
     """
     import sys
 
     if sys.platform != "win32":
         return
-    for name in ("stdin", "stdout", "stderr"):
+    policies = (
+        ("stdin", "surrogateescape"),
+        ("stdout", "replace"),
+        ("stderr", "replace"),
+    )
+    for name, errors in policies:
         stream = getattr(sys, name, None)
         reconfigure = getattr(stream, "reconfigure", None)
         if reconfigure is None:
             continue
         try:
-            reconfigure(encoding="utf-8", errors="strict")
+            reconfigure(encoding="utf-8", errors=errors)
         except Exception as exc:
             print(
                 f"WARNING: Could not reconfigure {name} to UTF-8: {exc}",

--- a/mempalace/fact_checker.py
+++ b/mempalace/fact_checker.py
@@ -306,40 +306,15 @@ def _edit_distance(s1: str, s2: str) -> int:
 def _reconfigure_stdio_utf8_on_windows():
     """Decode --stdin payload as UTF-8 on Windows.
 
-    Without this, Python defaults stdio to the system ANSI codepage
-    (cp1252/cp1251/cp950 depending on locale), which mojibakes
-    non-ASCII fact text before pattern parsing sees it.
-
-    Per-stream errors policy mirrors the primary CLI helper in
-    ``mempalace/cli.py``:
-      stdin  -- surrogateescape: malformed input bytes survive as lone
-                surrogates instead of crashing the read.
-      stdout -- replace: extracted fact text can include surrogate
-                halves round-tripped from filenames; replace prevents
-                a UnicodeEncodeError mid-print.
-      stderr -- replace: same protection for warning lines.
+    Thin wrapper around the shared helper in ``mempalace._stdio``. Mirrors
+    the primary CLI policy: stdout/stderr use ``replace`` because
+    extracted fact text can include surrogate halves round-tripped from
+    filenames -- ``strict`` would raise UnicodeEncodeError mid-print.
+    stdin keeps the default ``surrogateescape``.
     """
-    import sys
+    from ._stdio import reconfigure_stdio_utf8_on_windows
 
-    if sys.platform != "win32":
-        return
-    policies = (
-        ("stdin", "surrogateescape"),
-        ("stdout", "replace"),
-        ("stderr", "replace"),
-    )
-    for name, errors in policies:
-        stream = getattr(sys, name, None)
-        reconfigure = getattr(stream, "reconfigure", None)
-        if reconfigure is None:
-            continue
-        try:
-            reconfigure(encoding="utf-8", errors=errors)
-        except Exception as exc:
-            print(
-                f"WARNING: Could not reconfigure {name} to UTF-8: {exc}",
-                file=sys.stderr,
-            )
+    reconfigure_stdio_utf8_on_windows(stdout_errors="replace", stderr_errors="replace")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1076,10 +1076,13 @@ def test_reconfigures_stdio_to_utf8_on_windows():
     ):
         _reconfigure_stdio_utf8_on_windows()
 
-    expected = {"encoding": "utf-8", "errors": "strict"}
-    assert stdin.reconfigure_calls == [expected]
-    assert stdout.reconfigure_calls == [expected]
-    assert stderr.reconfigure_calls == [expected]
+    # Per-stream errors policy: stdin survives bad bytes via
+    # surrogateescape so a redirected non-UTF-8 file does not crash
+    # the read; stdout/stderr use replace so a drawer carrying a
+    # round-tripped surrogate half does not crash mid-print.
+    assert stdin.reconfigure_calls == [{"encoding": "utf-8", "errors": "surrogateescape"}]
+    assert stdout.reconfigure_calls == [{"encoding": "utf-8", "errors": "replace"}]
+    assert stderr.reconfigure_calls == [{"encoding": "utf-8", "errors": "replace"}]
 
 
 def test_reconfigure_stdio_is_noop_off_windows():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1042,3 +1042,55 @@ def test_cmd_repair_trailing_slash_does_not_recurse():
     palace_path = os.path.expanduser(args.palace).rstrip(os.sep)
     backup_path = palace_path + ".backup"
     assert not backup_path.startswith(palace_path + os.sep)
+
+
+# ── stdio reconfigure on Windows ─────────────────────────────────────
+
+
+class _ReconfigurableStringIO:
+    def __init__(self):
+        self.reconfigure_calls = []
+
+    def reconfigure(self, **kwargs):
+        self.reconfigure_calls.append(kwargs)
+
+
+def test_reconfigures_stdio_to_utf8_on_windows():
+    """Windows `mempalace` CLI must decode/encode stdio as UTF-8.
+
+    Without this, piped non-ASCII input (`mempalace search ... < q.txt`)
+    or piped non-ASCII output (`mempalace search "..." > out.txt`) is
+    mojibaked through the system ANSI codepage on non-Latin Windows
+    locales (cp1252/cp1251/cp950).
+    """
+    from mempalace.cli import _reconfigure_stdio_utf8_on_windows
+
+    stdin = _ReconfigurableStringIO()
+    stdout = _ReconfigurableStringIO()
+    stderr = _ReconfigurableStringIO()
+    with (
+        patch.object(sys, "platform", "win32"),
+        patch.object(sys, "stdin", stdin),
+        patch.object(sys, "stdout", stdout),
+        patch.object(sys, "stderr", stderr),
+    ):
+        _reconfigure_stdio_utf8_on_windows()
+
+    expected = {"encoding": "utf-8", "errors": "strict"}
+    assert stdin.reconfigure_calls == [expected]
+    assert stdout.reconfigure_calls == [expected]
+    assert stderr.reconfigure_calls == [expected]
+
+
+def test_reconfigure_stdio_is_noop_off_windows():
+    """Linux/macOS already default to UTF-8 stdio -- helper must not touch streams."""
+    from mempalace.cli import _reconfigure_stdio_utf8_on_windows
+
+    stdin = _ReconfigurableStringIO()
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch.object(sys, "stdin", stdin),
+    ):
+        _reconfigure_stdio_utf8_on_windows()
+
+    assert stdin.reconfigure_calls == []

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -286,3 +286,63 @@ class TestCLI:
         assert "similar_name" in out
         # Silence unused import warning.
         _ = (MagicMock, patch, fact_checker)
+
+    def test_reconfigures_stdio_to_utf8_on_windows(self):
+        """Windows fact_checker --stdin must decode payload as UTF-8.
+
+        Without this, Python defaults stdio to the system ANSI codepage
+        (cp1252/cp1251/cp950), which mojibakes non-ASCII text before
+        pattern parsing sees it.
+        """
+        import io
+        import sys
+
+        from mempalace.fact_checker import _reconfigure_stdio_utf8_on_windows
+
+        class _ReconfigurableStringIO(io.StringIO):
+            def __init__(self, initial_value=""):
+                super().__init__(initial_value)
+                self.reconfigure_calls = []
+
+            def reconfigure(self, **kwargs):
+                self.reconfigure_calls.append(kwargs)
+
+        stdin = _ReconfigurableStringIO()
+        stdout = _ReconfigurableStringIO()
+        stderr = _ReconfigurableStringIO()
+        with (
+            patch.object(sys, "platform", "win32"),
+            patch.object(sys, "stdin", stdin),
+            patch.object(sys, "stdout", stdout),
+            patch.object(sys, "stderr", stderr),
+        ):
+            _reconfigure_stdio_utf8_on_windows()
+
+        expected = {"encoding": "utf-8", "errors": "strict"}
+        assert stdin.reconfigure_calls == [expected]
+        assert stdout.reconfigure_calls == [expected]
+        assert stderr.reconfigure_calls == [expected]
+
+    def test_reconfigure_stdio_is_noop_off_windows(self):
+        """Linux/macOS already default to UTF-8 stdio -- helper must not touch streams."""
+        import io
+        import sys
+
+        from mempalace.fact_checker import _reconfigure_stdio_utf8_on_windows
+
+        class _ReconfigurableStringIO(io.StringIO):
+            def __init__(self):
+                super().__init__()
+                self.reconfigure_calls = []
+
+            def reconfigure(self, **kwargs):
+                self.reconfigure_calls.append(kwargs)
+
+        stdin = _ReconfigurableStringIO()
+        with (
+            patch.object(sys, "platform", "linux"),
+            patch.object(sys, "stdin", stdin),
+        ):
+            _reconfigure_stdio_utf8_on_windows()
+
+        assert stdin.reconfigure_calls == []

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -318,10 +318,13 @@ class TestCLI:
         ):
             _reconfigure_stdio_utf8_on_windows()
 
-        expected = {"encoding": "utf-8", "errors": "strict"}
-        assert stdin.reconfigure_calls == [expected]
-        assert stdout.reconfigure_calls == [expected]
-        assert stderr.reconfigure_calls == [expected]
+        # Per-stream errors policy: stdin uses surrogateescape so a stray
+        # malformed byte from a redirected file does not crash the read,
+        # stdout/stderr use replace so an extracted fact carrying a
+        # surrogate half does not crash mid-print.
+        assert stdin.reconfigure_calls == [{"encoding": "utf-8", "errors": "surrogateescape"}]
+        assert stdout.reconfigure_calls == [{"encoding": "utf-8", "errors": "replace"}]
+        assert stderr.reconfigure_calls == [{"encoding": "utf-8", "errors": "replace"}]
 
     def test_reconfigure_stdio_is_noop_off_windows(self):
         """Linux/macOS already default to UTF-8 stdio -- helper must not touch streams."""


### PR DESCRIPTION
## What

Reconfigure stdin/stdout/stderr to UTF-8 on Windows in two entry points, with a per-stream `errors` policy that matches what each one writes:

- `mempalace/cli.py:main()` -- the primary `mempalace` console_script
- `mempalace/fact_checker.py:__main__` -- `python -m mempalace.fact_checker --stdin`

Per-stream policy:

- **stdin** -- `surrogateescape`: a malformed byte from a redirected file (or a misbehaving caller) becomes a lone surrogate the consumer's parser surfaces, instead of `UnicodeDecodeError` killing the read on the first bad byte.
- **stdout** -- `replace`: `mempalace search` and the fact_checker `--stdin` path both print verbatim drawer / fact text. A drawer that round-tripped a filename through `surrogateescape` can carry a lone surrogate; `strict` would `UnicodeEncodeError` mid-print and lose the rest of the result block. `replace` substitutes U+FFFD instead and the result still renders.
- **stderr** -- `replace`: same hazard for warning lines that quote user-supplied paths.

## Why

On Windows, Python defaults stdio to the system ANSI codepage (cp1252/cp1251/cp950 depending on locale). That mojibakes non-ASCII content at the process boundary -- a hard bug to debug because verbatim drawer text gets corrupted in pipes, and arguments / interactive input read through `input()` come back garbled.

After auditing every stdio entry point on `develop`, three user-facing console_scripts / module invocations route non-ASCII content through `sys.stdin` / `sys.stdout`:

- `mempalace/mcp_server.py:main()` -- already fixed in #400
- `mempalace/hooks_cli.py:run_hook()` -- already fixed in #1280
- `mempalace/cli.py:main()` and `mempalace/fact_checker.py:__main__` -- this PR

After this PR all three of the package's user-facing stdio entry points reconfigure identically on Windows.

### `mempalace/cli.py:main()`

The primary CLI dispatches to subcommands that print verbatim drawer text and wing/room names (`mempalace search`, `mempalace status`, `mempalace wake-up`) and read non-ASCII names via `input()` through interactive flows (`mempalace init` -> onboarding -> entity / room detectors).

Concrete failure modes:

- `mempalace search "..." > out.txt` -- piped stdout mojibakes drawer text containing Cyrillic / CJK
- `mempalace ... < input.txt` -- piped stdin mojibakes non-ASCII content before subcommand sees it
- Interactive flows on a non-Latin Windows console fall back to ANSI codepage when stdin is redirected (CI scripts, test harnesses)

The reconfigure cascades to every subcommand because `sys.stdin` / `sys.stdout` are the same module-global streams that `cmd_init`, `cmd_search`, `cmd_status`, `cmd_hook`, etc. inherit.

### `mempalace/fact_checker.py:__main__`

`fact_checker.py:325` calls `sys.stdin.read()` from the `__main__` block when invoked as `python -m mempalace.fact_checker --stdin`. Same Windows codepage failure mode -- non-ASCII fact text comes back as mojibake before pattern parsing sees it. Low-traffic CLI utility, fixed for sweep consistency rather than in response to a user-filed bug.

## How

Shared helper in `mempalace/_stdio.py`:

```python
def reconfigure_stdio_utf8_on_windows(
    *,
    stdin_errors: str = "surrogateescape",
    stdout_errors: str = "strict",
    stderr_errors: str = "strict",
    on_failure: Callable[[str, BaseException], None] | None = None,
) -> None:
    ...
```

No-op off Windows. Each stream's reconfigure is wrapped in try/except so a replaced stream (Jupyter, test harness) routes through the `on_failure` callback (defaults to a `WARNING:` line on `sys.stderr`) and continues rather than crashing the entry point.

`cli.py` and `fact_checker.py` ship thin wrappers that pass the CLI policy (`stdout_errors="replace"`, `stderr_errors="replace"`); the MCP-side reconfigure (#400) shares the same helper with its strict policy via the same module. The thin wrappers preserve the existing `_reconfigure_stdio_utf8_on_windows()` import surface so existing tests stay shape-compatible.

## Tests

`tests/test_cli.py`:

- `test_reconfigures_stdio_to_utf8_on_windows` -- patches `sys.platform = "win32"` plus a `ReconfigurableStringIO` for each stream; asserts each received the right per-stream `reconfigure(encoding="utf-8", errors=...)` exactly once (stdin=surrogateescape, stdout/stderr=replace).
- `test_reconfigure_stdio_is_noop_off_windows` -- patches `sys.platform = "linux"`; asserts no reconfigure call.

`tests/test_fact_checker.py::TestCLI`:

- Same two tests against `fact_checker._reconfigure_stdio_utf8_on_windows`.

Local run: 83 passed (cli + fact_checker suites). `ruff check .` and `ruff format --check .` clean.

## Out of scope

- Existing CLI / `fact_checker` detection logic is unchanged.
- No changes to imports, public API, or behavior off Windows.
- File I/O sites with `open()` / `Path.read_text()` lacking explicit `encoding="utf-8"` are a separate bug class (mojibake on file content, not stdio) and would warrant their own audit.
- Internal utility scripts invoked as `python -m mempalace.<module>` for development (dialect, diary_ingest, repair, spellcheck, etc.) are not in this sweep -- they are reached through `mempalace ...` subcommands which now reconfigure at `cli.py:main()` and inherit the UTF-8 streams.

---

_Body updated 2026-05-03 to match landed code: `03643eb` switched the `errors` policy from blanket `strict` to per-stream (stdin=surrogateescape, stdout/stderr=replace) so a redirected file with bad bytes does not crash the read and a drawer carrying a surrogate half from a filename round-trip does not crash mid-print; `285b3b4` extracted the loop into `mempalace/_stdio.py` so the CLI / fact_checker / mcp_server entry points share one helper instead of carrying duplicate copies._
