### PR TITLE
fix(deps): cap chromadb<1.5.4 — Rust bindings UAF on macOS 26 ARM64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,15 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "chromadb>=1.5.4,<2",
+    # chromadb upper bound capped at <1.5.4 due to a use-after-free
+    # in `chromadb_rust_bindings.abi3.so` that crashes (SIGSEGV) on
+    # macOS 26 / ARM64 the moment a populated palace is opened. Bisect
+    # confirmed 1.5.3 works; 1.5.4 .. 1.5.9 (latest) all crash with
+    # the same recursive-walker / poisoned-pointer-in-mutex-unlock
+    # signature. See MemPalace/mempalace#1355 and
+    # chroma-core/chroma#6852. Lift this cap once upstream chroma
+    # ships a fix.
+    "chromadb>=1.5.0,<1.5.4",
     "pyyaml>=6.0,<7",
     "tomli>=2.0.0; python_version < '3.11'",
 ]


### PR DESCRIPTION
## Summary

Cap `chromadb<1.5.4` until upstream chroma fixes a use-after-free in
`chromadb_rust_bindings.abi3.so` that crashes mempalace on macOS 26 /
Apple Silicon the moment a populated palace is opened.

Refs:
- #1355 (mirror — same crash, two confirming reporters)
- chroma-core/chroma#6852 (upstream)
- #1340, #1274, #1329 (related symptoms — `status` / `mine` segfaults, MCP unrecoverable)

## Bisect

Tested against an existing 547,377-record palace (mempalace 3.3.4 on macOS 26.3.1 ARM64, Python 3.14.3, Apple M4 Pro):

| chromadb | result |
|---|---|
| 1.5.9 (latest) | SIGSEGV (exit 139) |
| 1.5.8 | SIGSEGV |
| 1.5.3 | works (count=547,377, peek returns IDs) |
| 1.5.0 | works |
| 1.4.0 | works |
| 1.3.0 | works |

Regression landed between 1.5.3 (2026-03-07) and 1.5.4. **1.5.9 (released 2026-05-04) is not a fix** — same crash signature.

The current pin `chromadb>=1.5.4,<2` forces every version in the broken range. This PR caps to `<1.5.4` so installations on macOS 26 don't pick up the broken release line.

## Crash diagnosis (without symbols)

Every crash on this machine has the same shape:

- 13 `tokio-rt-worker` threads, 2 `sqlx-sqlite-worker-*`, plus a pool of unnamed Rust workers all in the same deeply recursive call frames inside `chromadb_rust_bindings.abi3.so` (offsets `+10160324` / `+10161424` / `+10162124` / `+10398848` repeating — two alternating call sites and a key recursion frame; shape of an enum visitor on a tree with two recursive variants, almost certainly an HNSW/segment node walk).
- The crashing thread is in the unwind path right after the recursion returns. `x16 = pthread_mutex_unlock`, ESR is `byte read Translation fault`, faulting address is a poisoned pointer (`0x000001fede243d3a`, `0x00000200b0643d3a`, `0x000002077be43d3a` across runs — large, high-bit-set, not null).
- Many sibling threads are blocked on `std::__1::mutex::lock()`; one is in `operator new` mid-allocation.

That's a use-after-free of a node containing a mutex: concurrent walkers + a compaction/GC thread → one walker dereferences a node whose backing memory has been freed → unlocking the mutex faults.

Different fault-address shape than chroma#6852's reported null deref, but same library, same platform, same recursion pattern. Possibly two failure modes in the same code path, or the same bug with non-deterministic state.

12+ confirmed crashes on this machine in a 90-minute window today, all matching this signature, including ones with `parentProc: launchd` (the live MCP server, not just CLI invocations).

## Workaround envelope

`chromadb>=1.5.0,<1.5.4` matches what mempalace 3.3.x was likely built and tested against in the 1.5.x line. If maintainers want a wider lower bound, #426 already proposes `>=1.0,<2`; combining its lower-bound relaxation with this upper-bound cap would give the broadest working envelope.

Open to either bound; happy to amend.

## When to lift

Once chroma ships a fix that covers macOS 26 / ARM64, re-pin to `>=<fixed-version>,<2`.

## Test

Verified locally:

```python
import chromadb
client = chromadb.PersistentClient(path="~/.mempalace/palace")
col = client.get_collection("mempalace_drawers")
print(col.count())   # crashes on 1.5.4..1.5.9, prints 547377 on 1.5.3
print(col.peek(limit=2)["ids"])
```

Same script in a fresh venv on the same machine, same palace data — chromadb 1.5.3 succeeds end to end; 1.5.8 (current install) and 1.5.9 (latest) both exit 139.