### PR TITLE
fix(entity-registry): clean up temp file on save failure

### DIFF
--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -321,22 +321,39 @@ class EntityRegistry:
             self._path.parent.chmod(0o700)
         except (OSError, NotImplementedError):
             pass
+
         # Atomic write: serialize to a sibling temp file in the same dir
         # (so os.replace stays on one filesystem), fsync, then rename over
         # the target. A crash mid-write leaves the previous registry intact
         # instead of a half-written file or an empty file from the truncate.
+        #
+        # If a normal Python-visible write/flush/fsync/replace error occurs
+        # before the rename completes, remove the temp sidecar before
+        # re-raising so entity_registry.json.tmp does not linger as stale
+        # debris in the palace directory.
         payload = json.dumps(self._data, indent=2)
         tmp_path = self._path.with_name(self._path.name + ".tmp")
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            f.write(payload)
-            f.flush()
-            os.fsync(f.fileno())
+
         try:
-            tmp_path.chmod(0o600)
-        except (OSError, NotImplementedError):
-            pass
-        os.replace(tmp_path, self._path)
-        # On ext4 (and similar) the rename's durability across power loss
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                f.write(payload)
+                f.flush()
+                os.fsync(f.fileno())
+
+            try:
+                tmp_path.chmod(0o600)
+            except (OSError, NotImplementedError):
+                pass
+
+            os.replace(tmp_path, self._path)
+        except Exception:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+        # On ext4 (and similar), the rename's durability across power loss
         # requires an additional fsync on the parent directory. Without it,
         # the kernel can ack the rename and a crash reverts to the state
         # where the temp file is present and the target is at the old version.
@@ -347,8 +364,8 @@ class EntityRegistry:
             finally:
                 os.close(dir_fd)
         except OSError:
-            # Windows and some special filesystems reject directory fds — they
-            # have different durability semantics on rename anyway.
+            # Windows and some special filesystems reject directory fds —
+            # they have different durability semantics on rename anyway.
             pass
 
     @staticmethod

--- a/tests/test_entity_registry.py
+++ b/tests/test_entity_registry.py
@@ -115,6 +115,39 @@ def test_save_preserves_previous_on_serialization_failure(tmp_path, monkeypatch)
     # Restore os.replace before reading so the assertion can rely on it.
     monkeypatch.setattr(_os, "replace", real_replace)
     assert target.read_text(encoding="utf-8") == original
+    assert not (tmp_path / "entity_registry.json.tmp").exists()
+
+
+def test_save_removes_tmp_on_fsync_failure(tmp_path, monkeypatch):
+    """A temp-write failure must not leave entity_registry.json.tmp behind."""
+
+    registry = EntityRegistry.load(config_dir=tmp_path)
+    registry.seed(
+        mode="personal",
+        people=[{"name": "Alice", "relationship": "friend", "context": "personal"}],
+        projects=[],
+    )
+
+    target = tmp_path / "entity_registry.json"
+    original = target.read_text(encoding="utf-8")
+    tmp_file = tmp_path / "entity_registry.json.tmp"
+
+    import os as _os
+
+    def boom(fd):
+        raise OSError("simulated fsync failure")
+
+    monkeypatch.setattr(_os, "fsync", boom)
+
+    with pytest.raises(OSError):
+        registry.seed(
+            mode="personal",
+            people=[{"name": "Bob", "relationship": "friend", "context": "personal"}],
+            projects=[],
+        )
+
+    assert target.read_text(encoding="utf-8") == original
+    assert not tmp_file.exists()
 
 
 # ── seed ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes #1373.

This makes `EntityRegistry.save()` remove the sibling `.tmp` sidecar if the atomic-save path fails before `os.replace()` completes.

## What changed

- Wrapped the temp-write / flush / fsync / chmod / replace block in `try/except`.
- On any exception before the save completes:
  - attempt to unlink `entity_registry.json.tmp`
  - ignore cleanup failure
  - re-raise the original exception
- Kept the existing behavior where the parent directory is fsynced after a successful `os.replace()`.
- Added regression coverage for:
  - `os.replace()` failure leaving the previous registry intact and no `.tmp` sidecar
  - `os.fsync()` failure leaving the previous registry intact and no `.tmp` sidecar

## Why

The registry save path is already atomic for crash-mid-write durability, but normal Python-visible failures such as disk-full, permission changes, broken mounts, or fsync errors could leave `entity_registry.json.tmp` behind.

That temp file does not grow unbounded because the next save reuses the same filename, but it creates confusing stale debris in the palace directory.


## How to test

```bash
ruff format mempalace/entity_registry.py tests/test_entity_registry.py
ruff check mempalace/entity_registry.py tests/test_entity_registry.py
python -m pytest tests/test_entity_registry.py -q
python -m pytest tests/test_entity_registry.py tests/test_onboarding.py -q
python -m pytest tests/ -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
