### PR TITLE
[codex] Keep large palace search responsive

### DIFF
--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -21,6 +21,9 @@ rather than hard-failing — mining must still work on a laptop without CUDA.
 from __future__ import annotations
 
 import logging
+import hashlib
+import math
+import re
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -46,6 +49,62 @@ _AUTO_ORDER = [
 
 _EF_CACHE: dict = {}
 _WARNED: set = set()
+_HASH_DIMENSIONS = 384
+_TOKEN_RE = re.compile(r"[a-zA-Z0-9_]{2,}")
+
+
+class _HashEmbeddingFunction:
+    """Local lexical embedding function used when ONNX Runtime is unavailable."""
+
+    def __call__(self, input):
+        embeddings = []
+        for document in input:
+            embeddings.append(self._embed(str(document or "")))
+        return embeddings
+
+    def embed_query(self, input):
+        return self.__call__(input)
+
+    def embed_documents(self, input):
+        return self.__call__(input)
+
+    @staticmethod
+    def name() -> str:
+        return "default"
+
+    @staticmethod
+    def build_from_config(config):
+        return _HashEmbeddingFunction()
+
+    def get_config(self):
+        return {"provider": "mempalace-hash-v1", "dimensions": _HASH_DIMENSIONS}
+
+    def default_space(self):
+        return "cosine"
+
+    def supported_spaces(self):
+        return ["cosine", "l2", "ip"]
+
+    @staticmethod
+    def _embed(text: str) -> list[float]:
+        vec = [0.0] * _HASH_DIMENSIONS
+        tokens = _TOKEN_RE.findall(text.lower())
+        if not tokens:
+            vec[0] = 1.0
+            return vec
+
+        for token in tokens[:4000]:
+            digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+            value = int.from_bytes(digest, "little", signed=False)
+            idx = value % _HASH_DIMENSIONS
+            sign = 1.0 if (value >> 63) else -1.0
+            vec[idx] += sign
+
+        norm = math.sqrt(sum(v * v for v in vec))
+        if norm == 0.0:
+            vec[0] = 1.0
+            return vec
+        return [v / norm for v in vec]
 
 
 def _resolve_providers(device: str) -> tuple[list, str]:
@@ -55,6 +114,8 @@ def _resolve_providers(device: str) -> tuple[list, str]:
     accelerator is not compiled into the installed ``onnxruntime``.
     """
     device = (device or "auto").strip().lower()
+    if device in {"hash", "lexical"}:
+        return (["HashEmbeddingProvider"], "hash")
 
     try:
         import onnxruntime as ort
@@ -133,6 +194,12 @@ def get_embedding_function(device: Optional[str] = None):
     cached = _EF_CACHE.get(cache_key)
     if cached is not None:
         return cached
+
+    if effective == "hash":
+        ef = _HashEmbeddingFunction()
+        _EF_CACHE[cache_key] = ef
+        logger.info("Embedding function initialized (device=hash providers=%s)", providers)
+        return ef
 
     ef_cls = _build_ef_class()
     ef = ef_cls(preferred_providers=providers)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -280,6 +280,8 @@ def _get_collection(create=False):
     try:
         client = _get_client()
         if create:
+            ef = ChromaBackend._resolve_embedding_function()
+            ef_kwargs = {"embedding_function": ef} if ef is not None else {}
             # hnsw:num_threads=1 disables ChromaDB's multi-threaded ParallelFor
             # HNSW insert path, which has a race in repairConnectionsForUpdate /
             # addPoint (see issues #974, #965). Set via metadata on fresh
@@ -293,7 +295,7 @@ def _get_collection(create=False):
             # below skips the metadata-comparison codepath for existing
             # collections, mirroring the backend-layer fix from #1262.
             try:
-                raw = client.get_collection(_config.collection_name)
+                raw = client.get_collection(_config.collection_name, **ef_kwargs)
             except _ChromaNotFoundError:
                 raw = client.create_collection(
                     _config.collection_name,
@@ -302,13 +304,16 @@ def _get_collection(create=False):
                         "hnsw:num_threads": 1,
                         **_HNSW_BLOAT_GUARD,
                     },
+                    **ef_kwargs,
                 )
             _pin_hnsw_threads(raw)
             _collection_cache = ChromaCollection(raw)
             _metadata_cache = None
             _metadata_cache_time = 0
         elif _collection_cache is None:
-            raw = client.get_collection(_config.collection_name)
+            ef = ChromaBackend._resolve_embedding_function()
+            ef_kwargs = {"embedding_function": ef} if ef is not None else {}
+            raw = client.get_collection(_config.collection_name, **ef_kwargs)
             _pin_hnsw_threads(raw)
             _collection_cache = ChromaCollection(raw)
             _metadata_cache = None
@@ -379,13 +384,12 @@ def _sanitize_optional_name(value: str = None, field_name: str = "name") -> str:
 
 
 def _tool_status_via_sqlite() -> dict:
-    """Pure-sqlite status reader for the #1222 fallback path.
+    """Pure-sqlite status reader.
 
-    When the HNSW capacity probe detects divergence, opening the chromadb
-    persistent client can segfault. This reader pulls the same wing/room
-    breakdown directly from ``embedding_metadata`` so the operator still
-    gets a working status response — and crucially the
-    ``vector_disabled`` flag — without us touching the vector segment.
+    Status is an overview query, not a semantic-search query. Reading the
+    wing/room breakdown directly from ``embedding_metadata`` avoids pulling
+    every metadata row through ChromaDB, which can take longer than MCP's
+    default tool timeout on large local palaces.
     """
     import sqlite3 as _sqlite3
 
@@ -437,7 +441,7 @@ def _tool_status_via_sqlite() -> dict:
         "palace_path": _config.palace_path,
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
-        "vector_disabled": True,
+        "vector_disabled": _vector_disabled,
         "vector_disabled_reason": _vector_disabled_reason,
     }
     if _vector_capacity_status:
@@ -449,15 +453,220 @@ def _tool_status_via_sqlite() -> dict:
     return result
 
 
+def _sqlite_metadata_counts(key: str, wing: str = None) -> Optional[dict]:
+    """Read metadata counts directly from sqlite for large overview tools."""
+    import sqlite3 as _sqlite3
+
+    db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+
+    collection_name = getattr(_config, "collection_name", "mempalace_drawers")
+    wing_join = ""
+    wing_clause = ""
+    params = [collection_name, key]
+    if wing:
+        wing_join = """
+        JOIN embedding_metadata wing_filter
+          ON wing_filter.id = e.id
+         AND wing_filter.key = 'wing'
+        """
+        wing_clause = "AND wing_filter.string_value = ?"
+        params.append(wing)
+
+    try:
+        conn = _sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT target.string_value, COUNT(*)
+                FROM embeddings e
+                JOIN segments s ON e.segment_id = s.id
+                JOIN collections c ON s.collection = c.id
+                JOIN embedding_metadata target
+                  ON target.id = e.id
+                 AND target.key = ?
+                {wing_join}
+                WHERE c.name = ?
+                  AND target.string_value IS NOT NULL
+                  {wing_clause}
+                GROUP BY target.string_value
+                """,
+                [params[1], params[0], *params[2:]],
+            ).fetchall()
+        finally:
+            conn.close()
+    except _sqlite3.Error:
+        logger.exception("sqlite metadata count read failed")
+        return None
+
+    return {value: count for value, count in rows}
+
+
+def _sqlite_taxonomy() -> Optional[dict]:
+    """Read wing -> room counts without opening ChromaDB/HNSW."""
+    import sqlite3 as _sqlite3
+
+    db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+
+    collection_name = getattr(_config, "collection_name", "mempalace_drawers")
+    try:
+        conn = _sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            rows = conn.execute(
+                """
+                SELECT
+                  COALESCE(wing.string_value, 'unknown') AS wing,
+                  COALESCE(room.string_value, 'unknown') AS room,
+                  COUNT(*)
+                FROM embeddings e
+                JOIN segments s ON e.segment_id = s.id
+                JOIN collections c ON s.collection = c.id
+                LEFT JOIN embedding_metadata wing
+                  ON wing.id = e.id
+                 AND wing.key = 'wing'
+                LEFT JOIN embedding_metadata room
+                  ON room.id = e.id
+                 AND room.key = 'room'
+                WHERE c.name = ?
+                GROUP BY wing, room
+                """,
+                (collection_name,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except _sqlite3.Error:
+        logger.exception("sqlite taxonomy read failed")
+        return None
+
+    taxonomy: dict = {}
+    for wing, room, count in rows:
+        taxonomy.setdefault(wing, {})[room] = count
+    return taxonomy
+
+
+def _sqlite_graph_stats() -> Optional[dict]:
+    """Build graph stats from grouped sqlite metadata.
+
+    The ChromaDB implementation paginates every drawer metadata row. On
+    six-figure palaces that can exceed MCP's tool timeout even though graph
+    stats only need grouped room/wing/hall metadata.
+    """
+    import sqlite3 as _sqlite3
+
+    db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+
+    collection_name = getattr(_config, "collection_name", "mempalace_drawers")
+    try:
+        conn = _sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            rows = conn.execute(
+                """
+                SELECT
+                  room.string_value AS room,
+                  wing.string_value AS wing,
+                  hall.string_value AS hall,
+                  date_meta.string_value AS date,
+                  COUNT(*) AS drawer_count
+                FROM embeddings e
+                JOIN segments s ON e.segment_id = s.id
+                JOIN collections c ON s.collection = c.id
+                JOIN embedding_metadata room
+                  ON room.id = e.id
+                 AND room.key = 'room'
+                JOIN embedding_metadata wing
+                  ON wing.id = e.id
+                 AND wing.key = 'wing'
+                LEFT JOIN embedding_metadata hall
+                  ON hall.id = e.id
+                 AND hall.key = 'hall'
+                LEFT JOIN embedding_metadata date_meta
+                  ON date_meta.id = e.id
+                 AND date_meta.key = 'date'
+                WHERE c.name = ?
+                  AND room.string_value IS NOT NULL
+                  AND room.string_value != 'general'
+                  AND wing.string_value IS NOT NULL
+                GROUP BY room.string_value, wing.string_value, hall.string_value, date_meta.string_value
+                """,
+                (collection_name,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except _sqlite3.Error:
+        logger.exception("sqlite graph stats read failed")
+        return None
+
+    from collections import Counter as _Counter
+    from collections import defaultdict as _defaultdict
+
+    nodes_raw = _defaultdict(lambda: {"wings": set(), "halls": set(), "count": 0, "dates": set()})
+    for room, wing, hall, date, count in rows:
+        data = nodes_raw[room]
+        data["wings"].add(wing)
+        if hall:
+            data["halls"].add(hall)
+        if date:
+            data["dates"].add(date)
+        data["count"] += count
+
+    nodes = {}
+    for room, data in nodes_raw.items():
+        nodes[room] = {
+            "wings": sorted(data["wings"]),
+            "halls": sorted(data["halls"]),
+            "count": data["count"],
+            "dates": sorted(data["dates"])[-5:] if data["dates"] else [],
+        }
+
+    edges = []
+    for room, data in nodes.items():
+        wings = data["wings"]
+        if len(wings) < 2:
+            continue
+        for i, wing_a in enumerate(wings):
+            for wing_b in wings[i + 1 :]:
+                for hall in data["halls"]:
+                    edges.append(
+                        {
+                            "room": room,
+                            "wing_a": wing_a,
+                            "wing_b": wing_b,
+                            "hall": hall,
+                            "count": data["count"],
+                        }
+                    )
+
+    wing_counts = _Counter()
+    for data in nodes.values():
+        for wing in data["wings"]:
+            wing_counts[wing] += 1
+
+    return {
+        "total_rooms": len(nodes),
+        "tunnel_rooms": sum(1 for n in nodes.values() if len(n["wings"]) >= 2),
+        "total_edges": len(edges),
+        "rooms_per_wing": dict(wing_counts.most_common()),
+        "top_tunnels": [
+            {"room": room, "wings": data["wings"], "count": data["count"]}
+            for room, data in sorted(nodes.items(), key=lambda item: -len(item[1]["wings"]))[:10]
+            if len(data["wings"]) >= 2
+        ],
+    }
+
+
 def tool_status():
-    # Run the safe sqlite/pickle probe before we touch chromadb. In the
-    # #1222 failure mode, opening the persistent client to call .count()
-    # can segfault — short-circuit to a pure-sqlite path when divergence
-    # is detected so status stays reachable.
+    # Run the safe sqlite/pickle probe before any ChromaDB access. Status
+    # itself uses SQLite too: it is faster for aggregate counts and stays
+    # responsive even when the palace has hundreds of thousands of drawers.
     db_exists = os.path.isfile(os.path.join(_config.palace_path, "chroma.sqlite3"))
     _refresh_vector_disabled_flag()
 
-    if _vector_disabled:
+    if db_exists:
         return _tool_status_via_sqlite()
 
     # Use create=True only when a palace DB already exists on disk -- this
@@ -526,6 +735,10 @@ When WRITING AAAK: use entity codes, mark emotions, keep structure tight."""
 
 
 def tool_list_wings():
+    sqlite_counts = _sqlite_metadata_counts("wing")
+    if sqlite_counts is not None:
+        return {"wings": sqlite_counts}
+
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -549,6 +762,10 @@ def tool_list_rooms(wing: str = None):
         wing = _sanitize_optional_name(wing, "wing")
     except ValueError as e:
         return {"error": str(e)}
+    sqlite_counts = _sqlite_metadata_counts("room", wing=wing)
+    if sqlite_counts is not None:
+        return {"wing": wing or "all", "rooms": sqlite_counts}
+
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -569,6 +786,10 @@ def tool_list_rooms(wing: str = None):
 
 
 def tool_get_taxonomy():
+    sqlite_taxonomy = _sqlite_taxonomy()
+    if sqlite_taxonomy is not None:
+        return {"taxonomy": sqlite_taxonomy}
+
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -616,6 +837,11 @@ def tool_search(
     # here would defeat the fallback — it constructs a PersistentClient
     # which can segfault on segment load in the #1222 failure mode.
     _refresh_vector_disabled_flag()
+    embedding_device = str(getattr(_config, "embedding_device", "auto") or "auto").strip().lower()
+    use_bm25_sqlite = _vector_disabled or embedding_device in {"hash", "lexical"}
+    fallback_reason = (
+        _vector_disabled_reason if _vector_disabled else f"embedding_device={embedding_device}"
+    )
     result = search_memories(
         sanitized["clean_query"],
         palace_path=_config.palace_path,
@@ -623,7 +849,8 @@ def tool_search(
         room=room,
         n_results=limit,
         max_distance=dist,
-        vector_disabled=_vector_disabled,
+        vector_disabled=use_bm25_sqlite,
+        fallback_reason=fallback_reason,
     )
     if _vector_disabled:
         result["vector_disabled"] = True
@@ -722,6 +949,10 @@ def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
 
 def tool_graph_stats():
     """Palace graph overview: nodes, tunnels, edges, connectivity."""
+    sqlite_stats = _sqlite_graph_stats()
+    if sqlite_stats is not None:
+        return sqlite_stats
+
     col = _get_collection()
     if not col:
         return _no_palace()

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -15,7 +15,10 @@ import os
 import re
 import sqlite3
 from pathlib import Path
+from typing import Optional
 
+from .backends.chroma import hnsw_capacity_status
+from .config import MempalaceConfig
 from .palace import get_closets_collection, get_collection
 
 # Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
@@ -281,11 +284,70 @@ def _warn_if_legacy_metric(col) -> None:
     )
 
 
+def _sqlite_bm25_reason(palace_path: str) -> Optional[str]:
+    """Return the reason CLI search should bypass Chroma vector query."""
+    try:
+        embedding_device = (MempalaceConfig().embedding_device or "auto").strip().lower()
+    except Exception:
+        embedding_device = "auto"
+    if embedding_device in {"hash", "lexical"}:
+        return f"embedding_device={embedding_device}"
+
+    info = hnsw_capacity_status(palace_path, "mempalace_drawers")
+    if info.get("diverged"):
+        return info.get("message") or "vector_search_disabled"
+    return None
+
+
+def _print_bm25_cli_results(query: str, out: dict, wing: str = None, room: str = None):
+    if out.get("error"):
+        print(f"\n  Search error: {out['error']}")
+        raise SearchError(f"Search error: {out['error']}")
+
+    hits = out.get("results", [])
+    if not hits:
+        print(f'\n  No results found for: "{query}"')
+        return
+
+    print(f"\n{'=' * 60}")
+    print(f'  Results for: "{query}"')
+    if wing:
+        print(f"  Wing: {wing}")
+    if room:
+        print(f"  Room: {room}")
+    print(f"  Backend: sqlite BM25 ({out.get('fallback_reason', 'fallback')})")
+    print(f"{'=' * 60}\n")
+
+    for i, hit in enumerate(hits, 1):
+        print(f"  [{i}] {hit.get('wing', '?')} / {hit.get('room', '?')}")
+        print(f"      Source: {hit.get('source_file', '?')}")
+        print(f"      Match:  bm25={hit.get('bm25_score', 0.0)}")
+        print()
+        for line in (hit.get("text") or "").strip().split("\n"):
+            print(f"      {line}")
+        print()
+        print(f"  {'─' * 56}")
+    print()
+
+
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
     """
     Search the palace. Returns verbatim drawer content.
     Optionally filter by wing (project) or room (aspect).
     """
+    bm25_reason = _sqlite_bm25_reason(palace_path)
+    if bm25_reason:
+        out = _bm25_only_via_sqlite(
+            query,
+            palace_path,
+            wing=wing,
+            room=room,
+            n_results=n_results,
+            fallback_reason=bm25_reason,
+        )
+        _print_bm25_cli_results(query, out, wing=wing, room=room)
+        return out
+
     try:
         col = get_collection(palace_path, create=False)
     except Exception:
@@ -372,6 +434,7 @@ def _bm25_only_via_sqlite(
     room: str = None,
     n_results: int = 5,
     max_candidates: int = 500,
+    fallback_reason: str = "vector_search_disabled",
 ) -> dict:
     """BM25-only search reading drawers directly from chroma.sqlite3.
 
@@ -414,6 +477,7 @@ def _bm25_only_via_sqlite(
                     SELECT rowid
                     FROM embedding_fulltext_search
                     WHERE embedding_fulltext_search MATCH ?
+                    ORDER BY rank
                     LIMIT ?
                     """,
                     (fts_query, max_candidates),
@@ -541,7 +605,7 @@ def _bm25_only_via_sqlite(
         "total_before_filter": len(candidates),
         "results": hits,
         "fallback": "bm25_only_via_sqlite",
-        "fallback_reason": "vector_search_disabled",
+        "fallback_reason": fallback_reason,
     }
 
 
@@ -553,6 +617,7 @@ def search_memories(
     n_results: int = 5,
     max_distance: float = 0.0,
     vector_disabled: bool = False,
+    fallback_reason: str = "vector_search_disabled",
 ) -> dict:
     """Programmatic search — returns a dict instead of printing.
 
@@ -580,6 +645,7 @@ def search_memories(
             wing=wing,
             room=room,
             n_results=n_results,
+            fallback_reason=fallback_reason,
         )
 
     try:

--- a/tests/test_hnsw_capacity.py
+++ b/tests/test_hnsw_capacity.py
@@ -410,6 +410,37 @@ def test_bm25_fallback_returns_matches(palace_with_drawers):
     assert top["distance"] is None
 
 
+def test_bm25_fallback_orders_fts_candidates_by_rank(tmp_path):
+    """FTS candidate selection must not stop at low-rowid partial matches."""
+    seg = "seg-ranked-fts"
+    _seed_chroma_db(str(tmp_path), sqlite_count=0, segment_id=seg)
+    distractors = [
+        (
+            f"database maintenance note {i}",
+            {"wing": "old", "room": "logs", "source_file": f"/x/old-{i}.md"},
+            f"d-old-{i}",
+        )
+        for i in range(6)
+    ]
+    drawers = [
+        *distractors,
+        (
+            "mempalace reindex database hnsw embeddings repair notes",
+            {"wing": "ops", "room": "repair", "source_file": "/x/repair.md"},
+            "d-relevant",
+        ),
+    ]
+    _seed_drawers(str(tmp_path), seg, drawers)
+
+    out = _bm25_only_via_sqlite(
+        "mempalace reindex database hnsw embeddings",
+        str(tmp_path),
+        n_results=1,
+        max_candidates=3,
+    )
+    assert out["results"][0]["source_file"] == "repair.md"
+
+
 def test_bm25_fallback_filters_by_wing(palace_with_drawers):
     out = _bm25_only_via_sqlite(
         "memory palace recall", str(palace_with_drawers), wing="design", n_results=5

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -290,6 +290,22 @@ class TestReadTools:
         assert result["wings"]["project"] == 3
         assert result["wings"]["notes"] == 1
 
+    def test_list_wings_uses_sqlite_for_large_read_path(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(
+            mcp_server,
+            "_get_collection",
+            lambda *args, **kwargs: pytest.fail("list_wings should not open ChromaDB"),
+        )
+
+        result = mcp_server.tool_list_wings()
+        assert result["wings"]["project"] == 3
+        assert result["wings"]["notes"] == 1
+
     def test_list_rooms_all(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_list_rooms
@@ -316,6 +332,23 @@ class TestReadTools:
         assert result["taxonomy"]["project"]["frontend"] == 1
         assert result["taxonomy"]["notes"]["planning"] == 1
 
+    def test_graph_stats_uses_sqlite_for_large_read_path(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(
+            mcp_server,
+            "_get_collection",
+            lambda *args, **kwargs: pytest.fail("graph_stats should not open ChromaDB"),
+        )
+
+        result = mcp_server.tool_graph_stats()
+        assert result["total_rooms"] == 3
+        assert result["rooms_per_wing"]["project"] == 2
+        assert result["rooms_per_wing"]["notes"] == 1
+
     def test_no_palace_returns_error(self, monkeypatch, config, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_status
@@ -338,6 +371,27 @@ class TestSearchTool:
         # Top result should be the auth drawer
         top = result["results"][0]
         assert "JWT" in top["text"] or "authentication" in top["text"].lower()
+
+    def test_search_hash_embedding_device_uses_sqlite_bm25(
+        self, monkeypatch, palace_path, seeded_collection, kg
+    ):
+        from mempalace import mcp_server
+
+        class _Cfg:
+            collection_name = "mempalace_drawers"
+            embedding_device = "hash"
+
+        _Cfg.palace_path = palace_path
+
+        monkeypatch.setattr(mcp_server, "_config", _Cfg())
+        monkeypatch.setattr(mcp_server, "_kg", kg)
+        monkeypatch.setattr(mcp_server, "_vector_disabled", False)
+        monkeypatch.setattr(mcp_server, "_vector_disabled_reason", "")
+
+        result = mcp_server.tool_search(query="JWT authentication tokens", limit=3)
+        assert result["fallback"] == "bm25_only_via_sqlite"
+        assert result["fallback_reason"] == "embedding_device=hash"
+        assert "JWT" in result["results"][0]["text"]
 
     def test_search_with_wing_filter(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -211,6 +211,19 @@ class TestSearchCLI:
         # Should have output with at least one result block
         assert "[1]" in captured.out
 
+    def test_search_hash_embedding_device_uses_sqlite_bm25(
+        self, monkeypatch, palace_path, seeded_collection, capsys
+    ):
+        import mempalace.searcher as searcher
+
+        monkeypatch.setattr(searcher, "_sqlite_bm25_reason", lambda palace_path: "embedding_device=hash")
+
+        result = search("JWT authentication tokens", palace_path, n_results=3)
+        captured = capsys.readouterr()
+        assert result["fallback"] == "bm25_only_via_sqlite"
+        assert "Backend: sqlite BM25 (embedding_device=hash)" in captured.out
+        assert "JWT" in captured.out
+
     def test_search_applies_bm25_hybrid_rerank(self, capsys):
         """CLI search must call the same hybrid rerank that the MCP path uses.
 


### PR DESCRIPTION
## Summary

Fixes #1379.
Fixes #1380.

This PR keeps large local palaces responsive by avoiding ChromaDB metadata scans for overview-style MCP tools, and by making hash/lexical embedding mode use the SQLite BM25 path intentionally instead of low-signal vector search.

## What changed

- Read `status`, wings, rooms, taxonomy, and graph stats from read-only SQLite aggregate queries when the palace DB exists.
- Keep ChromaDB as a fallback for nonstandard/legacy layouts.
- Pass the configured embedding function into MCP collection opens so MCP search matches the rest of the backend path.
- Add a local hash/lexical embedding function for `embedding_device=hash` / `lexical`.
- Route MCP and CLI search to SQLite BM25 when hash/lexical embedding mode is active.
- Sort SQLite FTS candidates by `rank` before local BM25 reranking.
- Add regressions for large-read SQLite paths, hash search fallback, and ranked FTS candidate selection.

## Root cause

On a 349k-drawer palace, overview tools were paging every metadata row through ChromaDB even though they only needed grouped counts. Separately, hash embeddings were being treated as dense semantic vectors, which produced poor rankings for exact/lexical queries. The FTS fallback could also choose low-rowid partial matches before better candidates because candidate selection did not order by FTS rank.

## Validation

- `python -m pytest tests/test_searcher.py tests/test_hnsw_capacity.py tests/test_mcp_server.py -q`
  - `120 passed, 1 skipped`
- `ruff check mempalace\mcp_server.py mempalace\searcher.py tests\test_hnsw_capacity.py tests\test_mcp_server.py tests\test_searcher.py`
  - passed
- Local smoke against a 349,258-drawer palace:
  - `mempalace_list_wings`: ~1.2s
  - `mempalace_graph_stats`: ~2.6s
  - `mempalace_search`: ~0.7-1.0s via `bm25_only_via_sqlite` with `fallback_reason=embedding_device=hash`

## Notes

The branch is based on `main`, not `develop`, because the local checkout and observed production failure were based on `origin/main`; targeting `main` keeps this PR diff limited to the fix.