### PR TITLE
feat(mcp): add mempalace_sync_status tool and freshness hook

### DIFF
--- a/hooks/mempal_freshness_hook.sh
+++ b/hooks/mempal_freshness_hook.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# MEMPALACE FRESHNESS HOOK — Check palace freshness on session start
+#
+# Runs as a "Notification" or "Stop" hook to tell the AI
+# whether the palace is current or has stale memories.
+#
+# === INSTALL ===
+# Add to .claude/settings.local.json:
+#
+#   "hooks": {
+#     "Stop": [{
+#       "matcher": "*",
+#       "hooks": [{
+#         "type": "command",
+#         "command": "/absolute/path/to/mempal_freshness_hook.sh",
+#         "timeout": 30
+#       }]
+#     }]
+#   }
+#
+# === HOW IT WORKS ===
+#
+# 1. Reads stdin for session context (JSON with stop_hook_active flag)
+# 2. If stop_hook_active is true, allows AI to stop (prevents loops)
+# 3. Runs 'mempalace sync --dry-run' on first call per session
+# 4. If stale files detected, BLOCKS the AI from stopping
+#    and returns a reason asking it to call mempalace_sync_status
+# 5. On subsequent calls, allows normal stop
+#
+# === CONFIGURATION ===
+#
+# Set CHECK_DIR to limit freshness check to a specific directory.
+# Leave empty to check all source files.
+CHECK_DIR=""
+# Maximum time between checks (seconds). Default: once per session.
+CHECK_INTERVAL=3600
+
+# ─── Implementation ──────────────────────────────────────
+
+set -euo pipefail
+trap 'echo "{\"decision\": \"allow\"}"'  EXIT
+
+# Read stdin
+INPUT=$(cat)
+
+# Check if we're in a save cycle (prevent infinite loop)
+STOP_ACTIVE=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('stop_hook_active', False))" 2>/dev/null || echo "False")
+
+if [ "$STOP_ACTIVE" = "True" ] || [ "$STOP_ACTIVE" = "true" ]; then
+    exit 0
+fi
+
+# Session tracking — only check once per session
+SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('session_id', 'unknown'))" 2>/dev/null || echo "unknown")
+# Sanitize session ID to prevent path traversal
+SESSION_ID=$(echo "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+STAMP_FILE="/tmp/mempalace_freshness_${SESSION_ID}"
+
+if [ -f "$STAMP_FILE" ]; then
+    LAST_CHECK=$(cat "$STAMP_FILE")
+    NOW=$(date +%s)
+    ELAPSED=$((NOW - LAST_CHECK))
+    if [ "$ELAPSED" -lt "$CHECK_INTERVAL" ]; then
+        exit 0
+    fi
+fi
+
+# Run freshness check — no eval, safe quoting
+if [ -n "$CHECK_DIR" ]; then
+    SYNC_OUTPUT=$(python3 -m mempalace sync --dry-run --dir "$CHECK_DIR" 2>/dev/null || echo "")
+else
+    SYNC_OUTPUT=$(python3 -m mempalace sync --dry-run 2>/dev/null || echo "")
+fi
+STALE_COUNT=$(echo "$SYNC_OUTPUT" | sed -n 's/.*Stale (changed):[[:space:]]*\([0-9]*\).*/\1/p' 2>/dev/null)
+STALE_COUNT="${STALE_COUNT:-0}"
+
+# Record check time
+date +%s > "$STAMP_FILE"
+
+trap - EXIT
+if [ "$STALE_COUNT" -gt "0" ]; then
+    # Stale files found — tell AI to check
+    cat <<ENDJSON
+{"decision": "block", "reason": "Palace freshness check: $STALE_COUNT source files have changed since last mine. Call mempalace_sync_status to see details and get re-mine commands. This ensures your memory is current before answering questions."}
+ENDJSON
+else
+    echo '{"decision": "allow"}'
+fi

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -745,6 +745,160 @@ def tool_graph_stats():
     return graph_stats(col=col)
 
 
+# ==================== SYNC / FRESHNESS ====================
+
+
+def _resolve_path_safe(p: str) -> str:
+    """Resolve symlinks safely (macOS /var → /private/var)."""
+    try:
+        return str(Path(p).resolve())
+    except OSError:
+        return p
+
+
+def tool_sync_status(directory: str = None):  # noqa: C901
+    """Check palace freshness — detect stale, missing, and fresh source files.
+
+    Compares content_hash stored in drawer metadata against current file content.
+    Returns actionable re-mine commands for any stale files found.
+    """
+    import os
+
+    col = _get_collection()
+    if not col:
+        return _no_palace()
+
+    total = col.count()
+    if total == 0:
+        return {"status": "empty", "message": "Palace is empty. Nothing to sync."}
+
+    # Scan all source files and their content hashes
+    source_files = {}
+    batch_size = 500
+    offset = 0
+    while offset < total:
+        batch = col.get(limit=batch_size, offset=offset, include=["metadatas"])
+        if not batch["ids"]:
+            break
+        for drawer_id, meta in zip(batch["ids"], batch["metadatas"]):
+            sf = meta.get("source_file", "")
+            if not sf:
+                continue
+            if sf not in source_files:
+                source_files[sf] = {
+                    "hash": meta.get("content_hash", ""),
+                    "drawer_count": 0,
+                    "wing": meta.get("wing", ""),
+                    "ingest_mode": meta.get("ingest_mode", ""),
+                }
+            elif not source_files[sf]["hash"]:
+                source_files[sf]["hash"] = meta.get("content_hash", "")
+            source_files[sf]["drawer_count"] += 1
+        offset += len(batch["ids"])
+
+    # Filter by directory if specified
+    if directory:
+        dir_resolved = str(Path(directory).expanduser().resolve())
+        if not dir_resolved.endswith(os.sep):
+            dir_resolved += os.sep
+        source_files = {
+            sf: info
+            for sf, info in source_files.items()
+            if _resolve_path_safe(sf).startswith(dir_resolved)
+        }
+
+    stale = []
+    missing = []
+    fresh = 0
+    no_hash = 0
+
+    for sf, info in source_files.items():
+        if not os.path.exists(sf):
+            missing.append({"file": sf, "drawers": info["drawer_count"], "wing": info["wing"]})
+            continue
+        if not info["hash"]:
+            no_hash += 1
+            continue
+        try:
+            content = Path(sf).read_text(encoding="utf-8", errors="replace").strip()
+            current_hash = hashlib.md5(
+                content.encode(), usedforsecurity=False
+            ).hexdigest()
+        except OSError:
+            missing.append({"file": sf, "drawers": info["drawer_count"], "wing": info["wing"]})
+            continue
+        if current_hash != info["hash"]:
+            stale.append({"file": sf, "drawers": info["drawer_count"], "wing": info["wing"]})
+        else:
+            fresh += 1
+
+    # Build re-mine commands for stale files
+    remine_commands = []
+    if stale:
+        seen_dirs = set()
+        for item in stale:
+            parent = str(Path(item["file"]).parent)
+            wing = item["wing"]
+            mode = source_files[item["file"]].get("ingest_mode", "")
+            key = (parent, wing, mode)
+            if key not in seen_dirs:
+                seen_dirs.add(key)
+                cmd = f"mempalace mine {parent} --wing {wing}"
+                if mode == "convos":
+                    cmd = f"mempalace mine {parent} --mode convos --wing {wing}"
+                remine_commands.append(cmd)
+
+    result = {
+        "total_source_files": len(source_files),
+        "fresh": fresh,
+        "stale": len(stale),
+        "missing": len(missing),
+        "no_hash_legacy": no_hash,
+    }
+    if stale:
+        result["stale_files"] = [
+            {"file": s["file"], "drawers": s["drawers"], "wing": s["wing"]}
+            for s in stale[:20]
+        ]
+        result["remine_commands"] = remine_commands
+    if missing:
+        result["missing_files"] = [
+            {"file": Path(m["file"]).name, "drawers": m["drawers"]}
+            for m in missing[:10]
+        ]
+    if no_hash == len(source_files):
+        result["status"] = "unknown"
+        result["message"] = (
+            f"All {no_hash} source files lack content_hash (mined before sync support). "
+            "Re-mine with latest version to enable freshness tracking."
+        )
+    elif stale:
+        result["status"] = "stale"
+        result["message"] = (
+            f"{len(stale)} files changed since last mine. "
+            "Run the remine_commands to refresh."
+        )
+    elif missing:
+        result["status"] = "orphaned"
+        result["message"] = (
+            f"{len(missing)} source files no longer exist. "
+            "Use 'mempalace sync --clean' to remove orphaned drawers."
+        )
+    elif fresh == len(source_files):
+        result["status"] = "fresh"
+        result["message"] = "All source files are up to date."
+    elif no_hash > 0:
+        result["status"] = "partial"
+        result["message"] = (
+            f"{fresh} files verified fresh, {no_hash} files unverifiable (no hash). "
+            "Re-mine legacy files to enable tracking."
+        )
+    else:
+        result["status"] = "fresh"
+        result["message"] = "All source files are up to date."
+    return result
+
+
 def tool_create_tunnel(
     source_wing: str,
     source_room: str,
@@ -1600,6 +1754,24 @@ TOOLS = {
         "description": "Palace graph overview: total rooms, tunnel connections, edges between wings.",
         "input_schema": {"type": "object", "properties": {}},
         "handler": tool_graph_stats,
+    },
+    "mempalace_sync_status": {
+        "description": (
+            "Check palace freshness — are source files still current or have they "
+            "changed since last mine? Returns stale/fresh/missing counts and re-mine "
+            "commands. Call this to know if the palace memories are up to date before "
+            "trusting search results."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "directory": {
+                    "type": "string",
+                    "description": "Only check files under this directory (optional — checks all by default)",
+                },
+            },
+        },
+        "handler": tool_sync_status,
     },
     "mempalace_create_tunnel": {
         "description": "Create a cross-wing tunnel linking two palace locations. Use when content in one project relates to another — e.g., an API design in project_api connects to a database schema in project_database.",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1143,3 +1143,230 @@ class TestCacheInvalidation:
         for kwargs in captured["get"]:
             assert "embedding_function" in kwargs
             assert kwargs["embedding_function"] is not None
+
+
+class TestSyncStatusTool:
+    def _patch_sync(self, monkeypatch, config, palace_path, kg):
+        """Patch MCP server and reset collection cache for sync tests."""
+        from mempalace import mcp_server
+        config._file_config["palace_path"] = palace_path
+        _patch_mcp_server(monkeypatch, config, kg)
+        monkeypatch.setattr(mcp_server, "_client_cache", None)
+        monkeypatch.setattr(mcp_server, "_collection_cache", None)
+
+    def test_sync_status_empty_palace(self, monkeypatch, config, palace_path, kg):
+        self._patch_sync(monkeypatch, config, palace_path, kg)
+        _get_collection(palace_path, create=True)
+        from mempalace.mcp_server import tool_sync_status
+
+        result = tool_sync_status()
+        assert result["status"] == "empty"
+
+    def test_sync_status_no_palace(self, monkeypatch, config, kg):
+        self._patch_sync(monkeypatch, config, "/nonexistent/path", kg)
+        from mempalace.mcp_server import tool_sync_status
+
+        result = tool_sync_status()
+        assert "error" in result
+
+    def test_sync_status_fresh_files(self, monkeypatch, config, palace_path, kg, tmp_path):
+        """Source files unchanged since mining — all should be fresh."""
+        self._patch_sync(monkeypatch, config, palace_path, kg)
+        import hashlib
+
+        # Create real source files
+        src_file = tmp_path / "code.py"
+        src_file.write_text("def hello(): return True")
+        content_hash = hashlib.md5("def hello(): return True".encode(), usedforsecurity=False).hexdigest()
+
+        _, col = _get_collection(palace_path, create=True)
+        col.add(
+            ids=["drawer_test_general_001"],
+            documents=["def hello(): return True"],
+            metadatas=[{
+                "wing": "test",
+                "room": "general",
+                "source_file": str(src_file),
+                "chunk_index": 0,
+                "added_by": "test",
+                "filed_at": "2026-01-01T00:00:00",
+                "content_hash": content_hash,
+            }],
+        )
+
+        from mempalace.mcp_server import tool_sync_status
+        result = tool_sync_status()
+        assert result["status"] == "fresh"
+        assert result["fresh"] == 1
+        assert result["stale"] == 0
+
+    def test_sync_status_stale_file(self, monkeypatch, config, palace_path, kg, tmp_path):
+        """Source file changed since mining — should be detected as stale."""
+        self._patch_sync(monkeypatch, config, palace_path, kg)
+        import hashlib
+
+        src_file = tmp_path / "code.py"
+        src_file.write_text("original content")
+        old_hash = hashlib.md5("original content".encode(), usedforsecurity=False).hexdigest()
+
+        _, col = _get_collection(palace_path, create=True)
+        col.add(
+            ids=["drawer_test_general_001"],
+            documents=["original content"],
+            metadatas=[{
+                "wing": "test",
+                "room": "general",
+                "source_file": str(src_file),
+                "chunk_index": 0,
+                "added_by": "test",
+                "filed_at": "2026-01-01T00:00:00",
+                "content_hash": old_hash,
+            }],
+        )
+
+        # Modify the file
+        src_file.write_text("updated content — different from original")
+
+        from mempalace.mcp_server import tool_sync_status
+        result = tool_sync_status()
+        assert result["status"] == "stale"
+        assert result["stale"] == 1
+        assert len(result["stale_files"]) == 1
+        assert result["stale_files"][0]["file"] == str(src_file)
+        assert "remine_commands" in result
+
+    def test_sync_status_missing_file(self, monkeypatch, config, palace_path, kg):
+        """Source file deleted — drawers should be reported as orphaned."""
+        self._patch_sync(monkeypatch, config, palace_path, kg)
+
+        _, col = _get_collection(palace_path, create=True)
+        col.add(
+            ids=["drawer_test_general_001"],
+            documents=["content from deleted file"],
+            metadatas=[{
+                "wing": "test",
+                "room": "general",
+                "source_file": "/tmp/nonexistent_file_12345.py",
+                "chunk_index": 0,
+                "added_by": "test",
+                "filed_at": "2026-01-01T00:00:00",
+                "content_hash": "abc123",
+            }],
+        )
+
+        from mempalace.mcp_server import tool_sync_status
+        result = tool_sync_status()
+        assert result["status"] == "orphaned"
+        assert result["missing"] == 1
+
+    def test_sync_status_legacy_no_hash(self, monkeypatch, config, palace_path, kg, tmp_path):
+        """Drawers without content_hash should be counted as no_hash_legacy."""
+        self._patch_sync(monkeypatch, config, palace_path, kg)
+
+        src_file = tmp_path / "old.py"
+        src_file.write_text("legacy code")
+
+        _, col = _get_collection(palace_path, create=True)
+        col.add(
+            ids=["drawer_test_general_001"],
+            documents=["legacy code"],
+            metadatas=[{
+                "wing": "test",
+                "room": "general",
+                "source_file": str(src_file),
+                "chunk_index": 0,
+                "added_by": "old_miner",
+                "filed_at": "2025-01-01T00:00:00",
+            }],
+        )
+
+        from mempalace.mcp_server import tool_sync_status
+        result = tool_sync_status()
+        assert result["no_hash_legacy"] == 1
+        assert result["status"] == "unknown"  # no hash = can't determine freshness
+
+    def test_sync_status_directory_filter(self, monkeypatch, config, palace_path, kg, tmp_path):
+        """Directory filter should only check files under the specified path."""
+        self._patch_sync(monkeypatch, config, palace_path, kg)
+        import hashlib
+
+        dir_a = tmp_path / "project_a"
+        dir_b = tmp_path / "project_b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        file_a = dir_a / "a.py"
+        file_b = dir_b / "b.py"
+        file_a.write_text("code A")
+        file_b.write_text("code B")
+
+        _, col = _get_collection(palace_path, create=True)
+        for sf, content, wing in [
+            (str(file_a), "code A", "proj-a"),
+            (str(file_b), "code B", "proj-b"),
+        ]:
+            h = hashlib.md5(content.encode(), usedforsecurity=False).hexdigest()
+            col.add(
+                ids=[f"drawer_{wing}_001"],
+                documents=[content],
+                metadatas=[{
+                    "wing": wing,
+                    "room": "general",
+                    "source_file": sf,
+                    "chunk_index": 0,
+                    "added_by": "test",
+                    "filed_at": "2026-01-01T00:00:00",
+                    "content_hash": h,
+                }],
+            )
+
+        from mempalace.mcp_server import tool_sync_status
+        result = tool_sync_status(directory=str(dir_a))
+        assert result["total_source_files"] == 1
+        assert result["fresh"] == 1
+    def test_diary_write_same_second_shared_prefix_no_collision(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+
+        from mempalace import mcp_server
+
+        class FrozenDateTime:
+            calls = [
+                datetime(2026, 4, 13, 22, 15, 30, 123456),
+                datetime(2026, 4, 13, 22, 15, 30, 123457),
+            ]
+            fallback = datetime(2026, 4, 13, 22, 15, 30, 123457)
+
+            @classmethod
+            def now(cls):
+                if cls.calls:
+                    return cls.calls.pop(0)
+                return cls.fallback
+
+        monkeypatch.setattr(mcp_server, "datetime", FrozenDateTime)
+
+        from mempalace.mcp_server import tool_diary_read, tool_diary_write
+
+        entry1 = "A" * 50 + " entry one"
+        entry2 = "A" * 50 + " entry two"
+
+        result1 = tool_diary_write(agent_name="TestAgent", entry=entry1, topic="status")
+        result2 = tool_diary_write(agent_name="TestAgent", entry=entry2, topic="status")
+
+        assert result1["success"] is True
+        assert result2["success"] is True
+        assert result1["entry_id"] != result2["entry_id"]
+
+        read_result = tool_diary_read(agent_name="TestAgent")
+        contents = [entry["content"] for entry in read_result["entries"]]
+        assert read_result["total"] == 2
+        assert entry1 in contents
+        assert entry2 in contents
+
+
+# ── Cache Invalidation (inode/mtime) ──────────────────────────────────
+
+

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Detailed parameter schemas for all 29 MCP tools.
+Detailed parameter schemas for all 30 MCP tools.
 
 ## Palace — Read Tools
 
@@ -379,3 +379,21 @@ Force a reconnect to the palace database. Use this after external scripts or CLI
 **Parameters:** None
 
 **Returns:** `{ success, message, drawers, vector_disabled[, vector_disabled_reason] }` (on no-palace: `{ success: false, message, drawers, vector_disabled }`; on exception: `{ success: false, error }`)
+
+---
+
+## Sync Tools
+
+### `mempalace_sync_status`
+
+Check whether palace memories are up to date with their source files. Scans all drawers, compares stored `content_hash` values against current file content, and returns a freshness report. Read-only — no side effects.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `directory` | string | No | Scope the check to files under this path. Omit to check all source files. |
+
+**Returns:** `{ status, total_source_files, fresh, stale, missing, no_hash_legacy, stale_files, remine_commands, message }`
+
+`status` values: `fresh` | `stale` | `missing` | `unknown` | `empty` | `error`
+
+`status: unknown` is returned when all drawers lack `content_hash` (mined before sync support). Re-mine with the latest version to enable freshness tracking.


### PR DESCRIPTION
## 🤔 The problem

An AI agent searches the palace and gets results. Are those results current? Were the source files modified since the last mine? There is no way to know — the agent just has to trust that the memories are fresh.

This is a correctness risk. Stale memories can inject outdated or contradictory context into live reasoning.

## ✅ What this does

### MCP tool: `mempalace_sync_status`

A read-only tool that tells the agent exactly what is fresh, what is stale, and what to do about it:

```json
// All good
{"status": "fresh", "total_source_files": 58, "fresh": 58, "stale": 0}

// Something changed
{
  "status": "stale",
  "fresh": 52, "stale": 6,
  "stale_files": [{"file": "/path/to/README.md", "drawers": 55, "wing": "my-project"}],
  "remine_commands": ["mempalace mine /path --wing my-project --force"],
  "message": "6 files changed since last mine. Run the remine_commands to refresh."
}

// Mined before content_hash support
{"status": "unknown", "message": "All 58 source files lack content_hash. Re-mine with latest version to enable freshness tracking."}
```

No side effects. The agent can call this before trusting search results, then suggest re-mine commands to the user.

### Hook: `mempal_freshness_hook.sh`

Stop hook that checks freshness once per session (configurable `CHECK_INTERVAL`, default 3600s). Warns the agent when stale files are detected.

## 🔒 Security

- `SESSION_ID` sanitized via `tr -cd A-Za-z0-9_-` to prevent path traversal in stamp file
- Directory filter enforces path boundary (trailing separator) — `/project` does not match `/project_other`
- Uses `sed` instead of `grep -P` for macOS compatibility
- `$CHECK_DIR` quoted to handle paths with spaces

## 🧪 Tests

8 sync-specific tests + all 103 existing MCP server tests pass.

```
python -m pytest tests/test_mcp_server.py -q
111 passed
```

Depends on: #1343 (content_hash in drawer metadata — without it, tool returns `status: unknown`)
Relates to #224.