### PR TITLE
fix: MCP server JSON output ensure_ascii=False for non-ASCII support

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2053,7 +2053,11 @@ def handle_request(request):
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "result": {"content": [{"type": "text", "text": json.dumps(result, indent=2, ensure_ascii=False)}]},
+                "result": {
+                    "content": [
+                        {"type": "text", "text": json.dumps(result, indent=2, ensure_ascii=False)}
+                    ]
+                },
             }
         except Exception:
             logger.exception(f"Tool error in {tool_name}")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2053,7 +2053,7 @@ def handle_request(request):
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "result": {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]},
+                "result": {"content": [{"type": "text", "text": json.dumps(result, indent=2, ensure_ascii=False)}]},
             }
         except Exception:
             logger.exception(f"Tool error in {tool_name}")
@@ -2114,7 +2114,7 @@ def main():
             request = json.loads(line)
             response = handle_request(request)
             if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
+                sys.stdout.write(json.dumps(response, ensure_ascii=False) + "\n")
                 sys.stdout.flush()
         except KeyboardInterrupt:
             break


### PR DESCRIPTION
## Summary
- Add `ensure_ascii=False` to both `json.dumps` calls in MCP server, so non-ASCII characters (e.g. Chinese) are preserved as-is instead of being escaped as `\uXXXX`.

## Background
This change was originally part of PR #1291. Per reviewer feedback from @igrots, the `ensure_ascii=False` fix is being split into its own PR since it is independently valuable and applies to all platforms (not just Windows).

Without this fix, downstream MCP clients receive escaped Unicode sequences instead of the original characters, which breaks non-ASCII content display.

## Test plan
- [ ] Verify Chinese characters in tool results are returned verbatim (not as `\uXXXX`)
- [ ] Verify JSON-RPC responses preserve non-ASCII characters
- [ ] Verify no regression on ASCII-only content