### PR TITLE
feat(mine): add --force flag for atomic directory re-mine

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -484,11 +484,54 @@ def _maybe_run_mine_after_init(args, cfg) -> None:
         sys.exit(1)
 
 
+def _force_clean(palace_path: str, source_dir: str) -> int:
+    """Delete all drawers whose source_file is under source_dir. Returns count deleted."""
+    from pathlib import Path
+    from .palace import get_collection
+
+    try:
+        col = get_collection(palace_path)
+    except Exception:
+        return 0
+
+    source_prefix = str(Path(source_dir).expanduser().resolve())
+    if not source_prefix.endswith(os.sep):
+        source_prefix += os.sep
+
+    batch_size = 500
+    offset = 0
+    to_delete = []
+
+    while True:
+        batch = col.get(limit=batch_size, offset=offset, include=["metadatas"])
+        if not batch["ids"]:
+            break
+        for drawer_id, meta in zip(batch["ids"], batch["metadatas"]):
+            sf = meta.get("source_file", "")
+            try:
+                sf_resolved = str(Path(sf).resolve())
+            except OSError:
+                sf_resolved = sf
+            if sf_resolved.startswith(source_prefix) or sf_resolved == source_prefix.rstrip(os.sep):
+                to_delete.append(drawer_id)
+        offset += len(batch["ids"])
+
+    if to_delete:
+        print(f"\n  --force: removing {len(to_delete)} existing drawers from {source_prefix.rstrip(os.sep)}...")
+        for i in range(0, len(to_delete), 100):
+            col.delete(ids=to_delete[i : i + 100])
+        print("  Done. Re-mining fresh.\n")
+    return len(to_delete)
+
+
 def cmd_mine(args):
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     include_ignored = []
     for raw in args.include_ignored or []:
         include_ignored.extend(part.strip() for part in raw.split(",") if part.strip())
+
+    if getattr(args, "force", False) and not args.dry_run:
+        _force_clean(palace_path, args.dir)
 
     # --redetect-origin re-runs corpus_origin on the current corpus state
     # and overwrites <palace>/.mempalace/origin.json before mining proceeds.
@@ -1078,6 +1121,11 @@ def main():
     )
     p_mine.add_argument(
         "--dry-run", action="store_true", help="Show what would be filed without filing"
+    )
+    p_mine.add_argument(
+        "--force",
+        action="store_true",
+        help="Delete existing drawers for this directory before re-mining (atomic re-mine)",
     )
     p_mine.add_argument(
         "--extract",

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -307,7 +307,7 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
-def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode, content_hash=""):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
     Combines the per-file serialization that prevents concurrent agents from
@@ -361,6 +361,7 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                         "ingest_mode": "convos",
                         "extract_mode": extract_mode,
                         "normalize_version": NORMALIZE_VERSION,
+                        "content_hash": content_hash,
                     }
                 )
             try:
@@ -384,6 +385,7 @@ def mine_convos(
     limit: int = 0,
     dry_run: bool = False,
     extract_mode: str = "exchange",
+    filepath_filter: str = None,
 ):
     """Mine a directory of conversation files into the palace.
 
@@ -399,6 +401,8 @@ def mine_convos(
         wing = normalize_wing_name(convo_path.name)
 
     files = scan_convos(convo_dir)
+    if filepath_filter:
+        files = [f for f in files if str(f) == filepath_filter]
     if limit > 0:
         files = files[:limit]
 
@@ -483,8 +487,14 @@ def mine_convos(
 
         # Lock + purge stale + file fresh chunks. Lock serializes concurrent
         # agents; purge removes pre-v2 drawers so the schema bump applies.
+        try:
+            raw_content = filepath.read_text(encoding="utf-8", errors="replace").strip()
+            file_hash = hashlib.md5(raw_content.encode(), usedforsecurity=False).hexdigest()
+        except OSError:
+            file_hash = ""
         drawers_added, room_delta, skipped = _file_chunks_locked(
-            collection, source_file, chunks, wing, room, agent, extract_mode
+            collection, source_file, chunks, wing, room, agent, extract_mode,
+            content_hash=file_hash,
         )
         if skipped:
             files_skipped += 1

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -69,6 +69,14 @@ CHUNK_SIZE = 800  # chars per drawer
 CHUNK_OVERLAP = 100  # overlap between chunks
 MIN_CHUNK_SIZE = 50  # skip tiny chunks
 DRAWER_UPSERT_BATCH_SIZE = 1000
+
+
+def file_content_hash(filepath: Path) -> str:
+    """Compute MD5 of a file's content — single source of truth for sync/freshness checks."""
+    content = filepath.read_text(encoding="utf-8", errors="replace").strip()
+    return hashlib.md5(content.encode(), usedforsecurity=False).hexdigest()
+
+
 MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB — skip files larger than this.
 # Long Claude Code sessions and large transcript exports routinely exceed
 # 10 MB. The cap exists as a defensive rail against pathological binary
@@ -738,6 +746,7 @@ def _build_drawer_metadata(
     agent: str,
     content: str,
     source_mtime: Optional[float],
+    content_hash: str = "",
 ) -> dict:
     """Build the metadata dict for one drawer without upserting.
 
@@ -756,6 +765,11 @@ def _build_drawer_metadata(
     }
     if source_mtime is not None:
         metadata["source_mtime"] = source_mtime
+    # Store content hash for sync/freshness detection.
+    # Fall back to hashing the drawer content so MCP-created drawers also get a hash.
+    metadata["content_hash"] = content_hash or hashlib.md5(
+        content.encode(), usedforsecurity=False
+    ).hexdigest()
     metadata["hall"] = detect_hall(content)
     entities = _extract_entities_for_metadata(content)
     if entities:
@@ -852,6 +866,7 @@ def process_file(
             source_mtime = os.path.getmtime(source_file)
         except OSError:
             source_mtime = None
+        file_hash = file_content_hash(filepath)
 
         drawers_added = 0
         for batch_start in range(0, len(chunks), DRAWER_UPSERT_BATCH_SIZE):
@@ -871,6 +886,7 @@ def process_file(
                         agent,
                         chunk["content"],
                         source_mtime,
+                        file_hash,
                     )
                 )
             collection.upsert(

--- a/tests/test_force_clean.py
+++ b/tests/test_force_clean.py
@@ -1,0 +1,91 @@
+"""Tests for mine --force flag (PR #1344)."""
+import os
+from pathlib import Path
+
+import chromadb
+import pytest
+
+
+@pytest.fixture
+def palace(tmp_path):
+    p = str(tmp_path / "palace")
+    os.makedirs(p)
+    client = chromadb.PersistentClient(path=p)
+    client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
+    client.get_or_create_collection("mempalace_closets", metadata={"hnsw:space": "cosine"})
+    del client
+    return p
+
+
+@pytest.fixture
+def project(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "mempalace.yaml").write_text(
+        "wing: test\nrooms:\n  - name: general\n    keywords: []\n"
+    )
+    (d / "readme.md").write_text("# Test\n\nContent.\n" * 10)
+    (d / "code.py").write_text("x = 1\n" * 30)
+    return d
+
+
+class TestForceClean:
+    def test_deletes_all_drawers_for_directory(self, palace, project):
+        from mempalace.miner import mine
+        from mempalace.cli import _force_clean
+        from mempalace.palace import get_collection
+
+        mine(project_dir=str(project), palace_path=palace, agent="test")
+        col = get_collection(palace)
+        before = col.count()
+        assert before > 0
+
+        deleted = _force_clean(palace, str(project))
+        assert deleted == before
+        assert col.count() == 0
+
+    def test_path_boundary_isolation(self, palace, project, tmp_path):
+        """_force_clean('/proj') must not delete drawers from '/proj_other'."""
+        from mempalace.miner import mine
+        from mempalace.cli import _force_clean
+        from mempalace.palace import get_collection
+
+        other = tmp_path / "proj_other"
+        other.mkdir()
+        (other / "mempalace.yaml").write_text(
+            "wing: other\nrooms:\n  - name: general\n    keywords: []\n"
+        )
+        (other / "data.txt").write_text("other project data\n" * 30)
+
+        mine(project_dir=str(project), palace_path=palace, agent="test")
+        mine(project_dir=str(other), palace_path=palace, agent="test")
+        col = get_collection(palace)
+        total = col.count()
+
+        _force_clean(palace, str(project))
+        after = col.count()
+        assert 0 < after < total, "Should have deleted only one project's drawers"
+
+    def test_force_remine_updates_hashes(self, palace, project):
+        from mempalace.miner import mine, file_content_hash
+        from mempalace.cli import _force_clean
+        from mempalace.palace import get_collection
+
+        mine(project_dir=str(project), palace_path=palace, agent="test")
+
+        (project / "readme.md").write_text("# Rewritten\n" * 20)
+        new_hash = file_content_hash(project / "readme.md")
+
+        _force_clean(palace, str(project))
+        mine(project_dir=str(project), palace_path=palace, agent="test")
+
+        col = get_collection(palace)
+        result = col.get(include=["metadatas"])
+        readme_metas = [m for m in result["metadatas"] if "readme.md" in m.get("source_file", "")]
+        assert all(m["content_hash"] == new_hash for m in readme_metas)
+
+    def test_force_clean_empty_palace(self, palace):
+        from mempalace.cli import _force_clean
+
+        deleted = _force_clean(palace, "/nonexistent/path")
+        assert deleted == 0


### PR DESCRIPTION
## 🔄 The problem

You edited 50 files. You want fresh memories. You run `mempalace mine` — and nothing happens. The miner sees the files are already filed and skips them.

The only escape was to manually delete the palace and start over. That is not acceptable.

## ✅ What this does

Adds `--force` to `mempalace mine`:

```bash
mempalace mine ~/project --force
mempalace mine ~/.claude/projects/ --mode convos --force
```

`--force` deletes all existing drawers for the target directory, then re-mines fresh. Atomic: old drawers are gone, new ones (with `content_hash`) are in.

## 🔧 How it works

`_force_clean(palace_path, source_dir)`:
1. Scans the palace in batches of 500 drawers
2. Resolves symlinks for cross-platform path comparison (macOS `/var` → `/private/var`)
3. Enforces path boundary (trailing separator) — `/project` does not match `/project_other`
4. Deletes matching drawers in batches of 100
5. Uses `palace.get_collection()` — stays within the storage abstraction layer

`--force` is silently ignored with `--dry-run` (nothing is deleted).

## 🧪 Tests

All 54 existing CLI tests pass. No new failures introduced.

```
python -m pytest tests/test_cli.py -q
54 passed
```

Depends on: #1343 (content_hash stored after re-mine)
Relates to #224.