### PR TITLE
docs: clarify contributor git identity setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,3 +93,15 @@ If you're planning a significant change, open an issue first to discuss the appr
 ## License
 
 MIT — your contributions will be released under the same license.
+
+## Git identity for contributions
+
+Before pushing commits, verify that Git is configured with an email address that GitHub can associate with your account:
+
+```bash
+git config user.name
+git config user.email
+```
+
+This is especially important when commits are created through agentic coding tools or automation, because those tools may not inherit your normal shell Git configuration. Avoid placeholder values such as `your@email.com` or localized template text; unresolved author emails can create avoidable provenance and SBOM review friction for downstream users.
+


### PR DESCRIPTION
Adds a short CONTRIBUTING note asking contributors to verify their Git name and email before pushing commits, with a specific warning for agentic coding tools that may not inherit the user's normal Git config.

Closes #1317.

Tests:
- Reviewed CONTRIBUTING.md rendering/diff.
- Scanned the patch for credential-like strings.
