### PR TITLE
fix(lint): hoist hooks_cli_mod import to top of test_hooks_cli (E402)

### DIFF
--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import mempalace.hooks_cli as hooks_cli_mod
 from mempalace.hooks_cli import (
     SAVE_INTERVAL,
     _count_human_messages,
@@ -967,9 +968,6 @@ def test_stop_hook_rejects_injected_stop_hook_active(tmp_path):
 # possible "do not auto-capture" signal. Hooks must short-circuit BEFORE
 # touching disk — including before the log-line that previously triggered
 # STATE_DIR.mkdir() on its own.
-
-
-import mempalace.hooks_cli as hooks_cli_mod
 
 
 def _redirect_palace_root(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

The lint check on develop has been failing since #1305 merged with a red \`lint\` check (the other 5 OS lanes were green, so the merge went through). The failure is:

\`\`\`
tests/test_hooks_cli.py:972:1: E402 Module level import not at top of file
\`\`\`

\`import mempalace.hooks_cli as hooks_cli_mod\` was placed at line 972, below an explanatory comment block introduced by #1305. Every PR rebased onto develop now inherits this failure (just hit it on #988's rebase).

## Fix

Move the import next to the existing \`from mempalace.hooks_cli import (...)\` line at the top of the file. The comment block above the original location explains what the *tests* are checking, not why the import had to live there — there's no reason it can't sit with the other imports.

## Test plan
- [x] \`uvx ruff@0.4 check .\` — passes
- [x] \`uvx ruff@0.4 format --check .\` — passes
- [x] \`pytest tests/test_hooks_cli.py\` — 78 passed, 1 skipped (pre-existing)