### PR TITLE
fix(mine): detect concurrent palace holder, exit non-zero with clear error (#1264)

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -23,6 +23,7 @@ from .palace import (
     SKIP_DIRS,
     MineAlreadyRunning,
     build_closet_lines,
+    detect_palace_holder,
     file_already_mined,
     get_closets_collection,
     get_collection,
@@ -1019,6 +1020,24 @@ def mine(
             files=files,
         )
 
+    # Pre-flight: detect a concurrent writer (typically `mempalace.mcp_server`)
+    # holding chroma.sqlite3 BEFORE any other output. Without this check
+    # `mine` would print the auto-defaults stderr warning, then attempt its
+    # first chroma write, hit lock contention or a Rust-binding SIGSEGV,
+    # and exit with no diagnostic visible (issue #1264). `mine_palace_lock`
+    # below only catches mine-vs-mine; the structural lock-at-backend fix
+    # lives in #1162. This pre-flight closes the operator-visible gap on
+    # POSIX and degrades silently on Windows / when `lsof` is unavailable.
+    holder = detect_palace_holder(palace_path)
+    if holder is not None:
+        print(
+            f"mempalace mine: cannot start — palace at {palace_path} is held by "
+            f"{holder['kind']} (PID {holder['pid']}). "
+            "Wait for it to finish, or stop the holder before mining.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     try:
         with mine_palace_lock(palace_path):
             return _mine_impl(
@@ -1034,11 +1053,11 @@ def mine(
             )
     except MineAlreadyRunning:
         print(
-            f"mempalace: another `mine` is already running against "
-            f"{palace_path} — exiting cleanly.",
+            f"mempalace mine: cannot start — another `mempalace mine` is already "
+            f"running against {palace_path}. Wait for it to finish before mining.",
             file=sys.stderr,
         )
-        return
+        sys.exit(1)
 
 
 def _mine_impl(

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -9,7 +9,10 @@ import hashlib
 import logging
 import os
 import re
+import subprocess
+import sys
 import threading
+from typing import Optional
 
 from .backends.chroma import ChromaBackend
 
@@ -273,6 +276,89 @@ def upsert_closet_lines(closets_col, closet_id_base, lines, metadata):
 
     _flush()
     return closets_written
+
+
+def detect_palace_holder(palace_path: str) -> Optional[dict]:
+    """Best-effort detection of a process holding ``<palace>/chroma.sqlite3`` open.
+
+    Used by ``mine`` as a pre-flight check before opening ChromaDB so a
+    concurrent writer (typically ``mempalace.mcp_server``) is reported with
+    a clear stderr error instead of a silent SIGSEGV / lock contention.
+
+    POSIX implementation: shells out to ``lsof``. On Windows or if ``lsof``
+    is unavailable, returns ``None`` (graceful degrade — the caller proceeds
+    as before). Never raises; never blocks more than ~3s.
+
+    Returns a dict ``{"pid": int, "command": str, "kind": str}`` for the
+    first non-self holder found, or ``None`` when no holder is detected.
+
+    ``kind`` is a coarse classification — one of:
+      * ``"mempalace.mcp_server"`` — MCP server process
+      * ``"mempalace mine"`` — concurrent ``mine`` invocation
+      * the raw command name otherwise
+    """
+    db_path = os.path.join(os.path.expanduser(palace_path), "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+    if sys.platform == "win32":
+        return None
+    try:
+        result = subprocess.run(
+            ["lsof", "-Fpcn", "--", db_path],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode not in (0, 1):
+        # lsof returns 1 when no holders are found on some platforms;
+        # any other non-zero is a real failure — degrade silently.
+        return None
+
+    self_pid = os.getpid()
+    pid: Optional[int] = None
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        tag, value = line[0], line[1:]
+        if tag == "p":
+            try:
+                pid = int(value)
+            except ValueError:
+                pid = None
+        elif tag == "c" and pid is not None:
+            if pid == self_pid:
+                pid = None
+                continue
+            kind = _classify_palace_holder(pid, value)
+            return {"pid": pid, "command": value, "kind": kind}
+    return None
+
+
+def _classify_palace_holder(pid: int, command: str) -> str:
+    """Return a coarse process kind by inspecting full argv via ``ps``.
+
+    Falls back to the command name from ``lsof`` when ``ps`` is unavailable
+    or fails. Best-effort only — never raises.
+    """
+    if sys.platform == "win32":
+        return command or "unknown"
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "args="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return command or "unknown"
+    args = result.stdout.strip()
+    if "mempalace.mcp_server" in args or " mcp" in f" {args}":
+        return "mempalace.mcp_server"
+    if "mempalace mine" in args or "mempalace sweep" in args:
+        return "mempalace mine"
+    return command or "unknown"
 
 
 @contextlib.contextmanager

--- a/tests/test_detect_palace_holder.py
+++ b/tests/test_detect_palace_holder.py
@@ -1,0 +1,270 @@
+"""Tests for detect_palace_holder + mine pre-flight refusal (issue #1264).
+
+The bug: when an MCP server (or any other writer) holds the palace's
+chroma.sqlite3 open, ``mempalace mine`` would print only the auto-defaults
+warning and exit with no diagnostic — the chroma open would either block
+silently or SIGSEGV under chromadb 1.5.x's concurrent-writer behavior.
+
+The fix detects a live holder before opening chroma and refuses with a
+clear stderr message + non-zero exit. POSIX uses ``lsof``; Windows and
+hosts without ``lsof`` degrade silently to None.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+
+import pytest
+
+from mempalace import miner, palace
+from mempalace.palace import detect_palace_holder
+
+
+# ---------------------------------------------------------------------------
+# detect_palace_holder — pure unit tests (subprocess mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_when_palace_dir_missing(tmp_path):
+    """No chroma.sqlite3 → no holder, no subprocess call."""
+    assert detect_palace_holder(str(tmp_path / "missing_palace")) is None
+
+
+def test_returns_none_when_chroma_db_missing(tmp_path):
+    """Palace dir exists but no chroma.sqlite3 yet → no detection attempted."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    assert detect_palace_holder(str(palace_dir)) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only path")
+def test_returns_none_on_lsof_missing(tmp_path, monkeypatch):
+    """If `lsof` is not installed, degrade to None (don't crash)."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_bytes(b"")
+
+    def _raise_fnf(*_args, **_kwargs):
+        raise FileNotFoundError("lsof")
+
+    monkeypatch.setattr(subprocess, "run", _raise_fnf)
+    assert detect_palace_holder(str(palace_dir)) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only path")
+def test_returns_none_on_lsof_timeout(tmp_path, monkeypatch):
+    """A hung lsof must not hang the mine — we degrade after the timeout."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_bytes(b"")
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="lsof", timeout=2)
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    assert detect_palace_holder(str(palace_dir)) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only path")
+def test_returns_none_when_lsof_finds_no_holders(tmp_path, monkeypatch):
+    """Empty lsof output (returncode 0 or 1) → no holder."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_bytes(b"")
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess(args=a, returncode=1, stdout="", stderr=""),
+    )
+    assert detect_palace_holder(str(palace_dir)) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only path")
+def test_skips_self_pid(tmp_path, monkeypatch):
+    """If the only holder is our own PID, we are not "another writer"."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_bytes(b"")
+
+    own_pid = os.getpid()
+    lsof_output = f"p{own_pid}\ncPython\nn{palace_dir / 'chroma.sqlite3'}\n"
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess(
+            args=a, returncode=0, stdout=lsof_output, stderr=""
+        ),
+    )
+    assert detect_palace_holder(str(palace_dir)) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only path")
+def test_classifies_mcp_server_holder(tmp_path, monkeypatch):
+    """An MCP server holding the db is reported with kind='mempalace.mcp_server'."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_bytes(b"")
+
+    other_pid = os.getpid() + 1  # any PID that isn't us
+    lsof_output = f"p{other_pid}\ncPython\nn{palace_dir / 'chroma.sqlite3'}\n"
+
+    def _fake_run(cmd, *args, **kwargs):
+        if cmd[0] == "lsof":
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=lsof_output, stderr=""
+            )
+        if cmd[0] == "ps":
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="/usr/bin/python3 -m mempalace.mcp_server --palace ~/palace\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    holder = detect_palace_holder(str(palace_dir))
+    assert holder == {"pid": other_pid, "command": "Python", "kind": "mempalace.mcp_server"}
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only path")
+def test_classifies_concurrent_mine_holder(tmp_path, monkeypatch):
+    """A sibling `mempalace mine` is reported with kind='mempalace mine'."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_bytes(b"")
+
+    other_pid = os.getpid() + 1
+    lsof_output = f"p{other_pid}\ncPython\nn{palace_dir / 'chroma.sqlite3'}\n"
+
+    def _fake_run(cmd, *args, **kwargs):
+        if cmd[0] == "lsof":
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=lsof_output, stderr=""
+            )
+        if cmd[0] == "ps":
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="/usr/bin/python3 /usr/local/bin/mempalace mine /tmp/proj\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    holder = detect_palace_holder(str(palace_dir))
+    assert holder is not None
+    assert holder["kind"] == "mempalace mine"
+    assert holder["pid"] == other_pid
+
+
+def test_returns_none_on_windows(tmp_path, monkeypatch):
+    """Windows has no `lsof` — we degrade silently rather than crash."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_bytes(b"")
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert detect_palace_holder(str(palace_dir)) is None
+
+
+# ---------------------------------------------------------------------------
+# mine() pre-flight integration — refuses with non-zero exit and clear stderr
+# ---------------------------------------------------------------------------
+
+
+def test_mine_exits_nonzero_when_holder_detected(tmp_path, monkeypatch, capsys):
+    """When detect_palace_holder reports a holder, mine() must exit 1
+    with a clear stderr message — *before* the auto-defaults warning."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "main.py").write_text("print('hello world')\n" * 20)
+
+    palace_path = str(tmp_path / "palace")
+
+    fake_holder = {"pid": 12345, "command": "Python", "kind": "mempalace.mcp_server"}
+    monkeypatch.setattr(miner, "detect_palace_holder", lambda _p: fake_holder)
+
+    with pytest.raises(SystemExit) as exc_info:
+        miner.mine(project_dir=str(project_dir), palace_path=palace_path)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "cannot start" in captured.err
+    assert "mempalace.mcp_server" in captured.err
+    assert "PID 12345" in captured.err
+    assert palace_path in captured.err
+    # The auto-defaults warning lives in load_config, which must NOT have
+    # run yet — pre-flight refusal happens before any config inspection.
+    assert "auto-detected defaults" not in captured.err
+
+
+def test_mine_proceeds_when_no_holder(tmp_path, monkeypatch):
+    """When detect_palace_holder returns None, mine() proceeds normally."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "main.py").write_text("print('hello world')\n" * 20)
+
+    palace_path = str(tmp_path / "palace")
+
+    monkeypatch.setattr(miner, "detect_palace_holder", lambda _p: None)
+    monkeypatch.setenv("HOME", str(tmp_path))  # isolate the lock dir
+
+    # Should not raise SystemExit — mine should complete normally.
+    miner.mine(
+        project_dir=str(project_dir),
+        palace_path=palace_path,
+        wing_override="testwing",
+    )
+
+
+def test_mine_exits_nonzero_on_mine_already_running(tmp_path, monkeypatch, capsys):
+    """When mine_palace_lock raises MineAlreadyRunning, mine() exits 1 with
+    a clear message (was: silently exit 0 with 'exiting cleanly' wording)."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "main.py").write_text("print('hello world')\n" * 20)
+
+    palace_path = str(tmp_path / "palace")
+
+    monkeypatch.setattr(miner, "detect_palace_holder", lambda _p: None)
+
+    @contextlib.contextmanager
+    def _raise_lock(_path):
+        raise palace.MineAlreadyRunning("simulated contention")
+        yield  # pragma: no cover — unreachable, kept for generator validity
+
+    monkeypatch.setattr(miner, "mine_palace_lock", _raise_lock)
+
+    with pytest.raises(SystemExit) as exc_info:
+        miner.mine(project_dir=str(project_dir), palace_path=palace_path)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "cannot start" in captured.err
+    assert palace_path in captured.err
+    assert "another `mempalace mine`" in captured.err
+
+
+def test_dry_run_skips_pre_flight(tmp_path, monkeypatch, capsys):
+    """Dry-run mode does not open chroma, so it must not be blocked by a
+    detected holder — preserves the existing 'dry-run is always safe' contract."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "main.py").write_text("print('hello world')\n" * 20)
+
+    palace_path = str(tmp_path / "palace")
+
+    fake_holder = {"pid": 12345, "command": "Python", "kind": "mempalace.mcp_server"}
+    monkeypatch.setattr(miner, "detect_palace_holder", lambda _p: fake_holder)
+
+    # Dry run should NOT raise SystemExit — pre-flight is dry-run-bypassed.
+    miner.mine(
+        project_dir=str(project_dir),
+        palace_path=palace_path,
+        wing_override="testwing",
+        dry_run=True,
+    )


### PR DESCRIPTION
Fixes #1264.

## What does this PR do?

Closes the operator-visible silent-exit gap when `mempalace mine` is run while another writer (typically `mempalace.mcp_server`) holds the palace's `chroma.sqlite3` open.

Today, `mine` would:
1. Print the auto-defaults stderr warning from `load_config`.
2. Hit chromadb 1.5.x's concurrent-writer path on the first write attempt.
3. Exit silently — either via a Rust-binding SIGSEGV or with a swallowed lock contention. stdout's banner was lost to block-buffering on signal exit; only the stderr warning survived.

The result was the 200-byte log described in #1264.

This PR adds a **pre-flight detection** that runs *before* any other output and bails with a clear message + non-zero exit when a holder is found. It's complementary to #1162's structural fix at the `ChromaCollection` lock layer — once that lands, the lock-layer raise reaches the same loud `MineAlreadyRunning` handler instead of disappearing.

## Changes

### `mempalace/palace.py` — new helper
- `detect_palace_holder(palace_path) -> Optional[dict]`
- Uses `lsof -Fpcn` to find the first non-self process holding `<palace>/chroma.sqlite3`
- `_classify_palace_holder(pid, command)` inspects full argv via `ps` to classify the holder as `mempalace.mcp_server`, `mempalace mine`, or the raw command name as fallback
- POSIX-only: returns `None` on Windows or when `lsof` is unavailable, missing, or times out — graceful degrade preserves prior behavior on platforms we can't probe
- Never raises, never blocks more than ~3s (1s lsof + 1s ps with caps)

### `mempalace/miner.py` — wire pre-flight into `mine()`
- Pre-flight runs **before** `load_config`, the banner, and `get_collection`. The auto-defaults warning can no longer leak through as the only line of an operator's log.
- On detected holder: prints a one-line stderr message with palace path, holder PID, process kind, and a suggested next step, then `sys.exit(1)`.
- On `MineAlreadyRunning`: was `return` (clean exit 0 with `"exiting cleanly"` wording, which the issue called out as misleading); now `sys.exit(1)` with a clear `cannot start` message.
- Dry-run skips the pre-flight (it doesn't open chroma).

### `tests/test_detect_palace_holder.py` — new test file
13 tests covering:
- Missing palace dir / missing `chroma.sqlite3` → no detection attempt
- `lsof` unavailable / timeout / non-zero exit → graceful `None`
- Self-PID is filtered out
- MCP server and concurrent-mine classification via mocked `ps`
- Windows path returns `None` (`monkeypatch.setattr(sys, "platform", "win32")`)
- `mine()` exits 1 with clear stderr when a holder is detected, **without** the auto-defaults warning leaking
- `mine()` exits 1 with clear stderr on `MineAlreadyRunning`
- `mine()` proceeds normally when no holder is reported
- Dry-run skips the pre-flight

## How to test

```bash
# unit + integration tests
pytest tests/test_detect_palace_holder.py tests/test_palace_locks.py tests/test_miner.py -v

# end-to-end smoke (POSIX): hold the chroma file open in one shell, mine in another
mkdir -p /tmp/sm/proj /tmp/sm/palace && touch /tmp/sm/palace/chroma.sqlite3
echo 'def main(): pass' > /tmp/sm/proj/main.py
python3 -c "open('/tmp/sm/palace/chroma.sqlite3'); import time; time.sleep(60)" &
sleep 0.5
mempalace --palace /tmp/sm/palace mine /tmp/sm/proj
# Expect:
#   mempalace mine: cannot start — palace at /tmp/sm/palace is held by Python (PID <pid>). Wait for it to finish, or stop the holder before mining.
# Exit code: 1
```

Verified locally on macOS 26.4 (Apple Silicon, Python 3.14): `lsof` correctly identifies the holding PID, the message reaches stderr before any other output, and exit code is 1.

## Scope

- **In scope:** observability — make the failure loud at the `mine` entry point.
- **Out of scope (deferred):**
  - `mempalace sweep` — same writer entry-point class; the issue mentions it as plausible-same-shape but unverified. Suggest a follow-up PR mirroring this fix in `cmd_sweep` once we confirm the same silent-exit behavior there.
  - The structural fix at the chroma write-seam — that's #1162.
  - MCP server's own single-instance guard — that's #1229.

## Behavior change to flag

The `MineAlreadyRunning` handler now exits 1 instead of 0. The previous behavior was documented as "exiting cleanly", but per the issue's recommendation a non-zero exit makes nohup / shell wrappers / hooks see a useful signal. `mempalace.hooks_cli._spawn_mine` does not check the subprocess exit code, so the hook path is unaffected. If any caller relied on exit 0 from "another mine running", they should be updated to expect 1.

## Checklist
- [x] Tests pass (`pytest tests/ -v` — 1502 passed, 1 skipped)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .` — All checks passed)
- [x] No new dependencies (uses only `subprocess` and `sys` from stdlib)

Refs:
- #1264 (this fix)
- #1162 (structural fix at backend layer — complementary)
- #976 (existing `mine_palace_lock` for mine-vs-mine)
- #1229 (MCP server singleton guard — separate)
