### PR TITLE
fix(init): preserve external LLM consent provenance

### DIFF
--- a/mempalace/llm_client.py
+++ b/mempalace/llm_client.py
@@ -258,11 +258,30 @@ class OpenAICompatProvider(LLMProvider):
         endpoint: Optional[str] = None,
         api_key: Optional[str] = None,
         timeout: int = 120,
+        api_key_source: Optional[str] = None,
         **_: object,
     ):
-        if api_key:
+        if api_key_source is not None:
+            if api_key_source not in {"env", "flag"}:
+                raise LLMError(
+                    "api_key_source must be one of {'env', 'flag'} "
+                    f"or None, got {api_key_source!r}"
+                )
+            if api_key is not None:
+                resolved_key = api_key
+                source: Optional[str] = api_key_source
+            elif api_key_source == "env":
+                env_key = os.environ.get("OPENAI_API_KEY")
+                resolved_key = env_key or None
+                source = "env" if env_key else None
+            else:
+                raise LLMError(
+                    "api_key must be provided when api_key_source is set "
+                    f"to {api_key_source!r}"
+                )
+        elif api_key is not None:
             resolved_key = api_key
-            source: Optional[str] = "flag"
+            source = "flag"
         else:
             env_key = os.environ.get("OPENAI_API_KEY")
             resolved_key = env_key or None
@@ -271,8 +290,8 @@ class OpenAICompatProvider(LLMProvider):
             model=model,
             endpoint=endpoint,
             api_key=resolved_key,
-            timeout=timeout,
             api_key_source=source,
+            timeout=timeout,
         )
 
     def _resolve_url(self) -> str:
@@ -338,11 +357,30 @@ class AnthropicProvider(LLMProvider):
         api_key: Optional[str] = None,
         endpoint: Optional[str] = None,
         timeout: int = 120,
+        api_key_source: Optional[str] = None,
         **_: object,
     ):
-        if api_key:
+        if api_key_source is not None:
+            if api_key_source not in {"env", "flag"}:
+                raise LLMError(
+                    "api_key_source must be one of {'env', 'flag'} "
+                    f"or None, got {api_key_source!r}"
+                )
+            if api_key is not None:
+                resolved_key = api_key
+                source: Optional[str] = api_key_source
+            elif api_key_source == "env":
+                env_key = os.environ.get("ANTHROPIC_API_KEY")
+                resolved_key = env_key or None
+                source = "env" if env_key else None
+            else:
+                raise LLMError(
+                    "api_key must be provided when api_key_source is set "
+                    f"to {api_key_source!r}"
+                )
+        elif api_key is not None:
             resolved_key = api_key
-            source: Optional[str] = "flag"
+            source = "flag"
         else:
             env_key = os.environ.get("ANTHROPIC_API_KEY")
             resolved_key = env_key or None
@@ -351,8 +389,8 @@ class AnthropicProvider(LLMProvider):
             model=model,
             endpoint=endpoint or self.DEFAULT_ENDPOINT,
             api_key=resolved_key,
-            timeout=timeout,
             api_key_source=source,
+            timeout=timeout,
         )
 
     def check_available(self) -> tuple[bool, str]:
@@ -409,9 +447,16 @@ def get_provider(
     endpoint: Optional[str] = None,
     api_key: Optional[str] = None,
     timeout: int = 120,
+    api_key_source: Optional[str] = None,
 ) -> LLMProvider:
     """Build a provider by name. Raises LLMError on unknown provider."""
     cls = PROVIDERS.get(name)
     if cls is None:
         raise LLMError(f"Unknown provider '{name}'. Choices: {sorted(PROVIDERS.keys())}")
-    return cls(model=model, endpoint=endpoint, api_key=api_key, timeout=timeout)
+    return cls(
+        model=model,
+        endpoint=endpoint,
+        api_key=api_key,
+        api_key_source=api_key_source,
+        timeout=timeout,
+    )

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -13,6 +13,7 @@ import pytest
 from mempalace.llm_client import (
     AnthropicProvider,
     LLMError,
+    LLMProvider,
     OllamaProvider,
     OpenAICompatProvider,
     _http_post_json,
@@ -39,6 +40,57 @@ def test_get_provider_anthropic():
     p = get_provider("anthropic", "claude-haiku", api_key="sk-xxx")
     assert isinstance(p, AnthropicProvider)
     assert p.api_key == "sk-xxx"
+
+
+def test_get_provider_preserves_positional_timeout_compatibility():
+    p = get_provider("openai-compat", "foo", "http://localhost:1234", None, 30)
+    assert isinstance(p, OpenAICompatProvider)
+    assert p.timeout == 30
+
+
+def test_llm_provider_preserves_positional_timeout_compatibility():
+    p = LLMProvider("foo", "http://localhost:1234", None, 30)
+    assert p.endpoint == "http://localhost:1234"
+    assert p.timeout == 30
+    assert p.api_key_source is None
+
+
+def test_openai_compat_preserves_positional_timeout_compatibility():
+    p = OpenAICompatProvider("foo", "http://localhost:1234", None, 30)
+    assert p.endpoint == "http://localhost:1234"
+    assert p.timeout == 30
+
+
+def test_anthropic_preserves_positional_endpoint_timeout_compatibility():
+    p = AnthropicProvider("claude-haiku", "sk-ant-flag", "https://api.example", 30)
+    assert p.api_key == "sk-ant-flag"
+    assert p.endpoint == "https://api.example"
+    assert p.timeout == 30
+
+
+def test_get_provider_forwards_openai_compat_api_key_source(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    p = get_provider(
+        "openai-compat",
+        "foo",
+        endpoint="http://localhost:1234",
+        api_key_source="env",
+    )
+    assert isinstance(p, OpenAICompatProvider)
+    assert p.api_key == "sk-from-env"
+    assert p.api_key_source == "env"
+
+
+def test_get_provider_forwards_anthropic_api_key_source(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+    p = get_provider(
+        "anthropic",
+        "claude-haiku",
+        api_key_source="env",
+    )
+    assert isinstance(p, AnthropicProvider)
+    assert p.api_key == "sk-ant-env"
+    assert p.api_key_source == "env"
 
 
 def test_get_provider_unknown_raises():
@@ -463,6 +515,72 @@ def test_openai_compat_api_key_source_env_when_fallback(monkeypatch):
     ), f"Env-fallback api_key must produce api_key_source='env'; got {p.api_key_source!r}"
 
 
+def test_openai_compat_api_key_source_can_be_overridden_explicitly(monkeypatch):
+    """A caller that already resolved provenance should be able to pass
+    it through unchanged, even when the same env var is also present."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env-irrelevant")
+    p = OpenAICompatProvider(
+        model="x",
+        endpoint="http://h",
+        api_key="sk-from-flag",
+        api_key_source="env",
+    )
+    assert p.api_key == "sk-from-flag"
+    assert p.api_key_source == "env"
+
+
+def test_openai_compat_api_key_source_flag_without_key_is_rejected(monkeypatch):
+    """api_key_source='flag' must not be accepted without an explicit key."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    with pytest.raises(LLMError, match="api_key must be provided"):
+        OpenAICompatProvider(
+            model="x",
+            endpoint="http://h",
+            api_key_source="flag",
+        )
+
+
+def test_openai_compat_explicit_env_source_clears_when_env_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    p = OpenAICompatProvider(
+        model="x",
+        endpoint="http://h",
+        api_key_source="env",
+    )
+    assert p.api_key is None
+    assert p.api_key_source is None
+
+
+def test_openai_compat_explicit_env_source_clears_when_env_empty(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    p = OpenAICompatProvider(
+        model="x",
+        endpoint="http://h",
+        api_key_source="env",
+    )
+    assert p.api_key is None
+    assert p.api_key_source is None
+
+
+def test_openai_compat_empty_api_key_is_treated_as_explicit(monkeypatch):
+    """Explicit empty strings should still count as provided values."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    p = OpenAICompatProvider(model="x", endpoint="http://h", api_key="")
+    assert p.api_key == ""
+    assert p.api_key_source == "flag"
+
+
+def test_openai_compat_invalid_api_key_source_is_rejected():
+    """Only supported provenance values should be accepted."""
+    with pytest.raises(LLMError, match="api_key_source must be one of"):
+        OpenAICompatProvider(
+            model="x",
+            endpoint="http://h",
+            api_key="sk-from-flag",
+            api_key_source="bogus",
+        )
+
+
 def test_anthropic_api_key_source_tracking(monkeypatch):
     """AnthropicProvider tracks api_key_source the same way: 'flag' when
     passed explicitly, 'env' when resolved from ANTHROPIC_API_KEY env."""
@@ -476,6 +594,66 @@ def test_anthropic_api_key_source_tracking(monkeypatch):
     assert (
         p_env.api_key_source == "env"
     ), f"Env-fallback must produce 'env'; got {p_env.api_key_source!r}"
+
+
+def test_anthropic_api_key_source_can_be_overridden_explicitly(monkeypatch):
+    """Explicit provenance should be preserved even when an env key is present."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+    p = AnthropicProvider(
+        model="claude-haiku",
+        api_key="sk-ant-flag",
+        api_key_source="env",
+    )
+    assert p.api_key == "sk-ant-flag"
+    assert p.api_key_source == "env"
+
+
+def test_anthropic_api_key_source_flag_without_key_is_rejected(monkeypatch):
+    """api_key_source='flag' must not be accepted without an explicit key."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+    with pytest.raises(LLMError, match="api_key must be provided"):
+        AnthropicProvider(
+            model="claude-haiku",
+            api_key_source="flag",
+        )
+
+
+def test_anthropic_explicit_env_source_clears_when_env_missing(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    p = AnthropicProvider(
+        model="claude-haiku",
+        api_key_source="env",
+    )
+    assert p.api_key is None
+    assert p.api_key_source is None
+
+
+def test_anthropic_explicit_env_source_clears_when_env_empty(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    p = AnthropicProvider(
+        model="claude-haiku",
+        api_key_source="env",
+    )
+    assert p.api_key is None
+    assert p.api_key_source is None
+
+
+def test_anthropic_empty_api_key_is_treated_as_explicit(monkeypatch):
+    """Explicit empty strings should still count as provided values."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+    p = AnthropicProvider(model="claude-haiku", api_key="")
+    assert p.api_key == ""
+    assert p.api_key_source == "flag"
+
+
+def test_anthropic_invalid_api_key_source_is_rejected():
+    """Only supported provenance values should be accepted."""
+    with pytest.raises(LLMError, match="api_key_source must be one of"):
+        AnthropicProvider(
+            model="claude-haiku",
+            api_key="sk-ant-flag",
+            api_key_source="bogus",
+        )
 
 
 def test_ollama_api_key_source_is_none():


### PR DESCRIPTION
## What does this PR do?

- Preserves LLM API key provenance across direct provider construction and `get_provider()` for OpenAI-compatible and Anthropic providers.
- Distinguishes explicit keys from environment fallback so `mempalace init` can keep treating stray env keys as requiring consent.
- Rejects invalid provenance values and `api_key_source="flag"` without an explicit key.
- Normalizes explicit `api_key_source="env"` lookups so missing or empty env vars do not record an env-sourced key.
- Adds provider and factory tests for explicit keys, env fallback, explicit provenance overrides, invalid provenance, missing-key rejection, empty explicit keys, and missing/empty env variables.

## How to test

Focused LLM client tests and ruff passed locally.