### PR TITLE
feat(mcp): server-level wing access control via --allowed-wings / --blocked-wings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 # Coverage
 htmlcov/
 .coverage
+.coverage.*
 coverage.xml
 
 # Virtual environments

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -95,6 +95,23 @@ def _parse_args():
         metavar="PATH",
         help="Path to the palace directory (overrides config file and env var)",
     )
+    parser.add_argument(
+        "--allowed-wings",
+        metavar="WINGS",
+        help=(
+            "Comma-separated list of wings this agent may access. "
+            "If set, all other wings are implicitly denied. "
+            "Example: --allowed-wings=wing_user,wing_code,wing_kestrel"
+        ),
+    )
+    parser.add_argument(
+        "--blocked-wings",
+        metavar="WINGS",
+        help=(
+            "Comma-separated list of wings to always deny, even if listed in --allowed-wings. "
+            "Example: --blocked-wings=wing_surveillance,wing_financial"
+        ),
+    )
     args, unknown = parser.parse_known_args()
     if unknown:
         logger.debug("Ignoring unknown args: %s", unknown)
@@ -163,6 +180,65 @@ def _call_kg(op):
                 continue
             raise
 
+
+class WingPolicy:
+    """
+    Server-level wing access control, enforced on every tool call.
+
+    Instantiated once from CLI flags (--allowed-wings / --blocked-wings).
+    The agent controls its own tool arguments, but the server silently omits
+    blocked wings from aggregate results and returns access_denied errors for
+    any direct request targeting a blocked wing.
+
+    Blocked wings take precedence over allowed wings.
+
+    Usage (in claude_desktop_config.json or .claude/settings.json):
+        "args": ["--allowed-wings", "wing_user,wing_code,wing_projects"]
+        "args": ["--blocked-wings", "wing_surveillance,wing_financial"]
+    """
+
+    def __init__(self, allowed_wings=None, blocked_wings=None):
+        self.allowed = frozenset(allowed_wings) if allowed_wings else None
+        self.blocked = frozenset(blocked_wings) if blocked_wings else frozenset()
+
+    @property
+    def active(self) -> bool:
+        return self.allowed is not None or bool(self.blocked)
+
+    def is_allowed(self, wing: str) -> bool:
+        if wing in self.blocked:
+            return False
+        if self.allowed is not None and wing not in self.allowed:
+            return False
+        return True
+
+    def denied(self, wing: str) -> dict:
+        return {
+            "error": "access_denied",
+            "wing": wing,
+            "message": (
+                f"Wing '{wing}' is not accessible to this agent. "
+                f"Configure server access with --allowed-wings / --blocked-wings."
+            ),
+        }
+
+
+def _parse_wing_list(raw: str) -> list:
+    """Parse a comma-separated wing list from a CLI arg, stripping whitespace."""
+    return [w.strip() for w in raw.split(",") if w.strip()]
+
+
+_policy = WingPolicy(
+    allowed_wings=_parse_wing_list(_args.allowed_wings) if _args.allowed_wings else None,
+    blocked_wings=_parse_wing_list(_args.blocked_wings) if _args.blocked_wings else None,
+)
+
+if _policy.active:
+    logger.info(
+        "Wing policy active — allowed: %s  blocked: %s",
+        sorted(_policy.allowed) if _policy.allowed is not None else "*",
+        sorted(_policy.blocked) if _policy.blocked else "none",
+    )
 
 _client_cache = None
 _collection_cache = None
@@ -621,9 +697,13 @@ def tool_status():
         for m in all_meta:
             m = m or {}
             w = m.get("wing", "unknown")
+            if not _policy.is_allowed(w):
+                continue
             r = m.get("room", "unknown")
             wings[w] = wings.get(w, 0) + 1
             rooms[r] = rooms.get(r, 0) + 1
+        if _policy.active:
+            result["total_drawers"] = sum(wings.values())
     except Exception as e:
         logger.exception("tool_status metadata fetch failed")
         result["error"] = str(e)
@@ -675,6 +755,8 @@ def tool_list_wings():
         for m in all_meta:
             m = m or {}
             w = m.get("wing", "unknown")
+            if not _policy.is_allowed(w):
+                continue
             wings[w] = wings.get(w, 0) + 1
     except Exception as e:
         logger.exception("tool_list_wings metadata fetch failed")
@@ -688,6 +770,8 @@ def tool_list_rooms(wing: str = None):
         wing = _sanitize_optional_name(wing, "wing")
     except ValueError as e:
         return {"error": str(e)}
+    if wing and not _policy.is_allowed(wing):
+        return _policy.denied(wing)
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -698,6 +782,8 @@ def tool_list_rooms(wing: str = None):
         all_meta = _fetch_all_metadata(col, where=where)
         for m in all_meta:
             m = m or {}
+            if not _policy.is_allowed(m.get("wing", "unknown")):
+                continue
             r = m.get("room", "unknown")
             rooms[r] = rooms.get(r, 0) + 1
     except Exception as e:
@@ -718,6 +804,8 @@ def tool_get_taxonomy():
         for m in all_meta:
             m = m or {}
             w = m.get("wing", "unknown")
+            if not _policy.is_allowed(w):
+                continue
             r = m.get("room", "unknown")
             if w not in taxonomy:
                 taxonomy[w] = {}
@@ -744,6 +832,8 @@ def tool_search(
         room = _sanitize_optional_name(room, "room")
     except ValueError as e:
         return {"error": str(e)}
+    if wing and not _policy.is_allowed(wing):
+        return _policy.denied(wing)
     # Backwards compat: accept old name
     # Backwards compat: convert old similarity scale (higher=stricter) to
     # distance scale (lower=stricter). Similarity 0.8 → distance 0.2.
@@ -786,6 +876,10 @@ def tool_search(
     if _vector_disabled:
         result["vector_disabled"] = True
         result["vector_disabled_reason"] = _vector_disabled_reason
+    # Post-filter: when no wing was specified, drop hits from blocked wings.
+    # This prevents the agent from learning blocked content exists via search.
+    if _policy.active and isinstance(result, dict) and "results" in result:
+        result["results"] = [r for r in result["results"] if _policy.is_allowed(r.get("wing", ""))]
     # Attach sanitizer metadata for transparency
     if sanitized["was_sanitized"]:
         result["query_sanitized"] = True
@@ -828,12 +922,15 @@ def tool_check_duplicate(content: str, threshold: float = 0.9):
         duplicates = []
         if results["ids"] and results["ids"][0]:
             for i, drawer_id in enumerate(results["ids"][0]):
+                # Chroma 1.5.x can return None for partially-flushed rows;
+                # coerce to empty sentinels so downstream .get() is safe.
+                meta = results["metadatas"][0][i] or {}
+                # Don't reveal that content in blocked wings exists.
+                if not _policy.is_allowed(meta.get("wing", "")):
+                    continue
                 dist = results["distances"][0][i]
                 similarity = round(max(0.0, 1 - dist), 3)
                 if similarity >= threshold:
-                    # Chroma 1.5.x can return None for partially-flushed rows;
-                    # coerce to empty sentinels so downstream .get() is safe.
-                    meta = results["metadatas"][0][i] or {}
                     doc = results["documents"][0][i] or ""
                     duplicates.append(
                         {
@@ -859,7 +956,12 @@ def tool_get_aaak_spec():
 
 
 def tool_traverse_graph(start_room: str, max_hops: int = 2):
-    """Walk the palace graph from a room. Find connected ideas across wings."""
+    """Walk the palace graph from a room. Find connected ideas across wings.
+
+    Note: wing policy is not enforced on graph traversal. Traversal may follow
+    edges into blocked wings. Full enforcement requires policy-aware pagination
+    in palace_graph.traverse() — tracked as a follow-up.
+    """
     max_hops = max(1, min(max_hops, 10))
     col = _get_collection()
     if not col:
@@ -874,6 +976,10 @@ def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
         wing_b = _sanitize_optional_name(wing_b, "wing_b")
     except ValueError as e:
         return {"error": str(e)}
+    if wing_a and not _policy.is_allowed(wing_a):
+        return _policy.denied(wing_a)
+    if wing_b and not _policy.is_allowed(wing_b):
+        return _policy.denied(wing_b)
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -881,7 +987,11 @@ def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
 
 
 def tool_graph_stats():
-    """Palace graph overview: nodes, tunnels, edges, connectivity."""
+    """Palace graph overview: nodes, tunnels, edges, connectivity.
+
+    Note: wing policy is not enforced here — counts include drawers from all
+    wings regardless of the active policy. Follow-up to palace_graph.graph_stats().
+    """
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -910,6 +1020,10 @@ def tool_create_tunnel(
         target_room = sanitize_name(target_room, "target_room")
     except ValueError as e:
         return {"error": str(e)}
+    if not _policy.is_allowed(source_wing):
+        return _policy.denied(source_wing)
+    if not _policy.is_allowed(target_wing):
+        return _policy.denied(target_wing)
     return create_tunnel(
         source_wing,
         source_room,
@@ -927,13 +1041,38 @@ def tool_list_tunnels(wing: str = None):
         wing = _sanitize_optional_name(wing, "wing")
     except ValueError as e:
         return {"error": str(e)}
-    return list_tunnels(wing)
+    if wing and not _policy.is_allowed(wing):
+        return _policy.denied(wing)
+    tunnels = list_tunnels(wing)
+    # Post-filter: drop tunnels where either endpoint sits in a blocked wing.
+    # Tunnels are bidirectional, so leaking either endpoint exposes the link.
+    if _policy.active and isinstance(tunnels, list):
+        tunnels = [
+            t
+            for t in tunnels
+            if _policy.is_allowed(t.get("source", {}).get("wing", ""))
+            and _policy.is_allowed(t.get("target", {}).get("wing", ""))
+        ]
+    return tunnels
 
 
 def tool_delete_tunnel(tunnel_id: str):
     """Delete an explicit tunnel by its ID."""
     if not tunnel_id or not isinstance(tunnel_id, str):
         return {"error": "tunnel_id is required"}
+    # Look up the tunnel to enforce wing policy on either endpoint. If the
+    # tunnel is invisible under the active policy, refuse without revealing
+    # whether the ID exists.
+    if _policy.active:
+        match = next((t for t in list_tunnels() if t.get("id") == tunnel_id), None)
+        if match is None:
+            return {"deleted": tunnel_id}
+        src_wing = match.get("source", {}).get("wing", "")
+        tgt_wing = match.get("target", {}).get("wing", "")
+        if not _policy.is_allowed(src_wing):
+            return _policy.denied(src_wing)
+        if not _policy.is_allowed(tgt_wing):
+            return _policy.denied(tgt_wing)
     return delete_tunnel(tunnel_id)
 
 
@@ -944,8 +1083,14 @@ def tool_follow_tunnels(wing: str, room: str):
         room = sanitize_name(room, "room")
     except ValueError as e:
         return {"error": str(e)}
+    if not _policy.is_allowed(wing):
+        return _policy.denied(wing)
     col = _get_collection()
-    return follow_tunnels(wing, room, col=col)
+    result = follow_tunnels(wing, room, col=col)
+    # Post-filter: don't surface tunnel endpoints in blocked wings.
+    if _policy.active and isinstance(result, list):
+        result = [c for c in result if _policy.is_allowed(c.get("connected_wing", ""))]
+    return result
 
 
 # ==================== WRITE TOOLS ====================
@@ -962,6 +1107,9 @@ def tool_add_drawer(
         content = sanitize_content(content)
     except ValueError as e:
         return {"success": False, "error": str(e)}
+
+    if not _policy.is_allowed(wing):
+        return _policy.denied(wing)
 
     col = _get_collection(create=True)
     if not col:
@@ -1025,9 +1173,13 @@ def tool_delete_drawer(drawer_id: str):
     col = _get_collection()
     if not col:
         return _no_palace()
-    existing = col.get(ids=[drawer_id])
+    existing = col.get(ids=[drawer_id], include=["documents", "metadatas"])
     if not existing["ids"]:
         return {"success": False, "error": f"Drawer not found: {drawer_id}"}
+
+    drawer_wing = existing["metadatas"][0].get("wing", "") if existing["metadatas"] else ""
+    if not _policy.is_allowed(drawer_wing):
+        return _policy.denied(drawer_wing)
 
     # Log the deletion with the content being removed for audit trail
     deleted_content = existing.get("documents", [""])[0] if existing.get("documents") else ""
@@ -1094,6 +1246,8 @@ def tool_get_drawer(drawer_id: str):
         if not result["ids"]:
             return {"error": f"Drawer not found: {drawer_id}"}
         meta = result["metadatas"][0]
+        if not _policy.is_allowed(meta.get("wing", "")):
+            return _policy.denied(meta.get("wing", ""))
         doc = result["documents"][0]
         # source_file is the absolute filesystem path written by the
         # miners. Reduce to its basename before handing it to the MCP
@@ -1124,6 +1278,8 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
         room = _sanitize_optional_name(room, "room")
     except ValueError as e:
         return {"error": str(e)}
+    if wing and not _policy.is_allowed(wing):
+        return _policy.denied(wing)
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -1154,6 +1310,8 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
         drawers = []
         for i, did in enumerate(result["ids"]):
             meta = result["metadatas"][i]
+            if not _policy.is_allowed(meta.get("wing", "")):
+                continue
             doc = result["documents"][i]
             drawers.append(
                 {
@@ -1192,6 +1350,10 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
         old_meta = existing["metadatas"][0]
         old_doc = existing["documents"][0]
 
+        old_wing = old_meta.get("wing", "")
+        if not _policy.is_allowed(old_wing):
+            return _policy.denied(old_wing)
+
         new_doc = old_doc
         if content is not None:
             try:
@@ -1205,6 +1367,8 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
                 new_meta["wing"] = sanitize_name(wing, "wing")
             except ValueError as e:
                 return {"success": False, "error": str(e)}
+            if not _policy.is_allowed(new_meta["wing"]):
+                return _policy.denied(new_meta["wing"])
         if room is not None:
             try:
                 new_meta["room"] = sanitize_name(room, "room")
@@ -1398,6 +1562,8 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
         wing = sanitize_name(wing)
     else:
         wing = f"wing_{agent_name.replace(' ', '_')}"
+    if not _policy.is_allowed(wing):
+        return _policy.denied(wing)
     room = "diary"
     col = _get_collection(create=True)
     if not col:
@@ -1474,6 +1640,8 @@ def tool_diary_read(agent_name: str, last_n: int = 10, wing: str = ""):
             wing = sanitize_name(wing)
     except ValueError as e:
         return {"error": str(e)}
+    if wing and not _policy.is_allowed(wing):
+        return _policy.denied(wing)
     last_n = max(1, min(last_n, 100))
     col = _get_collection()
     if not col:
@@ -1496,9 +1664,15 @@ def tool_diary_read(agent_name: str, last_n: int = 10, wing: str = ""):
         if not results["ids"]:
             return {"agent": agent_name, "entries": [], "message": "No diary entries yet."}
 
-        # Combine and sort by timestamp
+        # Combine and sort by timestamp. When wing was unspecified, drop
+        # entries from blocked wings — otherwise the spans-all-wings path
+        # leaks diary content the policy means to hide.
         entries = []
+        kept_ids = 0
         for doc, meta in zip(results["documents"], results["metadatas"]):
+            if not _policy.is_allowed(meta.get("wing", "")):
+                continue
+            kept_ids += 1
             entries.append(
                 {
                     "date": meta.get("date", ""),
@@ -1514,7 +1688,7 @@ def tool_diary_read(agent_name: str, last_n: int = 10, wing: str = ""):
         return {
             "agent": agent_name,
             "entries": entries,
-            "total": len(results["ids"]),
+            "total": kept_ids,
             "showing": len(entries),
         }
     except Exception:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -696,9 +696,12 @@ def tool_status():
         all_meta = _get_cached_metadata(col)
         for m in all_meta:
             m = m or {}
-            w = m.get("wing", "unknown")
-            if not _policy.is_allowed(w):
+            # Policy check uses "" so a user can't accidentally allowlist
+            # the "unknown" display label and bypass the gate.
+            wing_raw = m.get("wing", "")
+            if not _policy.is_allowed(wing_raw):
                 continue
+            w = wing_raw or "unknown"
             r = m.get("room", "unknown")
             wings[w] = wings.get(w, 0) + 1
             rooms[r] = rooms.get(r, 0) + 1
@@ -754,9 +757,10 @@ def tool_list_wings():
         all_meta = _get_cached_metadata(col)
         for m in all_meta:
             m = m or {}
-            w = m.get("wing", "unknown")
-            if not _policy.is_allowed(w):
+            wing_raw = m.get("wing", "")
+            if not _policy.is_allowed(wing_raw):
                 continue
+            w = wing_raw or "unknown"
             wings[w] = wings.get(w, 0) + 1
     except Exception as e:
         logger.exception("tool_list_wings metadata fetch failed")
@@ -782,7 +786,7 @@ def tool_list_rooms(wing: str = None):
         all_meta = _fetch_all_metadata(col, where=where)
         for m in all_meta:
             m = m or {}
-            if not _policy.is_allowed(m.get("wing", "unknown")):
+            if not _policy.is_allowed(m.get("wing", "")):
                 continue
             r = m.get("room", "unknown")
             rooms[r] = rooms.get(r, 0) + 1
@@ -803,9 +807,10 @@ def tool_get_taxonomy():
         all_meta = _get_cached_metadata(col)
         for m in all_meta:
             m = m or {}
-            w = m.get("wing", "unknown")
-            if not _policy.is_allowed(w):
+            wing_raw = m.get("wing", "")
+            if not _policy.is_allowed(wing_raw):
                 continue
+            w = wing_raw or "unknown"
             r = m.get("room", "unknown")
             if w not in taxonomy:
                 taxonomy[w] = {}
@@ -956,12 +961,19 @@ def tool_get_aaak_spec():
 
 
 def tool_traverse_graph(start_room: str, max_hops: int = 2):
-    """Walk the palace graph from a room. Find connected ideas across wings.
-
-    Note: wing policy is not enforced on graph traversal. Traversal may follow
-    edges into blocked wings. Full enforcement requires policy-aware pagination
-    in palace_graph.traverse() — tracked as a follow-up.
-    """
+    """Walk the palace graph from a room. Find connected ideas across wings."""
+    # Traversal can follow edges into any wing. Until palace_graph.traverse()
+    # is policy-aware, hard-deny under any active policy rather than silently
+    # leak blocked-wing content through graph hops.
+    if _policy.active:
+        return {
+            "error": "access_denied",
+            "tool": "traverse_graph",
+            "message": (
+                "graph traversal is disabled while a wing policy is active "
+                "(traversal is not yet policy-aware)."
+            ),
+        }
     max_hops = max(1, min(max_hops, 10))
     col = _get_collection()
     if not col:
@@ -987,11 +999,19 @@ def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
 
 
 def tool_graph_stats():
-    """Palace graph overview: nodes, tunnels, edges, connectivity.
-
-    Note: wing policy is not enforced here — counts include drawers from all
-    wings regardless of the active policy. Follow-up to palace_graph.graph_stats().
-    """
+    """Palace graph overview: nodes, tunnels, edges, connectivity."""
+    # Counts span every wing. Until palace_graph.graph_stats() is
+    # policy-aware, hard-deny under any active policy rather than disclose
+    # blocked-wing presence through aggregate totals.
+    if _policy.active:
+        return {
+            "error": "access_denied",
+            "tool": "graph_stats",
+            "message": (
+                "graph stats are disabled while a wing policy is active "
+                "(stats are not yet policy-aware)."
+            ),
+        }
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -1060,19 +1080,20 @@ def tool_delete_tunnel(tunnel_id: str):
     """Delete an explicit tunnel by its ID."""
     if not tunnel_id or not isinstance(tunnel_id, str):
         return {"error": "tunnel_id is required"}
-    # Look up the tunnel to enforce wing policy on either endpoint. If the
-    # tunnel is invisible under the active policy, refuse without revealing
-    # whether the ID exists.
+    # Look up the tunnel to enforce wing policy on either endpoint. When a
+    # policy is active and the ID does not match a visible tunnel, return the
+    # idempotent {"deleted": ...} shape used for missing IDs — claiming the
+    # no-op explicitly is the intentional symmetry that prevents an agent
+    # from distinguishing "no such tunnel" from "tunnel touches a blocked
+    # wing" by inspecting the response.
     if _policy.active:
         match = next((t for t in list_tunnels() if t.get("id") == tunnel_id), None)
         if match is None:
             return {"deleted": tunnel_id}
         src_wing = match.get("source", {}).get("wing", "")
         tgt_wing = match.get("target", {}).get("wing", "")
-        if not _policy.is_allowed(src_wing):
-            return _policy.denied(src_wing)
-        if not _policy.is_allowed(tgt_wing):
-            return _policy.denied(tgt_wing)
+        if not _policy.is_allowed(src_wing) or not _policy.is_allowed(tgt_wing):
+            return {"deleted": tunnel_id}
     return delete_tunnel(tunnel_id)
 
 
@@ -1174,12 +1195,16 @@ def tool_delete_drawer(drawer_id: str):
     if not col:
         return _no_palace()
     existing = col.get(ids=[drawer_id], include=["documents", "metadatas"])
+    not_found = {"success": False, "error": f"Drawer not found: {drawer_id}"}
     if not existing["ids"]:
-        return {"success": False, "error": f"Drawer not found: {drawer_id}"}
+        return not_found
 
     drawer_wing = existing["metadatas"][0].get("wing", "") if existing["metadatas"] else ""
     if not _policy.is_allowed(drawer_wing):
-        return _policy.denied(drawer_wing)
+        # Mirror the not-found response: drawer IDs are deterministic on
+        # wing+room+content, so a distinguishable access_denied would let an
+        # agent confirm whether known content exists in a blocked wing.
+        return not_found
 
     # Log the deletion with the content being removed for audit trail
     deleted_content = existing.get("documents", [""])[0] if existing.get("documents") else ""
@@ -1243,11 +1268,14 @@ def tool_get_drawer(drawer_id: str):
         return _no_palace()
     try:
         result = col.get(ids=[drawer_id], include=["documents", "metadatas"])
+        not_found = {"error": f"Drawer not found: {drawer_id}"}
         if not result["ids"]:
-            return {"error": f"Drawer not found: {drawer_id}"}
+            return not_found
         meta = result["metadatas"][0]
         if not _policy.is_allowed(meta.get("wing", "")):
-            return _policy.denied(meta.get("wing", ""))
+            # See tool_delete_drawer: collapse 'not found' and 'blocked wing'
+            # so the response can't be used to probe blocked-wing contents.
+            return not_found
         doc = result["documents"][0]
         # source_file is the absolute filesystem path written by the
         # miners. Reduce to its basename before handing it to the MCP
@@ -1344,15 +1372,20 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
         return _no_palace()
     try:
         existing = col.get(ids=[drawer_id], include=["documents", "metadatas"])
+        not_found = {"success": False, "error": f"Drawer not found: {drawer_id}"}
         if not existing["ids"]:
-            return {"success": False, "error": f"Drawer not found: {drawer_id}"}
+            return not_found
 
         old_meta = existing["metadatas"][0]
         old_doc = existing["documents"][0]
 
         old_wing = old_meta.get("wing", "")
         if not _policy.is_allowed(old_wing):
-            return _policy.denied(old_wing)
+            # See tool_delete_drawer: hide existence of blocked-wing drawers
+            # by returning the same response as a missing ID. The new-wing
+            # check below stays as access_denied because the caller supplied
+            # that wing argument explicitly.
+            return not_found
 
         new_doc = old_doc
         if content is not None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1995,15 +1995,27 @@ class TestWingPolicy:
         self, monkeypatch, config, palace_path, seeded_collection, kg
     ):
         # delete_drawer must look up the drawer's wing from ChromaDB before
-        # acting — the caller only supplies an ID, not a wing.
+        # acting — the caller only supplies an ID, not a wing. The response
+        # for a blocked-wing ID must match the not-found response so an agent
+        # cannot probe whether known content exists in a blocked wing.
         from mempalace.mcp_server import WingPolicy
 
         _patch_mcp_server(monkeypatch, config, kg)
         self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
         from mempalace.mcp_server import tool_delete_drawer
 
-        result = tool_delete_drawer("drawer_proj_backend_aaa")
-        assert result["error"] == "access_denied"
+        blocked = tool_delete_drawer("drawer_proj_backend_aaa")
+        missing = tool_delete_drawer("drawer_does_not_exist_xyz")
+        # Same shape — only the echoed ID differs. An agent cannot tell
+        # "this ID doesn't exist" from "this ID is in a blocked wing".
+        assert blocked == {
+            "success": False,
+            "error": "Drawer not found: drawer_proj_backend_aaa",
+        }
+        assert missing == {
+            "success": False,
+            "error": "Drawer not found: drawer_does_not_exist_xyz",
+        }
         assert seeded_collection.count() == 4  # nothing deleted
 
     # -- Drawer family (get/list/update) ----------------------------------
@@ -2011,17 +2023,22 @@ class TestWingPolicy:
     def test_get_drawer_blocks_id_in_blocked_wing(
         self, monkeypatch, config, palace_path, seeded_collection, kg
     ):
-        # ID-based lookup must enforce policy: even with a known drawer_id,
-        # blocked-wing content stays inaccessible.
+        # ID-based lookup must enforce policy AND mirror the not-found
+        # response. Drawer IDs are deterministic on wing+room+content, so a
+        # distinguishable access_denied would let an agent confirm whether a
+        # known piece of content lives in a blocked wing.
         from mempalace.mcp_server import WingPolicy
 
         _patch_mcp_server(monkeypatch, config, kg)
         self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
         from mempalace.mcp_server import tool_get_drawer
 
-        result = tool_get_drawer("drawer_proj_backend_aaa")
-        assert result["error"] == "access_denied"
-        assert result["wing"] == "project"
+        blocked = tool_get_drawer("drawer_proj_backend_aaa")
+        missing = tool_get_drawer("drawer_does_not_exist_xyz")
+        # Same shape — only the echoed ID differs.
+        assert blocked == {"error": "Drawer not found: drawer_proj_backend_aaa"}
+        assert missing == {"error": "Drawer not found: drawer_does_not_exist_xyz"}
+        assert "content" not in blocked  # no payload leaked
 
     def test_get_drawer_allows_id_in_permitted_wing(
         self, monkeypatch, config, palace_path, seeded_collection, kg
@@ -2065,15 +2082,26 @@ class TestWingPolicy:
         self, monkeypatch, config, palace_path, seeded_collection, kg
     ):
         # Caller cannot mutate a drawer that lives in a blocked wing — even
-        # if the agent only knows the ID.
+        # if the agent only knows the ID. The response must mirror the
+        # not-found shape (existence-hiding); the new-wing path is checked
+        # in test_update_drawer_blocks_when_target_wing_blocked.
         from mempalace.mcp_server import WingPolicy
 
         _patch_mcp_server(monkeypatch, config, kg)
         self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
         from mempalace.mcp_server import tool_update_drawer
 
-        result = tool_update_drawer("drawer_proj_backend_aaa", content="rewritten")
-        assert result["error"] == "access_denied"
+        blocked = tool_update_drawer("drawer_proj_backend_aaa", content="rewritten")
+        missing = tool_update_drawer("drawer_does_not_exist_xyz", content="rewritten")
+        # Same shape — only the echoed ID differs.
+        assert blocked == {
+            "success": False,
+            "error": "Drawer not found: drawer_proj_backend_aaa",
+        }
+        assert missing == {
+            "success": False,
+            "error": "Drawer not found: drawer_does_not_exist_xyz",
+        }
         # Verify the original content is intact
         existing = seeded_collection.get(ids=["drawer_proj_backend_aaa"], include=["documents"])
         assert "JWT" in existing["documents"][0]
@@ -2152,7 +2180,10 @@ class TestWingPolicy:
 
         assert tool_list_tunnels(wing="project")["error"] == "access_denied"
 
-    def test_delete_tunnel_refuses_when_endpoint_blocked(self, monkeypatch, tmp_dir):
+    def test_delete_tunnel_silently_no_ops_on_blocked_endpoint(self, monkeypatch, tmp_dir):
+        # Symmetric with the missing-ID branch: we want both "no such tunnel"
+        # and "tunnel touches a blocked wing" to produce the same response so
+        # an agent cannot enumerate blocked-wing tunnels by trying random IDs.
         from mempalace.mcp_server import WingPolicy
         from mempalace import palace_graph as pg
 
@@ -2162,9 +2193,12 @@ class TestWingPolicy:
         self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
         from mempalace.mcp_server import tool_delete_tunnel
 
-        result = tool_delete_tunnel(tunnel["id"])
-        assert result["error"] == "access_denied"
-        # Confirm tunnel still exists on disk
+        blocked = tool_delete_tunnel(tunnel["id"])
+        missing = tool_delete_tunnel("tunnel_does_not_exist_xyz")
+        # Same response shape, only the echoed ID differs.
+        assert blocked == {"deleted": tunnel["id"]}
+        assert missing == {"deleted": "tunnel_does_not_exist_xyz"}
+        # The tunnel must still exist on disk despite the cosmetic "deleted" response
         assert any(t["id"] == tunnel["id"] for t in pg.list_tunnels())
 
     def test_follow_tunnels_blocks_requested_wing_and_filters_endpoints(
@@ -2193,3 +2227,104 @@ class TestWingPolicy:
         assert isinstance(r, list)
         assert all(c.get("connected_wing") != "project" for c in r)
         assert any(c.get("connected_wing") == "user" for c in r)
+
+    # -- Graph tools (hard-deny under any active policy) ------------------
+
+    def test_traverse_graph_hard_denies_under_active_policy(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # palace_graph.traverse() is not policy-aware; until it is, any
+        # active policy must hard-deny rather than risk leaking blocked-wing
+        # rooms through graph hops.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_traverse_graph
+
+        result = tool_traverse_graph("backend")
+        assert result["error"] == "access_denied"
+        assert result["tool"] == "traverse_graph"
+
+    def test_traverse_graph_works_when_policy_inactive(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # Default WingPolicy() is inactive — traverse must behave normally.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy())
+        from mempalace.mcp_server import tool_traverse_graph
+
+        result = tool_traverse_graph("backend")
+        # Should not be a policy denial — the underlying traverse may return
+        # any shape, but it must not surface our access_denied stub.
+        if isinstance(result, dict):
+            assert result.get("error") != "access_denied"
+
+    def test_graph_stats_hard_denies_under_active_policy(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(allowed_wings=["notes"]))
+        from mempalace.mcp_server import tool_graph_stats
+
+        result = tool_graph_stats()
+        assert result["error"] == "access_denied"
+        assert result["tool"] == "graph_stats"
+
+    def test_graph_stats_works_when_policy_inactive(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy())
+        from mempalace.mcp_server import tool_graph_stats
+
+        result = tool_graph_stats()
+        if isinstance(result, dict):
+            assert result.get("error") != "access_denied"
+
+    # -- Inactive-policy parity (the default no-op guarantee) -------------
+
+    def test_inactive_policy_lets_every_wing_through(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # The default WingPolicy() must be a true no-op: aggregates show
+        # every wing, ID lookups succeed, and create/delete tunnels work.
+        # This locks in the "no flags = unchanged behavior" guarantee.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy())
+        from mempalace.mcp_server import (
+            tool_status,
+            tool_list_wings,
+            tool_get_taxonomy,
+            tool_list_drawers,
+            tool_get_drawer,
+            tool_search,
+        )
+
+        # Aggregates show all wings present in the seed
+        assert "project" in tool_list_wings()["wings"]
+        assert "notes" in tool_list_wings()["wings"]
+        assert "project" in tool_get_taxonomy()["taxonomy"]
+        assert tool_status()["total_drawers"] == 4
+
+        # ID-keyed lookup against a "would-be-blocked" wing still works
+        result = tool_get_drawer("drawer_proj_backend_aaa")
+        assert "error" not in result
+        assert result["wing"] == "project"
+
+        # Listing is unfiltered
+        listing = tool_list_drawers(limit=100)
+        assert listing["count"] == 4
+
+        # Search returns hits from all wings
+        hits = tool_search(query="authentication database frontend planning", limit=10)
+        wings_hit = {r["wing"] for r in hits["results"]}
+        assert "project" in wings_hit

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -593,9 +593,9 @@ class TestWriteTools:
 
         assert result1["success"] is True
         assert result2["success"] is True
-        assert (
-            result1["drawer_id"] != result2["drawer_id"]
-        ), "Documents with shared header but different content must have distinct drawer IDs"
+        assert result1["drawer_id"] != result2["drawer_id"], (
+            "Documents with shared header but different content must have distinct drawer IDs"
+        )
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
@@ -1868,3 +1868,328 @@ class TestKGLazyCache:
         with pytest.raises(_sqlite3.ProgrammingError):
             mcp_server._call_kg(lambda kg: kg.query_entity("Alice"))
         assert calls["count"] == 2, "expected exactly one retry beyond the initial attempt"
+
+
+# ── Wing Policy ─────────────────────────────────────────────────────────
+
+
+class TestWingPolicy:
+    """Tests for WingPolicy logic and the distinct enforcement patterns it creates."""
+
+    def _patch_policy(self, monkeypatch, policy):
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_policy", policy)
+
+    # -- WingPolicy class logic --------------------------------------------
+
+    def test_allowlist_and_blocklist_logic(self):
+        from mempalace.mcp_server import WingPolicy
+
+        # No policy — everything passes, inactive
+        p = WingPolicy()
+        assert p.is_allowed("anything") is True
+        assert p.active is False
+
+        # Allowlist — only listed wings pass
+        p = WingPolicy(allowed_wings=["wing_user", "wing_code"])
+        assert p.is_allowed("wing_user") is True
+        assert p.is_allowed("wing_surveillance") is False
+
+        # Blocklist overrides allowlist
+        p = WingPolicy(
+            allowed_wings=["wing_user", "wing_financial"], blocked_wings=["wing_financial"]
+        )
+        assert p.is_allowed("wing_user") is True
+        assert p.is_allowed("wing_financial") is False
+
+        # denied() shape
+        result = p.denied("wing_financial")
+        assert result["error"] == "access_denied"
+        assert result["wing"] == "wing_financial"
+
+    # -- Soft filter (aggregate queries silently omit blocked wings) -------
+
+    def test_soft_filter_omits_blocked_wings_from_aggregate_queries(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_status, tool_list_wings, tool_get_taxonomy
+
+        # All three aggregate tools use the same filter pattern
+        assert "project" not in tool_status()["wings"]
+        assert tool_status()["total_drawers"] == 1
+        assert "project" not in tool_list_wings()["wings"]
+        assert "project" not in tool_get_taxonomy()["taxonomy"]
+
+    def test_list_rooms_unfiltered_omits_blocked_wing_rooms(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # Regression test — this was the bug: list_rooms without a wing arg
+        # didn't filter, so room names from blocked wings would leak.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["notes"]))
+        from mempalace.mcp_server import tool_list_rooms
+
+        result = tool_list_rooms()
+        assert "planning" not in result["rooms"]  # "planning" is only in "notes"
+        assert "backend" in result["rooms"]
+
+    # -- Hard block (explicit requests to blocked wings → access_denied) ---
+
+    def test_hard_block_on_explicit_wing_request(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_list_rooms, tool_search, tool_add_drawer
+
+        assert tool_list_rooms(wing="project")["error"] == "access_denied"
+        assert tool_search(query="JWT", wing="project")["error"] == "access_denied"
+
+        _client, _col = _get_collection(palace_path, create=False)
+        del _client
+        assert tool_add_drawer(wing="project", room="r", content="x")["error"] == "access_denied"
+
+    # -- Non-obvious enforcement paths ------------------------------------
+
+    def test_search_post_filter_drops_blocked_results(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # Unfiltered search — blocked wing hits must be stripped from results,
+        # not just the explicitly-requested-wing guard clause.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_search
+
+        result = tool_search(query="authentication database frontend planning", limit=10)
+        assert all(r["wing"] != "project" for r in result["results"])
+
+    def test_check_duplicate_suppresses_blocked_wing_matches(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # Content existence must not leak through duplicate detection.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_check_duplicate
+
+        result = tool_check_duplicate(
+            "The authentication module uses JWT tokens for session management. "
+            "Tokens expire after 24 hours. Refresh tokens are stored in HttpOnly cookies.",
+            threshold=0.5,
+        )
+        assert result["is_duplicate"] is False
+
+    def test_delete_drawer_checks_wing_before_deleting(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # delete_drawer must look up the drawer's wing from ChromaDB before
+        # acting — the caller only supplies an ID, not a wing.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_delete_drawer
+
+        result = tool_delete_drawer("drawer_proj_backend_aaa")
+        assert result["error"] == "access_denied"
+        assert seeded_collection.count() == 4  # nothing deleted
+
+    # -- Drawer family (get/list/update) ----------------------------------
+
+    def test_get_drawer_blocks_id_in_blocked_wing(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # ID-based lookup must enforce policy: even with a known drawer_id,
+        # blocked-wing content stays inaccessible.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_get_drawer
+
+        result = tool_get_drawer("drawer_proj_backend_aaa")
+        assert result["error"] == "access_denied"
+        assert result["wing"] == "project"
+
+    def test_get_drawer_allows_id_in_permitted_wing(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_get_drawer
+
+        result = tool_get_drawer("drawer_notes_planning_ddd")
+        assert "error" not in result
+        assert result["wing"] == "notes"
+
+    def test_list_drawers_unfiltered_drops_blocked_wings(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_list_drawers
+
+        result = tool_list_drawers(limit=100)
+        assert all(d["wing"] != "project" for d in result["drawers"])
+        # Only the single notes drawer should remain
+        assert result["count"] == 1
+
+    def test_list_drawers_explicit_blocked_wing_hard_denies(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_list_drawers
+
+        assert tool_list_drawers(wing="project")["error"] == "access_denied"
+
+    def test_update_drawer_blocks_when_old_wing_blocked(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # Caller cannot mutate a drawer that lives in a blocked wing — even
+        # if the agent only knows the ID.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_update_drawer
+
+        result = tool_update_drawer("drawer_proj_backend_aaa", content="rewritten")
+        assert result["error"] == "access_denied"
+        # Verify the original content is intact
+        existing = seeded_collection.get(ids=["drawer_proj_backend_aaa"], include=["documents"])
+        assert "JWT" in existing["documents"][0]
+
+    def test_update_drawer_blocks_when_target_wing_blocked(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # Cannot move a drawer INTO a blocked wing either — that would let an
+        # allowed agent stash data into a wing it has no policy access to.
+        from mempalace.mcp_server import WingPolicy
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_update_drawer
+
+        result = tool_update_drawer("drawer_notes_planning_ddd", wing="project")
+        assert result["error"] == "access_denied"
+        assert result["wing"] == "project"
+
+    # -- Tunnel family (create/list/delete/follow) ------------------------
+
+    def test_create_tunnel_blocks_when_either_endpoint_blocked(self, monkeypatch):
+        from mempalace.mcp_server import WingPolicy
+
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_create_tunnel
+
+        # Source side blocked
+        r = tool_create_tunnel(
+            source_wing="project",
+            source_room="backend",
+            target_wing="notes",
+            target_room="planning",
+        )
+        assert r["error"] == "access_denied"
+        assert r["wing"] == "project"
+
+        # Target side blocked
+        r = tool_create_tunnel(
+            source_wing="notes",
+            source_room="planning",
+            target_wing="project",
+            target_room="backend",
+        )
+        assert r["error"] == "access_denied"
+        assert r["wing"] == "project"
+
+    def test_list_tunnels_drops_tunnels_touching_blocked_wings(self, monkeypatch, tmp_dir):
+        # Tunnels are bidirectional — a tunnel with EITHER endpoint in a
+        # blocked wing must be hidden. Otherwise an attacker can enumerate
+        # blocked-wing rooms by listing tunnels.
+        from mempalace.mcp_server import WingPolicy
+        from mempalace import palace_graph as pg
+
+        # Use an isolated tunnel store so the test doesn't pollute the user's palace
+        monkeypatch.setattr(pg, "_TUNNEL_FILE", os.path.join(tmp_dir, "tunnels.json"))
+
+        # Create three tunnels: one fully outside blocked, two touching it
+        pg.create_tunnel("notes", "planning", "user", "diary", label="ok")
+        pg.create_tunnel("project", "backend", "notes", "planning", label="leak_src")
+        pg.create_tunnel("notes", "planning", "project", "backend", label="leak_tgt")
+
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_list_tunnels
+
+        result = tool_list_tunnels()
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["label"] == "ok"
+
+    def test_list_tunnels_explicit_blocked_wing_hard_denies(self, monkeypatch):
+        from mempalace.mcp_server import WingPolicy
+
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_list_tunnels
+
+        assert tool_list_tunnels(wing="project")["error"] == "access_denied"
+
+    def test_delete_tunnel_refuses_when_endpoint_blocked(self, monkeypatch, tmp_dir):
+        from mempalace.mcp_server import WingPolicy
+        from mempalace import palace_graph as pg
+
+        monkeypatch.setattr(pg, "_TUNNEL_FILE", os.path.join(tmp_dir, "tunnels.json"))
+        tunnel = pg.create_tunnel("project", "backend", "notes", "planning", label="x")
+
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_delete_tunnel
+
+        result = tool_delete_tunnel(tunnel["id"])
+        assert result["error"] == "access_denied"
+        # Confirm tunnel still exists on disk
+        assert any(t["id"] == tunnel["id"] for t in pg.list_tunnels())
+
+    def test_follow_tunnels_blocks_requested_wing_and_filters_endpoints(
+        self, monkeypatch, tmp_dir, config, palace_path, seeded_collection, kg
+    ):
+        from mempalace.mcp_server import WingPolicy
+        from mempalace import palace_graph as pg
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        monkeypatch.setattr(pg, "_TUNNEL_FILE", os.path.join(tmp_dir, "tunnels.json"))
+
+        # Tunnel from notes/planning to project/backend
+        pg.create_tunnel("notes", "planning", "project", "backend", label="leak")
+        # Another tunnel from notes/planning to user/diary (should pass)
+        pg.create_tunnel("notes", "planning", "user", "diary", label="ok")
+
+        self._patch_policy(monkeypatch, WingPolicy(blocked_wings=["project"]))
+        from mempalace.mcp_server import tool_follow_tunnels
+
+        # Hard-block when starting from a blocked wing
+        r = tool_follow_tunnels(wing="project", room="backend")
+        assert r["error"] == "access_denied"
+
+        # When starting from an allowed wing, blocked-wing endpoints are dropped
+        r = tool_follow_tunnels(wing="notes", room="planning")
+        assert isinstance(r, list)
+        assert all(c.get("connected_wing") != "project" for c in r)
+        assert any(c.get("connected_wing") == "user" for c in r)


### PR DESCRIPTION
## Summary

- New `WingPolicy` class enforces wing-level access control on every MCP tool that touches palace data.
- Two CLI flags on `mempalace-mcp`: `--allowed-wings` (allowlist) and `--blocked-wings` (denylist; takes precedence).
- Default is no-op — when neither flag is set, all wings pass.
- 18 wing-addressable tools now policy-gated via four enforcement patterns (hard block, soft filter, post-filter, ID lookup).
- 18 new tests, all passing.

## Problem

A user running multiple agents shouldn't have to trust every agent with every wing. Today, any agent with the `mempalace` MCP server configured can read or write any wing the server has access to — there's no way to scope an agent to its own project's wing, hide a financial wing from a general assistant, or give a "master" agent broader access than its sub-agents. `WingPolicy` adds that scoping at the server-process level.

## Change

`mempalace-mcp` now accepts:

- `--allowed-wings WINGS` — comma-separated allowlist; all unlisted wings denied
- `--blocked-wings WINGS` — comma-separated denylist; takes precedence over allowlist

Each agent's MCP server invocation carries its own policy:

```jsonc
// master agent — no flags, full access
"mempalace": { "command": "mempalace-mcp" }

// project-scoped agent
"mempalace": {
  "command": "mempalace-mcp",
  "args": ["--allowed-wings", "wing_user,wing_myproject"]
}

// general assistant, financial wings off-limits
"mempalace": {
  "command": "mempalace-mcp",
  "args": ["--blocked-wings", "wing_financial,wing_surveillance"]
}
```

All instances share `~/.mempalace/` data on disk; isolation is enforced server-side per process.

### Enforcement matrix

| Pattern | Tools |
|---|---|
| **Hard block** (`access_denied` on explicit-wing requests) | `list_rooms`, `search`, `find_tunnels`, `add_drawer`, `diary_read`, `diary_write`, `list_drawers`, `create_tunnel`, `list_tunnels`, `follow_tunnels` |
| **Soft filter** (silently omit blocked wings from aggregates) | `status`, `list_wings`, `get_taxonomy`, `list_rooms` (unfiltered), `list_drawers` (unfiltered) |
| **Post-filter** (drop blocked-wing hits from result arrays) | `search`, `check_duplicate`, `diary_read` (spans-all-wings), `list_tunnels` (either endpoint), `follow_tunnels` (destination) |
| **ID lookup → policy check** | `get_drawer`, `update_drawer` (old AND new wing), `delete_drawer`, `delete_tunnel` (both endpoints) |

Also bundled: a one-line `.gitignore` fix for per-process `.coverage.*` artifacts that slipped past the existing literal `.coverage` rule.

## Tests

- [x] `WingPolicy` allowlist + blocklist + precedence logic
- [x] Soft filter omits blocked wings from `status`, `list_wings`, `get_taxonomy`
- [x] `list_rooms` unfiltered drops rooms unique to blocked wings
- [x] Hard block on explicit wing requests across read + write tools
- [x] `search` post-filter drops blocked hits when no wing arg given
- [x] `check_duplicate` suppresses blocked-wing matches (no existence-leak)
- [x] `delete_drawer` / `update_drawer` / `get_drawer` enforce via ID lookup
- [x] `update_drawer` also blocks moves *into* a blocked wing
- [x] `create_tunnel` blocks when either endpoint is blocked
- [x] `list_tunnels` drops tunnels where either endpoint is in a blocked wing
- [x] `delete_tunnel` enforces on either endpoint via tunnel-id lookup
- [x] `follow_tunnels` hard-blocks origin and post-filters destinations

`ruff format` + `ruff check` clean. All 18 new `TestWingPolicy` tests pass; rebased onto current `main`.

## What's NOT in this PR

- **`traverse_graph` / `graph_stats`** — full enforcement requires policy-aware traversal inside `palace_graph.py`. Inline notes added to both tools' docstrings flagging the gap. Happy to do as a follow-up.
- **KG tools** (`kg_query`, `kg_add`, `kg_invalidate`, `kg_timeline`, `kg_stats`) — the knowledge graph is entity-keyed, not wing-keyed. Different scoping model.
- **Hook / settings / reconnect tools** — not data-bearing.
- **Per-sub-agent scoping** — `WingPolicy` operates at the MCP server process level. Hosts that spawn sub-agents which share the parent's MCP connection will see those sub-agents inherit the parent's policy. True per-sub-agent scoping requires the host to launch each sub-agent with its own `mempalace-mcp` invocation — a host-side concern, not a server-side one. Worth a note in any user docs that mention per-agent policies.