### PR TITLE
fix(backends/chroma): wire quarantine_stale_hnsw into _client() (#1121 #1132 #1263)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -993,7 +993,7 @@ class ChromaBackend(BaseBackend):
         )
 
         if cached is None or inode_changed or mtime_changed or mtime_appeared:
-            _fix_blob_seq_ids(palace_path)
+            ChromaBackend._prepare_palace_for_open(palace_path)
             cached = chromadb.PersistentClient(path=palace_path)
             self._clients[palace_path] = cached
             # Re-stat after the client constructor runs: chromadb creates
@@ -1029,6 +1029,31 @@ class ChromaBackend(BaseBackend):
     _quarantined_paths: set[str] = set()
 
     @staticmethod
+    def _prepare_palace_for_open(palace_path: str) -> None:
+        """Run the pre-open safety pass shared by :meth:`make_client` and
+        :meth:`_client`.
+
+        Two steps, both required before constructing a ``PersistentClient``:
+
+        1. ``_fix_blob_seq_ids`` — repairs the BLOB seq_id quirk that bites
+           certain chromadb migrations.
+        2. ``quarantine_stale_hnsw`` — gated by :attr:`_quarantined_paths` so
+           it fires once per palace per process. This is the SIGSEGV
+           prevention path for stale HNSW segments (see #1121, #1132, #1263);
+           wiring it through this helper means CLI mining, search, repair,
+           and status all benefit, not just the legacy ``make_client``
+           callers.
+
+        Idempotent: safe to call from any code path that is about to open or
+        re-open a palace. The ``_quarantined_paths`` gate prevents thrash on
+        hot paths (e.g. ``_client()`` is called on every backend operation).
+        """
+        _fix_blob_seq_ids(palace_path)
+        if palace_path not in ChromaBackend._quarantined_paths:
+            quarantine_stale_hnsw(palace_path)
+            ChromaBackend._quarantined_paths.add(palace_path)
+
+    @staticmethod
     def make_client(palace_path: str):
         """Create a fresh ``PersistentClient`` (fixes BLOB seq_ids first).
 
@@ -1040,10 +1065,7 @@ class ChromaBackend(BaseBackend):
         :attr:`_quarantined_paths` for the rationale (cold-start protection
         vs. runtime thrash on steady-write daemons).
         """
-        _fix_blob_seq_ids(palace_path)
-        if palace_path not in ChromaBackend._quarantined_paths:
-            quarantine_stale_hnsw(palace_path)
-            ChromaBackend._quarantined_paths.add(palace_path)
+        ChromaBackend._prepare_palace_for_open(palace_path)
         return chromadb.PersistentClient(path=palace_path)
 
     @staticmethod

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -730,9 +730,9 @@ def test_make_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeyp
     ChromaBackend.make_client(palace_path)
     ChromaBackend.make_client(palace_path)
 
-    assert calls == [palace_path], (
-        "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
-    )
+    assert calls == [
+        palace_path
+    ], "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
 
 
 def test_make_client_quarantines_each_palace_independently(tmp_path, monkeypatch):
@@ -820,9 +820,9 @@ def test_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeypatch)
     finally:
         backend.close()
 
-    assert calls == [palace_path], (
-        "quarantine_stale_hnsw should fire once per palace per process from _client(), not on every call"
-    )
+    assert (
+        calls == [palace_path]
+    ), "quarantine_stale_hnsw should fire once per palace per process from _client(), not on every call"
 
 
 # ── _pin_hnsw_threads (per-process retrofit, separate from this PR's gate) ──

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -764,6 +764,67 @@ def test_make_client_quarantines_each_palace_independently(tmp_path, monkeypatch
     assert calls == [palace_a, palace_b]
 
 
+# ── _client() cold-start gate (#1121, #1132, #1263) ──────────────────────
+
+
+def test_client_quarantines_corrupt_segment_on_first_open(tmp_path, monkeypatch):
+    """The instance ``_client()`` path must run ``quarantine_stale_hnsw``
+    on first open, mirroring the ``make_client()`` static helper. Before
+    PR #1173's wiring was extended here, CLI mining / search / repair /
+    status all skipped the quarantine pass and would SIGSEGV on a stale
+    HNSW segment (#1121, #1132, #1263)."""
+    now = 1_700_000_000.0
+    palace, seg = _make_palace_with_segment(
+        tmp_path,
+        hnsw_mtime=now - 7200,
+        sqlite_mtime=now,
+        meta_bytes=_CORRUPT_META,
+    )
+
+    monkeypatch.setattr(ChromaBackend, "_quarantined_paths", set())
+
+    backend = ChromaBackend()
+    try:
+        backend._client(str(palace))
+    finally:
+        backend.close()
+
+    assert not seg.exists(), "_client() should have quarantined the corrupt segment"
+    drift_dirs = [p for p in palace.iterdir() if ".drift-" in p.name]
+    assert len(drift_dirs) == 1
+
+
+def test_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeypatch):
+    """Repeated ``_client()`` calls for the same palace re-run quarantine
+    at most once — the ``_quarantined_paths`` gate prevents runtime
+    thrash on hot paths (``_client()`` is hit on every backend op)."""
+    palace_path = str(tmp_path / "palace")
+    os.makedirs(palace_path, exist_ok=True)
+    (Path(palace_path) / "chroma.sqlite3").write_text("")
+
+    monkeypatch.setattr(ChromaBackend, "_quarantined_paths", set())
+
+    calls: list[str] = []
+
+    def _spy(path, stale_seconds=300.0):
+        calls.append(path)
+        return []
+
+    monkeypatch.setattr("mempalace.backends.chroma.quarantine_stale_hnsw", _spy)
+
+    backend = ChromaBackend()
+    try:
+        backend._client(palace_path)
+        backend._client(palace_path)
+        backend._client(palace_path)
+    finally:
+        backend.close()
+
+    assert calls == [palace_path], (
+        "quarantine_stale_hnsw should fire once per palace per process from _client(), not on every call"
+    )
+
+
 # ── _pin_hnsw_threads (per-process retrofit, separate from this PR's gate) ──
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -730,9 +730,9 @@ def test_make_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeyp
     ChromaBackend.make_client(palace_path)
     ChromaBackend.make_client(palace_path)
 
-    assert calls == [
-        palace_path
-    ], "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
+    assert calls == [palace_path], (
+        "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
+    )
 
 
 def test_make_client_quarantines_each_palace_independently(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #1121. Closes #1132. Closes #1263.

## Root cause

PR #1173 wired `quarantine_stale_hnsw` into the static `ChromaBackend.make_client()` helper, but **not** into the instance `_client()` method that `get_collection` / `_get_or_create_collection` route through. As a result every non-MCP entry point — CLI mining, search, repair, status — skipped the cold-start quarantine pass and could SIGSEGV on a stale HNSW segment left over from a partial flush, a replicated palace, or a crashed-mid-write.

Three issues, one missed wire.

## Fix

Extract the `(_fix_blob_seq_ids + gated quarantine_stale_hnsw)` pre-open pass into a single private static helper `ChromaBackend._prepare_palace_for_open()`. Both `make_client()` and `_client()` now route through it.

Behaviour preserved:

- `_quarantined_paths` once-per-palace-per-process gate still applies, so no runtime thrash on hot paths (`_client()` is hit on every backend op).
- `make_client()` semantics are byte-identical to before (it now just delegates).
- `_client()` runs the prep pass only inside its existing rebuild block (`cached is None or inode_changed or mtime_changed or mtime_appeared`), so cached fast-path callers pay nothing.

<details>
<summary>Diff shape</summary>

```python
@staticmethod
def _prepare_palace_for_open(palace_path: str) -> None:
    _fix_blob_seq_ids(palace_path)
    if palace_path not in ChromaBackend._quarantined_paths:
        quarantine_stale_hnsw(palace_path)
        ChromaBackend._quarantined_paths.add(palace_path)

@staticmethod
def make_client(palace_path: str):
    ChromaBackend._prepare_palace_for_open(palace_path)
    return chromadb.PersistentClient(path=palace_path)

def _client(self, palace_path: str):
    ...
    if cached is None or inode_changed or mtime_changed or mtime_appeared:
        ChromaBackend._prepare_palace_for_open(palace_path)
        cached = chromadb.PersistentClient(path=palace_path)
        ...
```

</details>

## Tests

Two new tests mirror the existing `make_client` coverage:

- `test_client_quarantines_corrupt_segment_on_first_open` — builds a palace with a stale + corrupt HNSW segment, calls `_client()`, asserts the segment was renamed to `*.drift-*`.
- `test_client_quarantines_only_on_first_call_per_palace` — three back-to-back `_client()` calls fire `quarantine_stale_hnsw` exactly once (gate works on the hot path).

## Test plan

- [x] `pytest tests/ -v --ignore=tests/benchmarks -x -k "client or quarantine or chroma or hnsw"` — 94 passed
- [x] `pytest tests/ --ignore=tests/benchmarks -x` — 1472 passed, 1 skipped
- [x] `ruff check .` — clean
- [x] `ruff format --check` clean for the two files I touched (pre-existing format drift on develop in unrelated files is left alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)