### PR TITLE
feat(hooks): independent precompact toggle via config + env var

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -295,6 +295,39 @@ class MempalaceConfig:
         return self._file_config.get("hooks", {}).get("silent_save", True)
 
     @property
+    def hooks_save_interval(self) -> int:
+        """Number of exchanges between auto-save prompts. 0 = disabled.
+
+        Config: {"hooks": {"save_interval": 30}}
+        Env var (takes precedence): MEMPALACE_HOOKS_SAVE_INTERVAL=30
+        """
+        env_val = os.environ.get("MEMPALACE_HOOKS_SAVE_INTERVAL", "").strip()
+        if env_val:
+            try:
+                return max(0, int(env_val))
+            except ValueError:
+                pass
+        val = self._file_config.get("hooks", {}).get("save_interval", 15)
+        try:
+            return max(0, int(val))
+        except (TypeError, ValueError):
+            return 15
+
+    @property
+    def hooks_precompact(self) -> bool:
+        """Whether the precompact hook fires before context compaction. Default: True.
+
+        Config: {"hooks": {"precompact": false}}
+        Env var (takes precedence): MEMPALACE_HOOKS_PRECOMPACT=false
+        """
+        env_val = os.environ.get("MEMPALACE_HOOKS_PRECOMPACT", "").strip().lower()
+        if env_val in ("0", "false", "no", "off"):
+            return False
+        if env_val in ("1", "true", "yes", "on"):
+            return True
+        return bool(self._file_config.get("hooks", {}).get("precompact", True))
+
+    @property
     def hook_desktop_toast(self):
         """Whether the stop hook shows a desktop notification via notify-send."""
         return self._file_config.get("hooks", {}).get("desktop_toast", False)

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -596,7 +596,17 @@ def hook_stop(data: dict, harness: str):
 
     _log(f"Session {session_id}: {exchange_count} exchanges, {since_last} since last save")
 
-    if since_last >= SAVE_INTERVAL and exchange_count > 0:
+    try:
+        from .config import MempalaceConfig
+        save_interval = int(MempalaceConfig().hooks_save_interval)
+    except Exception:
+        save_interval = SAVE_INTERVAL
+
+    if save_interval == 0:
+        _output({})
+        return
+
+    if since_last >= save_interval and exchange_count > 0:
         _log(f"TRIGGERING SAVE at exchange {exchange_count}")
 
         # Read hook settings from config
@@ -678,6 +688,17 @@ def hook_precompact(data: dict, harness: str):
     transcript_path = parsed["transcript_path"]
 
     _log(f"PRE-COMPACT triggered for session {session_id}")
+
+    try:
+        from .config import MempalaceConfig
+        precompact_enabled = MempalaceConfig().hooks_precompact
+    except Exception:
+        precompact_enabled = True
+
+    if not precompact_enabled:
+        _log("Precompact hook disabled via config — skipping mine, allowing compaction")
+        _output({})
+        return
 
     # Capture tool output via our normalize path before compaction loses it
     if transcript_path:


### PR DESCRIPTION
## 🚫 The problem

You are in a long session. Context fills up. You type `/compact`. Nothing happens.

The precompact hook is blocking compaction. You cannot disable it without also disabling the stop hook. You are stuck.

This was the #1 reported issue after the initial precompact hook shipped. PR #863 fixed the hard-block by making precompact always return `{}` — but that dropped the save nudge entirely. Users now get no signal that compaction is imminent.

## ✅ What this does

Adds an independent toggle for the precompact hook:

```json
// ~/.mempalace/config.json
{"hooks": {"precompact": false}}
```

```bash
# Or via env var
MEMPALACE_HOOKS_PRECOMPACT=false
```

When disabled, `/compact` proceeds immediately — no mine, no delay.

## 🔑 Why independent controls matter

| Scenario | save_interval | precompact |
|----------|--------------|------------|
| Normal use | 15 (default) | true (default) |
| Quiet mode — fewer interruptions | 50 | true |
| Precompact causing issues | 15 | **false** |
| Fully silent | 0 | true |

Disabling `save_interval` does **not** disable precompact. Disabling `precompact` does **not** disable the stop hook. They are independent by design — so you can fix one without breaking the other.

## 🧪 Tests

All 104 existing hook and config tests pass.

```
python -m pytest tests/test_hooks_cli.py tests/test_config.py -q
104 passed
```

Depends on: #1345 (save_interval config, same config.py property pattern)
Closes #949. Closes #906.