### PR TITLE
fix: dry-run reports already-filed files as skipped

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -810,7 +810,9 @@ def process_file(
 
     # Skip if already filed
     source_file = str(filepath)
-    if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
+    if collection is not None and file_already_mined(collection, source_file, check_mtime=True):
+        if dry_run:
+            print(f"    [DRY RUN] {filepath.name} -> SKIP (already filed, mtime unchanged)")
         return 0, "general"
 
     try:
@@ -1089,7 +1091,13 @@ def _mine_impl(
         collection = get_collection(palace_path)
         closets_col = get_closets_collection(palace_path)
     else:
-        collection = None
+        # Read-only handle so the dry-run skip check has data to query.
+        # Falls back to None if the palace doesn't yet exist; process_file
+        # then treats every file as new (matches real-run behavior).
+        try:
+            collection = get_collection(palace_path, create=False)
+        except Exception:
+            collection = None
         closets_col = None
 
     total_drawers = 0
@@ -1118,7 +1126,7 @@ def _mine_impl(
                 raise
             files_processed = i
             last_file = filepath.name
-            if drawers == 0 and not dry_run:
+            if drawers == 0:
                 files_skipped += 1
             else:
                 total_drawers += drawers

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -761,3 +761,79 @@ def test_mine_does_not_remove_other_processes_pid_file(tmp_path):
 
     assert pid_file.exists(), "Foreign PID entries must not be removed"
     assert pid_file.read_text().strip() == str(other_pid)
+
+
+def test_mine_dry_run_reports_already_filed_files_as_skipped(tmp_path, capsys):
+    """Dry-run output must reflect what the real run will do.
+
+    Previously the skip check (file_already_mined) was guarded by
+    ``not dry_run``, so dry-run reported every already-filed file as
+    if it would be re-processed. That made dedup look broken and
+    overstated what work the real run would do.
+    """
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    _make_minable_project(project_root, n_files=2)
+    palace_path = project_root / "palace"
+
+    # Real mine to fill the palace, then discard its output.
+    mine(str(project_root), str(palace_path))
+    capsys.readouterr()
+
+    # Dry-run on the unchanged corpus — every file should now skip.
+    mine(str(project_root), str(palace_path), dry_run=True)
+    out = capsys.readouterr().out
+
+    assert out.count("SKIP (already filed, mtime unchanged)") == 2
+    assert "Files skipped (already filed): 2" in out
+    assert "Files processed: 0" in out
+    assert "Drawers filed: 0" in out
+
+
+def test_mine_dry_run_on_empty_palace_still_reports_new_files(tmp_path, capsys):
+    """Dry-run against a never-mined palace must not crash and must
+    list each file as a would-be ingest.
+
+    Guards the read-only ``get_collection(create=False)`` fallback
+    that the dry-run path uses to find already-filed entries.
+    """
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    _make_minable_project(project_root, n_files=1)
+    palace_path = project_root / "palace"  # does not exist yet
+
+    mine(str(project_root), str(palace_path), dry_run=True)
+    out = capsys.readouterr().out
+
+    assert "-> room:" in out
+    assert "SKIP" not in out
+    assert "Files skipped (already filed): 0" in out
+
+
+def test_mine_dry_run_reports_modified_files_as_processed(tmp_path, capsys):
+    """Dry-run on a file whose mtime changed must NOT report as skipped.
+
+    Ensures the skip check honors the same mtime gate the real run
+    uses, so a re-mine after editing a file shows up as work to do.
+    """
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    _make_minable_project(project_root, n_files=1)
+    palace_path = project_root / "palace"
+
+    mine(str(project_root), str(palace_path))
+    capsys.readouterr()
+
+    # Touch + rewrite the file so both content and mtime change.
+    target = project_root / "f0.py"
+    target.write_text("def fn_0_v2():\n    print('updated')\n" * 20)
+    # Belt-and-braces in case the rewrite happens within mtime resolution.
+    new_mtime = target.stat().st_mtime + 5
+    os.utime(target, (new_mtime, new_mtime))
+
+    mine(str(project_root), str(palace_path), dry_run=True)
+    out = capsys.readouterr().out
+
+    assert "SKIP" not in out
+    assert "-> room:" in out
+    assert "Files skipped (already filed): 0" in out


### PR DESCRIPTION
`mempalace mine --dry-run` reported `Files skipped (already filed): 0` even when the same files would be skipped in a real run, because the skip check at file_already_mined() was guarded by `not dry_run`. The preview output therefore overstated how much work the real run would do, leading users to think dedup wasn't working when it was.

Run the skip check in dry-run mode too, using a read-only collection handle (create=False, falling back to None if the palace doesn't yet exist). Print a `-> SKIP (already filed, mtime unchanged)` line for each file the real run would skip, and count it toward `files_skipped`.

No change to real-run behavior.

Found, diagnosed, and patched by Claude (Anthropic's coding assistant) during a debugging session. Opened by the user Claude was working with.

## What does this PR do?

## How to test

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)
