### PR TITLE
fix(cli): honor --palace flag in cmd_init (#1313)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -232,6 +232,13 @@ def cmd_init(args):
     from .project_scanner import discover_entities
     from .room_detector_local import detect_rooms_local
 
+    # Honor --palace (issue #1313): without this, init silently ignored the
+    # flag and always used ~/.mempalace. Mirror the env-var pattern used by
+    # mcp_server.py so every downstream read of ``cfg.palace_path`` (Pass 0,
+    # cfg.init(), the post-init mine) routes to the user-specified location.
+    if getattr(args, "palace", None):
+        os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(os.path.expanduser(args.palace))
+
     cfg = MempalaceConfig()
 
     # Resolve entity-detection languages: --lang overrides config.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -175,6 +175,55 @@ def test_cmd_init_normalizes_wing_name_for_topics_registry(mock_config_cls, tmp_
         assert mock_register.call_args.kwargs["wing"] == "my_cool_app"
 
 
+def test_cmd_init_honors_palace_flag(tmp_path, monkeypatch):
+    """Regression for #1313: ``cmd_init`` must honor ``--palace`` instead of
+    silently writing to ``~/.mempalace``. Mirrors the env-var pattern used
+    by ``cmd_mine`` / ``cmd_status`` / ``mcp_server`` so every downstream
+    read of ``cfg.palace_path`` (Pass 0, ``cfg.init()``, post-init mine)
+    routes to the user-specified location.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    palace = tmp_path / "custom_palace"
+
+    # Make sure no leftover env var from another test leaks in — we want to
+    # verify that --palace ALONE drives the resolution.
+    monkeypatch.delenv("MEMPALACE_PALACE_PATH", raising=False)
+    monkeypatch.delenv("MEMPAL_PALACE_PATH", raising=False)
+
+    args = argparse.Namespace(
+        dir=str(project),
+        palace=str(palace),
+        yes=True,
+        auto_mine=False,
+    )
+
+    captured = {}
+
+    def fake_pass_zero(project_dir, palace_dir, llm_provider):
+        # Capture the palace_dir Pass 0 sees — this is the smoking-gun
+        # value for the bug. Pre-fix it was always ~/.mempalace.
+        captured["pass_zero_palace_dir"] = palace_dir
+        return None
+
+    with (
+        patch("mempalace.entity_detector.scan_for_detection", return_value=[]),
+        patch("mempalace.room_detector_local.detect_rooms_local"),
+        patch("mempalace.cli._run_pass_zero", side_effect=fake_pass_zero),
+        patch("mempalace.cli._maybe_run_mine_after_init"),
+    ):
+        cmd_init(args)
+
+    expected = str(palace)
+    # Pass 0 must have been handed the --palace location, not ~/.mempalace.
+    assert captured["pass_zero_palace_dir"] == expected
+    # And the env var must point at the custom palace so any downstream
+    # ``cfg.palace_path`` read in this process resolves correctly too.
+    import os
+
+    assert os.environ.get("MEMPALACE_PALACE_PATH") == os.path.abspath(expected)
+
+
 @patch("mempalace.cli.MempalaceConfig")
 def test_cmd_init_with_entities_zero_total(mock_config_cls, tmp_path, capsys):
     """When entities detected but total is 0, prints 'No entities' message."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,9 +187,15 @@ def test_cmd_init_honors_palace_flag(tmp_path, monkeypatch):
     palace = tmp_path / "custom_palace"
 
     # Make sure no leftover env var from another test leaks in — we want to
-    # verify that --palace ALONE drives the resolution.
-    monkeypatch.delenv("MEMPALACE_PALACE_PATH", raising=False)
-    monkeypatch.delenv("MEMPAL_PALACE_PATH", raising=False)
+    # verify that --palace ALONE drives the resolution. Prime monkeypatch's
+    # undo list with setenv first so that the env var ``cmd_init`` writes
+    # below is rolled back at teardown (``delenv(raising=False)`` on a
+    # missing key registers no undo entry, which would leak into the next
+    # test).
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", "")
+    monkeypatch.setenv("MEMPAL_PALACE_PATH", "")
+    monkeypatch.delenv("MEMPALACE_PALACE_PATH")
+    monkeypatch.delenv("MEMPAL_PALACE_PATH")
 
     args = argparse.Namespace(
         dir=str(project),


### PR DESCRIPTION
Closes #1313.

## Root cause

`cmd_init` instantiated `MempalaceConfig()` without honoring `args.palace`. Every other command (`cmd_status`, `cmd_mine`, `cmd_search`, `cmd_repair`, `cmd_compress`, `cmd_wakeup`) resolves `--palace` first via `os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path`. `cmd_init` was the only outlier, so the flag was silently dropped and the palace always landed at `~/.mempalace/`.

## Fix

Mirror the env-var pattern already used by `mcp_server.py:103` — set `MEMPALACE_PALACE_PATH` from `args.palace` at the top of `cmd_init`. Every downstream read of `cfg.palace_path` inside the command (Pass 0 corpus-origin write, `cfg.init()`, the post-init `_maybe_run_mine_after_init`) then resolves to the user-specified location automatically. Path is normalized via `os.path.abspath(os.path.expanduser(...))` to match the existing env-var contract in `config.py:179-184`.

## Test plan

- [x] New regression test `tests/test_cli.py::test_cmd_init_honors_palace_flag` — passes `--palace` and asserts (a) Pass 0 received the custom palace dir, not `~/.mempalace`, and (b) `MEMPALACE_PALACE_PATH` is set in `os.environ`.
- [x] `python -m pytest tests/ -v --ignore=tests/benchmarks -x -k "init or palace"` — 164 passed.
- [x] `ruff check .` — clean.