### PR TITLE
feat(palace): add .obsidian, .terraform, vendor to SKIP_DIRS

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -121,6 +121,7 @@ SKIP_DIRS = {
     ".terraform",
     "vendor",
     "target",
+    ".obsidian",
 }
 
 # Files whose content is boilerplate prose — poisons entity detection.

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -35,6 +35,14 @@ SKIP_DIRS = {
     ".eggs",
     "htmlcov",
     "target",
+    # Tooling/plugin config directories that hold bundled JS/CSS the
+    # mine has no business indexing as user content. .obsidian alone
+    # produced 26K+ contaminated drawers in a real Obsidian vault — a
+    # single plugin (excalidraw) contributed 11.9K. Vendored deps land
+    # here too. Closes #1329.
+    ".obsidian",
+    ".terraform",
+    "vendor",
 }
 
 _DEFAULT_BACKEND = ChromaBackend()

--- a/mempalace/project_scanner.py
+++ b/mempalace/project_scanner.py
@@ -53,6 +53,7 @@ SKIP_DIRS = {
     ".pytest_cache",
     ".mypy_cache",
     ".ruff_cache",
+    ".obsidian",
 }
 
 MAX_DEPTH = 6

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -117,6 +117,9 @@ def detect_rooms_from_folders(project_dir: str) -> list:
         "build",
         ".next",
         "coverage",
+        ".obsidian",
+        ".terraform",
+        "vendor",
     }
 
     # Check top-level directories first (most reliable signal)
@@ -200,7 +203,18 @@ def detect_rooms_from_files(project_dir: str) -> list:
     project_path = Path(project_dir).expanduser().resolve()
     keyword_counts = defaultdict(int)
 
-    SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv", "dist", "build"}
+    SKIP_DIRS = {
+        ".git",
+        "node_modules",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "dist",
+        "build",
+        ".obsidian",
+        ".terraform",
+        "vendor",
+    }
 
     for root, dirs, filenames in os.walk(project_path):
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS]

--- a/tests/test_skip_dirs.py
+++ b/tests/test_skip_dirs.py
@@ -1,0 +1,82 @@
+"""Regression tests for SKIP_DIRS — make sure tooling/plugin config
+trees (.obsidian/plugins, .terraform, vendor) never get mined as user
+content.
+
+Background: a real Obsidian vault audit found 26,320 drawers in
+`wing=obsidian / room=operations` were `.obsidian/plugins/<plugin>/main.js`
+JavaScript source. The vault had ~9 real markdown files. The mine walk
+was not filtering `.obsidian/`. Adding it to palace.SKIP_DIRS (the
+canonical set imported by miner.py and convo_miner.py) fixes the
+file-walk path. The other modules (project_scanner, entity_detector,
+room_detector_local) have their own sets — fixed in parallel for
+consistency. Closes #1329.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mempalace import entity_detector, palace, project_scanner
+from mempalace.miner import scan_project
+
+
+def _make_obsidian_fixture(root: Path) -> None:
+    """Build a tiny Obsidian-shaped tree:
+    <root>/Notes/index.md     <- legitimate user content
+    <root>/.obsidian/plugins/excalidraw/main.js   <- bundled JS noise
+    <root>/.obsidian/themes/Minimal/theme.css     <- bundled CSS noise
+    """
+    notes = root / "Notes"
+    notes.mkdir(parents=True)
+    (notes / "index.md").write_text("# Notes\n\nReal content.\n")
+
+    plugin = root / ".obsidian" / "plugins" / "excalidraw"
+    plugin.mkdir(parents=True)
+    (plugin / "main.js").write_text("// 11k lines of bundled excalidraw JS pretend\n" * 100)
+
+    theme = root / ".obsidian" / "themes" / "Minimal"
+    theme.mkdir(parents=True)
+    (theme / "theme.css").write_text("/* minimal theme */\n")
+
+
+class TestPalaceSkipDirs:
+    def test_obsidian_in_palace_skip_dirs(self):
+        assert ".obsidian" in palace.SKIP_DIRS
+
+    def test_terraform_in_palace_skip_dirs(self):
+        assert ".terraform" in palace.SKIP_DIRS
+
+    def test_vendor_in_palace_skip_dirs(self):
+        assert "vendor" in palace.SKIP_DIRS
+
+
+class TestProjectScannerSkipDirs:
+    def test_obsidian_in_project_scanner_skip_dirs(self):
+        assert ".obsidian" in project_scanner.SKIP_DIRS
+
+
+class TestEntityDetectorSkipDirs:
+    def test_obsidian_in_entity_detector_skip_dirs(self):
+        assert ".obsidian" in entity_detector.SKIP_DIRS
+
+
+class TestScanProjectHonorsObsidianSkip:
+    """End-to-end: the file-walk that runs during `mempalace mine` must
+    not yield files under .obsidian/. miner.scan_project is the canonical
+    entry point; SKIP_DIRS is imported from palace.py."""
+
+    def test_scan_project_skips_obsidian_plugins(self, tmp_path):
+        _make_obsidian_fixture(tmp_path)
+
+        files = list(scan_project(str(tmp_path)))
+        rel_paths = {str(Path(f).relative_to(tmp_path)) for f in files}
+
+        # Real content present
+        assert "Notes/index.md" in rel_paths
+
+        # No .obsidian/* under any path
+        leaked = [p for p in rel_paths if ".obsidian" in p]
+        assert leaked == [], (
+            f"scan_project leaked .obsidian/ paths into mine corpus: {leaked}. "
+            "SKIP_DIRS in palace.py must include '.obsidian'."
+        )


### PR DESCRIPTION
## Summary
- Expands `palace.SKIP_DIRS` (the canonical set imported by `miner.py` and `convo_miner.py`) to include `.obsidian`, `.terraform`, and `vendor`.
- Mirrors the addition into the three other tooling-walk SKIP_DIRS sets (`entity_detector.py`, `project_scanner.py`, `room_detector_local.py`) where any of the three were missing, for symmetry.
- Eliminates the contamination class behind issue #1329.

## Why
`.obsidian/plugins/` ships large vendored JS bundles per Obsidian plugin. When a user runs mempalace's miner against an Obsidian vault, those bundles get ingested as drawers despite carrying no semantic value — purely framework / plugin code. Same pattern for `.terraform` (provider binaries) and `vendor/` (Go / PHP vendored dependencies).

Real-world reproducer (Obsidian vault, ~9 real markdown files): 26K+ contamination drawers from `.obsidian/plugins/` were ingested in a single mine pass before this fix; one plugin (excalidraw) alone contributed ~11.9K bundled JS lines.

## Tests
- `tests/test_skip_dirs.py` (new): 6 tests
  - 3 membership tests on `palace.SKIP_DIRS` (the canonical set imported by miner / convo_miner)
  - 1 each on `project_scanner.SKIP_DIRS` and `entity_detector.SKIP_DIRS`
  - 1 end-to-end test that builds a tiny Obsidian-shaped fixture (`Notes/index.md` + `.obsidian/plugins/.../main.js` + `.obsidian/themes/.../theme.css`) and verifies `miner.scan_project` yields the markdown but no `.obsidian/*` paths
- Full suite: 1495 pass + 1 skip (was 1489 + 1; +6 new). No regressions.

## Out of scope (Codex preflight finding, deferred)
Codex preflight flagged that `sweeper.py:311` uses `dir_p.rglob("*.jsonl")` and does NOT route through any SKIP_DIRS set, so `mempalace sweep <directory>` would still sweep `.jsonl` files under `.obsidian/`. This is a pre-existing coverage hole on `develop`, not introduced by this PR. It's intentionally deferred to a separate fix because (a) it requires its own behavior choice (filter `rglob` results vs. switch to `os.walk` with `dirs[:]` pruning) plus separate test coverage, and (b) bundling would expand the PR scope beyond the targeted #1329 fix. Happy to follow up with a separate PR if maintainers want it tackled here.

## Test plan
- [x] Existing test suite passes (1495 + 1 skipped)
- [x] New `test_skip_dirs.py` exercises end-to-end miner walk
- [ ] Manual verification: run `mempalace mine <obsidian-vault>` against a vault with `.obsidian/plugins/`; confirm zero drawers ingested from skip-dir paths

Closes #1329