### PR TITLE
fix(hooks/precompact): unblock /compact and auto-compact

### DIFF
--- a/.claude-plugin/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin/hooks/mempal-precompact-hook.sh
@@ -1,24 +1,8 @@
 #!/bin/bash
-# MemPalace PreCompact Hook — thin wrapper calling Python CLI
-# All logic lives in mempalace.hooks_cli for cross-harness extensibility
-run_mempalace_hook() {
-  if command -v mempalace >/dev/null 2>&1; then
-    mempalace hook run "$@"
-    return $?
-  fi
-
-  if command -v python3 >/dev/null 2>&1 && python3 -c "import mempalace" >/dev/null 2>&1; then
-    python3 -m mempalace hook run "$@"
-    return $?
-  fi
-
-  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
-    python -m mempalace hook run "$@"
-    return $?
-  fi
-
-  echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
-  return 1
-}
-
-run_mempalace_hook --hook precompact --harness claude-code
+# MemPalace PreCompact Hook
+# This hook MUST allow compaction to proceed. The previous implementation
+# routed through `mempalace hook run --hook precompact --harness claude-code`
+# which always returned a "block" decision, preventing both `/compact` and
+# auto-compact from working as documented.
+# Session saving is unaffected — it happens via the Stop hook (separate path).
+echo '{"decision": "allow"}'


### PR DESCRIPTION
## Problem

The PreCompact hook always ends up returning a `block` decision, preventing both `/compact` (manual) and auto-compact from working for any user installing this plugin.

The current upstream hook routes through:

```
run_mempalace_hook --hook precompact --harness claude-code
```

Which calls `mempalace hook run --hook precompact --harness claude-code`, and that path returns `block`. Net effect: no user can compact while this plugin is active.

## Fix

Have the hook return `{"decision": "allow"}` directly so compaction proceeds.

Session saving is **NOT affected** — it goes through the Stop hook (separate path), which continues to work as designed.

## Verification

Tested in production VPS Claude Code environment:

- `/compact` (manual) now works ✓
- Auto-compact at context threshold now works ✓
- Session saving via Stop hook unaffected ✓
- MemPalace MCP server continues responding correctly ✓

## Notes for maintainers

If the original blocking behavior was intentional (e.g. to enforce session save first), please consider an alternative implementation that allows compaction *and* triggers save — current behavior just blocks all compaction silently, which surprises users.

This patch takes the minimal-impact approach. Happy to iterate on a more nuanced solution if preferred.
