### PR TITLE
fix(mcp): always co-locate KG with palace directory

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -104,12 +104,10 @@ if _args.palace:
     os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(_args.palace)
 
 _config = MempalaceConfig()
-# Only override KG path when --palace is explicitly provided; otherwise use
-# KnowledgeGraph's default (~/.mempalace/knowledge_graph.sqlite3).
-if _args.palace:
-    _kg = KnowledgeGraph(db_path=os.path.join(_config.palace_path, "knowledge_graph.sqlite3"))
-else:
-    _kg = KnowledgeGraph()
+# Always co-locate the KG with the palace so layers.py (wake-up) and MCP
+# tools read/write the same database. The old default (~/.mempalace/knowledge_graph.sqlite3)
+# caused a split where kg_add wrote to root KG but session wake-up read palace KG.
+_kg = KnowledgeGraph(db_path=os.path.join(_config.palace_path, "knowledge_graph.sqlite3"))
 
 
 _client_cache = None


### PR DESCRIPTION
## Bug

`layers.py` (the session wake-up stack) opens the knowledge graph from the palace directory:

```python
# layers.py line 194
db_path = os.path.join(palace_path or cfg.palace_path, "knowledge_graph.sqlite3")
```

`mcp_server.py` fell back to `~/.mempalace/knowledge_graph.sqlite3` when `--palace` was not passed:

```python
if _args.palace:
    _kg = KnowledgeGraph(db_path=os.path.join(_config.palace_path, "knowledge_graph.sqlite3"))
else:
    _kg = KnowledgeGraph()  # ← ~/.mempalace/knowledge_graph.sqlite3
```

**Effect:** Every `mempalace_kg_add` call wrote to the root KG. The next session's wake-up read the palace KG. Newly added facts never appeared in the next session's context — the KG cross-session persistence was silently broken.

## Fix

Always resolve the KG path from `_config.palace_path`, which already reflects `--palace`, `MEMPALACE_PALACE_PATH env var`, or the default from `config.json`. The `--palace` arg still controls the palace path; the conditional was only needed for the now-removed special case.

## Testing

- With default config (no `--palace`): `kg_add` and `LayerKG` now both open `~/.mempalace/palace/knowledge_graph.sqlite3`
- With `--palace /custom/path`: unchanged behaviour — palace path set via env before `MempalaceConfig()` reads it

🤖 Generated with [Claude Code](https://claude.com/claude-code)