### PR TITLE
feat(backends): add sqlite_vec backend, fixes UAF crash on macOS/ARM64 (smaller footprint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`sqlite_vec` backend** — alternate vector backend implementing the full `BaseBackend` / `BaseCollection` contract using `sqlite-vec`'s `vec0` virtual table. Useful on platforms where `chromadb_rust_bindings` is unsafe (notably macOS 26 / ARM64; see chroma-core/chroma#6852, #1355, #1376) since it has no Tokio runtime, no Rust bindings, and no recursive-walker codepath. Storage is a single `sqlite_vec.db` file per palace with chroma-style metadata filters compiled to SQL over `json_extract(meta, ...)`. Optional dep — opt in via `pip install mempalace[sqlite-vec]` and select with the `mempalace.backends` registry by name `"sqlite_vec"`. A migration helper at `examples/migrate_chroma_to_sqlite_vec.py` reads `chroma.sqlite3` directly via stdlib `sqlite3` (no chromadb code involved, so the UAF cannot fire) and re-embeds via the existing ONNX MiniLM. Migration is resumable on `drawer_id` uniqueness. Tested on a 664k-drawer palace; exact count parity with the source. (#1386)
+
+---
+
 ## [3.3.5] — 2026-05-09
 
 ### Bug Fixes

--- a/examples/migrate_chroma_to_sqlite_vec.py
+++ b/examples/migrate_chroma_to_sqlite_vec.py
@@ -1,0 +1,191 @@
+"""One-shot migration: chromadb palace -> sqlite-vec backend.
+
+Reads ``chroma.sqlite3`` directly via stdlib ``sqlite3`` (no chromadb
+code involved, so platforms affected by chromadb-rust-bindings UAFs —
+e.g. macOS 26 / ARM64, see chroma-core/chroma#6852 — can run this without
+crashing). Re-embeds every document with the local ONNX MiniLM since
+chromadb wraps hnswlib's index with its own segment envelope and stock
+hnswlib can't load it. Writes a fresh ``sqlite_vec.db`` next to the
+chroma files; nothing in the original palace dir is touched, so a swap
+back is one config change away.
+
+Usage:
+    pip install mempalace[sqlite-vec]
+    python -m mempalace.examples.migrate_chroma_to_sqlite_vec [palace_path]
+
+Defaults palace_path to ``~/.mempalace/palace``.
+
+The script is **resumable** — re-running picks up where it left off via
+``drawer_id`` uniqueness on the destination side.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+from mempalace.backends.base import PalaceRef
+from mempalace.backends.sqlite_vec import SqliteVecBackend
+from mempalace.embedding import get_embedding_function
+
+BATCH = 256  # docs per re-embed batch — onnx model overhead amortizes here
+
+
+def _fetch_collection_meta(src):
+    """Yield ``(chroma_collection_id, name, dimension, metadata_segment_id)``."""
+    cur = src.execute(
+        """
+        SELECT c.id, c.name, c.dimension, s.id
+        FROM collections c
+        JOIN segments s ON s.collection = c.id
+        WHERE s.scope = 'METADATA'
+        """
+    )
+    yield from cur.fetchall()
+
+
+def _materialize_metadata(rows):
+    """Group flat ``embedding_metadata`` rows into ``{id: (doc, meta_dict)}``."""
+    out: dict[int, tuple[str, dict]] = {}
+    for eid, key, sv, iv, fv, bv in rows:
+        doc, meta = out.setdefault(eid, ("", {}))
+        if key == "chroma:document":
+            doc = sv or ""
+        else:
+            if sv is not None:
+                meta[key] = sv
+            elif iv is not None:
+                meta[key] = iv
+            elif fv is not None:
+                meta[key] = fv
+            elif bv is not None:
+                meta[key] = bool(bv)
+        out[eid] = (doc, meta)
+    return out
+
+
+def migrate(palace_path: Path) -> int:
+    """Migrate chroma.sqlite3 -> sqlite_vec.db. Return total drawers migrated."""
+    src_db = palace_path / "chroma.sqlite3"
+    if not src_db.is_file():
+        sys.exit(f"chroma.sqlite3 not found at {src_db}")
+
+    src = sqlite3.connect(f"file:{src_db}?mode=ro", uri=True)
+    src.execute("PRAGMA temp_store=MEMORY")
+
+    print("loading onnx embedder...", flush=True)
+    t0 = time.time()
+    ef = get_embedding_function()
+    print(f"  embedder ready ({time.time() - t0:.1f}s)", flush=True)
+
+    backend = SqliteVecBackend()
+    palace_ref = PalaceRef(id="default", local_path=str(palace_path))
+
+    grand_total = 0
+    grand_start = time.time()
+    for _chroma_col_id, col_name, dim, meta_seg_id in _fetch_collection_meta(src):
+        print(f"\n=== collection {col_name!r} (dim={dim}) ===", flush=True)
+        n_total = src.execute(
+            "SELECT COUNT(*) FROM embeddings WHERE segment_id=?", (meta_seg_id,)
+        ).fetchone()[0]
+        print(f"  source rows: {n_total}", flush=True)
+        if n_total == 0:
+            continue
+
+        col = backend.get_collection(
+            palace=palace_ref,
+            collection_name=col_name,
+            create=True,
+            options={"dimension": dim},
+        )
+
+        # Resume: skip drawers we already have on the destination side.
+        cur = backend._conn(str(palace_path)).cursor()
+        cur.execute("SELECT drawer_id FROM drawers WHERE collection=?", (col_name,))
+        seen = {r[0] for r in cur.fetchall()}
+        if seen:
+            print(f"  destination already has {len(seen)} rows — resuming", flush=True)
+
+        offset = 0
+        page = 1024
+        col_done = 0
+        col_skipped = 0
+        col_start = time.time()
+        while True:
+            rows = src.execute(
+                "SELECT id, embedding_id FROM embeddings WHERE segment_id=? "
+                "ORDER BY id LIMIT ? OFFSET ?",
+                (meta_seg_id, page, offset),
+            ).fetchall()
+            if not rows:
+                break
+            ids_in_page = [r[0] for r in rows]
+            drawer_by_id = {r[0]: r[1] for r in rows}
+            placeholders = ",".join(["?"] * len(ids_in_page))
+            md_rows = src.execute(
+                f"SELECT id, key, string_value, int_value, float_value, bool_value "
+                f"FROM embedding_metadata WHERE id IN ({placeholders})",
+                ids_in_page,
+            ).fetchall()
+            meta_map = _materialize_metadata(md_rows)
+
+            ids_buf, docs_buf, metas_buf = [], [], []
+            for eid in ids_in_page:
+                drawer_id = drawer_by_id[eid]
+                if drawer_id in seen:
+                    col_skipped += 1
+                    continue
+                doc, meta = meta_map.get(eid, ("", {}))
+                ids_buf.append(drawer_id)
+                docs_buf.append(doc)
+                metas_buf.append(meta)
+                seen.add(drawer_id)
+
+            for i in range(0, len(ids_buf), BATCH):
+                chunk_ids = ids_buf[i : i + BATCH]
+                chunk_docs = docs_buf[i : i + BATCH]
+                chunk_metas = metas_buf[i : i + BATCH]
+                # Empty docs would make the embedder unhappy; substitute a
+                # single space so the vector exists but carries no signal.
+                chunk_docs_safe = [d if d else " " for d in chunk_docs]
+                vecs = [list(v) for v in ef(chunk_docs_safe)]
+                col.add(
+                    documents=chunk_docs,
+                    ids=chunk_ids,
+                    metadatas=chunk_metas,
+                    embeddings=vecs,
+                )
+                col_done += len(chunk_ids)
+                rate = col_done / max(time.time() - col_start, 1e-3)
+                pct = (col_done + col_skipped) * 100.0 / n_total
+                print(
+                    f"  [{col_name}] {col_done:>7}/{n_total} migrated "
+                    f"({col_skipped} skipped) — {rate:.0f}/s — {pct:.1f}%",
+                    flush=True,
+                )
+            offset += len(rows)
+        elapsed = time.time() - col_start
+        print(
+            f"  done collection {col_name!r}: migrated {col_done}, "
+            f"skipped {col_skipped}, {elapsed:.0f}s",
+            flush=True,
+        )
+        grand_total += col_done
+
+    backend.close()
+    src.close()
+    total_time = time.time() - grand_start
+    print(f"\nALL DONE: migrated {grand_total} drawers in {total_time:.0f}s")
+    return grand_total
+
+
+def main():
+    palace = Path(sys.argv[1] if len(sys.argv) > 1 else "~/.mempalace/palace").expanduser()
+    migrate(palace)
+
+
+if __name__ == "__main__":
+    main()

--- a/mempalace/backends/sqlite_vec.py
+++ b/mempalace/backends/sqlite_vec.py
@@ -1,0 +1,640 @@
+"""sqlite-vec backend for mempalace.
+
+Drop-in replacement for the chroma backend on platforms where
+``chromadb_rust_bindings`` is unsafe (notably macOS 26 / ARM64, where the
+rust bindings have an intra-process UAF in the recursive segment walker —
+chroma#6852, mempalace#1355). All vector storage and ANN search go through
+``sqlite-vec``'s ``vec0`` virtual table; metadata lives in regular SQLite
+columns. No tokio, no rust-side concurrency; one Python process, one
+sqlite connection per palace.
+
+The on-disk layout is a single ``sqlite_vec.db`` file at
+``<palace_path>/sqlite_vec.db``. The chromadb dir on the same path is left
+untouched so the old data can be re-migrated or swapped back if needed.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import struct
+import threading
+from typing import Any, Iterable, Optional
+
+import sqlite_vec
+
+from .base import (
+    BackendClosedError,
+    BaseBackend,
+    BaseCollection,
+    DimensionMismatchError,
+    GetResult,
+    HealthStatus,
+    PalaceNotFoundError,
+    PalaceRef,
+    QueryResult,
+    UnsupportedFilterError,
+    _IncludeSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Where-clause compiler
+# ---------------------------------------------------------------------------
+
+def _normalize_get_collection_args(args, kwargs):
+    """Coerce the legacy positional form into the kwarg form ChromaBackend
+    accepts. Returns ``(PalaceRef, collection_name, create, options)``.
+    """
+    if args:
+        first = args[0]
+        if isinstance(first, PalaceRef):
+            palace = first
+            rest_args = args[1:]
+        elif isinstance(first, str):
+            palace = PalaceRef(id=first, local_path=first)
+            rest_args = args[1:]
+        else:
+            raise TypeError(
+                f"get_collection: first positional arg must be PalaceRef or palace path, got {type(first).__name__}"
+            )
+        collection_name = (
+            rest_args[0]
+            if rest_args
+            else kwargs.pop("collection_name", "mempalace_drawers")
+        )
+        create = (
+            rest_args[1] if len(rest_args) >= 2 else kwargs.pop("create", False)
+        )
+    else:
+        palace = kwargs.pop("palace", None)
+        if palace is None:
+            raise TypeError("get_collection requires palace= (PalaceRef) or a positional palace path")
+        if not isinstance(palace, PalaceRef):
+            palace = PalaceRef(id=str(palace), local_path=str(palace))
+        collection_name = kwargs.pop("collection_name", "mempalace_drawers")
+        create = kwargs.pop("create", False)
+    options = kwargs.pop("options", None)
+    return palace, collection_name, create, options
+
+
+_OP_MAP = {
+    "$eq": "=",
+    "$ne": "!=",
+    "$gt": ">",
+    "$gte": ">=",
+    "$lt": "<",
+    "$lte": "<=",
+}
+_LIST_OPS = {"$in", "$nin"}
+_LOGICAL_OPS = {"$and", "$or"}
+_DOC_OPS = {"$contains", "$not_contains"}
+_SUPPORTED_OPS = set(_OP_MAP) | _LIST_OPS | _LOGICAL_OPS
+
+
+def _coerce_value(v: Any) -> Any:
+    """Convert Python values to types SQLite handles natively."""
+    if isinstance(v, bool):
+        return 1 if v else 0
+    return v
+
+
+def _compile_where(where: Optional[dict], params: list) -> str:
+    """Compile a chroma-style ``where`` dict to a SQL clause over the
+    ``meta`` JSON column. Returns the clause (without leading WHERE) or
+    ``"1=1"`` for empty input. Mutates ``params`` in place.
+    """
+    if not where:
+        return "1=1"
+    return _compile_node(where, params)
+
+
+def _compile_node(node: Any, params: list) -> str:
+    if not isinstance(node, dict):
+        raise UnsupportedFilterError(f"where node must be a dict, got {type(node).__name__}")
+
+    if len(node) == 1:
+        (key, value), = node.items()
+        if key in _LOGICAL_OPS:
+            if not isinstance(value, list) or not value:
+                raise UnsupportedFilterError(f"{key} requires a non-empty list")
+            joiner = " AND " if key == "$and" else " OR "
+            return "(" + joiner.join(_compile_node(v, params) for v in value) + ")"
+        return _compile_field(key, value, params)
+
+    # Implicit AND across multiple keys.
+    parts = [_compile_field(k, v, params) for k, v in node.items()]
+    return "(" + " AND ".join(parts) + ")"
+
+
+def _compile_field(key: str, value: Any, params: list) -> str:
+    if key.startswith("$"):
+        raise UnsupportedFilterError(f"operator {key!r} not valid at field position")
+    extractor = "json_extract(meta, ?)"
+    json_path = "$." + key
+    if isinstance(value, dict):
+        if len(value) != 1:
+            raise UnsupportedFilterError(
+                f"field {key!r}: each operator dict must have exactly one entry"
+            )
+        ((op, opv),) = value.items()
+        if op in _OP_MAP:
+            params.extend([json_path, _coerce_value(opv)])
+            return f"{extractor} {_OP_MAP[op]} ?"
+        if op in _LIST_OPS:
+            if not isinstance(opv, (list, tuple)) or not opv:
+                raise UnsupportedFilterError(f"{op} requires a non-empty list")
+            placeholders = ",".join(["?"] * len(opv))
+            params.append(json_path)
+            params.extend(_coerce_value(x) for x in opv)
+            cmp = "IN" if op == "$in" else "NOT IN"
+            return f"{extractor} {cmp} ({placeholders})"
+        raise UnsupportedFilterError(f"operator {op!r} not supported")
+    # Bare scalar = equality.
+    params.extend([json_path, _coerce_value(value)])
+    return f"{extractor} = ?"
+
+
+def _compile_where_document(wd: Optional[dict], params: list) -> str:
+    if not wd:
+        return "1=1"
+    if len(wd) != 1:
+        raise UnsupportedFilterError("where_document must have exactly one operator")
+    ((op, value),) = wd.items()
+    if op in _LOGICAL_OPS:
+        if not isinstance(value, list) or not value:
+            raise UnsupportedFilterError(f"{op} requires a non-empty list")
+        joiner = " AND " if op == "$and" else " OR "
+        return "(" + joiner.join(_compile_where_document(v, params) for v in value) + ")"
+    if op == "$contains":
+        params.append(f"%{value}%")
+        return "doc LIKE ?"
+    if op == "$not_contains":
+        params.append(f"%{value}%")
+        return "doc NOT LIKE ?"
+    raise UnsupportedFilterError(f"where_document operator {op!r} not supported")
+
+
+# ---------------------------------------------------------------------------
+# Vector encoding
+# ---------------------------------------------------------------------------
+
+
+def _encode_vec(vec: list[float]) -> bytes:
+    """Pack a Python float list into the little-endian f32 blob sqlite-vec expects."""
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+def _decode_vec(blob: bytes) -> list[float]:
+    n = len(blob) // 4
+    return list(struct.unpack(f"{n}f", blob))
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+class SqliteVecCollection(BaseCollection):
+    def __init__(self, backend: "SqliteVecBackend", palace_path: str, name: str, dimension: int):
+        self._backend = backend
+        self._palace_path = palace_path
+        self._name = name
+        self._dim = dimension
+        self._closed = False
+
+    # ---- internals ----
+
+    def _conn(self) -> sqlite3.Connection:
+        if self._closed:
+            raise BackendClosedError("collection is closed")
+        return self._backend._conn(self._palace_path)
+
+    def _vec_table(self) -> str:
+        return f"vec_{self._name}"
+
+    def _check(self, embeddings: Optional[list[list[float]]]) -> None:
+        if embeddings is None:
+            return
+        for e in embeddings:
+            if len(e) != self._dim:
+                raise DimensionMismatchError(
+                    f"embedding dim {len(e)} != collection dim {self._dim}"
+                )
+
+    def _embed(self, texts: list[str]) -> list[list[float]]:
+        ef = self._backend._embedder()
+        result = ef(texts)
+        return [list(v) for v in result]
+
+    # ---- writes ----
+
+    def add(self, *, documents, ids, metadatas=None, embeddings=None):
+        self._upsert_impl(documents, ids, metadatas, embeddings, replace=False)
+
+    def upsert(self, *, documents, ids, metadatas=None, embeddings=None):
+        self._upsert_impl(documents, ids, metadatas, embeddings, replace=True)
+
+    def _upsert_impl(self, documents, ids, metadatas, embeddings, *, replace: bool):
+        if not ids:
+            return
+        if embeddings is None:
+            embeddings = self._embed(list(documents))
+        self._check(embeddings)
+        if metadatas is None:
+            metadatas = [{} for _ in ids]
+        conn = self._conn()
+        vec_tbl = self._vec_table()
+        with conn:
+            cur = conn.cursor()
+            for did, doc, meta, emb in zip(ids, documents, metadatas, embeddings):
+                meta_json = json.dumps(meta or {}, sort_keys=True, ensure_ascii=False)
+                if replace:
+                    cur.execute(
+                        f"""
+                        INSERT INTO drawers (collection, drawer_id, doc, meta)
+                        VALUES (?, ?, ?, ?)
+                        ON CONFLICT(collection, drawer_id) DO UPDATE SET
+                            doc=excluded.doc, meta=excluded.meta
+                        RETURNING rowid
+                        """,
+                        (self._name, did, doc, meta_json),
+                    )
+                    row_pk = cur.fetchone()[0]
+                    cur.execute(f"DELETE FROM {vec_tbl} WHERE rowid = ?", (row_pk,))
+                    cur.execute(
+                        f"INSERT INTO {vec_tbl} (rowid, embedding) VALUES (?, ?)",
+                        (row_pk, _encode_vec(emb)),
+                    )
+                else:
+                    cur.execute(
+                        "INSERT INTO drawers (collection, drawer_id, doc, meta) VALUES (?, ?, ?, ?)",
+                        (self._name, did, doc, meta_json),
+                    )
+                    row_pk = cur.lastrowid
+                    cur.execute(
+                        f"INSERT INTO {vec_tbl} (rowid, embedding) VALUES (?, ?)",
+                        (row_pk, _encode_vec(emb)),
+                    )
+
+    def update(self, *, ids, documents=None, metadatas=None, embeddings=None):
+        # Atomic per-row update overriding the BaseCollection default (which
+        # round-trips through get + upsert).
+        if documents is None and metadatas is None and embeddings is None:
+            raise ValueError("update requires at least one of documents, metadatas, embeddings")
+        self._check(embeddings)
+        n = len(ids)
+        for label, value in (
+            ("documents", documents),
+            ("metadatas", metadatas),
+            ("embeddings", embeddings),
+        ):
+            if value is not None and len(value) != n:
+                raise ValueError(f"{label} length {len(value)} does not match ids length {n}")
+        conn = self._conn()
+        vec_tbl = self._vec_table()
+        with conn:
+            cur = conn.cursor()
+            for i, did in enumerate(ids):
+                cur.execute(
+                    "SELECT rowid, doc, meta FROM drawers WHERE collection=? AND drawer_id=?",
+                    (self._name, did),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    continue  # silently skip missing ids (matches chroma)
+                row_pk, prev_doc, prev_meta = row
+                new_doc = documents[i] if documents is not None else prev_doc
+                new_meta = json.loads(prev_meta or "{}")
+                if metadatas is not None:
+                    new_meta.update(metadatas[i] or {})
+                cur.execute(
+                    "UPDATE drawers SET doc=?, meta=? WHERE rowid=?",
+                    (new_doc, json.dumps(new_meta, sort_keys=True, ensure_ascii=False), row_pk),
+                )
+                if embeddings is not None:
+                    cur.execute(f"DELETE FROM {vec_tbl} WHERE rowid=?", (row_pk,))
+                    cur.execute(
+                        f"INSERT INTO {vec_tbl} (rowid, embedding) VALUES (?, ?)",
+                        (row_pk, _encode_vec(embeddings[i])),
+                    )
+
+    def delete(self, *, ids=None, where=None):
+        conn = self._conn()
+        vec_tbl = self._vec_table()
+        with conn:
+            cur = conn.cursor()
+            if ids:
+                placeholders = ",".join(["?"] * len(ids))
+                cur.execute(
+                    f"SELECT rowid FROM drawers WHERE collection=? AND drawer_id IN ({placeholders})",
+                    [self._name, *ids],
+                )
+                rowids = [r[0] for r in cur.fetchall()]
+                if rowids:
+                    rp = ",".join(["?"] * len(rowids))
+                    cur.execute(f"DELETE FROM {vec_tbl} WHERE rowid IN ({rp})", rowids)
+                    cur.execute(f"DELETE FROM drawers WHERE rowid IN ({rp})", rowids)
+                return
+            if where:
+                params: list = [self._name]
+                clause = _compile_where(where, params)
+                cur.execute(
+                    f"SELECT rowid FROM drawers WHERE collection=? AND {clause}",
+                    params,
+                )
+                rowids = [r[0] for r in cur.fetchall()]
+                if rowids:
+                    rp = ",".join(["?"] * len(rowids))
+                    cur.execute(f"DELETE FROM {vec_tbl} WHERE rowid IN ({rp})", rowids)
+                    cur.execute(f"DELETE FROM drawers WHERE rowid IN ({rp})", rowids)
+
+    # ---- reads ----
+
+    def count(self) -> int:
+        cur = self._conn().cursor()
+        cur.execute("SELECT COUNT(*) FROM drawers WHERE collection=?", (self._name,))
+        return cur.fetchone()[0]
+
+    def get(
+        self,
+        *,
+        ids=None,
+        where=None,
+        where_document=None,
+        limit=None,
+        offset=None,
+        include=None,
+    ) -> GetResult:
+        spec = _IncludeSpec.resolve(include, default_distances=False)
+        conn = self._conn()
+        cur = conn.cursor()
+        params: list = [self._name]
+        clauses = ["collection=?"]
+        if ids:
+            placeholders = ",".join(["?"] * len(ids))
+            clauses.append(f"drawer_id IN ({placeholders})")
+            params.extend(ids)
+        if where:
+            clauses.append(_compile_where(where, params))
+        if where_document:
+            clauses.append(_compile_where_document(where_document, params))
+        sql = f"SELECT rowid, drawer_id, doc, meta FROM drawers WHERE {' AND '.join(clauses)} ORDER BY rowid"
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+            if offset is not None:
+                sql += f" OFFSET {int(offset)}"
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+        if not rows:
+            return GetResult.empty()
+        out_ids: list[str] = []
+        out_docs: list[str] = []
+        out_metas: list[dict] = []
+        out_embs: Optional[list[list[float]]] = [] if spec.embeddings else None
+        for rowid, drawer_id, doc, meta in rows:
+            out_ids.append(drawer_id)
+            out_docs.append(doc or "")
+            out_metas.append(json.loads(meta) if meta else {})
+            if spec.embeddings:
+                cur.execute(f"SELECT embedding FROM {self._vec_table()} WHERE rowid=?", (rowid,))
+                vrow = cur.fetchone()
+                out_embs.append(_decode_vec(vrow[0]) if vrow else [])
+        return GetResult(ids=out_ids, documents=out_docs, metadatas=out_metas, embeddings=out_embs)
+
+    def query(
+        self,
+        *,
+        query_texts=None,
+        query_embeddings=None,
+        n_results=10,
+        where=None,
+        where_document=None,
+        include=None,
+    ) -> QueryResult:
+        if (query_texts is None) == (query_embeddings is None):
+            raise ValueError("query requires exactly one of query_texts or query_embeddings")
+        if query_embeddings is None:
+            query_embeddings = self._embed(list(query_texts))
+        self._check(query_embeddings)
+
+        spec = _IncludeSpec.resolve(include, default_distances=True)
+        conn = self._conn()
+        cur = conn.cursor()
+        vec_tbl = self._vec_table()
+
+        # Build metadata pre-filter — we narrow rowids first, then KNN over them.
+        narrow_clauses = ["collection=?"]
+        narrow_params: list = [self._name]
+        if where:
+            narrow_clauses.append(_compile_where(where, narrow_params))
+        if where_document:
+            narrow_clauses.append(_compile_where_document(where_document, narrow_params))
+        cur.execute(
+            f"SELECT rowid FROM drawers WHERE {' AND '.join(narrow_clauses)}",
+            narrow_params,
+        )
+        candidate_rowids = [r[0] for r in cur.fetchall()]
+        if not candidate_rowids:
+            return QueryResult.empty(num_queries=len(query_embeddings), embeddings_requested=spec.embeddings)
+
+        out_ids: list[list[str]] = []
+        out_docs: list[list[str]] = []
+        out_metas: list[list[dict]] = []
+        out_dists: list[list[float]] = []
+        out_embs: Optional[list[list[list[float]]]] = [] if spec.embeddings else None
+
+        # sqlite-vec's KNN syntax: WHERE embedding MATCH ? AND rowid IN (...) ORDER BY distance LIMIT k
+        chunk = 500
+        for q in query_embeddings:
+            qblob = _encode_vec(list(q))
+            # In-clause has a SQLite limit; if huge candidate set, rely on metadata filter only via full table.
+            if len(candidate_rowids) > 5000:
+                sql = f"""
+                    SELECT v.rowid, v.distance, d.drawer_id, d.doc, d.meta
+                    FROM {vec_tbl} v
+                    JOIN drawers d ON d.rowid = v.rowid
+                    WHERE v.embedding MATCH ? AND k = ? AND d.collection = ?
+                    ORDER BY v.distance
+                """
+                cur.execute(sql, (qblob, n_results, self._name))
+            else:
+                placeholders = ",".join(["?"] * len(candidate_rowids))
+                sql = f"""
+                    SELECT v.rowid, v.distance, d.drawer_id, d.doc, d.meta
+                    FROM {vec_tbl} v
+                    JOIN drawers d ON d.rowid = v.rowid
+                    WHERE v.embedding MATCH ? AND k = ? AND v.rowid IN ({placeholders})
+                    ORDER BY v.distance
+                """
+                cur.execute(sql, (qblob, n_results, *candidate_rowids))
+            hits = cur.fetchall()
+            ids_i, docs_i, metas_i, dists_i = [], [], [], []
+            embs_i: Optional[list[list[float]]] = [] if spec.embeddings else None
+            for rowid, dist, did, doc, meta in hits:
+                ids_i.append(did)
+                docs_i.append(doc or "")
+                metas_i.append(json.loads(meta) if meta else {})
+                dists_i.append(float(dist))
+                if spec.embeddings:
+                    cur.execute(f"SELECT embedding FROM {vec_tbl} WHERE rowid=?", (rowid,))
+                    vrow = cur.fetchone()
+                    embs_i.append(_decode_vec(vrow[0]) if vrow else [])
+            out_ids.append(ids_i)
+            out_docs.append(docs_i)
+            out_metas.append(metas_i)
+            out_dists.append(dists_i)
+            if out_embs is not None:
+                out_embs.append(embs_i or [])
+
+        return QueryResult(
+            ids=out_ids,
+            documents=out_docs,
+            metadatas=out_metas,
+            distances=out_dists,
+            embeddings=out_embs,
+        )
+
+    def close(self) -> None:
+        self._closed = True
+
+    def health(self) -> HealthStatus:
+        try:
+            self.count()
+            return HealthStatus.healthy()
+        except Exception as e:
+            return HealthStatus.unhealthy(f"sqlite-vec: {e!r}")
+
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+
+
+class SqliteVecBackend(BaseBackend):
+    name = "sqlite_vec"
+    capabilities = frozenset({"supports_update"})
+
+    def __init__(self):
+        self._conns: dict[str, sqlite3.Connection] = {}
+        self._lock = threading.Lock()
+        self._ef = None
+
+    def _embedder(self):
+        if self._ef is None:
+            from ..embedding import get_embedding_function
+            self._ef = get_embedding_function()
+        return self._ef
+
+    def _conn(self, palace_path: str) -> sqlite3.Connection:
+        with self._lock:
+            conn = self._conns.get(palace_path)
+            if conn is not None:
+                return conn
+            import os
+            os.makedirs(palace_path, exist_ok=True)
+            db_path = os.path.join(palace_path, "sqlite_vec.db")
+            c = sqlite3.connect(db_path, check_same_thread=False, isolation_level=None)
+            c.enable_load_extension(True)
+            sqlite_vec.load(c)
+            c.enable_load_extension(False)
+            c.execute("PRAGMA journal_mode=WAL")
+            c.execute("PRAGMA synchronous=NORMAL")
+            c.execute("PRAGMA foreign_keys=ON")
+            self._init_schema(c)
+            self._conns[palace_path] = c
+            return c
+
+    def _init_schema(self, conn: sqlite3.Connection) -> None:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS collections (
+                name TEXT PRIMARY KEY,
+                dimension INTEGER NOT NULL,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS drawers (
+                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                collection TEXT NOT NULL,
+                drawer_id TEXT NOT NULL,
+                doc TEXT,
+                meta TEXT,
+                UNIQUE(collection, drawer_id)
+            )
+            """
+        )
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_drawers_collection ON drawers(collection)")
+
+    def get_collection(self, *args, **kwargs) -> BaseCollection:
+        """Accept the new kwarg form **and** the legacy positional form
+        ``get_collection(palace_path, collection_name, create=False)`` that
+        ``mempalace.palace.get_collection`` still passes through.
+        """
+        palace, collection_name, create, options = _normalize_get_collection_args(
+            args, kwargs
+        )
+        if not palace.local_path:
+            raise PalaceNotFoundError("sqlite_vec backend requires a filesystem palace path")
+        conn = self._conn(palace.local_path)
+        cur = conn.cursor()
+        cur.execute("SELECT dimension FROM collections WHERE name=?", (collection_name,))
+        row = cur.fetchone()
+        if row is None:
+            if not create:
+                raise PalaceNotFoundError(
+                    f"collection {collection_name!r} not found in palace at {palace.local_path}"
+                )
+            dim = (options or {}).get("dimension", 384)
+            with conn:
+                cur.execute("INSERT INTO collections (name, dimension) VALUES (?, ?)", (collection_name, dim))
+                # vec0 virtual table per-collection (different collections may have different dims)
+                cur.execute(
+                    f"CREATE VIRTUAL TABLE IF NOT EXISTS vec_{collection_name} "
+                    f"USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[{dim}])"
+                )
+        else:
+            dim = row[0]
+            cur.execute(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS vec_{collection_name} "
+                f"USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[{dim}])"
+            )
+        return SqliteVecCollection(self, palace.local_path, collection_name, dim)
+
+    def close_palace(self, palace: PalaceRef) -> None:
+        if not palace.local_path:
+            return
+        with self._lock:
+            conn = self._conns.pop(palace.local_path, None)
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        with self._lock:
+            for conn in self._conns.values():
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            self._conns.clear()
+
+    def health(self, palace: Optional[PalaceRef] = None) -> HealthStatus:
+        if palace is None or not palace.local_path:
+            return HealthStatus.healthy("backend ready (no palace bound)")
+        try:
+            self._conn(palace.local_path).execute("SELECT 1").fetchone()
+            return HealthStatus.healthy()
+        except Exception as e:
+            return HealthStatus.unhealthy(f"sqlite_vec: {e!r}")
+
+    @classmethod
+    def detect(cls, path: str) -> bool:
+        import os
+        return os.path.isfile(os.path.join(path, "sqlite_vec.db"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ mempalace-mcp = "mempalace.mcp_server:main"
 
 [project.entry-points."mempalace.backends"]
 chroma = "mempalace.backends.chroma:ChromaBackend"
+sqlite_vec = "mempalace.backends.sqlite_vec:SqliteVecBackend"
 
 # RFC 002 source-adapter entry-point group. Core publishes no first-party
 # adapters under this group yet; ``miner.py`` and ``convo_miner.py`` migrate
@@ -61,6 +62,12 @@ spellcheck = ["autocorrect>=2.0"]
 gpu = ["onnxruntime-gpu>=1.16"]
 dml = ["onnxruntime-directml>=1.16"]
 coreml = ["onnxruntime>=1.16"]
+# Alternate vector backend using sqlite-vec's vec0 virtual table. Useful on
+# platforms where the chromadb_rust_bindings extension is unsafe (notably
+# macOS 26 / ARM64; see chroma-core/chroma#6852, MemPalace/mempalace#1355,
+# MemPalace/mempalace#1376). Install via ``pip install mempalace[sqlite-vec]``
+# and select with the ``mempalace.backends`` registry by name ``"sqlite_vec"``.
+sqlite-vec = ["sqlite-vec>=0.1.6"]
 
 [dependency-groups]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]

--- a/tests/test_sqlite_vec_backend.py
+++ b/tests/test_sqlite_vec_backend.py
@@ -1,0 +1,347 @@
+"""Tests for the sqlite-vec backend.
+
+The backend is gated on the ``sqlite-vec`` PyPI package being importable
+(it is an optional extra: ``pip install mempalace[sqlite-vec]``). Tests
+skip cleanly when the dependency is missing so CI environments without
+the extra installed don't fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+sqlite_vec = pytest.importorskip("sqlite_vec")
+
+from mempalace.backends import (  # noqa: E402
+    GetResult,
+    PalaceRef,
+    QueryResult,
+    UnsupportedFilterError,
+)
+from mempalace.backends.base import BackendClosedError, DimensionMismatchError  # noqa: E402
+from mempalace.backends.sqlite_vec import SqliteVecBackend  # noqa: E402
+
+
+# A 4-dim space is enough to exercise every code path while keeping vectors
+# readable in failure messages.
+DIM = 4
+
+
+@pytest.fixture
+def backend(tmp_path):
+    b = SqliteVecBackend()
+    yield b
+    b.close()
+
+
+@pytest.fixture
+def palace(tmp_path):
+    return PalaceRef(id="test", local_path=str(tmp_path))
+
+
+@pytest.fixture
+def col(backend, palace):
+    return backend.get_collection(
+        palace=palace,
+        collection_name="t",
+        create=True,
+        options={"dimension": DIM},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_get_collection_create_false_raises_for_missing_collection(backend, palace):
+    with pytest.raises(Exception):
+        backend.get_collection(palace=palace, collection_name="missing", create=False)
+
+
+def test_get_collection_idempotent_create(backend, palace):
+    a = backend.get_collection(palace=palace, collection_name="t", create=True, options={"dimension": DIM})
+    b = backend.get_collection(palace=palace, collection_name="t", create=True, options={"dimension": DIM})
+    a.add(documents=["x"], ids=["1"], embeddings=[[1, 0, 0, 0]])
+    assert b.count() == 1  # second handle sees the first's writes
+
+
+def test_legacy_positional_signature(backend, tmp_path):
+    """Mempalace 3.3 callers still pass ``(palace_path, collection_name, create)``."""
+    col = backend.get_collection(str(tmp_path), "t", create=True, options={"dimension": DIM})
+    col.add(documents=["x"], ids=["1"], embeddings=[[1, 0, 0, 0]])
+    assert col.count() == 1
+
+
+def test_close_palace_evicts_handle(backend, palace):
+    backend.get_collection(palace=palace, collection_name="t", create=True, options={"dimension": DIM})
+    backend.close_palace(palace)
+    # Reopening creates a fresh connection — no error.
+    col = backend.get_collection(palace=palace, collection_name="t", create=False)
+    assert col.count() == 0
+
+
+def test_detect_returns_true_after_db_created(backend, palace, tmp_path):
+    backend.get_collection(palace=palace, collection_name="t", create=True, options={"dimension": DIM})
+    backend.close()
+    assert SqliteVecBackend.detect(str(tmp_path)) is True
+
+
+def test_detect_returns_false_for_empty_dir(tmp_path):
+    assert SqliteVecBackend.detect(str(tmp_path)) is False
+
+
+# ---------------------------------------------------------------------------
+# Writes
+# ---------------------------------------------------------------------------
+
+
+def test_add_persists_documents_metadata_and_vectors(col):
+    col.add(
+        documents=["red apple", "green apple"],
+        ids=["a", "b"],
+        metadatas=[{"color": "red"}, {"color": "green"}],
+        embeddings=[[1, 0, 0, 0], [0.9, 0.1, 0, 0]],
+    )
+    assert col.count() == 2
+    g = col.get(ids=["a"], include=["documents", "metadatas", "embeddings"])
+    assert g.ids == ["a"]
+    assert g.documents == ["red apple"]
+    assert g.metadatas == [{"color": "red"}]
+    assert g.embeddings is not None
+    assert g.embeddings[0] == pytest.approx([1.0, 0.0, 0.0, 0.0], rel=1e-5)
+
+
+def test_upsert_replaces_existing_row(col):
+    col.add(documents=["v1"], ids=["a"], embeddings=[[1, 0, 0, 0]])
+    col.upsert(
+        documents=["v2"],
+        ids=["a"],
+        metadatas=[{"k": "v"}],
+        embeddings=[[0, 1, 0, 0]],
+    )
+    assert col.count() == 1
+    g = col.get(ids=["a"], include=["documents", "metadatas", "embeddings"])
+    assert g.documents == ["v2"]
+    assert g.metadatas == [{"k": "v"}]
+    assert g.embeddings[0] == pytest.approx([0.0, 1.0, 0.0, 0.0], rel=1e-5)
+
+
+def test_dimension_mismatch_raises(col):
+    with pytest.raises(DimensionMismatchError):
+        col.add(documents=["x"], ids=["1"], embeddings=[[1, 0, 0]])  # dim 3, not 4
+
+
+def test_update_merges_metadata_and_replaces_embedding(col):
+    col.add(
+        documents=["d"],
+        ids=["a"],
+        metadatas=[{"keep": "yes", "old": "v1"}],
+        embeddings=[[1, 0, 0, 0]],
+    )
+    col.update(
+        ids=["a"],
+        metadatas=[{"old": "v2", "new": "added"}],
+        embeddings=[[0, 0, 1, 0]],
+    )
+    g = col.get(ids=["a"], include=["metadatas", "embeddings"])
+    assert g.metadatas == [{"keep": "yes", "old": "v2", "new": "added"}]
+    assert g.embeddings[0] == pytest.approx([0.0, 0.0, 1.0, 0.0], rel=1e-5)
+
+
+def test_update_skips_missing_id_silently(col):
+    col.add(documents=["x"], ids=["a"], embeddings=[[1, 0, 0, 0]])
+    col.update(ids=["nonexistent"], documents=["should not appear"])
+    assert col.count() == 1
+
+
+def test_delete_by_ids(col):
+    col.add(documents=["a", "b", "c"], ids=["a", "b", "c"], embeddings=[[1, 0, 0, 0]] * 3)
+    col.delete(ids=["a", "b"])
+    g = col.get()
+    assert g.ids == ["c"]
+
+
+def test_delete_by_where(col):
+    col.add(
+        documents=["a", "b", "c"],
+        ids=["a", "b", "c"],
+        metadatas=[{"keep": True}, {"keep": False}, {"keep": False}],
+        embeddings=[[1, 0, 0, 0]] * 3,
+    )
+    col.delete(where={"keep": False})
+    assert col.count() == 1
+    assert col.get().ids == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+
+def test_query_returns_typed_query_result(col):
+    col.add(
+        documents=["a", "b"],
+        ids=["a", "b"],
+        embeddings=[[1, 0, 0, 0], [0, 1, 0, 0]],
+    )
+    qr = col.query(query_embeddings=[[1, 0, 0, 0]], n_results=2)
+    assert isinstance(qr, QueryResult)
+    assert qr.ids == [["a", "b"]]
+    assert qr.distances[0][0] == pytest.approx(0.0, abs=1e-5)
+
+
+def test_query_rejects_missing_input(col):
+    with pytest.raises(ValueError):
+        col.query(n_results=1)
+
+
+def test_query_rejects_both_inputs(col):
+    with pytest.raises(ValueError):
+        col.query(query_texts=["x"], query_embeddings=[[1, 0, 0, 0]], n_results=1)
+
+
+def test_query_empty_collection_returns_empty_outer(col):
+    qr = col.query(query_embeddings=[[1, 0, 0, 0], [0, 1, 0, 0]], n_results=3)
+    assert qr.ids == [[], []]
+    assert qr.documents == [[], []]
+    assert qr.distances == [[], []]
+
+
+def test_query_with_where_filter(col):
+    col.add(
+        documents=["a", "b", "c"],
+        ids=["a", "b", "c"],
+        metadatas=[{"wing": "x"}, {"wing": "y"}, {"wing": "x"}],
+        embeddings=[[1, 0, 0, 0], [0.9, 0.1, 0, 0], [0.8, 0, 0.2, 0]],
+    )
+    qr = col.query(query_embeddings=[[1, 0, 0, 0]], n_results=5, where={"wing": "x"})
+    assert set(qr.ids[0]) == {"a", "c"}
+
+
+def test_query_supports_include_embeddings(col):
+    col.add(documents=["a"], ids=["a"], embeddings=[[1, 0, 0, 0]])
+    qr = col.query(
+        query_embeddings=[[1, 0, 0, 0]],
+        n_results=1,
+        include=["documents", "metadatas", "distances", "embeddings"],
+    )
+    assert qr.embeddings is not None
+    assert qr.embeddings[0][0] == pytest.approx([1.0, 0.0, 0.0, 0.0], rel=1e-5)
+
+
+def test_query_dict_compat_access(col):
+    col.add(documents=["a"], ids=["a"], embeddings=[[1, 0, 0, 0]])
+    qr = col.query(query_embeddings=[[1, 0, 0, 0]], n_results=1)
+    # transitional dict-protocol access still works for legacy callers
+    assert qr["ids"] == [["a"]]
+    assert qr.get("distances")[0][0] == pytest.approx(0.0, abs=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Where-clause compiler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "where, expected_ids",
+    [
+        ({"color": "red"}, {"a"}),
+        ({"color": {"$eq": "red"}}, {"a"}),
+        ({"color": {"$ne": "red"}}, {"b", "c"}),
+        ({"size": {"$gt": 5}}, {"b", "c"}),
+        ({"size": {"$gte": 5}}, {"a", "b", "c"}),
+        ({"size": {"$lt": 7}}, {"a"}),
+        ({"size": {"$lte": 5}}, {"a"}),
+        ({"color": {"$in": ["red", "blue"]}}, {"a", "c"}),
+        ({"color": {"$nin": ["red"]}}, {"b", "c"}),
+        ({"$and": [{"color": "red"}, {"size": 5}]}, {"a"}),
+        ({"$or": [{"color": "red"}, {"size": 9}]}, {"a", "c"}),
+        ({"color": "red", "size": 5}, {"a"}),  # implicit AND
+    ],
+)
+def test_where_compiler_supported_operators(col, where, expected_ids):
+    col.add(
+        documents=["a", "b", "c"],
+        ids=["a", "b", "c"],
+        metadatas=[
+            {"color": "red", "size": 5},
+            {"color": "green", "size": 7},
+            {"color": "blue", "size": 9},
+        ],
+        embeddings=[[1, 0, 0, 0]] * 3,
+    )
+    g = col.get(where=where)
+    assert set(g.ids) == expected_ids
+
+
+def test_where_compiler_rejects_unknown_operator(col):
+    col.add(documents=["a"], ids=["a"], metadatas=[{"k": 1}], embeddings=[[1, 0, 0, 0]])
+    with pytest.raises(UnsupportedFilterError):
+        col.get(where={"k": {"$regex": ".*"}})
+
+
+def test_where_document_contains_filter(col):
+    col.add(
+        documents=["red apple pie", "green apple", "yellow banana"],
+        ids=["a", "b", "c"],
+        embeddings=[[1, 0, 0, 0]] * 3,
+    )
+    g = col.get(where_document={"$contains": "apple"})
+    assert set(g.ids) == {"a", "b"}
+
+
+def test_where_document_not_contains_filter(col):
+    col.add(
+        documents=["red apple pie", "green apple", "yellow banana"],
+        ids=["a", "b", "c"],
+        embeddings=[[1, 0, 0, 0]] * 3,
+    )
+    g = col.get(where_document={"$not_contains": "apple"})
+    assert g.ids == ["c"]
+
+
+# ---------------------------------------------------------------------------
+# get with limit / offset
+# ---------------------------------------------------------------------------
+
+
+def test_get_limit_and_offset(col):
+    col.add(
+        documents=[f"d{i}" for i in range(5)],
+        ids=[f"r{i}" for i in range(5)],
+        embeddings=[[1, 0, 0, 0]] * 5,
+    )
+    page1 = col.get(limit=2)
+    page2 = col.get(limit=2, offset=2)
+    assert len(page1.ids) == 2
+    assert len(page2.ids) == 2
+    assert set(page1.ids).isdisjoint(set(page2.ids))
+
+
+def test_get_returns_typed_get_result(col):
+    col.add(documents=["d"], ids=["a"], metadatas=[{"k": 1}], embeddings=[[1, 0, 0, 0]])
+    g = col.get(ids=["a"])
+    assert isinstance(g, GetResult)
+    assert g.ids == ["a"]
+    assert g.documents == ["d"]
+    assert g.metadatas == [{"k": 1}]
+
+
+# ---------------------------------------------------------------------------
+# Backend selection via the public registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_exposes_sqlite_vec():
+    from mempalace.backends import available_backends
+
+    assert "sqlite_vec" in available_backends()
+
+
+def test_registry_get_backend_returns_singleton():
+    from mempalace.backends import get_backend
+
+    a = get_backend("sqlite_vec")
+    b = get_backend("sqlite_vec")
+    assert a is b


### PR DESCRIPTION
## Summary

Alternate vector backend at `mempalace.backends.sqlite_vec.SqliteVecBackend` implementing the full `BaseBackend` / `BaseCollection` contract with `sqlite-vec`'s `vec0` virtual table. Targets the platforms where `chromadb_rust_bindings` is unsafe — primarily macOS 26 / ARM64 where the rust bindings have an intra-process UAF in the recursive segment walker (chroma-core/chroma#6852, #1355, #1376).

The backend has no Rust extension and no chromadb dependency; this UAF vector does not exist in the call graph.

## Storage

One `sqlite_vec.db` file per palace. Per-collection `vec0` virtual table sized to the collection's `dimension`. Schema:

```sql
CREATE TABLE collections (
    name TEXT PRIMARY KEY,
    dimension INTEGER NOT NULL,
    created_at TEXT DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE drawers (
    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
    collection TEXT NOT NULL,
    drawer_id TEXT NOT NULL,
    doc TEXT,
    meta TEXT,         -- JSON; chroma-style filters compile to json_extract(meta, ?)
    UNIQUE(collection, drawer_id)
);
CREATE INDEX idx_drawers_collection ON drawers(collection);

-- Per-collection vec0 (rowid 1:1 with drawers.rowid)
CREATE VIRTUAL TABLE vec_<collection> USING vec0(
    rowid INTEGER PRIMARY KEY,
    embedding FLOAT[<dim>]
);
```

PRAGMAs at open: `journal_mode=WAL`, `synchronous=NORMAL`, `foreign_keys=ON`.

Supported `where` operators: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$and`, `$or`, plus bare-scalar equality. Supported `where_document` operators: `$contains`, `$not_contains`, `$and`, `$or`. Unknown operators raise `UnsupportedFilterError` per RFC 001 §1.4.

## Selection

Optional dependency — opt in via `pip install mempalace[sqlite-vec]`. Registered through the existing `mempalace.backends` entry-point group, so selection goes through the standard registry: `get_backend("sqlite_vec")`. The `mempalace.backends.chroma:ChromaBackend` registration is unchanged, so default behaviour is identical for users not opting in.

## Migration

`examples/migrate_chroma_to_sqlite_vec.py` reads `chroma.sqlite3` directly via stdlib `sqlite3` (no chromadb code is loaded, so the UAF cannot fire even on affected platforms) and re-embeds documents via the existing `get_embedding_function`. Stock hnswlib cannot load chromadb's segment envelope, hence re-embed rather than vector copy.

Resumable on `drawer_id` uniqueness — interrupted runs pick up where they left off. Validated on a 664k-drawer palace; final counts matched the source exactly (drawers 648700/648700, closets 15368/15368). Took ~60min at ~90 records/sec on M4 Pro.

## Disk footprint

Side benefit on my corpus (664k drawers, 384-dim embeddings): the sqlite_vec store ended up roughly 3x smaller than the chromadb palace it replaced.

| | chromadb | sqlite_vec |
|---|---:|---:|
| metadata sqlite | 4.2 GB | — |
| HNSW segment (drawers) | 1.3 GB | — |
| HNSW segment (closets) | 0.2 MB | — |
| sqlite_vec.db | — | 1.8 GB |
| **total** | **5.5 GB** | **1.8 GB** |

Where it comes from:

- No precomputed HNSW index on disk — `vec0` does brute-force SIMD scan, which is fast enough at this scale.
- Vectors stored once. chromadb writes each vector both as a serialized blob in `embedding_metadata` and inside the HNSW segment.
- No segment-management tables (`segments`, `segment_metadata`, `embeddings_queue`, `max_seq_id`).
- Part of the gain is a one-time defrag effect from soft-delete tombstones dropped on migration. A fresh palace migrated at insert-time would show less compression than 3x.

Numbers are from one corpus; mileage will vary, especially on smaller or less-churned palaces.

## Tests

39 new cases in `tests/test_sqlite_vec_backend.py` covering backend lifecycle, write paths (add / upsert / update / delete-by-ids / delete-by-where), query paths (with and without metadata filters, dimension-mismatch raises, dict-compat access), the where compiler parametrized over every supported operator, where_document filters, `get` pagination, and registry-side discovery. Skip cleanly when the `sqlite-vec` extra isn't installed.

Full test suite: 904 pass / 1 pre-existing failure (`test_mcp_stdio_protection`, also fails on `main` without my changes — unrelated).

## Out of scope for this PR

This PR is the contract impl only. The downstream selection plumbing (`palace.py` `_DEFAULT_BACKEND` and `mcp_server.py` `_get_collection`) is intentionally not touched. Follow-up PR if this looks good.
