### PR TITLE
fix(mcp): omit absolute filesystem paths from MCP tool responses

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -912,12 +912,21 @@ def tool_get_drawer(drawer_id: str):
             return {"error": f"Drawer not found: {drawer_id}"}
         meta = result["metadatas"][0]
         doc = result["documents"][0]
+        # source_file is the absolute filesystem path written by the
+        # miners. Reduce to its basename before handing it to the MCP
+        # client — same threat model as the palace_path leak fix:
+        # nested-agent / multi-server topologies treat the client as a
+        # separate trust domain. Basename preserves citation utility.
+        # Mirrors the searcher.search_memories() return shape.
+        safe_meta = dict(meta) if meta else {}
+        if safe_meta.get("source_file"):
+            safe_meta["source_file"] = Path(safe_meta["source_file"]).name
         return {
             "drawer_id": drawer_id,
             "content": doc,
-            "wing": meta.get("wing", ""),
-            "room": meta.get("room", ""),
-            "metadata": meta,
+            "wing": safe_meta.get("wing", ""),
+            "room": safe_meta.get("room", ""),
+            "metadata": safe_meta,
         }
     except Exception as e:
         return {"error": str(e)}

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -454,7 +454,6 @@ def _tool_status_via_sqlite() -> dict:
         "total_drawers": total,
         "wings": wings,
         "rooms": rooms,
-        "palace_path": _config.palace_path,
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
         "vector_disabled": True,
@@ -493,7 +492,6 @@ def tool_status():
         "total_drawers": count,
         "wings": wings,
         "rooms": rooms,
-        "palace_path": _config.palace_path,
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
     }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -531,6 +531,45 @@ class TestWriteTools:
         result = tool_get_drawer("nonexistent_drawer")
         assert "error" in result
 
+    def test_get_drawer_does_not_leak_absolute_source_file_path(
+        self, monkeypatch, config, palace_path, collection, kg
+    ):
+        """tool_get_drawer must not expose the absolute filesystem path
+        that the miners write into ``source_file``. Same threat class as
+        the palace_path leak in mempalace_status: in nested-agent or
+        multi-server MCP topologies the client is a separate trust
+        domain, and the directory layout of the host has no documented
+        client-side use. Basename is enough for citation."""
+        _patch_mcp_server(monkeypatch, config, kg)
+
+        secret_dir = "/private/home/alice/secret-research/2026"
+        absolute_source = f"{secret_dir}/notes.md"
+        collection.add(
+            ids=["drawer_leak_probe"],
+            documents=["verbatim drawer body for leak probe"],
+            metadatas=[
+                {
+                    "wing": "research",
+                    "room": "notes",
+                    "source_file": absolute_source,
+                    "chunk_index": 0,
+                    "added_by": "miner",
+                    "filed_at": "2026-05-03T00:00:00",
+                }
+            ],
+        )
+
+        from mempalace.mcp_server import tool_get_drawer
+
+        result = tool_get_drawer("drawer_leak_probe")
+        assert result["drawer_id"] == "drawer_leak_probe"
+        assert result["metadata"]["source_file"] == "notes.md"
+        # Defense-in-depth: no field anywhere in the response should
+        # contain the absolute path or its parent directory.
+        serialized = json.dumps(result)
+        assert absolute_source not in serialized
+        assert secret_dir not in serialized
+
     def test_list_drawers(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_list_drawers

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -122,7 +122,7 @@ Fetch a single drawer by ID — returns full content and metadata.
 |-----------|------|----------|-------------|
 | `drawer_id` | string | **Yes** | ID of the drawer to fetch |
 
-**Returns:** `{ drawer: { id, wing, room, content, ... } }`
+**Returns:** `{ drawer_id, content, wing, room, metadata }` where `metadata.source_file`, when present, is the basename only — the absolute path written by the miners is reduced before the dict is returned to MCP clients.
 
 ---
 

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -10,7 +10,7 @@ Palace overview: total drawers, wing and room counts, AAAK spec, and memory prot
 
 **Parameters:** None
 
-**Returns:** `{ total_drawers, wings, rooms, palace_path, protocol, aaak_dialect }`
+**Returns:** `{ total_drawers, wings, rooms, protocol, aaak_dialect }`
 
 ---
 
@@ -378,4 +378,4 @@ Force a reconnect to the palace database. Use this after external scripts or CLI
 
 **Parameters:** None
 
-**Returns:** `{ success, palace_path }`
+**Returns:** `{ success, message, drawers, vector_disabled[, vector_disabled_reason] }` (on no-palace: `{ success: false, message, drawers, vector_disabled }`; on exception: `{ success: false, error }`)


### PR DESCRIPTION
Two related fixes for absolute filesystem paths leaking from MCP tool responses to connected clients. On a single-user local deployment this is self-disclosure, but in nested-agent or multi-server MCP topologies the client is a separate trust domain and the host's directory layout has no documented client-side use.

Originally drafted on a private GHSA fork; bundled and brought to the public repo because the GHSA repo's PR/merge UI is currently broken on GitHub's side. No exploitation in the wild — disclosure path is local-only and tied to MCP topology.

## Fixes

| Surface | Leak | Mitigation |
|---------|------|------------|
| `mempalace_status` | `palace_path` (absolute palace dir) on both ChromaDB and #1222 sqlite-fallback paths | drop the field from both result dicts |
| `mempalace_get_drawer` | `metadata.source_file` (absolute path written by the miners) | basename via `Path(source_file).name` before returning, mirroring what `searcher.search_memories()` already does |

Documented client-side channels for clients that legitimately need the palace path are unchanged: the `MEMPALACE_PALACE_PATH` env var (or its legacy `MEMPAL_PALACE_PATH` alias), `~/.mempalace/config.json`, and the `--palace` CLI flag.

## Audit of remaining MCP tools

I scanned every entry in `TOOLS`. None of these leak host paths:

- `mempalace_search` — already basenames `source_file` and strips the internal `_source_file_full` field
- `mempalace_list_drawers` — wing/room/content_preview only, no metadata
- `mempalace_diary_read` — date/timestamp/topic/content only
- `mempalace_reconnect` — success/message/drawers/vector_disabled only
- `mempalace_kg_*` — entity strings, predicates, counts
- `mempalace_check_duplicate` — wing/room/preview only
- `mempalace_traverse_graph`, `mempalace_find_tunnels`, `mempalace_graph_stats`, `mempalace_kg_stats` — graph data only
- Write tools (`add_drawer`, `update_drawer`, `delete_drawer`, `kg_add`, `kg_invalidate`, `diary_write`) — drawer_id/wing/room/triple_id only
- `mempalace_hook_settings` — booleans
- `mempalace_memories_filed_away` — count/timestamp only

## Stale-docs correction (folded in)

`mempalace_reconnect` was documented as returning `{success, palace_path}` — actually returns four distinct shapes (`{success, message, drawers, vector_disabled[, vector_disabled_reason]}` on success, plus no-palace and exception variants). `website/reference/mcp-tools.md` updated to match.

## Commits

- `b2f259c` — fix(mcp): omit palace_path from tool_status responses (+ docs) — authored by @icciaaron
- `7fc260f` — fix(mcp): basename source_file in tool_get_drawer responses — companion fix from the same audit pass

## Test results

- `uv run pytest tests/ -q --ignore=tests/benchmarks` → 1471 passed, 1 skipped
- `uvx --from 'ruff>=0.4.0,<0.5' ruff check` and `ruff format --check` on touched files → clean
- New regression test `test_get_drawer_does_not_leak_absolute_source_file_path` asserts neither the absolute path nor its parent directory appears anywhere in the JSON-serialised response
