### PR TITLE
fix(closet_llm): retry _call_llm on JSONDecodeError (#1155)

### DIFF
--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -169,6 +169,9 @@ def _call_llm(cfg: LLMConfig, source_file: str, wing: str, room: str, content: s
             parsed = json.loads(text)
             return parsed, payload.get("usage")
         except json.JSONDecodeError:
+            if attempt < 2:
+                time.sleep(2**attempt)
+                continue
             return None, None
         except urllib.error.HTTPError as e:
             # 429 / 503 = retry with backoff

--- a/tests/test_closet_llm.py
+++ b/tests/test_closet_llm.py
@@ -200,7 +200,7 @@ class TestCallLLM:
             patch("urllib.request.urlopen", side_effect=fake_urlopen),
             patch("mempalace.closet_llm.time.sleep"),
         ):
-            parsed, usage = _call_llm(cfg, "/tmp/x", "w", "r", "c")
+            parsed, _ = _call_llm(cfg, "/tmp/x", "w", "r", "c")
         assert parsed is None
 
     def test_retries_on_json_decode_error(self):
@@ -220,7 +220,7 @@ class TestCallLLM:
             patch("urllib.request.urlopen", side_effect=fake_urlopen),
             patch("mempalace.closet_llm.time.sleep"),
         ):
-            parsed, usage = _call_llm(cfg, "/tmp/x", "w", "r", "c")
+            parsed, _ = _call_llm(cfg, "/tmp/x", "w", "r", "c")
         assert parsed is None
         assert call_count["n"] == 3
 

--- a/tests/test_closet_llm.py
+++ b/tests/test_closet_llm.py
@@ -196,9 +196,33 @@ class TestCallLLM:
                 }
             )
 
-        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with (
+            patch("urllib.request.urlopen", side_effect=fake_urlopen),
+            patch("mempalace.closet_llm.time.sleep"),
+        ):
             parsed, usage = _call_llm(cfg, "/tmp/x", "w", "r", "c")
         assert parsed is None
+
+    def test_retries_on_json_decode_error(self):
+        cfg = self._make_cfg()
+        call_count = {"n": 0}
+
+        def fake_urlopen(req, timeout=None):
+            call_count["n"] += 1
+            return _FakeResp(
+                {
+                    "choices": [{"message": {"content": "not json at all"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+            )
+
+        with (
+            patch("urllib.request.urlopen", side_effect=fake_urlopen),
+            patch("mempalace.closet_llm.time.sleep"),
+        ):
+            parsed, usage = _call_llm(cfg, "/tmp/x", "w", "r", "c")
+        assert parsed is None
+        assert call_count["n"] == 3
 
 
 # ── regenerate_closets error paths ───────────────────────────────────────


### PR DESCRIPTION
## Summary

`_call_llm` already retries with exponential backoff on HTTP 429/503 and rate-limit-shaped exceptions, but `JSONDecodeError` exited on the first failure. Local LLM runtimes occasionally produce malformed JSON under load (truncated streams, partial chunks), and the retry was effectively dead for that path.

This change mirrors the 429/503 branch: sleep with exponential backoff and continue through all 3 attempts, only returning `None` after the final failure.

## Changes

- `mempalace/closet_llm.py`: 3-line change in the JSONDecodeError handler.
- `tests/test_closet_llm.py`: new `test_retries_on_json_decode_error` asserts urlopen is called 3 times before bailout; existing `test_returns_none_on_invalid_json` patched to mock `time.sleep`.

## Test plan

- [x] `uv run pytest tests/test_closet_llm.py -v` — 18 passed (1 new)
- [x] `uvx --from 'ruff>=0.4.0,<0.5' ruff check` + format check — clean

Closes #1155