### PR TITLE
Add staged source metadata propagation

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
+from .miner import apply_source_metadata, extract_staged_source_metadata
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -310,7 +311,16 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
-def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+def _file_chunks_locked(
+    collection,
+    source_file,
+    chunks,
+    wing,
+    room,
+    agent,
+    extract_mode,
+    source_metadata=None,
+):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
     Combines the per-file serialization that prevents concurrent agents from
@@ -352,20 +362,19 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                 drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
                 batch_docs.append(chunk["content"])
                 batch_ids.append(drawer_id)
-                batch_metas.append(
-                    {
-                        "wing": wing,
-                        "room": chunk_room,
-                        "hall": _detect_hall_cached(chunk["content"]),
-                        "source_file": source_file,
-                        "chunk_index": chunk["chunk_index"],
-                        "added_by": agent,
-                        "filed_at": filed_at,
-                        "ingest_mode": "convos",
-                        "extract_mode": extract_mode,
-                        "normalize_version": NORMALIZE_VERSION,
-                    }
-                )
+                metadata = {
+                    "wing": wing,
+                    "room": chunk_room,
+                    "hall": _detect_hall_cached(chunk["content"]),
+                    "source_file": source_file,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": agent,
+                    "filed_at": filed_at,
+                    "ingest_mode": "convos",
+                    "extract_mode": extract_mode,
+                    "normalize_version": NORMALIZE_VERSION,
+                }
+                batch_metas.append(apply_source_metadata(metadata, source_metadata))
             try:
                 collection.upsert(
                     documents=batch_docs,
@@ -442,6 +451,7 @@ def mine_convos(
             if not dry_run:
                 _register_file(collection, source_file, wing, agent)
             continue
+        source_metadata = extract_staged_source_metadata(content)
 
         # Chunk — either exchange pairs or general extraction
         if extract_mode == "general":
@@ -487,7 +497,7 @@ def mine_convos(
         # Lock + purge stale + file fresh chunks. Lock serializes concurrent
         # agents; purge removes pre-v2 drawers so the schema bump applies.
         drawers_added, room_delta, skipped = _file_chunks_locked(
-            collection, source_file, chunks, wing, room, agent, extract_mode
+            collection, source_file, chunks, wing, room, agent, extract_mode, source_metadata
         )
         if skipped:
             files_skipped += 1

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -13,6 +13,7 @@ import shlex
 import hashlib
 import fnmatch
 import logging
+import json
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
@@ -85,6 +86,67 @@ MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB — skip files larger than this.
 # =============================================================================
 # IGNORE MATCHING
 # =============================================================================
+
+
+SOURCE_FRONTMATTER_FIELDS = (
+    "source_item_id",
+    "source_title",
+    "source_created_at",
+    "source_modified_at",
+    "source_observed_at",
+)
+
+
+def extract_staged_source_metadata(content: str) -> dict:
+    """Extract source metadata from mempalace-sync staged front matter."""
+
+    if not content.startswith("---\n"):
+        return {}
+    lines = content.splitlines()
+    if len(lines) < 4 or lines[0] != "---":
+        return {}
+    try:
+        end = lines[1:].index("---") + 1
+    except ValueError:
+        return {}
+
+    parsed: dict = {}
+    for line in lines[1:end]:
+        if ": " not in line:
+            continue
+        key, value = line.split(": ", 1)
+        if key == "source_item_id" and value:
+            parsed["source_item_id"] = value
+        elif key == "title" and value:
+            parsed["source_title"] = value
+        elif key == "metadata" and value:
+            try:
+                metadata = json.loads(value)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(metadata, dict):
+                continue
+            for field in (
+                "source_created_at",
+                "source_modified_at",
+                "source_observed_at",
+            ):
+                field_value = metadata.get(field)
+                if isinstance(field_value, (str, int, float, bool)) and field_value != "":
+                    parsed[field] = field_value
+    return parsed
+
+
+def apply_source_metadata(metadata: dict, source_metadata: Optional[dict]) -> dict:
+    """Copy supported staged source metadata fields into Chroma metadata."""
+
+    if not source_metadata:
+        return metadata
+    for field in SOURCE_FRONTMATTER_FIELDS:
+        value = source_metadata.get(field)
+        if isinstance(value, (str, int, float, bool)) and value != "":
+            metadata[field] = value
+    return metadata
 
 
 class GitignoreMatcher:
@@ -741,6 +803,7 @@ def _build_drawer_metadata(
     agent: str,
     content: str,
     source_mtime: Optional[float],
+    source_metadata: Optional[dict] = None,
 ) -> dict:
     """Build the metadata dict for one drawer without upserting.
 
@@ -759,6 +822,7 @@ def _build_drawer_metadata(
     }
     if source_mtime is not None:
         metadata["source_mtime"] = source_mtime
+    apply_source_metadata(metadata, source_metadata)
     metadata["hall"] = detect_hall(content)
     entities = _extract_entities_for_metadata(content)
     if entities:
@@ -821,6 +885,7 @@ def process_file(
     content = content.strip()
     if len(content) < MIN_CHUNK_SIZE:
         return 0, "general"
+    source_metadata = extract_staged_source_metadata(content)
 
     room = detect_room(filepath, content, rooms, project_path)
     chunks = chunk_text(content, source_file)
@@ -874,6 +939,7 @@ def process_file(
                         agent,
                         chunk["content"],
                         source_mtime,
+                        source_metadata,
                     )
                 )
             collection.upsert(
@@ -904,6 +970,7 @@ def process_file(
                 "filed_at": datetime.now().isoformat(),
                 "normalize_version": NORMALIZE_VERSION,
             }
+            apply_source_metadata(closet_meta, source_metadata)
             if entities:
                 closet_meta["entities"] = entities
             purge_file_closets(closets_col, source_file)

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -51,7 +51,8 @@ _DEFAULT_BACKEND = ChromaBackend()
 #
 # v2 (2026-04): introduced strip_noise() for Claude Code JSONL; previous
 #               drawers stored system tags / hook chrome verbatim.
-NORMALIZE_VERSION = 2
+# v3 (2026-05): conversation miner propagates mempalace-sync source metadata.
+NORMALIZE_VERSION = 3
 
 
 def get_collection(

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -176,6 +176,38 @@ def build_where_filter(wing: str = None, room: str = None) -> dict:
     return {}
 
 
+def _copy_source_fields(entry: dict, meta: dict) -> dict:
+    """Copy optional original source metadata into a search result entry."""
+
+    for field in (
+        "source_item_id",
+        "source_title",
+        "source_created_at",
+        "source_modified_at",
+        "source_observed_at",
+    ):
+        value = meta.get(field)
+        if value not in (None, ""):
+            entry[field] = value
+    return entry
+
+
+def _format_original_date_metadata(meta: dict) -> str:
+    """Return a compact display string for optional original source dates."""
+
+    labels = (
+        ("created", "source_created_at"),
+        ("modified", "source_modified_at"),
+        ("observed", "source_observed_at"),
+    )
+    parts = []
+    for label, field in labels:
+        value = meta.get(field)
+        if value not in (None, ""):
+            parts.append(f"{label}={value}")
+    return "  ".join(parts)
+
+
 def _extract_drawer_ids_from_closet(closet_doc: str) -> list:
     """Parse all `→drawer_id_a,drawer_id_b` pointers out of a closet document.
 
@@ -363,6 +395,13 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
         print(f"  [{i}] {wing_name} / {room_name}")
         print(f"      Source: {source}")
+        if meta.get("source_title"):
+            print(f"      Item:   {meta['source_title']}")
+        if meta.get("source_item_id"):
+            print(f"      ID:     {meta['source_item_id']}")
+        original_dates = _format_original_date_metadata(meta)
+        if original_dates:
+            print(f"      Dates:  {original_dates}")
         print(f"      Match:  cosine={vec_sim}  bm25={bm25}")
         print()
         # Print the verbatim text, indented
@@ -520,26 +559,25 @@ def _bm25_only_via_sqlite(
         if room and meta.get("room") != room:
             continue
         full_source = meta.get("source_file", "") or ""
-        candidates.append(
-            {
-                "text": d["text"],
-                "wing": meta.get("wing", "unknown"),
-                "room": meta.get("room", "unknown"),
-                "source_file": Path(full_source).name if full_source else "?",
-                "created_at": meta.get("filed_at", "unknown"),
-                # No vector distance available in BM25-only mode.
-                "similarity": None,
-                "distance": None,
-                "matched_via": "bm25_sqlite",
-                # Internal: full path + chunk_index let callers (notably
-                # candidate_strategy="union") dedupe at chunk granularity
-                # rather than basename — two files in different directories
-                # may share a basename, and one source_file is split across
-                # multiple chunks. Stripped before this helper returns.
-                "_source_file_full": full_source,
-                "_chunk_index": meta.get("chunk_index"),
-            }
-        )
+        entry = {
+            "text": d["text"],
+            "wing": meta.get("wing", "unknown"),
+            "room": meta.get("room", "unknown"),
+            "source_file": Path(full_source).name if full_source else "?",
+            "created_at": meta.get("filed_at", "unknown"),
+            # No vector distance available in BM25-only mode.
+            "similarity": None,
+            "distance": None,
+            "matched_via": "bm25_sqlite",
+            # Internal: full path + chunk_index let callers (notably
+            # candidate_strategy="union") dedupe at chunk granularity
+            # rather than basename — two files in different directories
+            # may share a basename, and one source_file is split across
+            # multiple chunks. Stripped before this helper returns.
+            "_source_file_full": full_source,
+            "_chunk_index": meta.get("chunk_index"),
+        }
+        candidates.append(_copy_source_fields(entry, meta))
 
     # Local BM25 over the candidate set.
     docs = [c["text"] for c in candidates]
@@ -853,6 +891,7 @@ def search_memories(
             "_source_file_full": source,
             "_chunk_index": meta.get("chunk_index"),
         }
+        _copy_source_fields(entry, meta)
         if closet_preview:
             entry["closet_preview"] = closet_preview
         scored.append(entry)

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -147,3 +147,49 @@ class TestFileChunksLocked:
         assert dict(room_counts) == {}
         assert skipped is False
         assert col.batch_sizes == [2, 2, 1]
+
+    def test_copies_source_metadata_to_conversation_drawers(self, monkeypatch):
+        import mempalace.convo_miner as convo_miner
+
+        class FakeCol:
+            def __init__(self):
+                self.metadatas = []
+
+            def delete(self, *args, **kwargs):
+                pass
+
+            def upsert(self, documents, ids, metadatas):
+                self.metadatas.extend(metadatas)
+
+        source_metadata = {
+            "source_item_id": "claude:conversation-1",
+            "source_title": "Conversation One",
+            "source_created_at": "2026-05-06T10:00:00+00:00",
+            "source_modified_at": "2026-05-06T10:05:00+00:00",
+        }
+        chunks = [{"content": "chunk content " * 20, "chunk_index": 0}]
+        col = FakeCol()
+        monkeypatch.setattr(
+            convo_miner, "file_already_mined", lambda collection, source_file: False
+        )
+        monkeypatch.setattr(convo_miner, "mine_lock", lambda source_file: contextlib.nullcontext())
+        monkeypatch.setattr(convo_miner, "_detect_hall_cached", lambda content: "conversations")
+
+        drawers, room_counts, skipped = _file_chunks_locked(
+            col,
+            "chat.md",
+            chunks,
+            "claude",
+            "technical",
+            "agent",
+            "exchange",
+            source_metadata,
+        )
+
+        assert drawers == 1
+        assert dict(room_counts) == {}
+        assert skipped is False
+        assert col.metadatas[0]["source_item_id"] == "claude:conversation-1"
+        assert col.metadatas[0]["source_title"] == "Conversation One"
+        assert col.metadatas[0]["source_created_at"] == "2026-05-06T10:00:00+00:00"
+        assert col.metadatas[0]["source_modified_at"] == "2026-05-06T10:05:00+00:00"

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shlex
 import shutil
@@ -7,7 +8,7 @@ from pathlib import Path
 import chromadb
 import yaml
 
-from mempalace.miner import load_config, mine, scan_project, status
+from mempalace.miner import extract_staged_source_metadata, load_config, mine, scan_project, status
 from mempalace.palace import NORMALIZE_VERSION, file_already_mined
 
 
@@ -440,6 +441,91 @@ def test_process_file_uses_bounded_upsert_batches(tmp_path, monkeypatch):
     assert drawers == 5
     assert room == "general"
     assert col.batch_sizes == [2, 2, 1]
+
+
+def test_extract_staged_source_metadata_reads_supported_front_matter_fields():
+    source_metadata = extract_staged_source_metadata(
+        "---\n"
+        "source_item_id: trilium:abc123\n"
+        "title: Source Note\n"
+        'metadata: {"source_created_at": "2026-05-01T10:00:00", '
+        '"source_modified_at": "2026-05-02T11:00:00", '
+        '"source_observed_at": "2026-05-03T12:00:00", '
+        '"other": "ignored"}\n'
+        "---\n\n"
+        "# Source Note\n\nBody text."
+    )
+
+    assert source_metadata == {
+        "source_item_id": "trilium:abc123",
+        "source_title": "Source Note",
+        "source_created_at": "2026-05-01T10:00:00",
+        "source_modified_at": "2026-05-02T11:00:00",
+        "source_observed_at": "2026-05-03T12:00:00",
+    }
+
+
+def test_process_file_copies_source_metadata_to_drawers_and_closets(tmp_path, monkeypatch):
+    from mempalace import miner
+
+    class FakeCol:
+        def __init__(self):
+            self.metadatas = []
+
+        def get(self, *args, **kwargs):
+            return {"ids": []}
+
+        def delete(self, *args, **kwargs):
+            pass
+
+        def upsert(self, documents, ids, metadatas):
+            self.metadatas.extend(metadatas)
+
+    source_metadata = {
+        "source_created_at": "2026-05-01T10:00:00",
+        "source_modified_at": "2026-05-02T11:00:00",
+        "source_observed_at": "2026-05-03T12:00:00",
+    }
+    source = tmp_path / "note.md"
+    source.write_text(
+        "---\n"
+        "source_item_id: trilium:abc123\n"
+        "title: Source Note\n"
+        f"metadata: {json.dumps(source_metadata, sort_keys=True)}\n"
+        "---\n\n"
+        "# Source Note\n\n"
+        + ("Body text. " * 20),
+        encoding="utf-8",
+    )
+    drawers = FakeCol()
+    closets = FakeCol()
+    monkeypatch.setattr(
+        miner,
+        "chunk_text",
+        lambda content, source_file: [{"content": "Body text. " * 20, "chunk_index": 0}],
+    )
+    monkeypatch.setattr(miner, "detect_hall", lambda content: "general")
+    monkeypatch.setattr(miner, "_extract_entities_for_metadata", lambda content: "")
+
+    drawer_count, room = miner.process_file(
+        source,
+        tmp_path,
+        drawers,
+        "wing",
+        [{"name": "general", "description": "General"}],
+        "agent",
+        False,
+        closets_col=closets,
+    )
+
+    assert drawer_count == 1
+    assert room == "general"
+    for metadata in (drawers.metadatas[0], closets.metadatas[0]):
+        assert metadata["source_item_id"] == "trilium:abc123"
+        assert metadata["source_title"] == "Source Note"
+        assert metadata["source_created_at"] == "2026-05-01T10:00:00"
+        assert metadata["source_modified_at"] == "2026-05-02T11:00:00"
+        assert metadata["source_observed_at"] == "2026-05-03T12:00:00"
 
 
 # ── normalize_version schema gate ───────────────────────────────────────

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -74,6 +74,40 @@ class TestSearchMemories:
         hit = result["results"][0]
         assert hit["created_at"] == "unknown"
 
+    def test_source_metadata_fields_are_returned_when_present(self):
+        """Original source metadata is surfaced alongside search result text."""
+        mock_col = MagicMock()
+        mock_col.query.return_value = {
+            "ids": [["drawer_source_date"]],
+            "documents": [["Source note body with original dates"]],
+            "metadatas": [
+                [
+                    {
+                        "wing": "project",
+                        "room": "backend",
+                        "source_file": "note.md",
+                        "filed_at": "2026-05-06T00:00:00",
+                        "source_item_id": "trilium:abc123",
+                        "source_title": "Source Note",
+                        "source_created_at": "2026-05-01T10:00:00",
+                        "source_modified_at": "2026-05-02T11:00:00",
+                        "source_observed_at": "2026-05-03T12:00:00",
+                    }
+                ]
+            ],
+            "distances": [[0.1]],
+        }
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            result = search_memories("original dates", "/fake/path")
+
+        hit = result["results"][0]
+        assert hit["source_item_id"] == "trilium:abc123"
+        assert hit["source_title"] == "Source Note"
+        assert hit["source_created_at"] == "2026-05-01T10:00:00"
+        assert hit["source_modified_at"] == "2026-05-02T11:00:00"
+        assert hit["source_observed_at"] == "2026-05-03T12:00:00"
+
     def test_search_memories_query_error(self):
         """search_memories returns error dict when query raises."""
         mock_col = MagicMock()
@@ -367,3 +401,33 @@ class TestSearchCLI:
         assert "[2]" in captured.out
         # Second result renders with fallback '?' values instead of crashing
         assert "second doc" in captured.out
+
+    def test_search_prints_source_metadata_when_present(self, capsys):
+        """CLI output includes original source metadata for GUI parsing."""
+        mock_col = MagicMock()
+        mock_col.metadata = {"hnsw:space": "cosine"}
+        mock_col.query.return_value = {
+            "documents": [["source body with original metadata"]],
+            "metadatas": [
+                [
+                    {
+                        "source_file": "note.md",
+                        "wing": "w",
+                        "room": "r",
+                        "source_item_id": "trilium:abc123",
+                        "source_title": "Source Note",
+                        "source_created_at": "2026-05-01T10:00:00",
+                        "source_modified_at": "2026-05-02T11:00:00",
+                    }
+                ]
+            ],
+            "distances": [[0.2]],
+        }
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search("metadata", "/fake/path")
+
+        captured = capsys.readouterr()
+        assert "Item:   Source Note" in captured.out
+        assert "ID:     trilium:abc123" in captured.out
+        assert "Dates:  created=2026-05-01T10:00:00  modified=2026-05-02T11:00:00" in captured.out


### PR DESCRIPTION
Parse mempalace-sync staged front matter for original source identifiers, titles, and item dates, then surface those fields through drawer/closet metadata and search results.

Validation:
- MemPalace full pytest suite: 1493 passed, 1 skipped, 106 deselected
- Ruff on touched Python files passed
- UI/API search metadata verification passed against a temporary palace

Co-Authored-By: Oz <oz-agent@warp.dev>