### PR TITLE
fix: resolve 10K drawer pagination bug in status/taxonomy tools

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -68,7 +68,7 @@ def tool_status():
     wings = {}
     rooms = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
+        all_meta = col.get(include=["metadatas"], limit=_TAXONOMY_AGGREGATE_LIMIT)["metadatas"]
         for m in all_meta:
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
@@ -119,13 +119,24 @@ Read AAAK naturally — expand codes mentally, treat *markers* as emotional cont
 When WRITING AAAK: use entity codes, mark emotions, keep structure tight."""
 
 
+# Aggregation hard cap. 2026-04-19: the prior `limit=10000` silently truncated
+# enumeration once the palace exceeded 10k drawers — ChromaDB's col.get() returns
+# rows in insertion order, so later-added wings (memory, claude-user-memory,
+# claude-project-memory, etc.) vanished from list_wings/list_rooms/get_taxonomy
+# even though search could still find them. At 18k+ drawers, 9 of 12 wings were
+# invisible. Raising the cap to 1M gives ~50x headroom vs the current 18k palace
+# while keeping the O(n) pull-all approach. When the palace grows past ~500k,
+# replace with a direct SQL aggregate on embedding_metadata for O(wings) memory.
+_TAXONOMY_AGGREGATE_LIMIT = 1_000_000
+
+
 def tool_list_wings():
     col = _get_collection()
     if not col:
         return _no_palace()
     wings = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
+        all_meta = col.get(include=["metadatas"], limit=_TAXONOMY_AGGREGATE_LIMIT)["metadatas"]
         for m in all_meta:
             w = m.get("wing", "unknown")
             wings[w] = wings.get(w, 0) + 1
@@ -140,7 +151,7 @@ def tool_list_rooms(wing: str = None):
         return _no_palace()
     rooms = {}
     try:
-        kwargs = {"include": ["metadatas"], "limit": 10000}
+        kwargs = {"include": ["metadatas"], "limit": _TAXONOMY_AGGREGATE_LIMIT}
         if wing:
             kwargs["where"] = {"wing": wing}
         all_meta = col.get(**kwargs)["metadatas"]
@@ -158,7 +169,7 @@ def tool_get_taxonomy():
         return _no_palace()
     taxonomy = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
+        all_meta = col.get(include=["metadatas"], limit=_TAXONOMY_AGGREGATE_LIMIT)["metadatas"]
         for m in all_meta:
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
@@ -406,7 +417,7 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
         results = col.get(
             where={"$and": [{"wing": wing}, {"room": "diary"}]},
             include=["documents", "metadatas"],
-            limit=10000,
+            limit=100000,
         )
 
         if not results["ids"]:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -653,16 +653,26 @@ def status(palace_path: str):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         return
 
-    # Count by wing and room
-    r = col.get(limit=10000, include=["metadatas"])
-    metas = r["metadatas"]
+    total = col.count()
+
+    # Fetch all metadata in batches (ChromaDB defaults to limit=10000)
+    _BATCH = 5000
+    metas = []
+    offset = 0
+    while offset < total:
+        batch = col.get(limit=_BATCH, offset=offset, include=["metadatas"])
+        batch_metas = batch.get("metadatas", []) or []
+        if not batch_metas:
+            break
+        metas.extend(batch_metas)
+        offset += len(batch_metas)
 
     wing_rooms = defaultdict(lambda: defaultdict(int))
     for m in metas:
         wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
 
     print(f"\n{'=' * 55}")
-    print(f"  MemPalace Status — {len(metas)} drawers")
+    print(f"  MemPalace Status — {total} drawers")
     print(f"{'=' * 55}\n")
     for wing, rooms in sorted(wing_rooms.items()):
         print(f"  WING: {wing}")

--- a/scripts/launch-mcp-persistent.sh
+++ b/scripts/launch-mcp-persistent.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# launch-mcp-persistent.sh — stdio MCP launcher for mempalace with
+# startup retry + exponential backoff, to work around the known
+# Claude Code "Failed to reconnect to mempalace" race at session start.
+#
+# Phase 3 Part 3 of workspace-redesign-phase-2.
+#
+# Why wrapper-at-startup only (not mid-session respawn):
+# stdio MCP is a one-shot JSON-RPC session over stdin/stdout. If the child
+# dies mid-session, the parent (Claude Code) has already lost the handshake;
+# respawning a fresh child can't restore the session. The only race this
+# tool can fix is the ONE at launch time — a flaky import or venv init on
+# cold start. We retry the preflight check up to 5 times (1s, 2s, 4s, 8s,
+# 16s), and when preflight succeeds we `exec` the real server so stdin/stdout
+# pass through to the child without an extra proxy layer.
+#
+# Observability: every attempt is logged to ~/.claude/backups/mempalace-launcher.log
+# and a sentinel ~/.claude/backups/mempalace-launcher.ready is touched on
+# successful handoff (cleared on EXIT).
+
+set -u
+
+MEMPAL_DIR="${MEMPAL_DIR:-$HOME/Development/platform/mempalace}"
+MEMPAL_PY="${MEMPAL_PY:-$MEMPAL_DIR/.venv/bin/python}"
+LOG_DIR="$HOME/.claude/backups"
+LOG="$LOG_DIR/mempalace-launcher.log"
+READY="$LOG_DIR/mempalace-launcher.ready"
+PIDFILE="$LOG_DIR/mempalace-launcher.pid"
+
+mkdir -p "$LOG_DIR"
+
+log() {
+    printf '[%s] [pid=%d] %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$$" "$*" >> "$LOG"
+}
+
+cleanup() {
+    rm -f "$READY" "$PIDFILE"
+    log "launcher EXIT pid=$$"
+}
+trap cleanup EXIT
+trap 'log "SIGINT received"; exit 130' INT
+trap 'log "SIGTERM received"; exit 143' TERM
+
+log "launcher START argv=[$*] MEMPAL_PY=$MEMPAL_PY"
+echo "$$" > "$PIDFILE"
+
+preflight() {
+    if [[ ! -x "$MEMPAL_PY" ]]; then
+        log "preflight FAIL: python not executable at $MEMPAL_PY"
+        return 1
+    fi
+    local out
+    if ! out=$("$MEMPAL_PY" -c "import mempalace.mcp_server; print('ok')" 2>&1); then
+        log "preflight FAIL: import mempalace.mcp_server: $out"
+        return 1
+    fi
+    return 0
+}
+
+backoff=1
+max_attempts=5
+attempt=0
+while (( attempt < max_attempts )); do
+    attempt=$((attempt + 1))
+    if preflight; then
+        log "preflight OK (attempt=$attempt)"
+        touch "$READY"
+        log "exec $MEMPAL_PY -m mempalace.mcp_server $*"
+        # replace ourselves with the real server — stdin/stdout/stderr pass through
+        exec "$MEMPAL_PY" -m mempalace.mcp_server "$@"
+        # unreachable
+    fi
+    log "preflight failed (attempt=$attempt), sleeping ${backoff}s"
+    sleep "$backoff"
+    backoff=$((backoff * 2))
+    if (( backoff > 16 )); then
+        backoff=16
+    fi
+done
+
+log "GAVE UP after $max_attempts attempts — mempalace MCP will not start"
+exit 1


### PR DESCRIPTION
# MemPalace 10K Drawer Bug — Root Cause Analysis

## Bug
`mempalace status` reports exactly 10,000 drawers. Real count: **24,775**.

## Root Cause
ChromaDB's `collection.get()` defaults to `limit=10000` when no limit is specified, and the code explicitly passes `limit=10000` in several places. Data IS being written correctly — it's a retrieval/display bug, not a write bug.

## Evidence
```
sqlite3 ~/.mempalace/palace/chroma.sqlite3 "SELECT COUNT(*) FROM embeddings;"
→ 24775

Wing breakdown (from raw SQLite):
  development         12122
  claude-project-memory 5033
  memory               3502
  claude-user-memory   2413
  mempalace            1076
  claude-sessions       609
  + 6 small wings
```

## Affected Code Sites

### 1. `mcp_server.py:71` — `tool_status()` (**REMAINING BUG**)
```python
all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
```
`col.count()` returns the true 24,775, but the wing/room dicts are built from only the first 10K rows. The MCP `mempalace_status` tool returns correct `total_drawers` but incomplete `wings`/`rooms`.

### 2. `miner.py:657` — CLI `status()` (**REMAINING BUG**)
```python
r = col.get(limit=10000, include=["metadatas"])
metas = r["metadatas"]
# ...
print(f"  MemPalace Status — {len(metas)} drawers")  # Shows 10000!
```
Uses `len(metas)` for display instead of `col.count()`. This is the source of the "exactly 10,000 drawers" report.

### 3. `mcp_server.py:420` — `tool_diary_read()` (low risk)
```python
limit=10000
```
Unlikely to hit 10K diary entries per agent, but should be fixed for consistency.

### 4. `mcp_server.py:122-130` — Already fixed (uncommitted)
`tool_list_wings`, `tool_list_rooms`, `tool_get_taxonomy` — already patched to use `_TAXONOMY_AGGREGATE_LIMIT = 1_000_000`. This fix is in the working tree but not committed.

## Fix
- Site 1: Change `tool_status()` to use `_TAXONOMY_AGGREGATE_LIMIT` like the other tools.
- Site 2: Change CLI `status()` to use `col.count()` for the header AND paginate the metadata fetch (same pattern as `cmd_repair` already uses).
- Site 3: Change `tool_diary_read()` to use a reasonable limit (100K) or paginate.

## Confidence
**HIGH** — verified by direct SQLite count (24,775) vs displayed count (10,000). The ChromaDB `limit=10000` default is documented behavior. The partial fix for list_wings/list_rooms/get_taxonomy in the uncommitted diff confirms this was already identified for those functions but `tool_status` and `miner.status` were missed.
