### PR TITLE
fix(cli): cmd_compress writes to mempalace_closets (#1244)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -902,7 +902,7 @@ def cmd_compress(args):
     # Store compressed versions (unless dry-run)
     if not args.dry_run:
         try:
-            comp_col = backend.get_or_create_collection(palace_path, "mempalace_compressed")
+            comp_col = backend.get_or_create_collection(palace_path, "mempalace_closets")
             for doc_id, compressed, meta, stats in compressed_entries:
                 comp_meta = dict(meta)
                 comp_meta["compression_ratio"] = round(stats["size_ratio"], 1)
@@ -913,7 +913,7 @@ def cmd_compress(args):
                     metadatas=[comp_meta],
                 )
             print(
-                f"  Stored {len(compressed_entries)} compressed drawers in 'mempalace_compressed' collection."
+                f"  Stored {len(compressed_entries)} compressed drawers in 'mempalace_closets' collection."
             )
         except Exception as e:
             print(f"  Error storing compressed drawers: {e}")

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -310,8 +310,7 @@ def cmd_init(args):
                 )
         except LLMError as e:
             print(
-                f"  LLM init failed ({e}). "
-                f"Running heuristics-only — pass --no-llm to silence this."
+                f"  LLM init failed ({e}). Running heuristics-only — pass --no-llm to silence this."
             )
 
     # Pass 0: detect whether the corpus is AI-dialogue. Writes

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -930,9 +930,9 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     # Verify the compress output goes to the closets collection so that
     # palace.get_closets_collection() / searcher can read it back (#1244).
     (call_args, _kwargs) = mock_backend.get_or_create_collection.call_args
-    assert call_args[1] == "mempalace_closets", (
-        f"compress should write to mempalace_closets, got {call_args[1]!r}"
-    )
+    assert (
+        call_args[1] == "mempalace_closets"
+    ), f"compress should write to mempalace_closets, got {call_args[1]!r}"
     assert "mempalace_closets" in out
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -889,7 +889,7 @@ def test_cmd_compress_with_config(mock_config_cls, tmp_path, capsys):
 
 @patch("mempalace.cli.MempalaceConfig")
 def test_cmd_compress_stores_results(mock_config_cls, capsys):
-    """Non-dry-run compress stores to mempalace_compressed collection."""
+    """Non-dry-run compress stores to mempalace_closets collection (#1244)."""
     mock_config_cls.return_value.palace_path = "/fake/palace"
     args = argparse.Namespace(palace=None, wing=None, dry_run=False, config=None)
     mock_col = MagicMock()
@@ -927,6 +927,53 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     assert "Stored" in out
     assert "Total:" in out
     mock_comp_col.upsert.assert_called_once()
+    # Verify the compress output goes to the closets collection so that
+    # palace.get_closets_collection() / searcher can read it back (#1244).
+    (call_args, _kwargs) = mock_backend.get_or_create_collection.call_args
+    assert call_args[1] == "mempalace_closets", (
+        f"compress should write to mempalace_closets, got {call_args[1]!r}"
+    )
+    assert "mempalace_closets" in out
+
+
+def test_cmd_compress_output_readable_via_get_closets_collection(tmp_path, capsys):
+    """End-to-end: cmd_compress output must be readable via the same code
+    path palace.py uses (`get_closets_collection`). Regression for #1244."""
+    from mempalace.backends.chroma import ChromaBackend
+    from mempalace.palace import get_closets_collection, get_collection
+
+    palace_path = str(tmp_path / "palace")
+
+    # Seed a drawer in the palace so cmd_compress has something to compress.
+    drawers = get_collection(palace_path, "mempalace_drawers", create=True)
+    drawers.upsert(
+        ids=["drawer-1"],
+        documents=["The quick brown fox jumps over the lazy dog."],
+        metadatas=[{"wing": "test", "room": "demo", "source_file": "fox.txt"}],
+    )
+
+    args = argparse.Namespace(palace=palace_path, wing=None, dry_run=False, config=None)
+    with patch("mempalace.cli.MempalaceConfig") as mock_config_cls:
+        mock_config_cls.return_value.palace_path = palace_path
+        # Use a real ChromaBackend so the write actually lands on disk and
+        # the read-side helper can find it.
+        with patch("mempalace.backends.chroma.ChromaBackend", side_effect=ChromaBackend):
+            cmd_compress(args)
+
+    out = capsys.readouterr().out
+    assert "Stored" in out
+
+    # Now read via the *same* code path palace.py / searcher uses.
+    closets = get_closets_collection(palace_path, create=False)
+    got = closets.get(ids=["drawer-1"], include=["documents", "metadatas"])
+    assert got["ids"] == ["drawer-1"], (
+        "compressed drawer not found in mempalace_closets — "
+        "cmd_compress wrote to the wrong collection (#1244)"
+    )
+    assert got["documents"] and got["documents"][0], "empty compressed doc"
+    meta = got["metadatas"][0]
+    assert meta.get("wing") == "test"
+    assert "compression_ratio" in meta
 
 
 def test_cmd_repair_trailing_slash_does_not_recurse():


### PR DESCRIPTION
Closes #1244.

## Problem

`cmd_compress` (in `mempalace/cli.py`) was writing AAAK-compressed drawers to a collection named `mempalace_compressed`, but every read path in the codebase reads from `mempalace_closets`:

- `mempalace/palace.py::get_closets_collection` (the canonical accessor)
- `mempalace/searcher.py` (hybrid search)
- `mempalace/repair.py` (HNSW capacity check)
- `mempalace/closet_llm.py`, `mempalace/diary_ingest.py`, `mempalace/miner.py`

So for any user running `mempalace compress` to backfill the closet/index layer on a non-mined palace, the compressed output was silently written to a dead collection nothing else opens — invisible to search, never scanned by the LLM.

## Fix

Update the writer in `cmd_compress` to use `mempalace_closets` (matching the readers), instead of renaming the 15+ readers. Rationale:

- "Closets" is the user-visible feature name in docs, the public API (`get_closets_collection`), README claims tests, and architectural diagrams.
- The compressed AAAK strings are exactly what closets are conceptually — compact pointers an LLM scans to locate the right drawer.
- Single-site change; no public API churn.

## Tests

- Updated `test_cmd_compress_stores_results` to assert the collection name passed to `get_or_create_collection` is `mempalace_closets`.
- Added `test_cmd_compress_output_readable_via_get_closets_collection` — end-to-end regression with a real `ChromaBackend`: seeds a drawer, runs `cmd_compress`, then reads back through the same `get_closets_collection` helper that `palace.py` / `searcher.py` use. Fails on the old code, passes on the fix.

## Test plan

- [x] `python -m pytest tests/ -v --ignore=tests/benchmarks -x -k "compress or closet"` — 94 passed
- [x] `python -m pytest tests/test_cli.py -v` — 54 passed
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check` — only pre-existing format drift on develop, no new issues introduced by this PR

Generated with [Claude Code](https://claude.com/claude-code)