### PR TITLE
fix(repair): harden recovery flows and serialize writers

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1231,14 +1231,9 @@ class ChromaBackend(BaseBackend):
         )
 
         if cached is None or inode_changed or mtime_changed or mtime_appeared:
-            # An inode swap means we are reopening a different physical DB
-            # (post-restore, fresh palace at the same path, etc.); drop the
-            # per-process gate so the quarantine pre-checks run again
-            # against the new disk state instead of trusting cached "we
-            # already cleaned this path" credit from the prior inode.
-            if inode_changed:
-                ChromaBackend._quarantined_paths.discard(palace_path)
-            ChromaBackend._prepare_palace_for_open(palace_path)
+            ChromaBackend._prepare_palace_for_open(
+                palace_path, reset_quarantine=inode_changed
+            )
             cached = chromadb.PersistentClient(path=palace_path)
             self._clients[palace_path] = cached
             # Re-stat after the client constructor runs: chromadb creates
@@ -1275,7 +1270,9 @@ class ChromaBackend(BaseBackend):
     _quarantined_paths: set[str] = set()
 
     @staticmethod
-    def _prepare_palace_for_open(palace_path: str) -> None:
+    def _prepare_palace_for_open(
+        palace_path: str, *, reset_quarantine: bool = False
+    ) -> None:
         """Run the pre-open safety pass shared by :meth:`make_client` and
         :meth:`_client`.
 
@@ -1283,22 +1280,19 @@ class ChromaBackend(BaseBackend):
 
         1. ``_fix_blob_seq_ids`` — repairs the BLOB seq_id quirk that bites
            certain chromadb migrations.
-        2. ``quarantine_invalid_hnsw_metadata`` — renames aside any HNSW
-           ``index_metadata.pickle`` that fails to load, so chromadb opens
-           against an empty index instead of crashing on the unloadable
-           pickle (#1266 / PR #1285).
-        3. ``quarantine_stale_hnsw`` — also gated by :attr:`_quarantined_paths`
-           so it fires once per palace per process. This is the SIGSEGV
-           prevention path for stale HNSW segments (see #1121, #1132, #1263);
-           wiring it through this helper means CLI mining, search, repair,
-           and status all benefit, not just the legacy ``make_client``
-           callers.
+        2. ``quarantine_invalid_hnsw_metadata`` + ``quarantine_stale_hnsw`` —
+           gated by :attr:`_quarantined_paths` so they fire once per palace
+           per process unless the underlying sqlite inode changes. This keeps
+           reconnect paths cheap while still re-running the preflight after an
+           on-disk palace replacement.
 
         Idempotent: safe to call from any code path that is about to open or
         re-open a palace. The ``_quarantined_paths`` gate prevents thrash on
         hot paths (e.g. ``_client()`` is called on every backend operation).
         """
         _fix_blob_seq_ids(palace_path)
+        if reset_quarantine:
+            ChromaBackend._quarantined_paths.discard(palace_path)
         if palace_path not in ChromaBackend._quarantined_paths:
             quarantine_invalid_hnsw_metadata(palace_path)
             quarantine_stale_hnsw(palace_path)

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1242,9 +1242,7 @@ class ChromaBackend(BaseBackend):
         )
 
         if cached is None or inode_changed or mtime_changed or mtime_appeared:
-            ChromaBackend._prepare_palace_for_open(
-                palace_path, reset_quarantine=inode_changed
-            )
+            ChromaBackend._prepare_palace_for_open(palace_path, reset_quarantine=inode_changed)
             cached = chromadb.PersistentClient(path=palace_path)
             self._clients[palace_path] = cached
             # Re-stat after the client constructor runs: chromadb creates
@@ -1282,9 +1280,7 @@ class ChromaBackend(BaseBackend):
     _quarantined_paths: set[str] = set()
 
     @staticmethod
-    def _prepare_palace_for_open(
-        palace_path: str, *, reset_quarantine: bool = False
-    ) -> None:
+    def _prepare_palace_for_open(palace_path: str, *, reset_quarantine: bool = False) -> None:
         """Run the pre-open safety pass shared by :meth:`make_client` and
         :meth:`_client`.
 

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -938,6 +938,16 @@ class ChromaCollection(BaseCollection):
         with self._write_lock():
             self._collection.upsert(**kwargs)
 
+    def modify(self, *, name=None, metadata=None, configuration=None):
+        kwargs: dict[str, Any] = {}
+        if name is not None:
+            kwargs["name"] = name
+        if metadata is not None:
+            kwargs["metadata"] = metadata
+        if configuration is not None:
+            kwargs["configuration"] = configuration
+        self._collection.modify(**kwargs)
+
     def update(
         self,
         *,
@@ -1246,27 +1256,28 @@ class ChromaBackend(BaseBackend):
     # Public static helpers (legacy; prefer :meth:`get_collection`)
     # ------------------------------------------------------------------
 
-    # Per-process record of palaces that have already had the cold-start
-    # quarantine invoked at least once. The proactive HNSW checks are a
-    # *cold-start* protection — they catch segments that arrive stale relative
-    # to ``chroma.sqlite3`` or invalid on disk (e.g. cross-machine replication,
-    # partial restore, crashed-mid-write). Once a long-running process has
-    # opened the palace cleanly, re-firing the stale check on every reconnect
-    # is a *runtime thrash*: the daemon's own writes bump sqlite mtime but HNSW
-    # flushes batch on chromadb's internal cadence, so the mtime gap naturally
-    # exceeds the threshold under steady write load even though nothing is
-    # corrupt.
+    # Per-process record of palaces that have already had stale-HNSW mtime
+    # quarantine invoked at least once. Stale quarantine is a *cold-start*
+    # protection — it catches segments that arrive stale relative to
+    # ``chroma.sqlite3`` (e.g. cross-machine replication, partial restore,
+    # crashed-mid-write). Once a long-running process has opened the palace
+    # cleanly, re-firing the stale check on every reconnect is a *runtime
+    # thrash*: the daemon's own writes bump sqlite mtime but HNSW flushes batch
+    # on chromadb's internal cadence, so the mtime gap naturally exceeds the
+    # threshold under steady write load even though nothing is corrupt.
+    # Invalid metadata quarantine is cheaper and deterministic, so it runs on
+    # every client open/reconnect and is not gated by this set.
     # Real runtime drift is still handled — palace-daemon's ``_auto_repair``
     # calls :func:`quarantine_stale_hnsw` directly on observed HNSW errors,
     # which bypasses this gate.
     #
     # Thread-safety: this set is mutated without a lock. Two concurrent
-    # ``make_client()`` calls for the same palace can both pass the
-    # membership check and both invoke the cold-start quarantine. That's
-    # safe because the functions are idempotent (mtime checks + timestamped
-    # rename of distinct directories), so the worst-case race produces one
-    # redundant rename attempt that no-ops. Idempotency is the safety
-    # property; locking would add cost without correctness gain.
+    # ``make_client()`` calls for the same palace can both pass the membership
+    # check and both invoke stale quarantine. That's safe because the function
+    # is idempotent (mtime checks + timestamped rename of distinct directories),
+    # so the worst-case race produces one redundant rename attempt that no-ops.
+    # Idempotency is the safety property; locking would add cost without
+    # correctness gain.
     _quarantined_paths: set[str] = set()
 
     @staticmethod
@@ -1280,21 +1291,23 @@ class ChromaBackend(BaseBackend):
 
         1. ``_fix_blob_seq_ids`` — repairs the BLOB seq_id quirk that bites
            certain chromadb migrations.
-        2. ``quarantine_invalid_hnsw_metadata`` + ``quarantine_stale_hnsw`` —
-           gated by :attr:`_quarantined_paths` so they fire once per palace
-           per process unless the underlying sqlite inode changes. This keeps
-           reconnect paths cheap while still re-running the preflight after an
-           on-disk palace replacement.
+        2. ``quarantine_invalid_hnsw_metadata`` — runs on every open so
+           reconnect paths still quarantine newly-corrupted metadata files.
+        3. ``quarantine_stale_hnsw`` — gated by :attr:`_quarantined_paths`
+           so it fires once per palace per process unless the underlying
+           sqlite inode changes. This keeps reconnect paths cheap while still
+           re-running the stale-segment preflight after an on-disk palace
+           replacement.
 
         Idempotent: safe to call from any code path that is about to open or
         re-open a palace. The ``_quarantined_paths`` gate prevents thrash on
         hot paths (e.g. ``_client()`` is called on every backend operation).
         """
         _fix_blob_seq_ids(palace_path)
+        quarantine_invalid_hnsw_metadata(palace_path)
         if reset_quarantine:
             ChromaBackend._quarantined_paths.discard(palace_path)
         if palace_path not in ChromaBackend._quarantined_paths:
-            quarantine_invalid_hnsw_metadata(palace_path)
             quarantine_stale_hnsw(palace_path)
             ChromaBackend._quarantined_paths.add(palace_path)
 
@@ -1306,9 +1319,10 @@ class ChromaBackend(BaseBackend):
         own client cache. New code should obtain a collection through
         :meth:`get_collection` which manages caching internally.
 
-        Quarantines HNSW segments **once per palace per process**. See
-        :attr:`_quarantined_paths` for the rationale (cold-start protection
-        vs. runtime thrash on steady-write daemons).
+        Runs invalid-metadata quarantine on every call, but only runs stale-HNSW
+        mtime quarantine once per palace per process. See
+        :attr:`_quarantined_paths` for the stale-quarantine rationale
+        (cold-start protection vs. runtime thrash on steady-write daemons).
         """
         ChromaBackend._prepare_palace_for_open(palace_path)
         return chromadb.PersistentClient(path=palace_path)

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -860,7 +860,7 @@ class ChromaCollection(BaseCollection):
     """Thin adapter translating ChromaDB dict returns into typed results.
 
     When ``palace_path`` is set, all write methods (``add``, ``upsert``,
-    ``update``, ``delete``) acquire ``mine_palace_lock(palace_path)`` for the
+    ``modify``, ``update``, ``delete``) acquire ``mine_palace_lock(palace_path)`` for the
     duration of the underlying chromadb call. This serializes MCP and other
     direct-backend writers against ``mempalace mine`` and against each other,
     closing the race between concurrent writers that triggers ChromaDB's
@@ -946,7 +946,8 @@ class ChromaCollection(BaseCollection):
             kwargs["metadata"] = metadata
         if configuration is not None:
             kwargs["configuration"] = configuration
-        self._collection.modify(**kwargs)
+        with self._write_lock():
+            self._collection.modify(**kwargs)
 
     def update(
         self,

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -51,6 +51,50 @@ _PASS_ZERO_LLM_PER_SAMPLE = 2_000  # for Tier 2 LLM call only
 _PASS_ZERO_LLM_MAX_SAMPLES = 20  # caps the LLM-tier sample count
 
 
+def _confirm_from_sqlite_rebuild(
+    *,
+    palace_path: str,
+    source_path: str,
+    archive_existing: bool,
+    assume_yes: bool,
+) -> bool:
+    """Confirm from-SQLite repair with wording that matches archive semantics."""
+    normalized_palace = os.path.realpath(os.path.abspath(os.path.expanduser(palace_path)))
+    normalized_source = os.path.realpath(os.path.abspath(os.path.expanduser(source_path)))
+    same_path = normalized_source == normalized_palace
+    if assume_yes:
+        return True
+
+    print(f"\n  Rebuild from SQLite will write to: {palace_path}")
+    if same_path and archive_existing:
+        print(
+            "  The existing palace directory will be renamed to "
+            "<palace>.pre-rebuild-<timestamp> before the new palace is created."
+        )
+        print("  This mode does not copy a backup before the rename.")
+    elif same_path:
+        print(
+            "  Source and destination are the same path. Pass --archive-existing "
+            "to rename the existing palace before rebuilding."
+        )
+        return False
+    else:
+        print(
+            "  The destination path already exists. Move it aside or choose a "
+            "different --palace path before rebuilding."
+        )
+        return False
+    try:
+        answer = input("  Continue? [y/N]: ").strip().lower()
+    except EOFError:
+        print("  Aborted. Re-run with --yes to confirm destructive changes.")
+        return False
+    if answer not in {"y", "yes"}:
+        print("  Aborted.")
+        return False
+    return True
+
+
 def _gather_origin_samples(project_dir) -> list:
     """Collect Tier-1 samples for corpus-origin detection.
 
@@ -734,7 +778,96 @@ def cmd_repair_status(args):
     from .repair import status as repair_status
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
-    repair_status(palace_path=palace_path)
+    repair_status(
+        palace_path=palace_path,
+        cleanup_temp=getattr(args, "cleanup_temp", False),
+        assume_yes=getattr(args, "yes", False),
+    )
+
+
+def _reject_unsupported_audit_content(args) -> None:
+    if getattr(args, "audit_content", False):
+        print("  --audit-content is only supported with --mode from-sqlite.")
+        sys.exit(1)
+
+
+def _acquire_repair_write_lock(palace_path: str):
+    from .palace import PalaceWriteAlreadyRunning, palace_write_lock
+
+    try:
+        repair_lock = palace_write_lock(palace_path, operation="repair")
+        repair_lock.__enter__()
+        return repair_lock
+    except PalaceWriteAlreadyRunning as exc:
+        print(f"\n  ABORT: {exc}")
+        sys.exit(1)
+
+
+def _delete_repair_temp_if_known(backend, palace_path: str, temp_name: str | None) -> None:
+    if temp_name is None:
+        return
+    try:
+        backend.delete_collection(palace_path, temp_name)
+    except Exception:
+        pass
+
+
+def _cmd_repair_from_sqlite(args, palace_path: str, collection_name: str) -> None:
+    from .repair import RebuildPartialError, rebuild_from_sqlite
+
+    source_path = getattr(args, "source", None)
+    source_path = os.path.abspath(os.path.expanduser(source_path)) if source_path else palace_path
+    archive_existing = getattr(args, "archive_existing", False)
+
+    # Gate any path that touches the user's existing palace dir
+    # behind confirm_destructive_action. The legacy mode already
+    # gates; from-sqlite needs the same protection because:
+    # (a) --archive-existing renames the existing palace,
+    # (b) --source PATH writes into --palace dir which the user
+    #     may not realize is also a palace.
+    # No prompt when source != dest AND dest does not exist (pure
+    # extract-into-fresh-dir case is non-destructive to existing
+    # palaces).
+    is_destructive_to_dest = source_path == palace_path or os.path.exists(palace_path)
+    if is_destructive_to_dest and not _confirm_from_sqlite_rebuild(
+        palace_path=palace_path,
+        source_path=source_path,
+        archive_existing=archive_existing,
+        assume_yes=getattr(args, "yes", False),
+    ):
+        sys.exit(1)
+
+    try:
+        rebuild_kwargs = {
+            "source_palace": source_path,
+            "dest_palace": palace_path,
+            "archive_existing_dest": archive_existing,
+            "collection_name": collection_name,
+            "reembed": getattr(args, "reembed", False),
+            "batch_size": getattr(args, "batch_size", None) or 5000,
+        }
+        if hasattr(args, "audit_content"):
+            rebuild_kwargs["audit_content"] = getattr(args, "audit_content", False)
+        counts = rebuild_from_sqlite(**rebuild_kwargs)
+        if counts == {}:
+            sys.exit(1)
+        primary_count = counts.get(collection_name)
+        if primary_count is not None and primary_count <= 0 and any(
+            count > 0 for count in counts.values()
+        ):
+            sys.exit(1)
+    except RebuildPartialError as exc:
+        # The error itself was already printed by rebuild_from_sqlite
+        # with recovery instructions; surface a non-zero exit so
+        # scripts and CI gates see the failure.
+        print(
+            "\n  Rebuild partial — see message above. "
+            f"Failed in collection: {exc.failed_collection}"
+        )
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001 - filesystem/setup failures are user-facing here
+        print(f"\n  Rebuild failed: {exc}")
+        sys.exit(1)
 
 
 def cmd_repair(args):
@@ -746,9 +879,12 @@ def cmd_repair(args):
         RebuildCollectionError,
         TruncationDetected,
         _close_chroma_handles,
-        _extract_drawers,
-        _rebuild_collection_via_temp,
+        _stage_collection_from_source,
+        _swap_temp_collection_into_live,
         check_extraction_safety,
+        sqlite_drawer_count,
+        maybe_repair_poisoned_max_seq_id_before_rebuild,
+        sqlite_drawer_count,
         maybe_repair_poisoned_max_seq_id_before_rebuild,
         print_sqlite_integrity_abort,
         sqlite_integrity_errors,
@@ -760,7 +896,12 @@ def cmd_repair(args):
         os.path.expanduser(args.palace) if args.palace else config.palace_path
     )
 
-    if getattr(args, "mode", "legacy") == "max-seq-id":
+    mode = getattr(args, "mode", "legacy")
+
+    if mode != "from-sqlite":
+        _reject_unsupported_audit_content(args)
+
+    if mode == "max-seq-id":
         from .repair import repair_max_seq_id
 
         repair_max_seq_id(
@@ -773,55 +914,8 @@ def cmd_repair(args):
         )
         return
 
-    if getattr(args, "mode", "legacy") == "from-sqlite":
-        from .migrate import confirm_destructive_action
-        from .repair import RebuildPartialError, rebuild_from_sqlite
-
-        source_path = getattr(args, "source", None)
-        source_path = (
-            os.path.abspath(os.path.expanduser(source_path)) if source_path else palace_path
-        )
-        archive_existing = getattr(args, "archive_existing", False)
-
-        # Gate any path that touches the user's existing palace dir
-        # behind confirm_destructive_action. The legacy mode already
-        # gates; from-sqlite needs the same protection because:
-        # (a) --archive-existing renames the existing palace,
-        # (b) --source PATH writes into --palace dir which the user
-        #     may not realize is also a palace.
-        # No prompt when source != dest AND dest does not exist (pure
-        # extract-into-fresh-dir case is non-destructive to existing
-        # palaces).
-        is_destructive_to_dest = source_path == palace_path or os.path.exists(palace_path)
-        if is_destructive_to_dest and not confirm_destructive_action(
-            "Rebuild from SQLite", palace_path, assume_yes=getattr(args, "yes", False)
-        ):
-            return
-
-        try:
-            counts = rebuild_from_sqlite(
-                source_palace=source_path,
-                dest_palace=palace_path,
-                archive_existing_dest=archive_existing,
-            )
-        except RebuildPartialError as exc:
-            # The error itself was already printed by rebuild_from_sqlite
-            # with recovery instructions; surface a non-zero exit so
-            # scripts and CI gates see the failure.
-            print(
-                "\n  Rebuild partial — see message above. "
-                f"Failed in collection: {exc.failed_collection}"
-            )
-            sys.exit(1)
-        # An empty counts dict is rebuild_from_sqlite's documented signal
-        # for a validation refusal (missing source, existing dest,
-        # in-place without --archive-existing). The library already
-        # printed an actionable message; exit non-zero so unattended
-        # scripts/CI distinguish "invalid inputs" from a successful
-        # rebuild that legitimately found zero rows (which still returns
-        # a populated dict with 0-valued counts).
-        if not counts:
-            sys.exit(1)
+    if mode == "from-sqlite":
+        _cmd_repair_from_sqlite(args, palace_path, collection_name)
         return
 
     db_path = os.path.join(palace_path, "chroma.sqlite3")
@@ -859,19 +953,13 @@ def cmd_repair(args):
     print(f"{'=' * 55}\n")
     print(f"  Palace: {palace_path}")
 
-    backend = ChromaBackend()
-
-    # Try to read existing drawers
-    try:
-        col = backend.get_collection(palace_path, collection_name)
-        total = col.count()
+    total = sqlite_drawer_count(palace_path, collection_name)
+    if total is None:
+        print("  Drawers found: (unreadable before repair lock)")
+    else:
         print(f"  Drawers found: {total}")
-    except Exception as e:
-        print(f"  Error reading palace: {e}")
-        print("  Cannot recover — palace may need to be re-mined from source files.")
-        return
 
-    if total == 0:
+    if total is not None and total == 0:
         print("  Nothing to repair.")
         return
 
@@ -880,60 +968,110 @@ def cmd_repair(args):
     ):
         return
 
-    # Extract all drawers in batches
+    repair_lock = _acquire_repair_write_lock(palace_path)
+
+    backend = ChromaBackend()
+
+    try:
+        col = backend.get_collection(palace_path, collection_name)
+        total = col.count()
+        if total == 0:
+            print("  Nothing to repair.")
+            repair_lock.__exit__(None, None, None)
+            return
+    except Exception as e:
+        print(f"  Error reading palace after acquiring repair lock: {e}")
+        repair_lock.__exit__(None, None, None)
+        sys.exit(1)
+
+    palace_path = os.path.normpath(palace_path)
+    backup_path = palace_path + ".backup"
+    try:
+        if os.path.exists(backup_path):
+            if not contains_palace_database(backup_path):
+                print(
+                    "  Backup validation failed: backup path exists but does not contain chroma.sqlite3. "
+                    f"Please remove or rename: {backup_path}"
+                )
+                repair_lock.__exit__(None, None, None)
+                return
+            shutil.rmtree(backup_path)
+        print(f"  Backing up to {backup_path}...")
+        shutil.copytree(palace_path, backup_path)
+    except Exception:
+        repair_lock.__exit__(None, None, None)
+        raise
+
+    # Stage drawers in batches after backup creation. Keep batches bounded
+    # without letting failed backup validation leave a temp collection behind.
     print("\n  Extracting drawers...")
     batch_size = 5000
-    all_ids, all_docs, all_metas = _extract_drawers(col, total, batch_size)
-    print(f"  Extracted {len(all_ids)} drawers")
-
-    # ── #1208 guard ──────────────────────────────────────────────────
-    # Cross-check against the SQLite ground truth before doing anything
-    # destructive. Catches the user-reported case where chromadb's
-    # collection-layer get() silently caps at 10,000 rows even on much
-    # larger palaces (e.g. after manual HNSW quarantine). Override with
-    # --confirm-truncation-ok only after independently verifying the
-    # extraction count is real.
+    reembed = getattr(args, "reembed", False)
+    temp_name = None
     try:
+        temp_col, temp_name, extracted = _stage_collection_from_source(
+            backend,
+            palace_path,
+            col,
+            total,
+            batch_size,
+            collection_name,
+            include_embeddings=not reembed,
+            progress=print,
+        )
+        print(f"  Extracted {extracted} drawers")
+
+        # ── #1208 guard ──────────────────────────────────────────────
+        # Cross-check against SQLite ground truth before live swap.
         check_extraction_safety(
             palace_path,
-            len(all_ids),
+            extracted,
             confirm_truncation_ok=getattr(args, "confirm_truncation_ok", False),
             collection_name=collection_name,
         )
     except TruncationDetected as e:
         print(e.message)
+        _delete_repair_temp_if_known(backend, palace_path, temp_name)
+        repair_lock.__exit__(None, None, None)
         return
-
-    palace_path = os.path.normpath(palace_path)
-    backup_path = palace_path + ".backup"
-    if os.path.exists(backup_path):
-        if not contains_palace_database(backup_path):
-            print(
-                "  Backup validation failed: backup path exists but does not contain chroma.sqlite3. "
-                f"Please remove or rename: {backup_path}"
-            )
-            return
-        shutil.rmtree(backup_path)
-    print(f"  Backing up to {backup_path}...")
-    shutil.copytree(palace_path, backup_path)
+    except Exception as exc:
+        _delete_repair_temp_if_known(backend, palace_path, temp_name)
+        print(f"  Repair failed: {exc}")
+        print("  Live collection was not replaced; leaving the original palace untouched.")
+        print(
+            "  The Chroma collection path could not complete staging. Try the SQLite "
+            "recovery path instead:"
+        )
+        print(
+            "    mempalace "
+            f"--palace {shlex.quote(palace_path)} repair "
+            "--mode from-sqlite --archive-existing --yes"
+        )
+        repair_lock.__exit__(None, None, None)
+        sys.exit(1)
 
     try:
-        filed = _rebuild_collection_via_temp(
+        filed = _swap_temp_collection_into_live(
             backend,
             palace_path,
-            all_ids,
-            all_docs,
-            all_metas,
-            batch_size,
-            collection_name=collection_name,
+            temp_col,
+            temp_name,
+            collection_name,
+            extracted,
             progress=print,
         )
-    except RebuildCollectionError as e:
+    except Exception as exc:
+        e = (
+            exc
+            if isinstance(exc, RebuildCollectionError)
+            else RebuildCollectionError(str(exc), live_replaced=False)
+        )
         print(f"  Repair failed: {e}")
         if getattr(e, "live_replaced", False):
             print("  Live collection was already replaced; restoring from backup...")
             try:
                 _close_chroma_handles(palace_path, backend=backend)
+                _delete_repair_temp_if_known(backend, palace_path, temp_name)
                 if os.path.exists(palace_path):
                     shutil.rmtree(palace_path)
                 shutil.copytree(backup_path, palace_path)
@@ -944,11 +1082,13 @@ def cmd_repair(args):
                 print(f"    1. Remove or rename the broken directory: {palace_path}")
                 print(f"    2. Restore the backup directory to: {palace_path}")
                 print(f"       Backup location: {backup_path}")
+        repair_lock.__exit__(None, None, None)
         sys.exit(1)
 
     print(f"\n  Repair complete. {filed} drawers rebuilt.")
     print(f"  Backup saved at {backup_path}")
     print(f"\n{'=' * 55}\n")
+    repair_lock.__exit__(None, None, None)
 
 
 def cmd_hook(args):
@@ -1436,6 +1576,28 @@ def main():
         ),
     )
     p_repair.add_argument(
+        "--reembed",
+        action="store_true",
+        help=(
+            "Regenerate embeddings during repair instead of reusing existing stored vectors. "
+            "Default repair rebuilds the index while preserving existing embeddings."
+        ),
+    )
+    p_repair.add_argument(
+        "--batch-size",
+        type=int,
+        default=5000,
+        help=(
+            "Rows per upsert batch for --mode from-sqlite (default: 5000). "
+            "The measured default keeps repair streaming while preserving rebuild throughput."
+        ),
+    )
+    p_repair.add_argument(
+        "--audit-content",
+        action="store_true",
+        help="After repair, compare full document content byte-for-byte (slower).",
+    )
+    p_repair.add_argument(
         "--mode",
         choices=["legacy", "max-seq-id", "from-sqlite"],
         default="legacy",
@@ -1490,9 +1652,19 @@ def main():
     )
 
     # repair-status — read-only HNSW capacity health check (#1222)
-    sub.add_parser(
+    p_repair_status = sub.add_parser(
         "repair-status",
-        help="Compare sqlite vs HNSW element counts (read-only; never opens a chromadb client)",
+        help="Compare sqlite vs HNSW element counts and report repair artifacts",
+    )
+    p_repair_status.add_argument(
+        "--cleanup-temp",
+        action="store_true",
+        help="Delete stale internal repair temp collections reported by status",
+    )
+    p_repair_status.add_argument(
+        "--yes",
+        action="store_true",
+        help="Required with --cleanup-temp to confirm deletion",
     )
 
     # mcp

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -27,6 +27,8 @@ Examples:
     mempalace search "pricing discussion" --wing my_app --room costs
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import shlex
@@ -852,8 +854,10 @@ def _cmd_repair_from_sqlite(args, palace_path: str, collection_name: str) -> Non
         if counts == {}:
             sys.exit(1)
         primary_count = counts.get(collection_name)
-        if primary_count is not None and primary_count <= 0 and any(
-            count > 0 for count in counts.values()
+        if (
+            primary_count is not None
+            and primary_count <= 0
+            and any(count > 0 for count in counts.values())
         ):
             sys.exit(1)
     except RebuildPartialError as exc:
@@ -882,8 +886,6 @@ def cmd_repair(args):
         _stage_collection_from_source,
         _swap_temp_collection_into_live,
         check_extraction_safety,
-        sqlite_drawer_count,
-        maybe_repair_poisoned_max_seq_id_before_rebuild,
         sqlite_drawer_count,
         maybe_repair_poisoned_max_seq_id_before_rebuild,
         print_sqlite_integrity_abort,
@@ -969,126 +971,129 @@ def cmd_repair(args):
         return
 
     repair_lock = _acquire_repair_write_lock(palace_path)
+    lock_released = False
 
-    backend = ChromaBackend()
+    def _release_repair_lock() -> None:
+        nonlocal lock_released
+        if not lock_released:
+            repair_lock.__exit__(None, None, None)
+            lock_released = True
+
+    backend = None
 
     try:
+        backend = ChromaBackend()
         col = backend.get_collection(palace_path, collection_name)
         total = col.count()
         if total == 0:
             print("  Nothing to repair.")
-            repair_lock.__exit__(None, None, None)
             return
     except Exception as e:
         print(f"  Error reading palace after acquiring repair lock: {e}")
-        repair_lock.__exit__(None, None, None)
+        _release_repair_lock()
         sys.exit(1)
 
-    palace_path = os.path.normpath(palace_path)
-    backup_path = palace_path + ".backup"
     try:
+        palace_path = os.path.normpath(palace_path)
+        backup_path = palace_path + ".backup"
         if os.path.exists(backup_path):
             if not contains_palace_database(backup_path):
                 print(
                     "  Backup validation failed: backup path exists but does not contain chroma.sqlite3. "
                     f"Please remove or rename: {backup_path}"
                 )
-                repair_lock.__exit__(None, None, None)
                 return
             shutil.rmtree(backup_path)
         print(f"  Backing up to {backup_path}...")
         shutil.copytree(palace_path, backup_path)
-    except Exception:
-        repair_lock.__exit__(None, None, None)
-        raise
 
-    # Stage drawers in batches after backup creation. Keep batches bounded
-    # without letting failed backup validation leave a temp collection behind.
-    print("\n  Extracting drawers...")
-    batch_size = 5000
-    reembed = getattr(args, "reembed", False)
-    temp_name = None
-    try:
-        temp_col, temp_name, extracted = _stage_collection_from_source(
-            backend,
-            palace_path,
-            col,
-            total,
-            batch_size,
-            collection_name,
-            include_embeddings=not reembed,
-            progress=print,
-        )
-        print(f"  Extracted {extracted} drawers")
+        # Stage drawers in batches after backup creation. Keep batches bounded
+        # without letting failed backup validation leave a temp collection behind.
+        print("\n  Extracting drawers...")
+        batch_size = 5000
+        reembed = getattr(args, "reembed", False)
+        temp_name = None
+        try:
+            temp_col, temp_name, extracted = _stage_collection_from_source(
+                backend,
+                palace_path,
+                col,
+                total,
+                batch_size,
+                collection_name,
+                include_embeddings=not reembed,
+                progress=print,
+            )
+            print(f"  Extracted {extracted} drawers")
 
-        # ── #1208 guard ──────────────────────────────────────────────
-        # Cross-check against SQLite ground truth before live swap.
-        check_extraction_safety(
-            palace_path,
-            extracted,
-            confirm_truncation_ok=getattr(args, "confirm_truncation_ok", False),
-            collection_name=collection_name,
-        )
-    except TruncationDetected as e:
-        print(e.message)
-        _delete_repair_temp_if_known(backend, palace_path, temp_name)
-        repair_lock.__exit__(None, None, None)
-        return
-    except Exception as exc:
-        _delete_repair_temp_if_known(backend, palace_path, temp_name)
-        print(f"  Repair failed: {exc}")
-        print("  Live collection was not replaced; leaving the original palace untouched.")
-        print(
-            "  The Chroma collection path could not complete staging. Try the SQLite "
-            "recovery path instead:"
-        )
-        print(
-            "    mempalace "
-            f"--palace {shlex.quote(palace_path)} repair "
-            "--mode from-sqlite --archive-existing --yes"
-        )
-        repair_lock.__exit__(None, None, None)
-        sys.exit(1)
+            # ── #1208 guard ──────────────────────────────────────────────
+            # Cross-check against SQLite ground truth before live swap.
+            check_extraction_safety(
+                palace_path,
+                extracted,
+                confirm_truncation_ok=getattr(args, "confirm_truncation_ok", False),
+                collection_name=collection_name,
+            )
+        except TruncationDetected as e:
+            print(e.message)
+            _delete_repair_temp_if_known(backend, palace_path, temp_name)
+            return
+        except Exception as exc:
+            _delete_repair_temp_if_known(backend, palace_path, temp_name)
+            print(f"  Repair failed: {exc}")
+            print("  Live collection was not replaced; leaving the original palace untouched.")
+            print(
+                "  The Chroma collection path could not complete staging. Try the SQLite "
+                "recovery path instead:"
+            )
+            print(
+                "    mempalace "
+                f"--palace {shlex.quote(palace_path)} repair "
+                "--mode from-sqlite --archive-existing --yes"
+            )
+            sys.exit(1)
 
-    try:
-        filed = _swap_temp_collection_into_live(
-            backend,
-            palace_path,
-            temp_col,
-            temp_name,
-            collection_name,
-            extracted,
-            progress=print,
-        )
-    except Exception as exc:
-        e = (
-            exc
-            if isinstance(exc, RebuildCollectionError)
-            else RebuildCollectionError(str(exc), live_replaced=False)
-        )
-        print(f"  Repair failed: {e}")
-        if getattr(e, "live_replaced", False):
-            print("  Live collection was already replaced; restoring from backup...")
-            try:
-                _close_chroma_handles(palace_path, backend=backend)
-                _delete_repair_temp_if_known(backend, palace_path, temp_name)
-                if os.path.exists(palace_path):
-                    shutil.rmtree(palace_path)
-                shutil.copytree(backup_path, palace_path)
-                print(f"  Restore complete from backup: {backup_path}")
-            except Exception as restore_error:
-                print(f"  Automatic restore failed: {restore_error}")
-                print("  Manual recovery required:")
-                print(f"    1. Remove or rename the broken directory: {palace_path}")
-                print(f"    2. Restore the backup directory to: {palace_path}")
-                print(f"       Backup location: {backup_path}")
-        repair_lock.__exit__(None, None, None)
-        sys.exit(1)
+        try:
+            filed = _swap_temp_collection_into_live(
+                backend,
+                palace_path,
+                temp_col,
+                temp_name,
+                collection_name,
+                extracted,
+                progress=print,
+            )
+        except Exception as exc:
+            e = (
+                exc
+                if isinstance(exc, RebuildCollectionError)
+                else RebuildCollectionError(str(exc), live_replaced=False)
+            )
+            print(f"  Repair failed: {e}")
+            if getattr(e, "live_replaced", False):
+                print("  Live collection was already replaced; restoring from backup...")
+                try:
+                    _close_chroma_handles(palace_path, backend=backend)
+                    _delete_repair_temp_if_known(backend, palace_path, temp_name)
+                    if os.path.exists(palace_path):
+                        shutil.rmtree(palace_path)
+                    shutil.copytree(backup_path, palace_path)
+                    print(f"  Restore complete from backup: {backup_path}")
+                except Exception as restore_error:
+                    print(f"  Automatic restore failed: {restore_error}")
+                    print("  Manual recovery required:")
+                    print(f"    1. Remove or rename the broken directory: {palace_path}")
+                    print(f"    2. Restore the backup directory to: {palace_path}")
+                    print(f"       Backup location: {backup_path}")
+            sys.exit(1)
 
-    print(f"\n  Repair complete. {filed} drawers rebuilt.")
-    print(f"  Backup saved at {backup_path}")
-    print(f"\n{'=' * 55}\n")
-    repair_lock.__exit__(None, None, None)
+        print(f"\n  Repair complete. {filed} drawers rebuilt.")
+        print(f"  Backup saved at {backup_path}")
+        print(f"\n{'=' * 55}\n")
+    finally:
+        if backend is not None:
+            backend.close()
+        _release_repair_lock()
 
 
 def cmd_hook(args):

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -486,6 +486,13 @@ def _write_lock_refused(exc: PalaceWriteAlreadyRunning) -> dict:
     }
 
 
+def _write_lock_error(exc: PalaceWriteAlreadyRunning) -> dict:
+    return {
+        "error": str(exc),
+        "code": "palace_write_lock_active",
+    }
+
+
 # ==================== HELPERS ====================
 
 
@@ -944,7 +951,7 @@ def tool_create_tunnel(
                 target_drawer_id=target_drawer_id,
             )
     except PalaceWriteAlreadyRunning as exc:
-        return _write_lock_refused(exc)
+        return _write_lock_error(exc)
 
 
 def tool_list_tunnels(wing: str = None):
@@ -964,7 +971,7 @@ def tool_delete_tunnel(tunnel_id: str):
         with palace_write_lock(_config.palace_path, operation="mcp delete_tunnel", blocking=True):
             return delete_tunnel(tunnel_id)
     except PalaceWriteAlreadyRunning as exc:
-        return _write_lock_refused(exc)
+        return _write_lock_error(exc)
 
 
 def tool_follow_tunnels(wing: str, room: str):
@@ -1065,7 +1072,9 @@ def tool_delete_drawer(drawer_id: str):
                 return {"success": False, "error": f"Drawer not found: {drawer_id}"}
 
             # Log the deletion with the content being removed for audit trail
-            deleted_content = existing.get("documents", [""])[0] if existing.get("documents") else ""
+            deleted_content = (
+                existing.get("documents", [""])[0] if existing.get("documents") else ""
+            )
             deleted_meta = existing.get("metadatas", [{}])[0] if existing.get("metadatas") else {}
             _wal_log(
                 "delete_drawer",
@@ -1394,9 +1403,7 @@ def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = N
                     "ended": resolved_ended,
                 },
             )
-            _call_kg(
-                lambda kg: kg.invalidate(subject, predicate, object, ended=resolved_ended)
-            )
+            _call_kg(lambda kg: kg.invalidate(subject, predicate, object, ended=resolved_ended))
             return {
                 "success": True,
                 "fact": f"{subject} → {predicate} → {object}",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -56,6 +56,7 @@ from typing import Optional  # noqa: E402
 
 from .config import (  # noqa: E402
     MempalaceConfig,
+    DEFAULT_COLLECTION_NAME,
     sanitize_kg_value,
     sanitize_name,
     sanitize_content,
@@ -225,6 +226,17 @@ _vector_disabled_reason = ""
 _vector_capacity_status: Optional[dict] = None
 
 
+def _collection_name() -> str:
+    """Return the configured drawer collection name with a safe default.
+
+    Some tests and embedding callers swap ``_config`` for a tiny stand-in
+    that only exposes ``palace_path``. Fallback/status paths should keep
+    working in that setup instead of assuming the full ``MempalaceConfig``
+    surface is present.
+    """
+    return getattr(_config, "collection_name", DEFAULT_COLLECTION_NAME)
+
+
 def _refresh_vector_disabled_flag() -> None:
     """Re-run the HNSW capacity probe and update the module-level flag.
 
@@ -235,7 +247,7 @@ def _refresh_vector_disabled_flag() -> None:
     """
     global _vector_disabled, _vector_disabled_reason, _vector_capacity_status
     try:
-        info = hnsw_capacity_status(_config.palace_path, _config.collection_name)
+        info = hnsw_capacity_status(_config.palace_path, _collection_name())
     except Exception:
         logger.debug("HNSW capacity probe raised", exc_info=True)
         return
@@ -532,7 +544,7 @@ def _tool_status_via_sqlite() -> dict:
     db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return _no_palace()
-    collection_name = _config.collection_name
+    collection_name = _collection_name()
 
     wings: dict = {}
     rooms: dict = {}

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -83,6 +83,7 @@ from .palace_graph import (  # noqa: E402
     delete_tunnel,
     follow_tunnels,
 )
+from .palace import PalaceWriteAlreadyRunning, palace_write_lock  # noqa: E402
 
 from .knowledge_graph import KnowledgeGraph, DEFAULT_KG_PATH  # noqa: E402
 
@@ -474,6 +475,14 @@ def _no_palace():
     return {
         "error": "No palace found",
         "hint": "Run: mempalace init <dir> && mempalace mine <dir>",
+    }
+
+
+def _write_lock_refused(exc: PalaceWriteAlreadyRunning) -> dict:
+    return {
+        "success": False,
+        "error": str(exc),
+        "code": "palace_write_lock_active",
     }
 
 
@@ -923,15 +932,19 @@ def tool_create_tunnel(
         target_room = sanitize_name(target_room, "target_room")
     except ValueError as e:
         return {"error": str(e)}
-    return create_tunnel(
-        source_wing,
-        source_room,
-        target_wing,
-        target_room,
-        label=label,
-        source_drawer_id=source_drawer_id,
-        target_drawer_id=target_drawer_id,
-    )
+    try:
+        with palace_write_lock(_config.palace_path, operation="mcp create_tunnel", blocking=True):
+            return create_tunnel(
+                source_wing,
+                source_room,
+                target_wing,
+                target_room,
+                label=label,
+                source_drawer_id=source_drawer_id,
+                target_drawer_id=target_drawer_id,
+            )
+    except PalaceWriteAlreadyRunning as exc:
+        return _write_lock_refused(exc)
 
 
 def tool_list_tunnels(wing: str = None):
@@ -947,7 +960,11 @@ def tool_delete_tunnel(tunnel_id: str):
     """Delete an explicit tunnel by its ID."""
     if not tunnel_id or not isinstance(tunnel_id, str):
         return {"error": "tunnel_id is required"}
-    return delete_tunnel(tunnel_id)
+    try:
+        with palace_write_lock(_config.palace_path, operation="mcp delete_tunnel", blocking=True):
+            return delete_tunnel(tunnel_id)
+    except PalaceWriteAlreadyRunning as exc:
+        return _write_lock_refused(exc)
 
 
 def tool_follow_tunnels(wing: str, room: str):
@@ -976,10 +993,6 @@ def tool_add_drawer(
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
-    col = _get_collection(create=True)
-    if not col:
-        return _no_palace()
-
     drawer_id = (
         f"drawer_{wing}_{room}_{hashlib.sha256((wing + room + content).encode()).hexdigest()[:24]}"
     )
@@ -996,38 +1009,45 @@ def tool_add_drawer(
         },
     )
 
-    # Idempotency: if the deterministic ID already exists, return success as a no-op.
     try:
-        existing = col.get(ids=[drawer_id], include=[])
-        if existing.ids:
-            return {"success": True, "reason": "already_exists", "drawer_id": drawer_id}
-    except Exception:
-        logger.debug("Idempotency pre-check failed for %s", drawer_id, exc_info=True)
+        with palace_write_lock(_config.palace_path, operation="mcp add_drawer", blocking=True):
+            col = _get_collection(create=True)
+            if not col:
+                return _no_palace()
 
-    try:
-        col.upsert(
-            ids=[drawer_id],
-            documents=[content],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "source_file": source_file or "",
-                    "chunk_index": 0,
-                    "added_by": added_by,
-                    "filed_at": datetime.now().isoformat(),
-                }
-            ],
-        )
-        inserted = col.get(ids=[drawer_id], include=[])
-        if not inserted.ids:
-            raise RuntimeError(
-                "Drawer write was acknowledged but the new ID is not readable. "
-                "The palace index may be stale; run reconnect or repair."
+            # Idempotency: if the deterministic ID already exists, return success as a no-op.
+            try:
+                existing = col.get(ids=[drawer_id], include=[])
+                if existing.ids:
+                    return {"success": True, "reason": "already_exists", "drawer_id": drawer_id}
+            except Exception:
+                pass
+
+            col.upsert(
+                ids=[drawer_id],
+                documents=[content],
+                metadatas=[
+                    {
+                        "wing": wing,
+                        "room": room,
+                        "source_file": source_file or "",
+                        "chunk_index": 0,
+                        "added_by": added_by,
+                        "filed_at": datetime.now().isoformat(),
+                    }
+                ],
             )
-        _metadata_cache = None
-        logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
-        return {"success": True, "drawer_id": drawer_id, "wing": wing, "room": room}
+            inserted = col.get(ids=[drawer_id], include=[])
+            if not inserted.ids:
+                raise RuntimeError(
+                    "Drawer write was acknowledged but the new ID is not readable. "
+                    "The palace index may be stale; run reconnect or repair."
+                )
+            _metadata_cache = None
+            logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
+            return {"success": True, "drawer_id": drawer_id, "wing": wing, "room": room}
+    except PalaceWriteAlreadyRunning as exc:
+        return _write_lock_refused(exc)
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -1035,30 +1055,33 @@ def tool_add_drawer(
 def tool_delete_drawer(drawer_id: str):
     """Delete a single drawer by ID."""
     global _metadata_cache
-    col = _get_collection()
-    if not col:
-        return _no_palace()
-    existing = col.get(ids=[drawer_id])
-    if not existing["ids"]:
-        return {"success": False, "error": f"Drawer not found: {drawer_id}"}
-
-    # Log the deletion with the content being removed for audit trail
-    deleted_content = existing.get("documents", [""])[0] if existing.get("documents") else ""
-    deleted_meta = existing.get("metadatas", [{}])[0] if existing.get("metadatas") else {}
-    _wal_log(
-        "delete_drawer",
-        {
-            "drawer_id": drawer_id,
-            "deleted_meta": deleted_meta,
-            "content_preview": deleted_content[:200],
-        },
-    )
-
     try:
-        col.delete(ids=[drawer_id])
-        _metadata_cache = None
-        logger.info(f"Deleted drawer: {drawer_id}")
-        return {"success": True, "drawer_id": drawer_id}
+        with palace_write_lock(_config.palace_path, operation="mcp delete_drawer", blocking=True):
+            col = _get_collection()
+            if not col:
+                return _no_palace()
+            existing = col.get(ids=[drawer_id])
+            if not existing["ids"]:
+                return {"success": False, "error": f"Drawer not found: {drawer_id}"}
+
+            # Log the deletion with the content being removed for audit trail
+            deleted_content = existing.get("documents", [""])[0] if existing.get("documents") else ""
+            deleted_meta = existing.get("metadatas", [{}])[0] if existing.get("metadatas") else {}
+            _wal_log(
+                "delete_drawer",
+                {
+                    "drawer_id": drawer_id,
+                    "deleted_meta": deleted_meta,
+                    "content_preview": deleted_content[:200],
+                },
+            )
+
+            col.delete(ids=[drawer_id])
+            _metadata_cache = None
+            logger.info(f"Deleted drawer: {drawer_id}")
+            return {"success": True, "drawer_id": drawer_id}
+    except PalaceWriteAlreadyRunning as exc:
+        return _write_lock_refused(exc)
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -1194,64 +1217,67 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
     if content is None and wing is None and room is None:
         return {"success": True, "drawer_id": drawer_id, "noop": True}
 
-    col = _get_collection()
-    if not col:
-        return _no_palace()
     try:
-        existing = col.get(ids=[drawer_id], include=["documents", "metadatas"])
-        if not existing["ids"]:
-            return {"success": False, "error": f"Drawer not found: {drawer_id}"}
+        with palace_write_lock(_config.palace_path, operation="mcp update_drawer", blocking=True):
+            col = _get_collection()
+            if not col:
+                return _no_palace()
+            existing = col.get(ids=[drawer_id], include=["documents", "metadatas"])
+            if not existing["ids"]:
+                return {"success": False, "error": f"Drawer not found: {drawer_id}"}
 
-        old_meta = existing["metadatas"][0]
-        old_doc = existing["documents"][0]
+            old_meta = existing["metadatas"][0]
+            old_doc = existing["documents"][0]
 
-        new_doc = old_doc
-        if content is not None:
-            try:
-                new_doc = sanitize_content(content)
-            except ValueError as e:
-                return {"success": False, "error": str(e)}
+            new_doc = old_doc
+            if content is not None:
+                try:
+                    new_doc = sanitize_content(content)
+                except ValueError as e:
+                    return {"success": False, "error": str(e)}
 
-        new_meta = dict(old_meta)
-        if wing is not None:
-            try:
-                new_meta["wing"] = sanitize_name(wing, "wing")
-            except ValueError as e:
-                return {"success": False, "error": str(e)}
-        if room is not None:
-            try:
-                new_meta["room"] = sanitize_name(room, "room")
-            except ValueError as e:
-                return {"success": False, "error": str(e)}
+            new_meta = dict(old_meta)
+            if wing is not None:
+                try:
+                    new_meta["wing"] = sanitize_name(wing, "wing")
+                except ValueError as e:
+                    return {"success": False, "error": str(e)}
+            if room is not None:
+                try:
+                    new_meta["room"] = sanitize_name(room, "room")
+                except ValueError as e:
+                    return {"success": False, "error": str(e)}
 
-        _wal_log(
-            "update_drawer",
-            {
+            _wal_log(
+                "update_drawer",
+                {
+                    "drawer_id": drawer_id,
+                    "old_wing": old_meta.get("wing", ""),
+                    "old_room": old_meta.get("room", ""),
+                    "new_wing": new_meta.get("wing", ""),
+                    "new_room": new_meta.get("room", ""),
+                    "content_changed": content is not None,
+                    "content_preview": new_doc[:200] if content is not None else None,
+                },
+            )
+
+            update_kwargs = {"ids": [drawer_id]}
+            if content is not None:
+                update_kwargs["documents"] = [new_doc]
+            update_kwargs["metadatas"] = [new_meta]
+            col.update(**update_kwargs)
+
+            _metadata_cache = None
+
+            logger.info(f"Updated drawer: {drawer_id}")
+            return {
+                "success": True,
                 "drawer_id": drawer_id,
-                "old_wing": old_meta.get("wing", ""),
-                "old_room": old_meta.get("room", ""),
-                "new_wing": new_meta.get("wing", ""),
-                "new_room": new_meta.get("room", ""),
-                "content_changed": content is not None,
-                "content_preview": new_doc[:200] if content is not None else None,
-            },
-        )
-
-        update_kwargs = {"ids": [drawer_id]}
-        if content is not None:
-            update_kwargs["documents"] = [new_doc]
-        update_kwargs["metadatas"] = [new_meta]
-        col.update(**update_kwargs)
-
-        _metadata_cache = None
-
-        logger.info(f"Updated drawer: {drawer_id}")
-        return {
-            "success": True,
-            "drawer_id": drawer_id,
-            "wing": new_meta.get("wing", ""),
-            "room": new_meta.get("room", ""),
-        }
+                "wing": new_meta.get("wing", ""),
+                "room": new_meta.get("room", ""),
+            }
+    except PalaceWriteAlreadyRunning as exc:
+        return _write_lock_refused(exc)
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -1302,33 +1328,40 @@ def tool_kg_add(
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
-    _wal_log(
-        "kg_add",
-        {
-            "subject": subject,
-            "predicate": predicate,
-            "object": object,
-            "valid_from": valid_from,
-            "valid_to": valid_to,
-            "source_closet": source_closet,
-            "source_file": source_file,
-            "source_drawer_id": source_drawer_id,
-        },
-    )
-
-    triple_id = _call_kg(
-        lambda kg: kg.add_triple(
-            subject,
-            predicate,
-            object,
-            valid_from=valid_from,
-            valid_to=valid_to,
-            source_closet=source_closet,
-            source_file=source_file,
-            source_drawer_id=source_drawer_id,
-        )
-    )
-    return {"success": True, "triple_id": triple_id, "fact": f"{subject} → {predicate} → {object}"}
+    try:
+        with palace_write_lock(_config.palace_path, operation="mcp kg_add", blocking=True):
+            _wal_log(
+                "kg_add",
+                {
+                    "subject": subject,
+                    "predicate": predicate,
+                    "object": object,
+                    "valid_from": valid_from,
+                    "valid_to": valid_to,
+                    "source_closet": source_closet,
+                    "source_file": source_file,
+                    "source_drawer_id": source_drawer_id,
+                },
+            )
+            triple_id = _call_kg(
+                lambda kg: kg.add_triple(
+                    subject,
+                    predicate,
+                    object,
+                    valid_from=valid_from,
+                    valid_to=valid_to,
+                    source_closet=source_closet,
+                    source_file=source_file,
+                    source_drawer_id=source_drawer_id,
+                )
+            )
+            return {
+                "success": True,
+                "triple_id": triple_id,
+                "fact": f"{subject} → {predicate} → {object}",
+            }
+    except PalaceWriteAlreadyRunning as exc:
+        return _write_lock_refused(exc)
 
 
 def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = None):
@@ -1350,23 +1383,27 @@ def tool_kg_invalidate(subject: str, predicate: str, object: str, ended: str = N
         return {"success": False, "error": str(e)}
 
     resolved_ended = ended or date.today().isoformat()
-
-    _wal_log(
-        "kg_invalidate",
-        {
-            "subject": subject,
-            "predicate": predicate,
-            "object": object,
-            "ended": resolved_ended,
-        },
-    )
-
-    _call_kg(lambda kg: kg.invalidate(subject, predicate, object, ended=resolved_ended))
-    return {
-        "success": True,
-        "fact": f"{subject} → {predicate} → {object}",
-        "ended": resolved_ended,
-    }
+    try:
+        with palace_write_lock(_config.palace_path, operation="mcp kg_invalidate", blocking=True):
+            _wal_log(
+                "kg_invalidate",
+                {
+                    "subject": subject,
+                    "predicate": predicate,
+                    "object": object,
+                    "ended": resolved_ended,
+                },
+            )
+            _call_kg(
+                lambda kg: kg.invalidate(subject, predicate, object, ended=resolved_ended)
+            )
+            return {
+                "success": True,
+                "fact": f"{subject} → {predicate} → {object}",
+                "ended": resolved_ended,
+            }
+    except PalaceWriteAlreadyRunning as exc:
+        return _write_lock_refused(exc)
 
 
 def tool_kg_timeline(entity: str = None):
@@ -1412,10 +1449,6 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
     else:
         wing = f"wing_{agent_name.replace(' ', '_')}"
     room = "diary"
-    col = _get_collection(create=True)
-    if not col:
-        return _no_palace()
-
     now = datetime.now()
     entry_id = (
         f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_"
@@ -1433,34 +1466,41 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
     )
 
     try:
-        # TODO: Future versions should expand AAAK before embedding to improve
-        # semantic search quality. For now, store raw AAAK in metadata so it's
-        # preserved, and keep the document as-is for embedding (even though
-        # compressed AAAK degrades embedding quality).
-        col.add(
-            ids=[entry_id],
-            documents=[entry],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "hall": "hall_diary",
-                    "topic": topic,
-                    "type": "diary_entry",
-                    "agent": agent_name,
-                    "filed_at": now.isoformat(),
-                    "date": now.strftime("%Y-%m-%d"),
-                }
-            ],
-        )
-        logger.info(f"Diary entry: {entry_id} → {wing}/diary/{topic}")
-        return {
-            "success": True,
-            "entry_id": entry_id,
-            "agent": agent_name,
-            "topic": topic,
-            "timestamp": now.isoformat(),
-        }
+        with palace_write_lock(_config.palace_path, operation="mcp diary_write", blocking=True):
+            col = _get_collection(create=True)
+            if not col:
+                return _no_palace()
+
+            # TODO: Future versions should expand AAAK before embedding to improve
+            # semantic search quality. For now, store raw AAAK in metadata so it's
+            # preserved, and keep the document as-is for embedding (even though
+            # compressed AAAK degrades embedding quality).
+            col.add(
+                ids=[entry_id],
+                documents=[entry],
+                metadatas=[
+                    {
+                        "wing": wing,
+                        "room": room,
+                        "hall": "hall_diary",
+                        "topic": topic,
+                        "type": "diary_entry",
+                        "agent": agent_name,
+                        "filed_at": now.isoformat(),
+                        "date": now.strftime("%Y-%m-%d"),
+                    }
+                ],
+            )
+            logger.info(f"Diary entry: {entry_id} → {wing}/diary/{topic}")
+            return {
+                "success": True,
+                "entry_id": entry_id,
+                "agent": agent_name,
+                "topic": topic,
+                "timestamp": now.isoformat(),
+            }
+    except PalaceWriteAlreadyRunning as exc:
+        return _write_lock_refused(exc)
     except Exception as e:
         return {"success": False, "error": str(e)}
 

--- a/mempalace/migrate.py
+++ b/mempalace/migrate.py
@@ -210,10 +210,7 @@ def _drop_migrate_probe_drawers(drawers: list[dict]) -> list[dict]:
     filtered = []
     for drawer in drawers:
         drawer_id = str(drawer.get("id", ""))
-        source_file = str(drawer.get("metadata", {}).get("source_file", ""))
         if drawer_id.startswith("_mempalace_migrate_probe_"):
-            continue
-        if source_file == "mempalace_migrate_probe":
             continue
         filtered.append(drawer)
     return filtered
@@ -284,15 +281,11 @@ def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
         print(f"  Would migrate {len(drawers)} drawers.")
         return True
 
-    confirmed = False
     if readable_collection is not None:
-        if not confirm_destructive_action("Migration", palace_path, assume_yes=confirm):
-            return False
-        confirmed = True
-
         # A plain count() is not enough: some 0.6.x -> 1.5.x migrated
         # collections are readable but silently drop upsert/delete operations.
-        # Probe only after the user has confirmed the migration path.
+        # For non-dry-run flows we must still distinguish the healthy
+        # no-op case from the rebuild-needed case before prompting.
         if collection_write_roundtrip_works(readable_collection):
             print(f"\n Palace is already readable and writable by chromadb {target_version}.")
             print(f" {readable_count} drawers found. No migration needed.")
@@ -325,9 +318,7 @@ def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
         for room, count in sorted(rooms.items(), key=lambda x: -x[1]):
             print(f"      ROOM: {room:30} {count:5}")
 
-    if not confirmed and not confirm_destructive_action(
-        "Migration", palace_path, assume_yes=confirm
-    ):
+    if not confirm_destructive_action("Migration", palace_path, assume_yes=confirm):
         return False
 
     # Backup the old palace

--- a/mempalace/migrate.py
+++ b/mempalace/migrate.py
@@ -205,6 +205,20 @@ def collection_write_roundtrip_works(col) -> bool:
         return False
 
 
+def _drop_migrate_probe_drawers(drawers: list[dict]) -> list[dict]:
+    """Filter synthetic migrate probe rows from SQLite fallback extraction."""
+    filtered = []
+    for drawer in drawers:
+        drawer_id = str(drawer.get("id", ""))
+        source_file = str(drawer.get("metadata", {}).get("source_file", ""))
+        if drawer_id.startswith("_mempalace_migrate_probe_"):
+            continue
+        if source_file == "mempalace_migrate_probe":
+            continue
+        filtered.append(drawer)
+    return filtered
+
+
 def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
     """Migrate a palace to the currently installed ChromaDB version."""
     from .backends.chroma import ChromaBackend
@@ -229,30 +243,68 @@ def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
     print(f"  Source:    ChromaDB {source_version}")
     print(f"  Target:    ChromaDB {target_version}")
 
-    # Try reading and writing with current chromadb first.
+    # Check whether the current backend can at least read the live collection.
     #
-    # A plain count() is not enough: some 0.6.x -> 1.5.x migrated collections
-    # are readable but silently drop upsert/delete operations. In that state,
-    # migrate must rebuild from SQLite instead of returning "No migration needed."
+    # We defer the write/delete round-trip probe until after dry-run and
+    # destructive-action confirmation so no-op flows never mutate the source
+    # palace with probe rows.
+    readable_collection = None
+    readable_count = None
     try:
         col = ChromaBackend().get_collection(palace_path, "mempalace_drawers")
-        count = col.count()
+        readable_count = col.count()
+        readable_collection = col
+        print(f"\n Palace is readable by chromadb {target_version}.")
+    except Exception:
+        print(f"\n Palace is NOT readable by chromadb {target_version}.")
+        print(" Extracting from SQLite directly...")
 
-        if collection_write_roundtrip_works(col):
+    if dry_run:
+        if readable_collection is not None:
+            print("  DRY RUN skips live write/delete verification.")
+
+        drawers = _drop_migrate_probe_drawers(extract_drawers_from_sqlite(db_path))
+        print(f"  Extracted {len(drawers)} drawers from SQLite")
+
+        if drawers:
+            wings = defaultdict(lambda: defaultdict(int))
+            for d in drawers:
+                w = d["metadata"].get("wing", "?")
+                r = d["metadata"].get("room", "?")
+                wings[w][r] += 1
+
+            print("\n  Summary:")
+            for wing, rooms in sorted(wings.items()):
+                total = sum(rooms.values())
+                print(f"    WING: {wing} ({total} drawers)")
+                for room, count in sorted(rooms.items(), key=lambda x: -x[1]):
+                    print(f"      ROOM: {room:30} {count:5}")
+
+        print("\n  DRY RUN — no changes made.")
+        print(f"  Would migrate {len(drawers)} drawers.")
+        return True
+
+    confirmed = False
+    if readable_collection is not None:
+        if not confirm_destructive_action("Migration", palace_path, assume_yes=confirm):
+            return False
+        confirmed = True
+
+        # A plain count() is not enough: some 0.6.x -> 1.5.x migrated
+        # collections are readable but silently drop upsert/delete operations.
+        # Probe only after the user has confirmed the migration path.
+        if collection_write_roundtrip_works(readable_collection):
             print(f"\n Palace is already readable and writable by chromadb {target_version}.")
-            print(f" {count} drawers found. No migration needed.")
+            print(f" {readable_count} drawers found. No migration needed.")
             return True
 
         print(
             f"\n Palace is readable by chromadb {target_version}, but write/delete verification failed."
         )
         print(" Rebuilding from SQLite to restore native write/delete behavior...")
-    except Exception:
-        print(f"\n Palace is NOT readable by chromadb {target_version}.")
-        print(" Extracting from SQLite directly...")
 
     # Extract all drawers via raw SQL
-    drawers = extract_drawers_from_sqlite(db_path)
+    drawers = _drop_migrate_probe_drawers(extract_drawers_from_sqlite(db_path))
     print(f"  Extracted {len(drawers)} drawers from SQLite")
 
     if not drawers:
@@ -273,12 +325,9 @@ def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
         for room, count in sorted(rooms.items(), key=lambda x: -x[1]):
             print(f"      ROOM: {room:30} {count:5}")
 
-    if dry_run:
-        print("\n  DRY RUN — no changes made.")
-        print(f"  Would migrate {len(drawers)} drawers.")
-        return True
-
-    if not confirm_destructive_action("Migration", palace_path, assume_yes=confirm):
+    if not confirmed and not confirm_destructive_action(
+        "Migration", palace_path, assume_yes=confirm
+    ):
         return False
 
     # Backup the old palace

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import threading
+import time
 from typing import Optional
 
 from .backends.chroma import ChromaBackend
@@ -320,8 +321,8 @@ def mine_lock(source_file: str):
         lf.close()
 
 
-class MineAlreadyRunning(RuntimeError):
-    """Raised when another `mempalace mine` already holds the per-palace lock."""
+class PalaceWriteAlreadyRunning(RuntimeError):
+    """Raised when another writer already holds the per-palace write lock."""
 
 
 # Per-thread record of palaces this thread already holds the lock for. Used by
@@ -413,8 +414,8 @@ def _write_lock_holder(lock_file) -> None:
 
 
 @contextlib.contextmanager
-def mine_palace_lock(palace_path: str):
-    """Per-palace non-blocking lock around the full `mine` pipeline.
+def palace_write_lock(palace_path: str, *, operation: str = "write", blocking: bool = False):
+    """Per-palace lock around palace write operations.
 
     The per-file `mine_lock` only protects delete+insert interleave for a
     single source; it does not prevent N copies of `mempalace mine <dir>`
@@ -433,9 +434,11 @@ def mine_palace_lock(palace_path: str):
     normcase, `C:\\Palace` and `c:\\palace` would hash to different keys
     on Windows and let two concurrent mines touch the same on-disk palace.
 
-    Non-blocking: if another `mine` is already writing to this palace,
-    raise MineAlreadyRunning so the caller can exit cleanly instead of
-    piling up as a waiting worker.
+    By default this is non-blocking: if another operation is already writing
+    to this palace, raise PalaceWriteAlreadyRunning so callers like repair can
+    exit cleanly. Callers that are normal background writers, such as MCP
+    tools, may pass ``blocking=True`` to wait for the existing writer and then
+    serialize their write behind it.
 
     Re-entrant: if the current thread already holds the lock for the same
     palace, the context manager passes through without re-acquiring. This
@@ -480,25 +483,35 @@ def mine_palace_lock(palace_path: str):
             import msvcrt
 
             try:
-                msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
-                acquired = True
+                if blocking:
+                    while True:
+                        try:
+                            msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
+                            acquired = True
+                            break
+                        except OSError:
+                            time.sleep(0.05)
+                else:
+                    msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
+                    acquired = True
             except OSError as exc:
                 holder = _read_lock_holder(lf)
-                raise MineAlreadyRunning(
+                raise PalaceWriteAlreadyRunning(
                     f"palace {resolved} is held by {holder}; "
-                    "wait for it to finish or stop the holder before retrying"
+                    f"refusing `{operation}`"
                 ) from exc
         else:
             import fcntl
 
             try:
-                fcntl.flock(lf, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+                fcntl.flock(lf, flags)
                 acquired = True
             except BlockingIOError as exc:
                 holder = _read_lock_holder(lf)
-                raise MineAlreadyRunning(
+                raise PalaceWriteAlreadyRunning(
                     f"palace {resolved} is held by {holder}; "
-                    "wait for it to finish or stop the holder before retrying"
+                    f"refusing `{operation}`"
                 ) from exc
         # Record our own identity for any later contender's diagnostic message.
         _write_lock_holder(lf)
@@ -523,6 +536,20 @@ def mine_palace_lock(palace_path: str):
             except Exception:
                 pass
         lf.close()
+
+
+class MineAlreadyRunning(PalaceWriteAlreadyRunning):
+    """Raised when another writer already holds the per-palace lock."""
+
+
+@contextlib.contextmanager
+def mine_palace_lock(palace_path: str):
+    """Per-palace non-blocking lock around the full `mine` pipeline."""
+    try:
+        with palace_write_lock(palace_path, operation="mine"):
+            yield
+    except PalaceWriteAlreadyRunning as exc:
+        raise MineAlreadyRunning(str(exc)) from exc
 
 
 # Backward-compatible alias (previous patch iteration used a single global

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -511,8 +511,7 @@ def palace_write_lock(palace_path: str, *, operation: str = "write", blocking: b
                         raise
                     holder = _read_lock_holder(lf)
                     raise PalaceWriteAlreadyRunning(
-                        f"palace {resolved} is held by {holder}; "
-                        f"refusing `{operation}`"
+                        f"palace {resolved} is held by {holder}; refusing `{operation}`"
                     ) from exc
         else:
             import fcntl
@@ -524,8 +523,7 @@ def palace_write_lock(palace_path: str, *, operation: str = "write", blocking: b
             except BlockingIOError as exc:
                 holder = _read_lock_holder(lf)
                 raise PalaceWriteAlreadyRunning(
-                    f"palace {resolved} is held by {holder}; "
-                    f"refusing `{operation}`"
+                    f"palace {resolved} is held by {holder}; refusing `{operation}`"
                 ) from exc
         # Record our own identity for any later contender's diagnostic message.
         _write_lock_holder(lf)

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -5,6 +5,7 @@ Consolidates collection access patterns used by both miners and the MCP server.
 """
 
 import contextlib
+import errno
 import hashlib
 import logging
 import os
@@ -413,6 +414,15 @@ def _write_lock_holder(lock_file) -> None:
         pass
 
 
+def _is_windows_lock_contention(exc: OSError) -> bool:
+    """Return True when msvcrt.locking failed because another writer holds the lock."""
+    return getattr(exc, "winerror", None) in {33, 36} or exc.errno in {
+        errno.EACCES,
+        errno.EAGAIN,
+        errno.EDEADLK,
+    }
+
+
 @contextlib.contextmanager
 def palace_write_lock(palace_path: str, *, operation: str = "write", blocking: bool = False):
     """Per-palace lock around palace write operations.
@@ -482,24 +492,28 @@ def palace_write_lock(palace_path: str, *, operation: str = "write", blocking: b
         if os.name == "nt":
             import msvcrt
 
-            try:
-                if blocking:
-                    while True:
-                        try:
-                            msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
-                            acquired = True
-                            break
-                        except OSError:
-                            time.sleep(0.05)
-                else:
+            if blocking:
+                while True:
+                    try:
+                        msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
+                        acquired = True
+                        break
+                    except OSError as exc:
+                        if not _is_windows_lock_contention(exc):
+                            raise
+                        time.sleep(0.05)
+            else:
+                try:
                     msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
                     acquired = True
-            except OSError as exc:
-                holder = _read_lock_holder(lf)
-                raise PalaceWriteAlreadyRunning(
-                    f"palace {resolved} is held by {holder}; "
-                    f"refusing `{operation}`"
-                ) from exc
+                except OSError as exc:
+                    if not _is_windows_lock_contention(exc):
+                        raise
+                    holder = _read_lock_holder(lf)
+                    raise PalaceWriteAlreadyRunning(
+                        f"palace {resolved} is held by {holder}; "
+                        f"refusing `{operation}`"
+                    ) from exc
         else:
             import fcntl
 

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -31,10 +31,13 @@ Usage (from CLI):
 
 import argparse
 import os
+import re
+import secrets
+import shlex
 import shutil
 import sqlite3
 import time
-from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 import re
 from typing import Callable, Iterator, Optional
@@ -42,6 +45,7 @@ from typing import Callable, Iterator, Optional
 from chromadb.errors import NotFoundError as ChromaNotFoundError
 
 from .backends.chroma import ChromaBackend, hnsw_capacity_status
+from .palace import PalaceWriteAlreadyRunning, palace_write_lock
 
 
 COLLECTION_NAME = "mempalace_drawers"
@@ -87,6 +91,282 @@ def _recoverable_collections() -> tuple[str, ...]:
 # should call ``_recoverable_collections()`` so config changes are picked
 # up at call time.
 RECOVERABLE_COLLECTIONS = (COLLECTION_NAME, CLOSETS_COLLECTION_NAME)
+DEFAULT_FROM_SQLITE_BATCH_SIZE = 5000
+
+_SQLITE_EXTRACT_ROWS_SQL = """
+SELECT e.embedding_id, em.key, em.string_value, em.int_value,
+       em.float_value, em.bool_value
+FROM embeddings e
+JOIN embedding_metadata em ON em.id = e.id
+WHERE e.segment_id = ?
+ORDER BY e.segment_id, e.embedding_id
+"""
+
+
+def _sqlite_metadata_segment_id(conn: sqlite3.Connection, collection_name: str) -> Optional[str]:
+    row = conn.execute(
+        """
+        SELECT s.id FROM segments s
+        JOIN collections c ON s.collection = c.id
+        WHERE c.name = ? AND s.scope = 'METADATA'
+        """,
+        (collection_name,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _sqlite_collection_id(conn: sqlite3.Connection, collection_name: str) -> Optional[str]:
+    row = conn.execute(
+        "SELECT id FROM collections WHERE name = ?",
+        (collection_name,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _sqlite_collection_topic(conn: sqlite3.Connection, collection_name: str) -> Optional[str]:
+    collection_id = _sqlite_collection_id(conn, collection_name)
+    if collection_id is None:
+        return None
+
+    topic = f"persistent://default/default/{collection_id}"
+    row = conn.execute(
+        "SELECT 1 FROM embeddings_queue WHERE topic = ? LIMIT 1",
+        (topic,),
+    ).fetchone()
+    if row:
+        return topic
+
+    row = conn.execute(
+        "SELECT topic FROM embeddings_queue WHERE topic LIKE ? LIMIT 1",
+        (f"%/{collection_id}",),
+    ).fetchone()
+    return row[0] if row else topic
+
+
+def _load_sqlite_vectors(palace_path: str, collection_name: str) -> dict[str, object]:
+    """Load latest stored vectors for a collection from Chroma's queue WAL.
+
+    ChromaDB stores vector payloads in ``embeddings_queue`` as FLOAT32 blobs.
+    Passing those vectors back to ``upsert`` avoids re-embedding every document
+    during SQLite recovery. The table has no useful topic/id index, so this
+    intentionally does one sequential scan for the collection topic and keeps
+    the newest non-null vector per embedding ID.
+    """
+    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(sqlite_path):
+        return {}
+
+    import numpy as np
+
+    conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
+    try:
+        topic = _sqlite_collection_topic(conn, collection_name)
+        if topic is None:
+            return {}
+
+        vectors = {}
+        for emb_id, vector, encoding in conn.execute(
+            """
+            SELECT id, vector, encoding
+            FROM embeddings_queue
+            WHERE topic = ? AND vector IS NOT NULL
+            ORDER BY seq_id
+            """,
+            (topic,),
+        ):
+            if encoding and encoding.upper() != "FLOAT32":
+                continue
+            vectors[emb_id] = np.frombuffer(vector, dtype="<f4")
+        return vectors
+    finally:
+        conn.close()
+
+
+def _sqlite_embedding_ids(palace_path: str, collection_name: str) -> list[str]:
+    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(sqlite_path):
+        return []
+
+    conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
+    try:
+        segment_id = _sqlite_metadata_segment_id(conn, collection_name)
+        if segment_id is None:
+            return []
+        rows = conn.execute(
+            "SELECT embedding_id FROM embeddings WHERE segment_id = ? ORDER BY embedding_id",
+            (segment_id,),
+        ).fetchall()
+        return [str(row[0]) for row in rows]
+    finally:
+        conn.close()
+
+
+def _recoverable_collection_names(palace_path: str, primary_collection: str) -> tuple[str, ...]:
+    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    fallback = (
+        (primary_collection, "mempalace_closets")
+        if primary_collection != "mempalace_closets"
+        else (primary_collection,)
+    )
+    if not os.path.isfile(sqlite_path):
+        return fallback
+
+    try:
+        conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
+        try:
+            rows = conn.execute(
+                """
+                SELECT c.name
+                FROM collections c
+                JOIN segments s ON s.collection = c.id AND s.scope = 'METADATA'
+                JOIN embeddings e ON e.segment_id = s.id
+                GROUP BY c.name
+                HAVING COUNT(e.embedding_id) > 0
+                """
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return fallback
+
+    names = {str(row[0]) for row in rows if not _is_repair_internal_collection(str(row[0]))}
+    ordered = [primary_collection]
+    if "mempalace_closets" in names and primary_collection != "mempalace_closets":
+        ordered.append("mempalace_closets")
+    ordered.extend(sorted(names - set(ordered)))
+    return tuple(name for name in ordered if name in names or name == primary_collection)
+
+
+def _is_repair_internal_collection(collection_name: str) -> bool:
+    """Return whether ``collection_name`` is an internal repair staging collection."""
+    return bool(
+        re.search(
+            r"__repair_tmp__\d{20}__\d+__[0-9a-f]{8}$",
+            collection_name,
+        )
+    )
+
+
+def _unique_temp_collection_name(collection_name: str) -> str:
+    ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
+    return f"{collection_name}__repair_tmp__{ts}__{os.getpid()}__{secrets.token_hex(4)}"
+
+
+@dataclass(frozen=True)
+class CollectionInventory:
+    name: str
+    count: int
+    ids: frozenset[str]
+    missing_documents: frozenset[str]
+
+
+def _sqlite_collection_inventory(palace_path: str, collection_name: str) -> CollectionInventory:
+    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(sqlite_path):
+        raise RuntimeError(f"source palace has no chroma.sqlite3 at {sqlite_path}")
+
+    conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
+    try:
+        segment_id = _sqlite_metadata_segment_id(conn, collection_name)
+        if segment_id is None:
+            return CollectionInventory(collection_name, 0, frozenset(), frozenset())
+
+        id_rows = conn.execute(
+            "SELECT embedding_id FROM embeddings WHERE segment_id = ?",
+            (segment_id,),
+        ).fetchall()
+        ids = frozenset(str(row[0]) for row in id_rows)
+        doc_rows = conn.execute(
+            """
+            SELECT e.embedding_id
+            FROM embeddings e
+            LEFT JOIN embedding_metadata em
+              ON em.id = e.id AND em.key = 'chroma:document'
+            WHERE e.segment_id = ? AND em.id IS NULL
+            """,
+            (segment_id,),
+        ).fetchall()
+        missing = frozenset(str(row[0]) for row in doc_rows)
+        return CollectionInventory(collection_name, len(ids), ids, missing)
+    finally:
+        conn.close()
+
+
+def _sqlite_inventories(
+    palace_path: str, collection_names: tuple[str, ...]
+) -> dict[str, CollectionInventory]:
+    return {
+        name: _sqlite_collection_inventory(palace_path, name)
+        for name in collection_names
+        if not _is_repair_internal_collection(name)
+    }
+
+
+def _validate_no_missing_documents(inventories: dict[str, CollectionInventory]) -> None:
+    offenders = {
+        name: inv.missing_documents for name, inv in inventories.items() if inv.missing_documents
+    }
+    if not offenders:
+        return
+    parts = []
+    for name, missing in offenders.items():
+        sample = ", ".join(sorted(missing)[:5])
+        parts.append(f"{name}: {len(missing)} row(s) missing chroma:document ({sample})")
+    raise RuntimeError("source SQLite metadata corruption: " + "; ".join(parts))
+
+
+def _validate_destination_inventory(
+    expected: CollectionInventory, actual: CollectionInventory
+) -> None:
+    if actual.count != expected.count:
+        raise RuntimeError(
+            f"{expected.name} count mismatch: expected {expected.count}, got {actual.count}; "
+            "run again with --audit-content after resolving the inventory mismatch"
+        )
+    if actual.ids != expected.ids:
+        missing = expected.ids - actual.ids
+        extra = actual.ids - expected.ids
+        detail = []
+        if missing:
+            detail.append(f"missing IDs: {', '.join(sorted(missing)[:5])}")
+        if extra:
+            detail.append(f"extra IDs: {', '.join(sorted(extra)[:5])}")
+        raise RuntimeError(
+            f"{expected.name} ID set mismatch ({'; '.join(detail)}); "
+            "run again with --audit-content after resolving the inventory mismatch"
+        )
+    if actual.missing_documents:
+        sample = ", ".join(sorted(actual.missing_documents)[:5])
+        raise RuntimeError(
+            f"{expected.name} destination has {len(actual.missing_documents)} row(s) "
+            f"missing chroma:document ({sample})"
+        )
+
+
+def _sqlite_documents_by_id(palace_path: str, collection_name: str) -> dict[str, str]:
+    return {emb_id: doc for emb_id, doc, _meta in extract_via_sqlite(palace_path, collection_name)}
+
+
+def _audit_collection_content(source_palace: str, dest_palace: str, collection_name: str) -> None:
+    source_docs = _sqlite_documents_by_id(source_palace, collection_name)
+    dest_docs = _sqlite_documents_by_id(dest_palace, collection_name)
+    if source_docs == dest_docs:
+        return
+    missing = set(source_docs) - set(dest_docs)
+    extra = set(dest_docs) - set(source_docs)
+    changed = {
+        emb_id
+        for emb_id in source_docs.keys() & dest_docs.keys()
+        if source_docs[emb_id] != dest_docs[emb_id]
+    }
+    detail = []
+    if missing:
+        detail.append(f"missing docs: {', '.join(sorted(missing)[:5])}")
+    if extra:
+        detail.append(f"extra docs: {', '.join(sorted(extra)[:5])}")
+    if changed:
+        detail.append(f"changed docs: {', '.join(sorted(changed)[:5])}")
+    raise RuntimeError(f"{collection_name} content audit failed ({'; '.join(detail)})")
 
 
 def _get_palace_path():
@@ -139,30 +419,143 @@ def _paginate_ids(col, where=None):
     return ids
 
 
-def _extract_drawers(col, total: int, batch_size: int):
+def _sanitize_metadatas(metadatas):
+    # ChromaDB 1.5.x rejects None / {} metadata during upsert; preserve
+    # rebuild progress by replacing sparse historical rows with a sentinel.
+    return [
+        m if (isinstance(m, dict) and len(m) > 0) else {"_repaired_empty_meta": True}
+        for m in metadatas
+    ]
+
+
+def _extract_drawers(col, total: int, batch_size: int, include_embeddings: bool = False):
     all_ids = []
     all_docs = []
     all_metas = []
+    all_embeddings = []
     offset = 0
+    include = ["documents", "metadatas"]
+    if include_embeddings:
+        include.append("embeddings")
     while offset < total:
-        batch = col.get(limit=batch_size, offset=offset, include=["documents", "metadatas"])
+        batch = col.get(
+            limit=batch_size,
+            offset=offset,
+            include=include,
+        )
         if not batch["ids"]:
             break
         all_ids.extend(batch["ids"])
         all_docs.extend(batch["documents"])
-        # chromadb 1.5.x's upsert validates that every metadatas[i] is a
-        # non-empty dict (chromadb/api/types.py:validate_metadata). Drawers
-        # extracted from sqlite ground truth can come back with None or {}
-        # for sparse historical writes — coerce those to a sentinel so the
-        # rebuild upsert can complete instead of raising ValueError ~80%
-        # through a multi-hour run. See #1458 for full context.
-        sanitized_metas = [
-            m if (isinstance(m, dict) and len(m) > 0) else {"_repaired_empty_meta": True}
-            for m in batch["metadatas"]
-        ]
-        all_metas.extend(sanitized_metas)
+        all_metas.extend(_sanitize_metadatas(batch["metadatas"]))
+        if include_embeddings:
+            embeddings = batch.get("embeddings")
+            if embeddings is not None:
+                all_embeddings.extend(embeddings)
         offset += len(batch["ids"])
-    return all_ids, all_docs, all_metas
+    if len(all_embeddings) != len(all_ids):
+        all_embeddings = []
+    return all_ids, all_docs, all_metas, all_embeddings or None
+
+
+def _stage_collection_from_source(
+    backend,
+    palace_path: str,
+    source_col,
+    total: int,
+    batch_size: int,
+    collection_name: str,
+    *,
+    include_embeddings: bool,
+    temp_name: Optional[str] = None,
+    progress=print,
+):
+    temp_name = temp_name or _unique_temp_collection_name(collection_name)
+    _delete_collection_if_exists(backend, palace_path, temp_name)
+
+    progress(f"  Building temporary collection: {temp_name}")
+    temp_col = backend.create_collection(palace_path, temp_name)
+    include = ["documents", "metadatas"]
+    if include_embeddings:
+        include.append("embeddings")
+
+    staged = 0
+    offset = 0
+    try:
+        while offset < total:
+            batch = source_col.get(limit=batch_size, offset=offset, include=include)
+            batch_ids = batch.get("ids") or []
+            if not batch_ids:
+                break
+            kwargs = {
+                "ids": batch_ids,
+                "documents": batch["documents"],
+                "metadatas": _sanitize_metadatas(batch["metadatas"]),
+            }
+            embeddings = batch.get("embeddings") if include_embeddings else None
+            if include_embeddings:
+                if embeddings is None or len(embeddings) != len(batch_ids):
+                    progress(
+                        "  Stored embeddings were not returned for a full batch; "
+                        "restarting temp rebuild with fresh embeddings for every row."
+                    )
+                    _delete_collection_if_exists(backend, palace_path, temp_name)
+                    return _stage_collection_from_source(
+                        backend,
+                        palace_path,
+                        source_col,
+                        total,
+                        batch_size,
+                        collection_name,
+                        include_embeddings=False,
+                        temp_name=temp_name,
+                        progress=progress,
+                    )
+                kwargs["embeddings"] = embeddings
+            temp_col.upsert(**kwargs)
+            staged += len(batch_ids)
+            offset += len(batch_ids)
+            progress(f"  Staged {staged}/{total} drawers...")
+
+        _verify_collection_count(temp_col, staged, "temporary rebuild")
+    except Exception:
+        _delete_collection_if_exists(backend, palace_path, temp_name)
+        raise
+    return temp_col, temp_name, staged
+
+
+def _swap_temp_collection_into_live(
+    backend,
+    palace_path: str,
+    temp_col,
+    temp_name: str,
+    collection_name: str,
+    expected: int,
+    *,
+    progress=print,
+) -> int:
+    progress("  Swapping temporary collection into live name...")
+    try:
+        backend.delete_collection(palace_path, collection_name)
+    except Exception as exc:
+        try:
+            _delete_collection_if_exists(backend, palace_path, temp_name)
+        except Exception:
+            pass
+        raise RebuildCollectionError(str(exc), live_replaced=False) from exc
+
+    try:
+        _rename_collection(temp_col, collection_name)
+        live_col = backend.get_collection(palace_path, collection_name)
+        _verify_collection_count(live_col, expected, "rebuilt live collection")
+    except Exception as exc:
+        raise RebuildCollectionError(str(exc), live_replaced=True) from exc
+
+    try:
+        _delete_collection_if_exists(backend, palace_path, temp_name)
+    except Exception:
+        pass
+    return expected
 
 
 def _verify_collection_count(col, expected: int, label: str) -> None:
@@ -187,6 +580,10 @@ def _delete_collection_if_exists(backend, palace_path: str, collection_name: str
         return
 
 
+def _rename_collection(collection, new_name: str) -> None:
+    collection.modify(name=new_name)
+
+
 class RebuildCollectionError(RuntimeError):
     """Raised when temp rebuild fails, carrying whether the live swap happened."""
 
@@ -204,11 +601,11 @@ def _rebuild_collection_via_temp(
     batch_size: int,
     collection_name: Optional[str] = None,
     progress=print,
+    all_embeddings=None,
 ) -> int:
     expected = len(all_ids)
     collection_name = collection_name or _drawers_collection_name()
-    temp_name = f"{collection_name}__repair_tmp"
-    live_replaced = False
+    temp_name = _unique_temp_collection_name(collection_name)
 
     try:
         _delete_collection_if_exists(backend, palace_path, temp_name)
@@ -220,37 +617,35 @@ def _rebuild_collection_via_temp(
             batch_ids = all_ids[i : i + batch_size]
             batch_docs = all_docs[i : i + batch_size]
             batch_metas = all_metas[i : i + batch_size]
-            temp_col.upsert(documents=batch_docs, ids=batch_ids, metadatas=batch_metas)
+            kwargs = {"documents": batch_docs, "ids": batch_ids, "metadatas": batch_metas}
+            if all_embeddings is not None:
+                kwargs["embeddings"] = all_embeddings[i : i + batch_size]
+            temp_col.upsert(**kwargs)
             staged += len(batch_ids)
             progress(f"  Staged {staged}/{expected} drawers...")
         _verify_collection_count(temp_col, expected, "temporary rebuild")
 
-        progress("  Rebuilding live collection...")
-        backend.delete_collection(palace_path, collection_name)
-        live_replaced = True
-        new_col = backend.create_collection(palace_path, collection_name)
-
-        rebuilt = 0
-        for i in range(0, expected, batch_size):
-            batch_ids = all_ids[i : i + batch_size]
-            batch_docs = all_docs[i : i + batch_size]
-            batch_metas = all_metas[i : i + batch_size]
-            new_col.upsert(documents=batch_docs, ids=batch_ids, metadatas=batch_metas)
-            rebuilt += len(batch_ids)
-            progress(f"  Re-filed {rebuilt}/{expected} drawers...")
-        _verify_collection_count(new_col, expected, "rebuilt live collection")
-
+        return _swap_temp_collection_into_live(
+            backend,
+            palace_path,
+            temp_col,
+            temp_name,
+            collection_name,
+            expected,
+            progress=progress,
+        )
+    except RebuildCollectionError as exc:
         try:
             _delete_collection_if_exists(backend, palace_path, temp_name)
         except Exception:
             pass
-        return rebuilt
+        raise exc
     except Exception as exc:
         try:
             _delete_collection_if_exists(backend, palace_path, temp_name)
         except Exception:
             pass
-        raise RebuildCollectionError(str(exc), live_replaced=live_replaced) from exc
+        raise RebuildCollectionError(str(exc), live_replaced=False) from exc
 
 
 def scan_palace(palace_path=None, only_wing=None, collection_name: Optional[str] = None):
@@ -482,20 +877,18 @@ def sqlite_drawer_count(palace_path: str, collection_name: Optional[str] = None)
     sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
     if not os.path.exists(sqlite_path):
         return None
+    collection_name = collection_name or _get_collection_name()
     try:
         import sqlite3
 
         conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
         try:
+            segment_id = _sqlite_metadata_segment_id(conn, collection_name)
+            if segment_id is None:
+                return 0
             row = conn.execute(
-                """
-                SELECT COUNT(*)
-                FROM embeddings e
-                JOIN segments s ON e.segment_id = s.id
-                JOIN collections c ON s.collection = c.id
-                WHERE c.name = ?
-                """,
-                (collection_name,),
+                "SELECT COUNT(*) FROM embeddings WHERE segment_id = ?",
+                (segment_id,),
             ).fetchone()
             return int(row[0]) if row and row[0] is not None else None
         finally:
@@ -695,16 +1088,17 @@ def rebuild_index(
     confirm_truncation_ok: bool = False,
     collection_name: Optional[str] = None,
     progress: Optional[Callable[[str], None]] = None,
+    reembed: bool = False,
 ):
-    """Rebuild the HNSW index from scratch.
+    """Rebuild the HNSW index through a verified temporary collection.
 
-    1. Extract all drawers via ChromaDB get()
-    2. Cross-check against the SQLite ground truth (#1208 guard)
-    3. Back up ONLY chroma.sqlite3 (not the bloated HNSW files)
-    4. Delete and recreate the collection with hnsw:space=cosine
-    5. Upsert all drawers back
+    1. Back up ONLY chroma.sqlite3 (not the bloated HNSW files)
+    2. Stream drawers from ChromaDB into a temporary collection
+    3. Cross-check the staged count against SQLite ground truth (#1208 guard)
+    4. Swap the temporary collection into the live collection name
+    5. Restore the SQLite backup if the live swap fails
 
-    ``confirm_truncation_ok`` overrides the safety guard from step 2.
+    ``confirm_truncation_ok`` overrides the safety guard from step 3.
     Set to ``True`` only when you have independently verified that the
     palace genuinely contains exactly the extracted number of drawers
     (typically only a concern for palaces sized at exactly 10 000 rows).
@@ -714,14 +1108,32 @@ def rebuild_index(
     annotations on ``Staged N/M`` and ``Re-filed N/M`` lines. Pass a
     custom callable (e.g. a daemon-side capture for HTTP status, or a
     silent ``lambda *_: None`` for tests) to override.
+
+    By default, stored embeddings are reused batch-by-batch while staging.
+    ``reembed=True`` omits embeddings from the staged upserts so ChromaDB
+    regenerates every vector under the configured embedding function.
     """
     if progress is None:
         progress = _DefaultProgress()
     palace_path = palace_path or _get_palace_path()
     collection_name = collection_name or _drawers_collection_name()
+    try:
+        repair_lock = palace_write_lock(palace_path, operation="repair")
+        repair_lock.__enter__()
+    except PalaceWriteAlreadyRunning as exc:
+        print(f"\n  ABORT: {exc}")
+        return
+    lock_released = False
+
+    def _release_repair_lock() -> None:
+        nonlocal lock_released
+        if not lock_released:
+            repair_lock.__exit__(None, None, None)
+            lock_released = True
 
     if not os.path.isdir(palace_path):
         progress(f"\n  No palace found at {palace_path}")
+        _release_repair_lock()
         return
 
     progress(f"\n{'=' * 55}")
@@ -738,6 +1150,7 @@ def rebuild_index(
     sqlite_errors = sqlite_integrity_errors(palace_path)
     if sqlite_errors:
         print_sqlite_integrity_abort(palace_path, sqlite_errors)
+        _release_repair_lock()
         return
 
     preflight = maybe_repair_poisoned_max_seq_id_before_rebuild(
@@ -745,87 +1158,128 @@ def rebuild_index(
         assume_yes=True,
     )
     if preflight is not None:
+        _release_repair_lock()
         return
 
-    backend = ChromaBackend()
+    try:
+        backend = ChromaBackend()
+    except Exception:
+        _release_repair_lock()
+        raise
     try:
         col = backend.get_collection(palace_path, collection_name)
         total = col.count()
     except Exception as e:
         progress(f"  Error reading palace: {e}")
         progress("  Palace may need to be re-mined from source files.")
+        _release_repair_lock()
         return
 
     progress(f"  Drawers found: {total}")
 
     if total == 0:
         progress("  Nothing to repair.")
+        _release_repair_lock()
         return
 
-    # Extract all drawers in batches
+    # Back up BEFORE creating the temp collection. The snapshot must represent
+    # the pre-repair palace, and backup failures must not leave temp HNSW files.
+    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    backup_path = sqlite_path + ".backup"
+    if os.path.exists(sqlite_path):
+        try:
+            size_mb = os.path.getsize(sqlite_path) / 1e6
+            progress(f"  Backing up chroma.sqlite3 ({size_mb:.0f} MB)...")
+            shutil.copy2(sqlite_path, backup_path)
+        except Exception:
+            _release_repair_lock()
+            raise
+        progress(f"  Backup: {backup_path}")
+
+    # Stage drawers in batches. Keep batches bounded instead of materializing
+    # the full embedding matrix in Python memory.
     progress("\n  Extracting drawers...")
     batch_size = 5000
-    all_ids, all_docs, all_metas = _extract_drawers(col, total, batch_size)
-    progress(f"  Extracted {len(all_ids)} drawers")
-
-    # ── #1208 guard ──────────────────────────────────────────────────
-    # Refuse to ``delete_collection`` + rebuild when extraction looks
-    # short of the SQLite ground truth (or when extraction == chromadb
-    # default get() cap and the SQLite check couldn't run).
+    temp_col = None
+    temp_name = None
     try:
+        temp_col, temp_name, extracted = _stage_collection_from_source(
+            backend,
+            palace_path,
+            col,
+            total,
+            batch_size,
+            collection_name,
+            include_embeddings=not reembed,
+            progress=progress,
+        )
+        progress(f"  Extracted {extracted} drawers")
+
+        # ── #1208 guard ──────────────────────────────────────────────
+        # Refuse to swap when extraction looks short of SQLite ground truth.
         check_extraction_safety(
             palace_path,
-            len(all_ids),
+            extracted,
             confirm_truncation_ok,
             collection_name=collection_name,
         )
     except TruncationDetected as e:
         progress(e.message)
+        if temp_name is not None:
+            _delete_collection_if_exists(backend, palace_path, temp_name)
+        _release_repair_lock()
         return
+    except Exception as exc:
+        if temp_name is not None:
+            _delete_collection_if_exists(backend, palace_path, temp_name)
+        e = RebuildCollectionError(str(exc), live_replaced=False)
+        progress(f"\n  ERROR during rebuild: {e}")
+        progress("  Rebuild aborted before completion.")
+        progress("  Live collection was not replaced; leaving the original palace untouched.")
+        _release_repair_lock()
+        raise e
 
-    # Back up ONLY the SQLite database, not the bloated HNSW files
-    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
-    backup_path = sqlite_path + ".backup"
-    if os.path.exists(sqlite_path):
-        progress(f"  Backing up chroma.sqlite3 ({os.path.getsize(sqlite_path) / 1e6:.0f} MB)...")
-        shutil.copy2(sqlite_path, backup_path)
-        progress(f"  Backup: {backup_path}")
-
-    # Rebuild with correct HNSW settings
     progress("  Rebuilding collection with hnsw:space=cosine...")
     try:
-        filed = _rebuild_collection_via_temp(
+        filed = _swap_temp_collection_into_live(
             backend,
             palace_path,
-            all_ids,
-            all_docs,
-            all_metas,
-            batch_size,
-            collection_name=collection_name,
+            temp_col,
+            temp_name,
+            collection_name,
+            extracted,
             progress=progress,
         )
-    except RebuildCollectionError as e:
+    except Exception as exc:
+        e = (
+            exc
+            if isinstance(exc, RebuildCollectionError)
+            else RebuildCollectionError(str(exc), live_replaced=False)
+        )
         progress(f"\n  ERROR during rebuild: {e}")
         progress("  Rebuild aborted before completion.")
         if e.live_replaced and os.path.exists(backup_path):
             progress(f"  Restoring from backup: {backup_path}")
             try:
                 _close_chroma_handles(palace_path, backend=backend)
+                _delete_collection_if_exists(backend, palace_path, temp_name)
                 _delete_collection_if_exists(backend, palace_path, collection_name)
                 shutil.copy2(backup_path, sqlite_path)
                 progress("  Backup restored. Palace is back to pre-repair state.")
             except Exception as restore_error:
                 progress(f"  Backup restore failed: {restore_error}")
                 progress(f"  Manual restore required from: {backup_path}")
-        elif e.live_replaced:
-            progress("  No backup available. Re-mine from source files to recover.")
+        elif not e.live_replaced:
+            progress("  Live collection was not replaced; leaving the original palace untouched.")
         else:
-            print("  Live collection was not replaced; leaving the original palace untouched.")
-        raise
+            progress("  No backup available. Re-mine from source files to recover.")
+        _release_repair_lock()
+        raise e
 
-    print(f"\n  Repair complete. {filed} drawers rebuilt.")
-    print("  HNSW index is now clean with cosine distance metric.")
-    print(f"\n{'=' * 55}\n")
+    progress(f"\n  Repair complete. {filed} drawers rebuilt.")
+    progress("  HNSW index is now clean with cosine distance metric.")
+    progress(f"\n{'=' * 55}\n")
+    _release_repair_lock()
 
 
 class RebuildPartialError(Exception):
@@ -864,6 +1318,7 @@ def _rebuild_one_collection(
     batch_size: int,
     archive_path: Optional[str],
     counts_so_far: dict[str, int],
+    reembed: bool = False,
 ) -> int:
     """Stream rows for one collection from SQLite and upsert into a
     freshly-created collection at ``dest_palace``. Returns rows
@@ -872,17 +1327,29 @@ def _rebuild_one_collection(
     caller can stop the loop and print recovery instructions instead of
     silently shipping a partial palace.
     """
+    vectors_by_id = {}
     ids: list[str] = []
     docs: list[str] = []
     metas: list[dict] = []
     upserted = 0
+    failure_stage = "preparing rebuild"
     col = None
 
     def _flush() -> int:
         nonlocal upserted
         if not ids:
             return upserted
-        col.upsert(ids=list(ids), documents=list(docs), metadatas=list(metas))
+
+        if vectors_by_id:
+            col.upsert(
+                ids=list(ids),
+                documents=list(docs),
+                metadatas=list(metas),
+                embeddings=[vectors_by_id[emb_id] for emb_id in ids],
+            )
+        else:
+            col.upsert(ids=list(ids), documents=list(docs), metadatas=list(metas))
+
         upserted += len(ids)
         print(f"    upserted {upserted}")
         ids.clear()
@@ -897,8 +1364,20 @@ def _rebuild_one_collection(
         # reported as a structured ``RebuildPartialError`` carrying
         # ``archive_path`` — instead of an unstructured exception that
         # strands the user without recovery instructions.
+        failure_stage = "loading source IDs"
+        source_ids = _sqlite_embedding_ids(source_palace, collection_name)
+        failure_stage = "loading stored embeddings"
+        vectors_by_id = {} if reembed else _load_sqlite_vectors(source_palace, collection_name)
+        if vectors_by_id:
+            source_id_set = set(source_ids)
+            if not source_id_set or not source_id_set.issubset(vectors_by_id):
+                print("    stored embeddings incomplete; re-embedding this collection")
+                vectors_by_id = {}
+        if vectors_by_id:
+            print(f"    loaded {len(vectors_by_id)} stored embeddings")
+        failure_stage = "creating destination collection"
         col = backend.create_collection(dest_palace, collection_name)
-
+        failure_stage = "extracting and upserting rows"
         for emb_id, doc, meta in extract_via_sqlite(source_palace, collection_name):
             ids.append(emb_id)
             docs.append(doc or "")
@@ -913,23 +1392,32 @@ def _rebuild_one_collection(
             if len(ids) >= batch_size:
                 _flush()
         _flush()
+        if source_ids and upserted != len(source_ids):
+            failure_stage = "validating extracted source row count"
+            raise RuntimeError(
+                f"source/extracted count mismatch for {collection_name!r}: "
+                f"source has {len(source_ids)} rows, extracted {upserted}"
+            )
+        failure_stage = "validating destination count"
+        _verify_collection_count(col, upserted, f"rebuilt {collection_name}")
     except Exception as exc:  # noqa: BLE001 — chromadb raises many shapes
         partial = dict(counts_so_far)
         partial[collection_name] = upserted
         msg_parts = [
-            f"Upsert failed in collection {collection_name!r} after {upserted} rows: {exc!r}",
+            f"Rebuild failed in collection {collection_name!r} during {failure_stage} "
+            f"after {upserted} rows: {exc!r}",
             f"Partial palace left at: {dest_palace}",
         ]
         if archive_path is not None:
             msg_parts.append(f"Original palace archived at: {archive_path}")
             msg_parts.append(
                 "  Recover by removing the partial dest and re-running with "
-                f"--source {archive_path}"
+                f"mempalace --palace {shlex.quote(dest_palace)} repair "
+                f"--mode from-sqlite --source {shlex.quote(archive_path)} --yes"
             )
         else:
             msg_parts.append("  Source palace is unchanged. Remove the partial dest and re-run.")
         message = "\n  ".join(msg_parts)
-        print(f"\n  ERROR: {message}")
         raise RebuildPartialError(
             message,
             partial_counts=partial,
@@ -975,48 +1463,71 @@ def extract_via_sqlite(palace_path: str, collection_name: str) -> Iterator[tuple
 
     conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
     try:
-        seg_row = conn.execute(
-            """
-            SELECT s.id FROM segments s
-            JOIN collections c ON s.collection = c.id
-            WHERE c.name = ? AND s.scope = 'METADATA'
-            """,
-            (collection_name,),
-        ).fetchone()
-        if not seg_row:
+        segment_id = _sqlite_metadata_segment_id(conn, collection_name)
+        if segment_id is None:
             return
-        segment_id = seg_row[0]
 
-        per_id: dict[str, dict] = defaultdict(dict)
-        order: list[str] = []
-        for emb_id, key, sv, iv, fv, bv in conn.execute(
-            """
-            SELECT e.embedding_id, em.key, em.string_value, em.int_value,
-                   em.float_value, em.bool_value
-            FROM embedding_metadata em
-            JOIN embeddings e ON em.id = e.id
-            WHERE e.segment_id = ?
-            ORDER BY em.id
-            """,
-            (segment_id,),
-        ):
-            if emb_id not in per_id:
-                order.append(emb_id)
+        current_id: Optional[str] = None
+        current_meta: dict = {}
+
+        def _value_from_columns(sv, iv, fv, bv):
             if sv is not None:
-                per_id[emb_id][key] = sv
-            elif iv is not None:
-                per_id[emb_id][key] = iv
-            elif fv is not None:
-                per_id[emb_id][key] = fv
-            elif bv is not None:
-                per_id[emb_id][key] = bool(bv)
+                return sv
+            if iv is not None:
+                return iv
+            if fv is not None:
+                return fv
+            if bv is not None:
+                return bool(bv)
+            return None
 
-        for emb_id in order:
-            kv = per_id[emb_id]
-            doc = kv.pop("chroma:document", "")
-            yield emb_id, doc, kv
+        def _emit_current():
+            if current_id is None:
+                return None
+            kv = dict(current_meta)
+            if "chroma:document" not in kv:
+                return None
+            doc = kv.pop("chroma:document")
+            return current_id, doc, kv
+
+        for emb_id, key, sv, iv, fv, bv in conn.execute(_SQLITE_EXTRACT_ROWS_SQL, (segment_id,)):
+            if current_id is None:
+                current_id = emb_id
+            elif emb_id != current_id:
+                emitted = _emit_current()
+                if emitted is not None:
+                    yield emitted
+                current_id = emb_id
+                current_meta = {}
+
+            value = _value_from_columns(sv, iv, fv, bv)
+            if value is not None:
+                current_meta[key] = value
+
+        emitted = _emit_current()
+        if emitted is not None:
+            yield emitted
     finally:
         conn.close()
+
+
+def _restore_in_place_rebuild_archive(
+    *,
+    archive_path: str,
+    dest_palace: str,
+    collection_name: str,
+    source_inventories: dict[str, CollectionInventory],
+    backend: ChromaBackend | None,
+) -> int:
+    print("  In-place rebuild failed before completion; restoring archived palace...")
+    _close_chroma_handles(dest_palace, backend=backend)
+    if os.path.exists(dest_palace):
+        shutil.rmtree(dest_palace)
+    shutil.move(archive_path, dest_palace)
+    restored = _sqlite_collection_inventory(dest_palace, collection_name)
+    _validate_destination_inventory(source_inventories[collection_name], restored)
+    print(f"  Restore verified: {restored.count} rows in {collection_name}")
+    return restored.count
 
 
 def rebuild_from_sqlite(
@@ -1024,7 +1535,10 @@ def rebuild_from_sqlite(
     dest_palace: str,
     *,
     archive_existing_dest: bool = False,
-    batch_size: int = 1000,
+    batch_size: int = DEFAULT_FROM_SQLITE_BATCH_SIZE,
+    collection_name: Optional[str] = None,
+    reembed: bool = False,
+    audit_content: bool = False,
 ) -> dict[str, int]:
     """Rebuild a palace by reading drawers from ``source_palace``'s
     ``chroma.sqlite3`` and upserting them into a fresh palace at
@@ -1040,12 +1554,9 @@ def rebuild_from_sqlite(
     function bypasses the chromadb read path entirely via
     :func:`extract_via_sqlite`.
 
-    Re-embeds documents at upsert time using the configured embedding
-    function; the original HNSW vectors are not preserved (they live in
-    the corrupt ``data_level0.bin`` / ``link_lists.bin``, not in
-    SQLite). Acceptable for a corruption-recovery flow because the
-    embedding model is deterministic — same model + same document text
-    yields semantically equivalent search results.
+    Reuses stored vectors from Chroma's SQLite queue by default so recovery
+    does not call the embedding model for every row. Pass ``reembed=True`` to
+    regenerate vectors instead.
 
     ``archive_existing_dest`` controls behavior when ``dest_palace``
     already exists:
@@ -1059,18 +1570,12 @@ def rebuild_from_sqlite(
 
     Returns a ``{collection_name: row_count}`` dict so callers (CLI,
     tests) can verify the per-collection rebuild count without parsing
-    stdout. A successful rebuild always returns a dict with one key per
-    recoverable collection (values may be ``0`` when a collection is
-    legitimately empty in the source). The empty dict ``{}`` is reserved
-    for validation refusals (missing source DB, refusing to overwrite an
-    existing dest, in-place mode without ``archive_existing_dest``); CLI
-    callers should treat ``{}`` as an error and exit non-zero so CI and
-    scripts can distinguish "invalid inputs" from "successful recovery
-    that found zero rows." Raises :class:`RebuildPartialError` if a
-    chromadb upsert fails partway through; the dest palace is left in
-    place so the user can inspect what landed, and the in-place archive
-    (when applicable) is reported in the error so the user can re-run
-    against it.
+    stdout. Returns ``{}`` on validation failures (missing source,
+    refusing to overwrite). Raises :class:`RebuildPartialError` if a
+    chromadb upsert fails partway through. Cross-palace partial rebuilds
+    are left in place so the user can inspect what landed. In-place
+    partial rebuilds restore the archived palace before returning the
+    nonzero failure to the caller.
 
     .. warning::
 
@@ -1096,18 +1601,43 @@ def rebuild_from_sqlite(
     is a known divergence and matches the existing migrate-path
     behavior.
     """
-    source_palace = os.path.abspath(os.path.expanduser(source_palace))
-    dest_palace = os.path.abspath(os.path.expanduser(dest_palace))
+    source_palace = os.path.realpath(os.path.abspath(os.path.expanduser(source_palace)))
+    dest_palace = os.path.realpath(os.path.abspath(os.path.expanduser(dest_palace)))
+    collection_name = collection_name or _drawers_collection_name()
 
     src_db = os.path.join(source_palace, "chroma.sqlite3")
 
-    in_place = source_palace == dest_palace
+    in_place = os.path.normcase(source_palace) == os.path.normcase(dest_palace)
+    repair_locks = []
+
+    def _release_repair_locks() -> None:
+        while repair_locks:
+            repair_locks.pop().__exit__(None, None, None)
+
+    try:
+        repair_lock = palace_write_lock(dest_palace, operation="repair")
+        repair_lock.__enter__()
+        repair_locks.append(repair_lock)
+        if not in_place:
+            source_lock = palace_write_lock(source_palace, operation="repair source")
+            source_lock.__enter__()
+            repair_locks.append(source_lock)
+    except PalaceWriteAlreadyRunning as exc:
+        _release_repair_locks()
+        print(f"\n  ABORT: {exc}")
+        return {}
 
     print(f"\n{'=' * 55}")
     print("  MemPalace Repair — Rebuild from SQLite")
     print(f"{'=' * 55}\n")
     print(f"  Source: {source_palace}")
     print(f"  Dest:   {dest_palace}")
+
+    def _source_primary_count() -> "int | None":
+        count = sqlite_drawer_count(source_palace, collection_name)
+        if count == 0:
+            print(f"\n  Source collection {collection_name!r} has no rows; refusing rebuild.")
+        return count
 
     # Validate source BEFORE any destructive moves. An earlier draft
     # archived the dest first and surfaced the missing-chroma.sqlite3
@@ -1122,13 +1652,22 @@ def rebuild_from_sqlite(
                 "the existing palace aside, or pass a different source_palace= "
                 "(CLI: --source)."
             )
+            _release_repair_locks()
             return {}
         if not os.path.isfile(src_db):
             print(f"\n  Source palace has no chroma.sqlite3 at {src_db}")
+            _release_repair_locks()
+            return {}
+        if _source_primary_count() == 0:
+            _release_repair_locks()
             return {}
     else:
         if not os.path.isfile(src_db):
             print(f"\n  Source palace has no chroma.sqlite3 at {src_db}")
+            _release_repair_locks()
+            return {}
+        if _source_primary_count() == 0:
+            _release_repair_locks()
             return {}
         if os.path.exists(dest_palace):
             print(
@@ -1137,12 +1676,20 @@ def rebuild_from_sqlite(
                 "archive_existing_dest=True if rebuilding in place "
                 "(source_palace == dest_palace)."
             )
+            _release_repair_locks()
             return {}
+
+    try:
+        recoverable_collections = _recoverable_collection_names(source_palace, collection_name)
+        source_inventories = _sqlite_inventories(source_palace, recoverable_collections)
+        _validate_no_missing_documents(source_inventories)
+    except Exception:
+        _release_repair_locks()
+        raise
 
     archive_path: Optional[str] = None
     if in_place:
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        archive_path = f"{dest_palace}.pre-rebuild-{ts}"
+        archive_path = _unique_archive_path(dest_palace)
         print(f"  Archiving {dest_palace} → {archive_path}")
         shutil.move(dest_palace, archive_path)
         source_palace = archive_path
@@ -1164,21 +1711,12 @@ def rebuild_from_sqlite(
                 "in-place rebuild may fail with 'Collection already exists'."
             )
 
-    os.makedirs(dest_palace, exist_ok=True)
-
-    # Backend lifetime is wrapped in try/finally so the dest palace's
-    # PersistentClient handle (opened lazily inside ``create_collection``
-    # / ``get_collection``) is released on every exit path: success,
-    # ``RebuildPartialError``, or any unexpected exception. Without this,
-    # a long-running process that calls ``rebuild_from_sqlite`` would
-    # leak SQLite/HNSW file handles into Chroma's ``SharedSystemClient``
-    # cache, surfacing later as "Collection already exists" on the next
-    # in-place rebuild or as a Windows file-lock failure on cleanup
-    # (cf. #1285's lifecycle hardening for the legacy rebuild path).
-    backend = ChromaBackend()
+    backend: ChromaBackend | None = None
     counts: dict[str, int] = {}
     try:
-        for cname in _recoverable_collections():
+        os.makedirs(dest_palace, exist_ok=True)
+        backend = ChromaBackend()
+        for cname in recoverable_collections:
             print(f"\n  [{cname}]")
             upserted = _rebuild_one_collection(
                 backend=backend,
@@ -1188,21 +1726,150 @@ def rebuild_from_sqlite(
                 batch_size=batch_size,
                 archive_path=archive_path,
                 counts_so_far=counts,
+                reembed=reembed,
             )
             counts[cname] = upserted
             if upserted == 0:
                 print(f"    no rows found for {cname} in source palace")
             else:
                 print(f"    done: {upserted} rows in {cname}")
+            actual = _sqlite_collection_inventory(dest_palace, cname)
+            _validate_destination_inventory(source_inventories[cname], actual)
+            if audit_content:
+                _audit_collection_content(source_palace, dest_palace, cname)
+    except RebuildPartialError as exc:
+        try:
+            if archive_path is not None:
+                restored_count = _restore_in_place_rebuild_archive(
+                    archive_path=archive_path,
+                    dest_palace=dest_palace,
+                    collection_name=collection_name,
+                    source_inventories=source_inventories,
+                    backend=backend,
+                )
+                restored_message = "\n  ".join(
+                    [
+                        exc.message.split("\n", 1)[0],
+                        f"Original palace restored at: {dest_palace}",
+                        f"Restore verified: {restored_count} rows in {collection_name}",
+                        "Failed partial rebuild was removed; the source palace is the restored live path.",
+                    ]
+                )
+                print(f"\n  ERROR: {restored_message}")
+                raise RebuildPartialError(
+                    restored_message,
+                    partial_counts=exc.partial_counts,
+                    failed_collection=exc.failed_collection,
+                    dest_palace=dest_palace,
+                    archive_path=None,
+                ) from exc
+            print(f"\n  ERROR: {exc.message}")
+            raise
+        finally:
+            if backend is not None:
+                backend.close()
+            _release_repair_locks()
+    except Exception:
+        try:
+            if archive_path is not None:
+                _restore_in_place_rebuild_archive(
+                    archive_path=archive_path,
+                    dest_palace=dest_palace,
+                    collection_name=collection_name,
+                    source_inventories=source_inventories,
+                    backend=backend,
+                )
+            raise
+        finally:
+            if backend is not None:
+                backend.close()
+            _release_repair_locks()
 
-        print(f"\n  Rebuild complete. {sum(counts.values())} total rows.")
-        if archive_path is not None:
-            print(f"  Original palace archived at: {archive_path}")
-        print(f"{'=' * 55}\n")
-        return counts
-    finally:
+    print(f"\n  Rebuild complete. {sum(counts.values())} total rows.")
+    if archive_path is not None:
+        print(f"  Original palace archived at: {archive_path}")
+    print(f"{'=' * 55}\n")
+    if backend is not None:
         backend.close()
-def status(palace_path=None, collection_name: Optional[str] = None) -> dict:
+    _release_repair_locks()
+    return counts
+
+
+def _unique_archive_path(dest_palace: str) -> str:
+    """Return a non-existing in-place rebuild archive path for ``dest_palace``."""
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    base = f"{dest_palace}.pre-rebuild-{ts}"
+    if not os.path.exists(base):
+        return base
+    for suffix in range(2, 1000):
+        candidate = f"{base}-{suffix}"
+        if not os.path.exists(candidate):
+            return candidate
+    raise RuntimeError(f"could not allocate unique archive path for {dest_palace}")
+
+
+def _repair_internal_collection_counts(palace_path: str) -> dict[str, int]:
+    """Return stale internal repair collection names and metadata row counts."""
+    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(sqlite_path):
+        return {}
+
+    conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
+    try:
+        rows = conn.execute(
+            """
+            SELECT c.name, COUNT(e.id)
+            FROM collections c
+            JOIN segments s ON s.collection = c.id
+            LEFT JOIN embeddings e ON e.segment_id = s.id
+            WHERE s.scope = 'METADATA'
+              AND c.name LIKE ?
+            GROUP BY c.name
+            ORDER BY c.name
+            """,
+            ("%__repair_tmp%",),
+        ).fetchall()
+        return {
+            str(name): int(count)
+            for name, count in rows
+            if _is_repair_internal_collection(str(name))
+        }
+    finally:
+        conn.close()
+
+
+def _cleanup_repair_internal_collections(
+    palace_path: str, artifacts: dict[str, int]
+) -> dict[str, str]:
+    """Delete internal repair staging collections via Chroma and report outcomes."""
+    if not artifacts:
+        return {}
+    outcomes: dict[str, str] = {}
+    try:
+        with palace_write_lock(palace_path, operation="repair cleanup"):
+            backend = ChromaBackend()
+            try:
+                for name in artifacts:
+                    try:
+                        backend.delete_collection(palace_path, name)
+                        outcomes[name] = "deleted"
+                    except Exception as exc:  # noqa: BLE001 - Chroma raises several shapes
+                        outcomes[name] = f"failed: {exc}"
+            finally:
+                backend.close()
+    except PalaceWriteAlreadyRunning as exc:
+        for name in artifacts:
+            outcomes[name] = f"refused: {exc}"
+    return outcomes
+
+
+def status(
+    palace_path=None,
+    collection_name: Optional[str] = None,
+    *,
+    cleanup_temp: bool = False,
+    assume_yes: bool = False,
+) -> dict:
     """Read-only health check: compare sqlite vs HNSW element counts.
 
     Catches the #1222 failure mode where chromadb's HNSW segment freezes
@@ -1215,9 +1882,14 @@ def status(palace_path=None, collection_name: Optional[str] = None) -> dict:
     The check itself never opens a chromadb client and never imports
     hnswlib — it reads ``chroma.sqlite3`` and ``index_metadata.pickle``
     directly via :func:`mempalace.backends.chroma.hnsw_capacity_status`.
+    Passing ``cleanup_temp=True`` is the explicit exception: it takes the
+    palace write lock and deletes stale internal collections matching
+    MemPalace's generated repair-temp naming scheme after reporting them.
 
-    Returns the capacity-status dict (also printed). Returns a dict with
-    ``status="unknown"`` when no palace exists at the given path.
+    Returns a wrapper dict with per-collection capacity checks
+    (``drawers`` and ``closets``), detected ``repair_artifacts``, and
+    ``cleanup`` outcomes. Missing palace paths return the same wrapper
+    shape with unknown per-collection statuses.
     """
     palace_path = palace_path or _get_palace_path()
     collection_name = collection_name or _drawers_collection_name()
@@ -1228,8 +1900,24 @@ def status(palace_path=None, collection_name: Optional[str] = None) -> dict:
 
     if not os.path.isdir(palace_path):
         print("  No palace found.\n")
-        return {"status": "unknown", "message": "no palace at path"}
+        unknown = {
+            "status": "unknown",
+            "message": "no palace at path",
+            "sqlite_count": None,
+            "hnsw_count": None,
+            "divergence": None,
+            "diverged": False,
+        }
+        return {
+            "status": "unknown",
+            "message": "no palace at path",
+            "drawers": unknown,
+            "closets": unknown,
+            "repair_artifacts": {},
+            "cleanup": {},
+        }
 
+    artifacts = _repair_internal_collection_counts(palace_path)
     drawers = hnsw_capacity_status(palace_path, collection_name)
     closets = hnsw_capacity_status(palace_path, CLOSETS_COLLECTION_NAME)
 
@@ -1252,8 +1940,50 @@ def status(palace_path=None, collection_name: Optional[str] = None) -> dict:
 
     if drawers["diverged"] or closets["diverged"]:
         print("\n  Recommended: run `mempalace repair` to rebuild the index.")
+    cleanup_results: dict[str, str] = {}
+    print("\n  [repair artifacts]")
+    if not artifacts:
+        print("    none found")
+    else:
+        for name, count in artifacts.items():
+            print(f"    {name}: {count:,} rows")
+        print("    status:         stale internal temp collection(s)")
+        print(
+            "    note:           live collections are present; temp collections are ignored by recovery"
+        )
+        print(
+            "    cleanup:        mempalace "
+            f"--palace {shlex.quote(palace_path)} repair-status --cleanup-temp --yes"
+        )
+        if cleanup_temp:
+            if not assume_yes:
+                print(
+                    "    cleanup skipped: pass --yes with --cleanup-temp to delete temp collections"
+                )
+            else:
+                cleanup_results = _cleanup_repair_internal_collections(palace_path, artifacts)
+                for name, outcome in cleanup_results.items():
+                    print(f"    cleanup {name}: {outcome}")
+                artifacts = {
+                    name: count
+                    for name, count in artifacts.items()
+                    if cleanup_results.get(name) != "deleted"
+                }
     print()
-    return {"drawers": drawers, "closets": closets}
+    if drawers["diverged"] or closets["diverged"]:
+        status_value = "needs_repair"
+    elif artifacts:
+        status_value = "artifacts"
+    else:
+        status_value = "ok"
+    return {
+        "status": status_value,
+        "message": "",
+        "drawers": drawers,
+        "closets": closets,
+        "repair_artifacts": artifacts,
+        "cleanup": cleanup_results,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -1210,7 +1210,9 @@ def rebuild_index(
                 e = RebuildCollectionError(str(exc), live_replaced=False)
                 progress(f"\n  ERROR during rebuild: {e}")
                 progress("  Rebuild aborted before completion.")
-                progress("  Live collection was not replaced; leaving the original palace untouched.")
+                progress(
+                    "  Live collection was not replaced; leaving the original palace untouched."
+                )
                 raise e
 
             progress("  Rebuilding collection with hnsw:space=cosine...")

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -29,6 +29,8 @@ Usage (from CLI):
     mempalace repair-prune --confirm
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import re
@@ -39,7 +41,6 @@ import sqlite3
 import time
 from dataclasses import dataclass
 from datetime import datetime
-import re
 from typing import Callable, Iterator, Optional
 
 from chromadb.errors import NotFoundError as ChromaNotFoundError
@@ -1118,168 +1119,144 @@ def rebuild_index(
     palace_path = palace_path or _get_palace_path()
     collection_name = collection_name or _drawers_collection_name()
     try:
-        repair_lock = palace_write_lock(palace_path, operation="repair")
-        repair_lock.__enter__()
-    except PalaceWriteAlreadyRunning as exc:
-        print(f"\n  ABORT: {exc}")
-        return
-    lock_released = False
+        with palace_write_lock(palace_path, operation="repair"):
+            if not os.path.isdir(palace_path):
+                progress(f"\n  No palace found at {palace_path}")
+                return
 
-    def _release_repair_lock() -> None:
-        nonlocal lock_released
-        if not lock_released:
-            repair_lock.__exit__(None, None, None)
-            lock_released = True
+            progress(f"\n{'=' * 55}")
+            progress("  MemPalace Repair — Index Rebuild")
+            progress(f"{'=' * 55}\n")
+            progress(f" Palace: {palace_path}")
 
-    if not os.path.isdir(palace_path):
-        progress(f"\n  No palace found at {palace_path}")
-        _release_repair_lock()
-        return
+            # Run the SQLite integrity preflight before any chromadb client open.
+            # ChromaDB's rust binding raises pyo3_runtime.PanicException (which is
+            # not a regular Exception subclass) on a malformed page, propagating
+            # past the try/except around get_collection below. Catching the
+            # corruption here lets us surface the clear recovery instructions and
+            # exit cleanly before chromadb's compactor touches the disk.
+            sqlite_errors = sqlite_integrity_errors(palace_path)
+            if sqlite_errors:
+                print_sqlite_integrity_abort(palace_path, sqlite_errors)
+                return
 
-    progress(f"\n{'=' * 55}")
-    progress("  MemPalace Repair — Index Rebuild")
-    progress(f"{'=' * 55}\n")
-    progress(f" Palace: {palace_path}")
+            preflight = maybe_repair_poisoned_max_seq_id_before_rebuild(
+                palace_path,
+                assume_yes=True,
+            )
+            if preflight is not None:
+                return
 
-    # Run the SQLite integrity preflight before any chromadb client open.
-    # ChromaDB's rust binding raises pyo3_runtime.PanicException (which is
-    # not a regular Exception subclass) on a malformed page, propagating
-    # past the try/except around get_collection below. Catching the
-    # corruption here lets us surface the clear recovery instructions and
-    # exit cleanly before chromadb's compactor touches the disk.
-    sqlite_errors = sqlite_integrity_errors(palace_path)
-    if sqlite_errors:
-        print_sqlite_integrity_abort(palace_path, sqlite_errors)
-        _release_repair_lock()
-        return
-
-    preflight = maybe_repair_poisoned_max_seq_id_before_rebuild(
-        palace_path,
-        assume_yes=True,
-    )
-    if preflight is not None:
-        _release_repair_lock()
-        return
-
-    try:
-        backend = ChromaBackend()
-    except Exception:
-        _release_repair_lock()
-        raise
-    try:
-        col = backend.get_collection(palace_path, collection_name)
-        total = col.count()
-    except Exception as e:
-        progress(f"  Error reading palace: {e}")
-        progress("  Palace may need to be re-mined from source files.")
-        _release_repair_lock()
-        return
-
-    progress(f"  Drawers found: {total}")
-
-    if total == 0:
-        progress("  Nothing to repair.")
-        _release_repair_lock()
-        return
-
-    # Back up BEFORE creating the temp collection. The snapshot must represent
-    # the pre-repair palace, and backup failures must not leave temp HNSW files.
-    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
-    backup_path = sqlite_path + ".backup"
-    if os.path.exists(sqlite_path):
-        try:
-            size_mb = os.path.getsize(sqlite_path) / 1e6
-            progress(f"  Backing up chroma.sqlite3 ({size_mb:.0f} MB)...")
-            shutil.copy2(sqlite_path, backup_path)
-        except Exception:
-            _release_repair_lock()
-            raise
-        progress(f"  Backup: {backup_path}")
-
-    # Stage drawers in batches. Keep batches bounded instead of materializing
-    # the full embedding matrix in Python memory.
-    progress("\n  Extracting drawers...")
-    batch_size = 5000
-    temp_col = None
-    temp_name = None
-    try:
-        temp_col, temp_name, extracted = _stage_collection_from_source(
-            backend,
-            palace_path,
-            col,
-            total,
-            batch_size,
-            collection_name,
-            include_embeddings=not reembed,
-            progress=progress,
-        )
-        progress(f"  Extracted {extracted} drawers")
-
-        # ── #1208 guard ──────────────────────────────────────────────
-        # Refuse to swap when extraction looks short of SQLite ground truth.
-        check_extraction_safety(
-            palace_path,
-            extracted,
-            confirm_truncation_ok,
-            collection_name=collection_name,
-        )
-    except TruncationDetected as e:
-        progress(e.message)
-        if temp_name is not None:
-            _delete_collection_if_exists(backend, palace_path, temp_name)
-        _release_repair_lock()
-        return
-    except Exception as exc:
-        if temp_name is not None:
-            _delete_collection_if_exists(backend, palace_path, temp_name)
-        e = RebuildCollectionError(str(exc), live_replaced=False)
-        progress(f"\n  ERROR during rebuild: {e}")
-        progress("  Rebuild aborted before completion.")
-        progress("  Live collection was not replaced; leaving the original palace untouched.")
-        _release_repair_lock()
-        raise e
-
-    progress("  Rebuilding collection with hnsw:space=cosine...")
-    try:
-        filed = _swap_temp_collection_into_live(
-            backend,
-            palace_path,
-            temp_col,
-            temp_name,
-            collection_name,
-            extracted,
-            progress=progress,
-        )
-    except Exception as exc:
-        e = (
-            exc
-            if isinstance(exc, RebuildCollectionError)
-            else RebuildCollectionError(str(exc), live_replaced=False)
-        )
-        progress(f"\n  ERROR during rebuild: {e}")
-        progress("  Rebuild aborted before completion.")
-        if e.live_replaced and os.path.exists(backup_path):
-            progress(f"  Restoring from backup: {backup_path}")
+            backend = ChromaBackend()
             try:
-                _close_chroma_handles(palace_path, backend=backend)
-                _delete_collection_if_exists(backend, palace_path, temp_name)
-                _delete_collection_if_exists(backend, palace_path, collection_name)
-                shutil.copy2(backup_path, sqlite_path)
-                progress("  Backup restored. Palace is back to pre-repair state.")
-            except Exception as restore_error:
-                progress(f"  Backup restore failed: {restore_error}")
-                progress(f"  Manual restore required from: {backup_path}")
-        elif not e.live_replaced:
-            progress("  Live collection was not replaced; leaving the original palace untouched.")
-        else:
-            progress("  No backup available. Re-mine from source files to recover.")
-        _release_repair_lock()
-        raise e
+                col = backend.get_collection(palace_path, collection_name)
+                total = col.count()
+            except Exception as e:
+                progress(f"  Error reading palace: {e}")
+                progress("  Palace may need to be re-mined from source files.")
+                return
 
-    progress(f"\n  Repair complete. {filed} drawers rebuilt.")
-    progress("  HNSW index is now clean with cosine distance metric.")
-    progress(f"\n{'=' * 55}\n")
-    _release_repair_lock()
+            progress(f"  Drawers found: {total}")
+
+            if total == 0:
+                progress("  Nothing to repair.")
+                return
+
+            # Back up BEFORE creating the temp collection. The snapshot must represent
+            # the pre-repair palace, and backup failures must not leave temp HNSW files.
+            sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+            backup_path = sqlite_path + ".backup"
+            if os.path.exists(sqlite_path):
+                size_mb = os.path.getsize(sqlite_path) / 1e6
+                progress(f"  Backing up chroma.sqlite3 ({size_mb:.0f} MB)...")
+                shutil.copy2(sqlite_path, backup_path)
+                progress(f"  Backup: {backup_path}")
+
+            # Stage drawers in batches. Keep batches bounded instead of materializing
+            # the full embedding matrix in Python memory.
+            progress("\n  Extracting drawers...")
+            batch_size = 5000
+            temp_col = None
+            temp_name = None
+            try:
+                temp_col, temp_name, extracted = _stage_collection_from_source(
+                    backend,
+                    palace_path,
+                    col,
+                    total,
+                    batch_size,
+                    collection_name,
+                    include_embeddings=not reembed,
+                    progress=progress,
+                )
+                progress(f"  Extracted {extracted} drawers")
+
+                # ── #1208 guard ──────────────────────────────────────────────
+                # Refuse to swap when extraction looks short of SQLite ground truth.
+                check_extraction_safety(
+                    palace_path,
+                    extracted,
+                    confirm_truncation_ok,
+                    collection_name=collection_name,
+                )
+            except TruncationDetected as e:
+                progress(e.message)
+                if temp_name is not None:
+                    _delete_collection_if_exists(backend, palace_path, temp_name)
+                return
+            except Exception as exc:
+                if temp_name is not None:
+                    _delete_collection_if_exists(backend, palace_path, temp_name)
+                e = RebuildCollectionError(str(exc), live_replaced=False)
+                progress(f"\n  ERROR during rebuild: {e}")
+                progress("  Rebuild aborted before completion.")
+                progress("  Live collection was not replaced; leaving the original palace untouched.")
+                raise e
+
+            progress("  Rebuilding collection with hnsw:space=cosine...")
+            try:
+                filed = _swap_temp_collection_into_live(
+                    backend,
+                    palace_path,
+                    temp_col,
+                    temp_name,
+                    collection_name,
+                    extracted,
+                    progress=progress,
+                )
+            except Exception as exc:
+                e = (
+                    exc
+                    if isinstance(exc, RebuildCollectionError)
+                    else RebuildCollectionError(str(exc), live_replaced=False)
+                )
+                progress(f"\n  ERROR during rebuild: {e}")
+                progress("  Rebuild aborted before completion.")
+                if e.live_replaced and os.path.exists(backup_path):
+                    progress(f"  Restoring from backup: {backup_path}")
+                    try:
+                        _close_chroma_handles(palace_path, backend=backend)
+                        _delete_collection_if_exists(backend, palace_path, temp_name)
+                        _delete_collection_if_exists(backend, palace_path, collection_name)
+                        shutil.copy2(backup_path, sqlite_path)
+                        progress("  Backup restored. Palace is back to pre-repair state.")
+                    except Exception as restore_error:
+                        progress(f"  Backup restore failed: {restore_error}")
+                        progress(f"  Manual restore required from: {backup_path}")
+                elif not e.live_replaced:
+                    progress(
+                        "  Live collection was not replaced; leaving the original palace untouched."
+                    )
+                else:
+                    progress("  No backup available. Re-mine from source files to recover.")
+                raise e
+
+            progress(f"\n  Repair complete. {filed} drawers rebuilt.")
+            progress("  HNSW index is now clean with cosine distance metric.")
+            progress(f"\n{'=' * 55}\n")
+    except PalaceWriteAlreadyRunning as exc:
+        progress(f"\n  ABORT: {exc}")
+        return
 
 
 class RebuildPartialError(Exception):
@@ -1633,51 +1610,21 @@ def rebuild_from_sqlite(
     print(f"  Source: {source_palace}")
     print(f"  Dest:   {dest_palace}")
 
-    def _source_primary_count() -> "int | None":
-        count = sqlite_drawer_count(source_palace, collection_name)
-        if count == 0:
-            print(f"\n  Source collection {collection_name!r} has no rows; refusing rebuild.")
-        return count
-
     # Validate source BEFORE any destructive moves. An earlier draft
     # archived the dest first and surfaced the missing-chroma.sqlite3
     # error after — leaving the user with a renamed dir to manually undo
     # when the archive itself was empty. Validate first so a user error
     # (--source pointing at a non-palace dir) bails cleanly.
-    if in_place:
-        if not archive_existing_dest:
-            print(
-                "\n  Source and dest are the same path. Pass "
-                "archive_existing_dest=True (CLI: --archive-existing) to move "
-                "the existing palace aside, or pass a different source_palace= "
-                "(CLI: --source)."
-            )
-            _release_repair_locks()
-            return {}
-        if not os.path.isfile(src_db):
-            print(f"\n  Source palace has no chroma.sqlite3 at {src_db}")
-            _release_repair_locks()
-            return {}
-        if _source_primary_count() == 0:
-            _release_repair_locks()
-            return {}
-    else:
-        if not os.path.isfile(src_db):
-            print(f"\n  Source palace has no chroma.sqlite3 at {src_db}")
-            _release_repair_locks()
-            return {}
-        if _source_primary_count() == 0:
-            _release_repair_locks()
-            return {}
-        if os.path.exists(dest_palace):
-            print(
-                f"\n  Refusing to rebuild into existing path: {dest_palace}\n"
-                "  Move it aside, pass a different dest, or set "
-                "archive_existing_dest=True if rebuilding in place "
-                "(source_palace == dest_palace)."
-            )
-            _release_repair_locks()
-            return {}
+    if not _validate_rebuild_from_sqlite_inputs(
+        source_palace,
+        dest_palace,
+        source_db_path=src_db,
+        collection_name=collection_name,
+        in_place=in_place,
+        archive_existing_dest=archive_existing_dest,
+    ):
+        _release_repair_locks()
+        return {}
 
     try:
         recoverable_collections = _recoverable_collection_names(source_palace, collection_name)
@@ -1689,27 +1636,13 @@ def rebuild_from_sqlite(
 
     archive_path: Optional[str] = None
     if in_place:
-        archive_path = _unique_archive_path(dest_palace)
-        print(f"  Archiving {dest_palace} → {archive_path}")
-        shutil.move(dest_palace, archive_path)
-        source_palace = archive_path
-        src_db = os.path.join(source_palace, "chroma.sqlite3")
-
-        # In-place only: drop chromadb's process-wide System registry so
-        # the new client at dest_palace builds a fresh System. Without
-        # this, ``create_collection`` raises "Collection already exists"
-        # because the cached System still holds the pre-rename schema.
-        # Cross-palace mode does not need this and would needlessly
-        # invalidate other callers' clients (see docstring warning).
         try:
-            from chromadb.api.client import SharedSystemClient
-
-            SharedSystemClient.clear_system_cache()
-        except Exception as exc:  # noqa: BLE001
-            print(
-                f"  Warning: could not clear chromadb system cache ({exc!r}); "
-                "in-place rebuild may fail with 'Collection already exists'."
-            )
+            archive_path = _prepare_in_place_rebuild_source(dest_palace)
+            source_palace = archive_path
+            src_db = os.path.join(source_palace, "chroma.sqlite3")
+        except Exception:
+            _release_repair_locks()
+            raise
 
     backend: ChromaBackend | None = None
     counts: dict[str, int] = {}
@@ -1795,6 +1728,73 @@ def rebuild_from_sqlite(
     return counts
 
 
+def _validate_rebuild_from_sqlite_inputs(
+    source_palace: str,
+    dest_palace: str,
+    *,
+    source_db_path: str,
+    collection_name: str,
+    in_place: bool,
+    archive_existing_dest: bool,
+) -> bool:
+    """Return True when the from-SQLite rebuild preflight passes."""
+
+    def _source_primary_count() -> "int | None":
+        count = sqlite_drawer_count(source_palace, collection_name)
+        if count == 0:
+            print(f"\n  Source collection {collection_name!r} has no rows; refusing rebuild.")
+        return count
+
+    if not in_place and os.path.exists(dest_palace):
+        print(
+            f"\n  Refusing to rebuild into existing path: {dest_palace}\n"
+            "  Move it aside, pass a different dest, or set "
+            "archive_existing_dest=True if rebuilding in place "
+            "(source_palace == dest_palace)."
+        )
+        return False
+
+    if in_place and not archive_existing_dest:
+        print(
+            "\n  Source and dest are the same path. Pass "
+            "archive_existing_dest=True (CLI: --archive-existing) to move "
+            "the existing palace aside, or pass a different source_palace= "
+            "(CLI: --source)."
+        )
+        return False
+
+    if not os.path.isfile(source_db_path):
+        print(f"\n  Source palace has no chroma.sqlite3 at {source_db_path}")
+        return False
+
+    return _source_primary_count() != 0
+
+
+def _prepare_in_place_rebuild_source(dest_palace: str) -> str:
+    """Archive ``dest_palace`` and clear the cached Chroma system state."""
+    archive_path = _unique_archive_path(dest_palace)
+    print(f"  Archiving {dest_palace} → {archive_path}")
+    shutil.move(dest_palace, archive_path)
+
+    # In-place only: drop chromadb's process-wide System registry so
+    # the new client at dest_palace builds a fresh System. Without
+    # this, ``create_collection`` raises "Collection already exists"
+    # because the cached System still holds the pre-rename schema.
+    # Cross-palace mode does not need this and would needlessly
+    # invalidate other callers' clients (see docstring warning).
+    try:
+        from chromadb.api.client import SharedSystemClient
+
+        SharedSystemClient.clear_system_cache()
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"  Warning: could not clear chromadb system cache ({exc!r}); "
+            "in-place rebuild may fail with 'Collection already exists'."
+        )
+
+    return archive_path
+
+
 def _unique_archive_path(dest_palace: str) -> str:
     """Return a non-existing in-place rebuild archive path for ``dest_palace``."""
     ts = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
@@ -1823,11 +1823,10 @@ def _repair_internal_collection_counts(palace_path: str) -> dict[str, int]:
             JOIN segments s ON s.collection = c.id
             LEFT JOIN embeddings e ON e.segment_id = s.id
             WHERE s.scope = 'METADATA'
-              AND c.name LIKE ?
+              AND instr(c.name, '__repair_tmp__') > 0
             GROUP BY c.name
             ORDER BY c.name
-            """,
-            ("%__repair_tmp%",),
+            """
         ).fetchall()
         return {
             str(name): int(count)

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -100,6 +100,16 @@ def _get_palace_path():
         return default
 
 
+def _get_collection_name() -> str:
+    """Resolve drawers collection name from config."""
+    try:
+        from .config import get_configured_collection_name
+
+        return get_configured_collection_name()
+    except Exception:
+        return COLLECTION_NAME
+
+
 def _paginate_ids(col, where=None):
     """Pull all IDs in a collection using pagination."""
     ids = []
@@ -1192,8 +1202,6 @@ def rebuild_from_sqlite(
         return counts
     finally:
         backend.close()
-
-
 def status(palace_path=None, collection_name: Optional[str] = None) -> dict:
     """Read-only health check: compare sqlite vs HNSW element counts.
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -821,9 +821,9 @@ def test_make_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeyp
     ChromaBackend.make_client(palace_path)
     ChromaBackend.make_client(palace_path)
 
-    assert calls == [
-        palace_path
-    ], "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
+    assert calls == [palace_path], (
+        "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
+    )
 
 
 def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch):
@@ -852,6 +852,34 @@ def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch)
     ChromaBackend.make_client(palace_path)
 
     assert calls == [palace_path]
+
+
+def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch):
+    """Invalid metadata quarantine runs on each open; stale-HNSW gating is separate."""
+    from mempalace.backends.chroma import ChromaBackend
+
+    palace_path = str(tmp_path / "palace")
+    os.makedirs(palace_path, exist_ok=True)
+    (Path(palace_path) / "chroma.sqlite3").write_text("")
+
+    monkeypatch.setattr(ChromaBackend, "_quarantined_paths", set())
+
+    calls: list[str] = []
+
+    def _invalid(path, *args, **kwargs):
+        calls.append(path)
+        return []
+
+    def _stale(path, stale_seconds=300.0):
+        return []
+
+    monkeypatch.setattr("mempalace.backends.chroma.quarantine_invalid_hnsw_metadata", _invalid)
+    monkeypatch.setattr("mempalace.backends.chroma.quarantine_stale_hnsw", _stale)
+
+    ChromaBackend.make_client(palace_path)
+    ChromaBackend.make_client(palace_path)
+
+    assert calls == [palace_path, palace_path]
 
 
 def test_make_client_quarantines_each_palace_independently(tmp_path, monkeypatch):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -842,9 +842,9 @@ def test_make_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeyp
     ChromaBackend.make_client(palace_path)
     ChromaBackend.make_client(palace_path)
 
-    assert calls == [palace_path], (
-        "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
-    )
+    assert calls == [
+        palace_path
+    ], "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
 
 
 def test_make_client_runs_invalid_metadata_on_each_call(tmp_path, monkeypatch):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,7 +3,9 @@ import pickle
 import shutil
 import sqlite3
 from contextlib import closing
+from contextlib import nullcontext
 from pathlib import Path
+from unittest.mock import patch
 
 import chromadb
 import pytest
@@ -65,6 +67,9 @@ class _FakeCollection:
 
     def delete(self, **kwargs):
         self.calls.append(("delete", kwargs))
+
+    def modify(self, **kwargs):
+        self.calls.append(("modify", kwargs))
 
     def count(self):
         self.calls.append(("count", {}))
@@ -141,11 +146,27 @@ def test_chroma_collection_delegates_writes():
 
     collection.add(documents=["d"], ids=["1"], metadatas=[{"wing": "w"}])
     collection.upsert(documents=["u"], ids=["2"], metadatas=[{"room": "r"}])
+    collection.modify(name="renamed", metadata={"hnsw:space": "cosine"})
     collection.delete(ids=["1"])
     assert collection.count() == 7
 
     kinds = [call[0] for call in fake.calls]
-    assert kinds == ["add", "upsert", "delete", "count"]
+    assert kinds == ["add", "upsert", "modify", "delete", "count"]
+    assert fake.calls[2] == (
+        "modify",
+        {"name": "renamed", "metadata": {"hnsw:space": "cosine"}},
+    )
+
+
+def test_chroma_collection_modify_uses_write_lock():
+    fake = _FakeCollection()
+    collection = ChromaCollection(fake, palace_path="/fake/palace")
+
+    with patch.object(collection, "_write_lock", return_value=nullcontext()) as lock:
+        collection.modify(name="renamed")
+
+    lock.assert_called_once_with()
+    assert fake.calls == [("modify", {"name": "renamed"})]
 
 
 def test_registry_exposes_chroma_by_default():
@@ -826,8 +847,8 @@ def test_make_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeyp
     )
 
 
-def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch):
-    """Invalid metadata quarantine is gated on the first make_client() call."""
+def test_make_client_runs_invalid_metadata_on_each_call(tmp_path, monkeypatch):
+    """Invalid metadata quarantine stays unconditional; stale quarantine is gated."""
     from mempalace.backends.chroma import ChromaBackend
 
     palace_path = str(tmp_path / "palace")
@@ -836,13 +857,15 @@ def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch)
 
     monkeypatch.setattr(ChromaBackend, "_quarantined_paths", set())
 
-    calls: list[str] = []
+    invalid_calls: list[str] = []
+    stale_calls: list[str] = []
 
     def _invalid(path, *args, **kwargs):
-        calls.append(path)
+        invalid_calls.append(path)
         return []
 
     def _stale(path, stale_seconds=300.0):
+        stale_calls.append(path)
         return []
 
     monkeypatch.setattr("mempalace.backends.chroma.quarantine_invalid_hnsw_metadata", _invalid)
@@ -851,7 +874,8 @@ def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch)
     ChromaBackend.make_client(palace_path)
     ChromaBackend.make_client(palace_path)
 
-    assert calls == [palace_path]
+    assert invalid_calls == [palace_path, palace_path]
+    assert stale_calls == [palace_path]
 
 
 def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch):
@@ -1216,6 +1240,7 @@ def test_chroma_backend_stale_quarantine_is_cold_start_only_on_refresh(tmp_path,
         ("invalid", str(palace)),
         ("stale", str(palace)),
         ("blob", str(palace)),
+        ("invalid", str(palace)),
     ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,15 +127,19 @@ def test_confirm_from_sqlite_same_path_without_archive_does_not_prompt(capsys):
 def test_confirm_from_sqlite_canonicalizes_same_path(tmp_path, capsys):
     palace = tmp_path / "palace"
     palace.mkdir()
-    relative_palace = os.path.relpath(palace, Path.cwd())
+    original_cwd = Path.cwd()
+    os.chdir(tmp_path)
 
-    with patch("builtins.input", return_value="y"):
-        confirmed = _confirm_from_sqlite_rebuild(
-            palace_path=relative_palace,
-            source_path=str(palace.resolve()),
-            archive_existing=True,
-            assume_yes=False,
-        )
+    try:
+        with patch("builtins.input", return_value="y"):
+            confirmed = _confirm_from_sqlite_rebuild(
+                palace_path="palace",
+                source_path=str(palace.resolve()),
+                archive_existing=True,
+                assume_yes=False,
+            )
+    finally:
+        os.chdir(original_cwd)
 
     out = capsys.readouterr().out
     assert confirmed is True
@@ -1165,7 +1169,7 @@ def test_cmd_repair_staging_failure_suggests_sqlite_recovery(mock_config_cls, tm
     assert excinfo.value.code == 1
     assert "Live collection was not replaced" in out
     assert (
-        f"mempalace --palace {str(palace_dir)} repair --mode from-sqlite --archive-existing --yes"
+        f"mempalace --palace {shlex.quote(str(palace_dir))} repair --mode from-sqlite --archive-existing --yes"
     ) in out
     assert mock_backend.delete_collection.call_args_list == [
         call(str(palace_dir), ANY),
@@ -1246,6 +1250,29 @@ def test_cmd_repair_releases_write_lock_on_backup_failure(mock_config_cls, tmp_p
     ):
         cmd_repair(args)
 
+    lock.__enter__.assert_called_once_with()
+    lock.__exit__.assert_called_once_with(None, None, None)
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_releases_write_lock_when_backend_init_fails(mock_config_cls, tmp_path):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(palace=None, yes=True)
+    lock = MagicMock()
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.palace.palace_write_lock", return_value=lock),
+        patch("mempalace.backends.chroma.ChromaBackend", side_effect=RuntimeError("init failed")),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cmd_repair(args)
+
+    assert excinfo.value.code == 1
     lock.__enter__.assert_called_once_with()
     lock.__exit__.assert_called_once_with(None, None, None)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,17 +7,19 @@ import sqlite3
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
 from mempalace.cli import (
+    _confirm_from_sqlite_rebuild,
     cmd_compress,
     cmd_hook,
     cmd_init,
     cmd_instructions,
     cmd_mine,
     cmd_repair,
+    cmd_repair_status,
     cmd_search,
     cmd_split,
     cmd_status,
@@ -89,6 +91,71 @@ def test_cli_main_strips_leaked_pythonpath_from_env():
 
 
 # ── cmd_status ─────────────────────────────────────────────────────────
+
+
+def test_confirm_from_sqlite_archive_prompt_names_rename(capsys):
+    with patch("builtins.input", return_value="y"):
+        confirmed = _confirm_from_sqlite_rebuild(
+            palace_path="/palace",
+            source_path="/palace",
+            archive_existing=True,
+            assume_yes=False,
+        )
+
+    out = capsys.readouterr().out
+    assert confirmed is True
+    assert "renamed to <palace>.pre-rebuild-<timestamp>" in out
+    assert "does not copy a backup before the rename" in out
+    assert "A backup will be created first" not in out
+
+
+def test_confirm_from_sqlite_same_path_without_archive_does_not_prompt(capsys):
+    with patch("builtins.input") as input_mock:
+        confirmed = _confirm_from_sqlite_rebuild(
+            palace_path="/palace",
+            source_path="/palace",
+            archive_existing=False,
+            assume_yes=False,
+        )
+
+    out = capsys.readouterr().out
+    assert confirmed is False
+    assert "Pass --archive-existing" in out
+    input_mock.assert_not_called()
+
+
+def test_confirm_from_sqlite_canonicalizes_same_path(tmp_path, capsys):
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    relative_palace = os.path.relpath(palace, Path.cwd())
+
+    with patch("builtins.input", return_value="y"):
+        confirmed = _confirm_from_sqlite_rebuild(
+            palace_path=relative_palace,
+            source_path=str(palace.resolve()),
+            archive_existing=True,
+            assume_yes=False,
+        )
+
+    out = capsys.readouterr().out
+    assert confirmed is True
+    assert "renamed to <palace>.pre-rebuild-<timestamp>" in out
+    assert "destination path already exists" not in out
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_status_forwards_cleanup_flags(mock_config_cls, tmp_path):
+    mock_config_cls.return_value.palace_path = str(tmp_path)
+    args = argparse.Namespace(palace=None, cleanup_temp=True, yes=True)
+
+    with patch("mempalace.repair.status") as repair_status:
+        cmd_repair_status(args)
+
+    repair_status.assert_called_once_with(
+        palace_path=str(tmp_path),
+        cleanup_temp=True,
+        assume_yes=True,
+    )
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -881,13 +948,18 @@ def test_cmd_repair_error_reading(mock_config_cls, tmp_path, capsys):
     sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
     mock_config_cls.return_value.palace_path = str(palace_dir)
     mock_config_cls.return_value.collection_name = "mempalace_drawers"
-    args = argparse.Namespace(palace=None)
+    args = argparse.Namespace(palace=None, yes=True)
     mock_backend = MagicMock()
     mock_backend.get_collection.side_effect = Exception("corrupt db")
-    with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
-        cmd_repair(args)
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            cmd_repair(args)
     out = capsys.readouterr().out
-    assert "Error reading palace" in out
+    assert excinfo.value.code == 1
+    assert "Error reading palace after acquiring repair lock" in out
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -901,10 +973,14 @@ def test_cmd_repair_zero_drawers(mock_config_cls, tmp_path, capsys):
     mock_col = MagicMock()
     mock_col.count.return_value = 0
     mock_backend = _mock_backend_for(col=mock_col)
-    with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
+    with (
+        patch("mempalace.repair.sqlite_drawer_count", return_value=0),
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+    ):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "Nothing to repair" in out
+    mock_backend.get_collection.assert_not_called()
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -921,26 +997,25 @@ def test_cmd_repair_success(mock_config_cls, tmp_path, capsys):
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
-    mock_new_col = MagicMock()
-    mock_new_col.count.return_value = 2
-    mock_backend = _mock_backend_for(col=mock_col, new_col=mock_new_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    mock_backend = _mock_backend_for(col=mock_col)
+    mock_backend.create_collection.return_value = mock_temp_col
     with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
         cmd_repair(args)
     out = capsys.readouterr().out
     assert "Repair complete" in out
     assert "2 drawers rebuilt" in out
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(palace_dir), "mempalace_drawers__repair_tmp"),
+        call(str(palace_dir), ANY),
         call(str(palace_dir), "mempalace_drawers"),
-        call(str(palace_dir), "mempalace_drawers__repair_tmp"),
+        call(str(palace_dir), ANY),
     ]
     mock_temp_col.upsert.assert_called_once()
-    mock_new_col.upsert.assert_called_once()
-    mock_new_col.add.assert_not_called()
+    mock_temp_col.modify.assert_called_once_with(name="mempalace_drawers")
+    mock_temp_col.add.assert_not_called()
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -957,29 +1032,29 @@ def test_cmd_repair_uses_configured_collection(mock_config_cls, tmp_path, capsys
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
-    mock_new_col = MagicMock()
-    mock_new_col.count.return_value = 2
-    mock_backend = _mock_backend_for(col=mock_col, new_col=mock_new_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    mock_backend = _mock_backend_for(col=mock_col)
+    mock_backend.create_collection.return_value = mock_temp_col
 
     with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
         cmd_repair(args)
 
     out = capsys.readouterr().out
     assert "Repair complete" in out
-    mock_backend.get_collection.assert_called_once_with(str(palace_dir), "custom_drawers")
-    assert mock_backend.create_collection.call_args_list == [
-        call(str(palace_dir), "custom_drawers__repair_tmp"),
+    assert mock_backend.get_collection.call_args_list == [
+        call(str(palace_dir), "custom_drawers"),
         call(str(palace_dir), "custom_drawers"),
     ]
+    assert mock_backend.create_collection.call_args_list == [call(str(palace_dir), ANY)]
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(palace_dir), "custom_drawers__repair_tmp"),
+        call(str(palace_dir), ANY),
         call(str(palace_dir), "custom_drawers"),
-        call(str(palace_dir), "custom_drawers__repair_tmp"),
+        call(str(palace_dir), ANY),
     ]
+    mock_temp_col.modify.assert_called_once_with(name="custom_drawers")
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -996,12 +1071,17 @@ def test_cmd_repair_restores_backup_on_live_rebuild_failure(mock_config_cls, tmp
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
+    mock_temp_col.modify.side_effect = RuntimeError("live rename failed")
     mock_backend = _mock_backend_for(col=mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, RuntimeError("live build failed")]
-    with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
+    mock_backend.create_collection.return_value = mock_temp_col
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+    ):
         with pytest.raises(SystemExit) as excinfo:
             cmd_repair(args)
     out = capsys.readouterr().out
@@ -1010,10 +1090,231 @@ def test_cmd_repair_restores_backup_on_live_rebuild_failure(mock_config_cls, tmp
     assert "restoring from backup" in out
     mock_backend.close_palace.assert_called_once_with(str(palace_dir))
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(palace_dir), "mempalace_drawers__repair_tmp"),
+        call(str(palace_dir), ANY),
         call(str(palace_dir), "mempalace_drawers"),
-        call(str(palace_dir), "mempalace_drawers__repair_tmp"),
+        call(str(palace_dir), ANY),
     ]
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_pre_swap_delete_failure_does_not_restore_backup(
+    mock_config_cls, tmp_path, capsys
+):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(palace=None, yes=True)
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_col.get.return_value = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+    }
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 2
+    mock_backend = _mock_backend_for(col=mock_col)
+    mock_backend.create_collection.return_value = mock_temp_col
+    mock_backend.delete_collection.side_effect = [
+        None,
+        RuntimeError("delete failed before live replacement"),
+    ]
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            cmd_repair(args)
+
+    out = capsys.readouterr().out
+    assert excinfo.value.code == 1
+    assert "Repair failed" in out
+    assert "restoring from backup" not in out
+    mock_backend.close_palace.assert_not_called()
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_staging_failure_suggests_sqlite_recovery(mock_config_cls, tmp_path, capsys):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(palace=None, yes=True)
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_col.get.side_effect = RuntimeError(
+        "Error executing plan: Internal error: Error finding id"
+    )
+    mock_temp_col = MagicMock()
+    mock_backend = _mock_backend_for(col=mock_col)
+    mock_backend.create_collection.return_value = mock_temp_col
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            cmd_repair(args)
+
+    out = capsys.readouterr().out
+    assert excinfo.value.code == 1
+    assert "Live collection was not replaced" in out
+    assert (
+        f"mempalace --palace {str(palace_dir)} repair --mode from-sqlite --archive-existing --yes"
+    ) in out
+    assert mock_backend.delete_collection.call_args_list == [
+        call(str(palace_dir), ANY),
+        call(str(palace_dir), ANY),
+    ]
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_refuses_when_write_lock_active(mock_config_cls, tmp_path, capsys):
+    from mempalace.palace import PalaceWriteAlreadyRunning
+
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(palace=None, yes=True)
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.palace.palace_write_lock", side_effect=PalaceWriteAlreadyRunning("busy")),
+        patch("mempalace.backends.chroma.ChromaBackend") as backend_cls,
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cmd_repair(args)
+
+    out = capsys.readouterr().out
+    assert excinfo.value.code == 1
+    assert "ABORT: busy" in out
+    backend_cls.assert_not_called()
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_does_not_take_write_lock_when_confirmation_aborts(mock_config_cls, tmp_path):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(palace=None, yes=False)
+    lock = MagicMock()
+    mock_col = MagicMock()
+    mock_col.count.return_value = 1
+    mock_backend = _mock_backend_for(col=mock_col)
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.palace.palace_write_lock", return_value=lock),
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+        patch("builtins.input", return_value="n"),
+    ):
+        cmd_repair(args)
+
+    lock.__enter__.assert_not_called()
+    lock.__exit__.assert_not_called()
+    mock_backend.create_collection.assert_not_called()
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_releases_write_lock_on_backup_failure(mock_config_cls, tmp_path):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(palace=None, yes=True)
+    lock = MagicMock()
+    mock_col = MagicMock()
+    mock_col.count.return_value = 1
+    mock_backend = _mock_backend_for(col=mock_col)
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.palace.palace_write_lock", return_value=lock),
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+        patch("shutil.copytree", side_effect=OSError("copy failed")),
+        pytest.raises(OSError, match="copy failed"),
+    ):
+        cmd_repair(args)
+
+    lock.__enter__.assert_called_once_with()
+    lock.__exit__.assert_called_once_with(None, None, None)
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_forwards_audit_content_when_present(mock_config_cls, tmp_path):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    mock_config_cls.return_value.palace_path = str(dest)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(
+        palace=None,
+        mode="from-sqlite",
+        source=str(source),
+        archive_existing=False,
+        reembed=False,
+        batch_size=5000,
+        audit_content=True,
+        yes=True,
+    )
+
+    with patch(
+        "mempalace.repair.rebuild_from_sqlite", return_value={"mempalace_drawers": 1}
+    ) as rebuild:
+        cmd_repair(args)
+
+    assert rebuild.call_args.kwargs["audit_content"] is True
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_rejects_audit_content_outside_from_sqlite(mock_config_cls, tmp_path, capsys):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(
+        palace=None,
+        mode="legacy",
+        audit_content=True,
+        yes=True,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_repair(args)
+
+    assert excinfo.value.code == 1
+    assert "--audit-content is only supported with --mode from-sqlite" in capsys.readouterr().out
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_rejects_audit_content_in_max_seq_id_mode(mock_config_cls, tmp_path, capsys):
+    mock_config_cls.return_value.palace_path = str(tmp_path / "palace")
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(
+        palace=None,
+        mode="max-seq-id",
+        audit_content=True,
+        segment=None,
+        from_sidecar=None,
+        backup=True,
+        dry_run=False,
+        yes=True,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_repair(args)
+
+    assert excinfo.value.code == 1
+    assert "--audit-content is only supported with --mode from-sqlite" in capsys.readouterr().out
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -1035,6 +1336,146 @@ def test_cmd_repair_aborts_without_confirmation(mock_config_cls, tmp_path, capsy
     out = capsys.readouterr().out
     assert "Aborted." in out
     mock_backend.create_collection.assert_not_called()
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_from_sqlite_uses_configured_collection(mock_config_cls, tmp_path):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    mock_config_cls.return_value.palace_path = str(dest)
+    mock_config_cls.return_value.collection_name = "custom_drawers"
+    args = argparse.Namespace(
+        palace=None,
+        mode="from-sqlite",
+        source=str(source),
+        archive_existing=False,
+        reembed=False,
+        batch_size=5000,
+        yes=True,
+    )
+
+    with patch(
+        "mempalace.repair.rebuild_from_sqlite", return_value={"custom_drawers": 1}
+    ) as rebuild:
+        cmd_repair(args)
+
+    rebuild.assert_called_once_with(
+        source_palace=str(source),
+        dest_palace=str(dest),
+        archive_existing_dest=False,
+        collection_name="custom_drawers",
+        reembed=False,
+        batch_size=5000,
+    )
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_from_sqlite_empty_result_exits_nonzero(mock_config_cls, tmp_path):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    mock_config_cls.return_value.palace_path = str(dest)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(
+        palace=None,
+        mode="from-sqlite",
+        source=str(source),
+        archive_existing=False,
+        reembed=False,
+        batch_size=5000,
+        yes=True,
+    )
+
+    with (
+        patch("mempalace.repair.rebuild_from_sqlite", return_value={}),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cmd_repair(args)
+
+    assert excinfo.value.code == 1
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_from_sqlite_zero_primary_collection_exits_nonzero(mock_config_cls, tmp_path):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    mock_config_cls.return_value.palace_path = str(dest)
+    mock_config_cls.return_value.collection_name = "custom_drawers"
+    args = argparse.Namespace(
+        palace=None,
+        mode="from-sqlite",
+        source=str(source),
+        archive_existing=False,
+        reembed=False,
+        batch_size=5000,
+        yes=True,
+    )
+
+    with (
+        patch(
+            "mempalace.repair.rebuild_from_sqlite",
+            return_value={"custom_drawers": 0, "mempalace_closets": 1},
+        ),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cmd_repair(args)
+
+    assert excinfo.value.code == 1
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_from_sqlite_refused_preflight_exits_nonzero(mock_config_cls, tmp_path, capsys):
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").write_text("db")
+    mock_config_cls.return_value.palace_path = str(palace)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(
+        palace=None,
+        mode="from-sqlite",
+        source=None,
+        archive_existing=False,
+        reembed=False,
+        batch_size=5000,
+        yes=False,
+    )
+
+    with (
+        patch("mempalace.repair.rebuild_from_sqlite") as rebuild,
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cmd_repair(args)
+
+    out = capsys.readouterr().out
+    assert excinfo.value.code == 1
+    assert "Pass --archive-existing" in out
+    rebuild.assert_not_called()
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_from_sqlite_setup_exception_exits_nonzero(mock_config_cls, tmp_path, capsys):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    mock_config_cls.return_value.palace_path = str(dest)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(
+        palace=None,
+        mode="from-sqlite",
+        source=str(source),
+        archive_existing=False,
+        reembed=False,
+        batch_size=5000,
+        yes=True,
+    )
+
+    with (
+        patch("mempalace.repair.rebuild_from_sqlite", side_effect=OSError("move failed")),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cmd_repair(args)
+
+    out = capsys.readouterr().out
+    assert excinfo.value.code == 1
+    assert "Rebuild failed: move failed" in out
 
 
 # ── cmd_compress ───────────────────────────────────────────────────────
@@ -1350,4 +1791,30 @@ def test_cmd_repair_from_sqlite_success_does_not_exit(mock_config_cls, tmp_path)
     fake_counts = {"mempalace_drawers": 0, "mempalace_closets": 0}
     with patch("mempalace.repair.rebuild_from_sqlite", return_value=fake_counts):
         # Should return cleanly; no SystemExit raised.
+        cmd_repair(args)
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_from_sqlite_empty_custom_primary_success_does_not_exit(
+    mock_config_cls, tmp_path
+):
+    """A legitimately empty rebuild must also succeed when the configured
+    primary drawers collection uses a non-default name."""
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    mock_config_cls.return_value.palace_path = str(dest)
+    mock_config_cls.return_value.collection_name = "custom_drawers"
+
+    args = argparse.Namespace(
+        palace=None,
+        mode="from-sqlite",
+        source=str(source),
+        archive_existing=False,
+        reembed=False,
+        batch_size=5000,
+        yes=True,
+    )
+
+    fake_counts = {"custom_drawers": 0, "mempalace_closets": 0}
+    with patch("mempalace.repair.rebuild_from_sqlite", return_value=fake_counts):
         cmd_repair(args)

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -904,9 +904,9 @@ class TestTunnels:
 
         assert not errors, f"worker raised: {errors}"
         tunnels = list_tunnels()
-        assert len(tunnels) == 5, (
-            f"expected 5 concurrent tunnels, got {len(tunnels)} — " "write race dropped some"
-        )
+        assert (
+            len(tunnels) == 5
+        ), f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
 
     def test_created_at_is_timezone_aware(self):
         """Regression: created_at must be tz-aware UTC, not naive."""

--- a/tests/test_corpus_origin_integration.py
+++ b/tests/test_corpus_origin_integration.py
@@ -177,9 +177,9 @@ def test_corpus_origin_reclassifies_personas(
 
     # All three personas land in the new bucket.
     expected_personas = {"Echo", "Sparrow", "Cipher"}
-    assert expected_personas <= persona_names_in_bucket, (
-        f"Expected all three personas in agent_personas, got: " f"{persona_names_in_bucket}"
-    )
+    assert (
+        expected_personas <= persona_names_in_bucket
+    ), f"Expected all three personas in agent_personas, got: {persona_names_in_bucket}"
 
     # And NONE of them remain in the people bucket.
     leaked = expected_personas & persona_names_in_people
@@ -292,10 +292,9 @@ def test_init_pass_zero_writes_origin_json_to_palace(ai_dialogue_corpus: Path, t
     assert "result" in data, "origin.json must wrap the CorpusOriginResult under 'result'"
     assert isinstance(data["result"].get("likely_ai_dialogue"), bool)
     # Fixture is heavy AI-dialogue — heuristic should classify as such.
-    assert data["result"]["likely_ai_dialogue"] is True, (
-        "Heuristic should classify the AI-dialogue fixture as AI-dialogue. "
-        f"Got: {data['result']}"
-    )
+    assert (
+        data["result"]["likely_ai_dialogue"] is True
+    ), f"Heuristic should classify the AI-dialogue fixture as AI-dialogue. Got: {data['result']}"
 
 
 def test_init_pass_zero_passes_corpus_origin_to_discover_entities(
@@ -1614,20 +1613,19 @@ def test_merge_tier_fields_heuristic_yes_llm_yes_combines_evidence():
     ), f"LLM evidence string missing from merged result. Got: {res['evidence']}"
     # Heuristic always produces at least one evidence line for AI-dialogue
     # input (brand-term match), so the combined list has more than just LLM's.
-    assert len(res["evidence"]) >= 2, (
-        f"Combined evidence should include both heuristic + LLM lines. " f"Got: {res['evidence']}"
-    )
+    assert (
+        len(res["evidence"]) >= 2
+    ), f"Combined evidence should include both heuristic + LLM lines. Got: {res['evidence']}"
     # Each entry must carry its tier prefix so on-disk origin.json is
     # auditable — readers can tell which tier produced which signal line.
     tier1_lines = [e for e in res["evidence"] if e.startswith("Tier-1 heuristic: ")]
     tier2_lines = [e for e in res["evidence"] if e.startswith("Tier-2 LLM: ")]
-    assert tier1_lines, (
-        f"Expected at least one 'Tier-1 heuristic: ' prefixed evidence line. "
-        f"Got: {res['evidence']}"
-    )
-    assert tier2_lines, (
-        f"Expected at least one 'Tier-2 LLM: ' prefixed evidence line. " f"Got: {res['evidence']}"
-    )
+    assert (
+        tier1_lines
+    ), f"Expected at least one 'Tier-1 heuristic: ' prefixed evidence line. Got: {res['evidence']}"
+    assert (
+        tier2_lines
+    ), f"Expected at least one 'Tier-2 LLM: ' prefixed evidence line. Got: {res['evidence']}"
     # Every entry should be tier-prefixed (no untagged passthrough).
     untagged = [
         e
@@ -1758,9 +1756,9 @@ def test_init_prints_privacy_warning_when_provider_is_external(
         cmd_init(args)
 
     out = capsys.readouterr().out
-    assert "EXTERNAL API" in out, (
-        f"Privacy warning must mention 'EXTERNAL API' when provider is external. " f"Got: {out!r}"
-    )
+    assert (
+        "EXTERNAL API" in out
+    ), f"Privacy warning must mention 'EXTERNAL API' when provider is external. Got: {out!r}"
     assert (
         "--no-llm" in out
     ), f"Privacy warning must point users at --no-llm to opt out. Got: {out!r}"
@@ -1803,9 +1801,9 @@ def test_init_no_privacy_warning_when_provider_is_local(
         cmd_init(args)
 
     out = capsys.readouterr().out
-    assert "EXTERNAL API" not in out, (
-        f"Privacy warning fired for a LOCAL provider — should not have. " f"Got: {out!r}"
-    )
+    assert (
+        "EXTERNAL API" not in out
+    ), f"Privacy warning fired for a LOCAL provider — should not have. Got: {out!r}"
 
 
 def test_init_no_privacy_warning_with_no_llm_flag(ai_dialogue_corpus: Path, tmp_path: Path, capsys):

--- a/tests/test_hybrid_candidate_union.py
+++ b/tests/test_hybrid_candidate_union.py
@@ -78,10 +78,9 @@ class TestCandidateUnion:
         _seed_drawers(palace)
         result = search_memories(_NARRATIVE_QUERY, palace, n_results=5, candidate_strategy="union")
         ids = [h["source_file"] for h in result["results"]]
-        assert "brand_voice_D4.md" in ids, (
-            "union mode must surface BM25-strong docs even when vector signal "
-            f"is weak; got {ids}"
-        )
+        assert (
+            "brand_voice_D4.md" in ids
+        ), f"union mode must surface BM25-strong docs even when vector signal is weak; got {ids}"
 
     def test_union_preserves_vector_hits(self, tmp_path):
         """Union mode must not drop docs that vector-only mode finds —

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -650,9 +650,9 @@ class TestWriteTools:
 
         assert result1["success"] is True
         assert result2["success"] is True
-        assert (
-            result1["drawer_id"] != result2["drawer_id"]
-        ), "Documents with shared header but different content must have distinct drawer IDs"
+        assert result1["drawer_id"] != result2["drawer_id"], (
+            "Documents with shared header but different content must have distinct drawer IDs"
+        )
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -687,9 +687,9 @@ class TestWriteTools:
 
         assert result1["success"] is True
         assert result2["success"] is True
-        assert result1["drawer_id"] != result2["drawer_id"], (
-            "Documents with shared header but different content must have distinct drawer IDs"
-        )
+        assert (
+            result1["drawer_id"] != result2["drawer_id"]
+        ), "Documents with shared header but different content must have distinct drawer IDs"
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
@@ -727,6 +727,34 @@ class TestWriteTools:
 
         result = tool_delete_drawer("nonexistent_drawer")
         assert result["success"] is False
+
+    def test_create_tunnel_lock_refusal_uses_error_shape(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(
+            mcp_server,
+            "palace_write_lock",
+            MagicMock(side_effect=mcp_server.PalaceWriteAlreadyRunning("busy")),
+        )
+
+        result = mcp_server.tool_create_tunnel("a", "r1", "b", "r2")
+
+        assert result == {"error": "busy", "code": "palace_write_lock_active"}
+
+    def test_delete_tunnel_lock_refusal_uses_error_shape(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(
+            mcp_server,
+            "palace_write_lock",
+            MagicMock(side_effect=mcp_server.PalaceWriteAlreadyRunning("busy")),
+        )
+
+        result = mcp_server.tool_delete_tunnel("tunnel-1")
+
+        assert result == {"error": "busy", "code": "palace_write_lock_active"}
 
     def test_check_duplicate_handles_none_metadata(self, monkeypatch, config, kg):
         """tool_check_duplicate must tolerate None entries in the result lists

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -12,6 +12,8 @@ import os
 import subprocess
 import sys
 from unittest.mock import MagicMock
+import threading
+import time
 
 import pytest
 
@@ -631,6 +633,41 @@ class TestWriteTools:
         assert result["success"] is False
         assert "not readable" in result["error"]
 
+    def test_add_drawer_waits_when_palace_write_lock_active(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+        from mempalace.palace import palace_write_lock
+
+        class _FakeGetResult:
+            def __init__(self, ids=None):
+                self.ids = ids or []
+
+        class _FakeCol:
+            written = False
+
+            def get(self, **kwargs):
+                return _FakeGetResult(["drawer"]) if self.written else _FakeGetResult()
+
+            def upsert(self, **kwargs):
+                self.written = True
+
+        palace = config.palace_path
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda create=False: _FakeCol())
+        result_box = {}
+
+        with palace_write_lock(palace, operation="repair"):
+            thread = threading.Thread(
+                target=lambda: result_box.setdefault(
+                    "result", mcp_server.tool_add_drawer("w", "r", "content")
+                )
+            )
+            thread.start()
+            time.sleep(0.1)
+            assert result_box == {}
+
+        thread.join(timeout=2)
+        assert result_box["result"]["success"] is True
+
     def test_add_drawer_shared_header_no_collision(self, monkeypatch, config, palace_path, kg):
         """Documents sharing a >100-char header must get distinct IDs (full-content hash)."""
         _patch_mcp_server(monkeypatch, config, kg)
@@ -660,6 +697,28 @@ class TestWriteTools:
 
         result = tool_delete_drawer("drawer_proj_backend_aaa")
         assert result["success"] is True
+        assert seeded_collection.count() == 3
+
+    def test_delete_drawer_waits_when_palace_write_lock_active(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_delete_drawer
+        from mempalace.palace import palace_write_lock
+
+        result_box = {}
+        with palace_write_lock(palace_path, operation="repair"):
+            thread = threading.Thread(
+                target=lambda: result_box.setdefault(
+                    "result", tool_delete_drawer("drawer_proj_backend_aaa")
+                )
+            )
+            thread.start()
+            time.sleep(0.1)
+            assert result_box == {}
+
+        thread.join(timeout=3)
+        assert result_box["result"]["success"] is True
         assert seeded_collection.count() == 3
 
     def test_delete_drawer_not_found(self, monkeypatch, config, palace_path, seeded_collection, kg):
@@ -898,6 +957,25 @@ class TestKGTools:
             valid_from="2025-01-01",
         )
         assert result["success"] is True
+
+    def test_kg_add_waits_when_palace_write_lock_active(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_kg_add
+        from mempalace.palace import palace_write_lock
+
+        result_box = {}
+        with palace_write_lock(palace_path, operation="repair"):
+            thread = threading.Thread(
+                target=lambda: result_box.setdefault(
+                    "result", tool_kg_add("Alice", "likes", "coffee")
+                )
+            )
+            thread.start()
+            time.sleep(0.1)
+            assert result_box == {}
+
+        thread.join(timeout=2)
+        assert result_box["result"]["success"] is True
 
     def test_kg_query(self, monkeypatch, config, palace_path, seeded_kg):
         _patch_mcp_server(monkeypatch, config, seeded_kg)
@@ -1282,6 +1360,27 @@ class TestDiaryTools:
         assert r["total"] == 1
         assert r["entries"][0]["topic"] == "architecture"
         assert "authentication" in r["entries"][0]["content"]
+
+    def test_diary_write_waits_when_palace_write_lock_active(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_diary_write
+        from mempalace.palace import palace_write_lock
+
+        result_box = {}
+        with palace_write_lock(palace_path, operation="repair"):
+            thread = threading.Thread(
+                target=lambda: result_box.setdefault(
+                    "result", tool_diary_write("TestAgent", "SESSION:test", topic="status")
+                )
+            )
+            thread.start()
+            time.sleep(0.1)
+            assert result_box == {}
+
+        thread.join(timeout=3)
+        assert result_box["result"]["success"] is True
 
     def test_diary_read_empty(self, monkeypatch, config, palace_path, kg):
         _patch_mcp_server(monkeypatch, config, kg)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -207,20 +207,31 @@ def test_migrate_dry_run_rebuilds_when_collection_is_readable_but_not_writable(t
     assert "DRY RUN" in out
 
 
-def test_migrate_confirmation_abort_skips_live_write_probe(tmp_path, capsys):
+def test_migrate_confirmation_abort_skips_rebuild_when_probe_fails(tmp_path, capsys):
     palace_dir = tmp_path / "palace"
     palace_dir.mkdir()
     (palace_dir / "chroma.sqlite3").write_text("db")
 
     fake_col = MagicMock()
     fake_col.count.return_value = 102
+    drawers = [
+        {
+            "id": "id1",
+            "document": "hello",
+            "metadata": {"wing": "test-wing", "room": "general"},
+        }
+    ]
 
     with (
         patch("mempalace.migrate.detect_chromadb_version", return_value="1.x"),
         patch("mempalace.backends.chroma.ChromaBackend") as mock_backend,
-        patch("mempalace.migrate.collection_write_roundtrip_works") as mock_probe,
+        patch(
+            "mempalace.migrate.collection_write_roundtrip_works", return_value=False
+        ) as mock_probe,
         patch("builtins.input", return_value="n"),
-        patch("mempalace.migrate.extract_drawers_from_sqlite") as mock_extract,
+        patch(
+            "mempalace.migrate.extract_drawers_from_sqlite", return_value=drawers
+        ) as mock_extract,
         patch("mempalace.migrate.shutil.copytree") as mock_copytree,
     ):
         mock_backend.backend_version.return_value = "1.5.8"
@@ -232,9 +243,42 @@ def test_migrate_confirmation_abort_skips_live_write_probe(tmp_path, capsys):
 
     assert result is False
     assert "Aborted." in out
-    mock_probe.assert_not_called()
-    mock_extract.assert_not_called()
+    mock_probe.assert_called_once_with(fake_col)
+    mock_extract.assert_called_once_with(
+        os.path.join(os.path.abspath(os.fspath(palace_dir)), "chroma.sqlite3")
+    )
     mock_copytree.assert_not_called()
+
+
+def test_migrate_healthy_readable_palace_returns_success_without_confirmation(tmp_path, capsys):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_text("db")
+
+    fake_col = MagicMock()
+    fake_col.count.return_value = 102
+
+    with (
+        patch("mempalace.migrate.detect_chromadb_version", return_value="1.x"),
+        patch("mempalace.backends.chroma.ChromaBackend") as mock_backend,
+        patch(
+            "mempalace.migrate.collection_write_roundtrip_works", return_value=True
+        ) as mock_probe,
+        patch("mempalace.migrate.confirm_destructive_action") as confirm_action,
+        patch("mempalace.migrate.extract_drawers_from_sqlite") as mock_extract,
+    ):
+        mock_backend.backend_version.return_value = "1.5.8"
+        mock_backend.return_value.get_collection.return_value = fake_col
+
+        result = migrate(str(palace_dir))
+
+    out = capsys.readouterr().out
+
+    assert result is True
+    mock_probe.assert_called_once_with(fake_col)
+    confirm_action.assert_not_called()
+    mock_extract.assert_not_called()
+    assert "No migration needed." in out
 
 
 def test_drop_migrate_probe_drawers_filters_synthetic_probe_rows():
@@ -249,6 +293,11 @@ def test_drop_migrate_probe_drawers_filters_synthetic_probe_rows():
             "document": "real",
             "metadata": {"source_file": "notes.md"},
         },
+        {
+            "id": "real-user-drawer",
+            "document": "user content",
+            "metadata": {"source_file": "mempalace_migrate_probe"},
+        },
     ]
 
     filtered = _drop_migrate_probe_drawers(drawers)
@@ -258,5 +307,10 @@ def test_drop_migrate_probe_drawers_filters_synthetic_probe_rows():
             "id": "real-drawer",
             "document": "real",
             "metadata": {"source_file": "notes.md"},
-        }
+        },
+        {
+            "id": "real-user-drawer",
+            "document": "user content",
+            "metadata": {"source_file": "mempalace_migrate_probe"},
+        },
     ]

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -4,7 +4,12 @@ import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from mempalace.migrate import collection_write_roundtrip_works, _restore_stale_palace, migrate
+from mempalace.migrate import (
+    _drop_migrate_probe_drawers,
+    _restore_stale_palace,
+    collection_write_roundtrip_works,
+    migrate,
+)
 
 
 def test_migrate_requires_palace_database(tmp_path, capsys):
@@ -191,12 +196,67 @@ def test_migrate_dry_run_rebuilds_when_collection_is_readable_but_not_writable(t
     out = capsys.readouterr().out
 
     assert result is True
-    mock_probe.assert_called_once_with(fake_col)
+    mock_probe.assert_not_called()
     mock_extract.assert_called_once_with(
         os.path.join(os.path.abspath(os.fspath(palace_dir)), "chroma.sqlite3")
     )
 
-    assert "readable by chromadb 1.5.8, but write/delete verification failed" in out
-    assert "Rebuilding from SQLite" in out
+    assert "Palace is readable by chromadb 1.5.8." in out
+    assert "DRY RUN skips live write/delete verification." in out
     assert "Extracted 1 drawers from SQLite" in out
     assert "DRY RUN" in out
+
+
+def test_migrate_confirmation_abort_skips_live_write_probe(tmp_path, capsys):
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "chroma.sqlite3").write_text("db")
+
+    fake_col = MagicMock()
+    fake_col.count.return_value = 102
+
+    with (
+        patch("mempalace.migrate.detect_chromadb_version", return_value="1.x"),
+        patch("mempalace.backends.chroma.ChromaBackend") as mock_backend,
+        patch("mempalace.migrate.collection_write_roundtrip_works") as mock_probe,
+        patch("builtins.input", return_value="n"),
+        patch("mempalace.migrate.extract_drawers_from_sqlite") as mock_extract,
+        patch("mempalace.migrate.shutil.copytree") as mock_copytree,
+    ):
+        mock_backend.backend_version.return_value = "1.5.8"
+        mock_backend.return_value.get_collection.return_value = fake_col
+
+        result = migrate(str(palace_dir))
+
+    out = capsys.readouterr().out
+
+    assert result is False
+    assert "Aborted." in out
+    mock_probe.assert_not_called()
+    mock_extract.assert_not_called()
+    mock_copytree.assert_not_called()
+
+
+def test_drop_migrate_probe_drawers_filters_synthetic_probe_rows():
+    drawers = [
+        {
+            "id": "_mempalace_migrate_probe_deadbeef",
+            "document": "probe",
+            "metadata": {"source_file": "mempalace_migrate_probe"},
+        },
+        {
+            "id": "real-drawer",
+            "document": "real",
+            "metadata": {"source_file": "notes.md"},
+        },
+    ]
+
+    filtered = _drop_migrate_probe_drawers(drawers)
+
+    assert filtered == [
+        {
+            "id": "real-drawer",
+            "document": "real",
+            "metadata": {"source_file": "notes.md"},
+        }
+    ]

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1336,11 +1336,7 @@ class TestStripNoiseRemovesSystemChrome:
 
     def test_strips_line_anchored_system_reminder_block(self):
         text = (
-            "> User:\n"
-            "<system-reminder>\n"
-            "Auto-save reminder...\n"
-            "</system-reminder>\n"
-            "> Real message."
+            "> User:\n<system-reminder>\nAuto-save reminder...\n</system-reminder>\n> Real message."
         )
         out = strip_noise(text)
         assert "system-reminder" not in out
@@ -1350,7 +1346,7 @@ class TestStripNoiseRemovesSystemChrome:
     def test_strips_system_reminder_with_blockquote_prefix(self):
         # _messages_to_transcript prefixes lines with "> ", so the line
         # anchor must also accept that shape.
-        text = "> User:\n" "> <system-reminder>Injected noise</system-reminder>\n" "> Real message."
+        text = "> User:\n> <system-reminder>Injected noise</system-reminder>\n> Real message."
         out = strip_noise(text)
         assert "Injected noise" not in out
         assert "Real message." in out

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -11,14 +11,17 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import threading
 import time
 
 import pytest
 
 from mempalace.palace import (
     MineAlreadyRunning,
+    PalaceWriteAlreadyRunning,
     mine_global_lock,
     mine_palace_lock,
+    palace_write_lock,
 )
 
 
@@ -310,3 +313,107 @@ def test_mine_global_lock_is_alias_for_back_compat(tmp_path, monkeypatch):
     assert mine_global_lock is mine_palace_lock
     with mine_global_lock(str(tmp_path / "palace")):
         pass  # the alias accepts the same palace_path argument
+
+
+def test_mine_lock_conflicts_with_shared_writer_lock(tmp_path, monkeypatch):
+    """Repair and mine must share the same per-palace write boundary."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    palace = str(tmp_path / "palace")
+    result_box = {}
+
+    with palace_write_lock(palace, operation="repair"):
+        thread = threading.Thread(
+            target=lambda: result_box.setdefault(
+                "result",
+                "busy"
+                if _raises_mine_busy(palace)
+                else "free",
+            )
+        )
+        thread.start()
+        thread.join(timeout=2)
+
+    assert result_box["result"] == "busy"
+
+
+def _raises_mine_busy(palace_path: str) -> bool:
+    try:
+        with mine_palace_lock(palace_path):
+            return False
+    except MineAlreadyRunning:
+        return True
+
+
+def test_shared_writer_lock_conflicts_with_mine_lock(tmp_path, monkeypatch):
+    """The compatibility mine lock must block generic palace writers too."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    palace = str(tmp_path / "palace")
+    result_box = {}
+
+    with mine_palace_lock(palace):
+        thread = threading.Thread(
+            target=lambda: result_box.setdefault(
+                "result",
+                "busy"
+                if _raises_writer_busy(palace)
+                else "free",
+            )
+        )
+        thread.start()
+        thread.join(timeout=2)
+
+    assert result_box["result"] == "busy"
+
+
+def _raises_writer_busy(palace_path: str) -> bool:
+    try:
+        with palace_write_lock(palace_path, operation="repair"):
+            return False
+    except PalaceWriteAlreadyRunning:
+        return True
+
+
+def test_shared_writer_lock_normalizes_symlink_and_trailing_slash(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    real = tmp_path / "real_palace"
+    real.mkdir()
+    link = tmp_path / "palace_link"
+    link.symlink_to(real, target_is_directory=True)
+    result_box = {}
+
+    with palace_write_lock(str(real) + "/", operation="repair"):
+        thread = threading.Thread(
+            target=lambda: result_box.setdefault(
+                "result",
+                "busy"
+                if _raises_writer_busy(str(link))
+                else "free",
+            )
+        )
+        thread.start()
+        thread.join(timeout=2)
+
+    assert result_box["result"] == "busy"
+
+
+def test_shared_writer_lock_can_wait_for_existing_writer(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    palace = str(tmp_path / "palace")
+    acquired = []
+    waiter = {}
+
+    def wait_for_lock():
+        cm = palace_write_lock(palace, operation="mcp add_drawer", blocking=True)
+        cm.__enter__()
+        waiter["cm"] = cm
+        acquired.append("entered")
+
+    with palace_write_lock(palace, operation="repair"):
+        thread = threading.Thread(target=wait_for_lock)
+        thread.start()
+        time.sleep(0.1)
+        assert acquired == []
+
+    thread.join(timeout=2)
+    assert acquired == ["entered"]
+    waiter["cm"].__exit__(None, None, None)

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -11,11 +11,15 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import sys
 import threading
 import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
+import mempalace.palace as palace_mod
 from mempalace.palace import (
     MineAlreadyRunning,
     PalaceWriteAlreadyRunning,
@@ -325,9 +329,7 @@ def test_mine_lock_conflicts_with_shared_writer_lock(tmp_path, monkeypatch):
         thread = threading.Thread(
             target=lambda: result_box.setdefault(
                 "result",
-                "busy"
-                if _raises_mine_busy(palace)
-                else "free",
+                "busy" if _raises_mine_busy(palace) else "free",
             )
         )
         thread.start()
@@ -354,9 +356,7 @@ def test_shared_writer_lock_conflicts_with_mine_lock(tmp_path, monkeypatch):
         thread = threading.Thread(
             target=lambda: result_box.setdefault(
                 "result",
-                "busy"
-                if _raises_writer_busy(palace)
-                else "free",
+                "busy" if _raises_writer_busy(palace) else "free",
             )
         )
         thread.start()
@@ -385,9 +385,7 @@ def test_shared_writer_lock_normalizes_symlink_and_trailing_slash(tmp_path, monk
         thread = threading.Thread(
             target=lambda: result_box.setdefault(
                 "result",
-                "busy"
-                if _raises_writer_busy(str(link))
-                else "free",
+                "busy" if _raises_writer_busy(str(link)) else "free",
             )
         )
         thread.start()
@@ -417,3 +415,18 @@ def test_shared_writer_lock_can_wait_for_existing_writer(tmp_path, monkeypatch):
     thread.join(timeout=2)
     assert acquired == ["entered"]
     waiter["cm"].__exit__(None, None, None)
+
+
+def test_shared_writer_lock_windows_blocking_reraises_non_contention_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(palace_mod.os, "name", "nt", raising=False)
+    fake_msvcrt = SimpleNamespace(
+        LK_NBLCK=1,
+        LK_UNLCK=2,
+        locking=MagicMock(side_effect=OSError(5, "simulated I/O failure")),
+    )
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+    with pytest.raises(OSError, match="simulated I/O failure"):
+        with palace_write_lock(str(tmp_path / "palace"), operation="mcp add_drawer", blocking=True):
+            pass

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -90,9 +90,7 @@ def test_extract_drawers_preserves_valid_metadata():
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a", "room": "1"}, {"wing": "b", "room": "2"}],
     }
-    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(
-        col, total=2, batch_size=2
-    )
+    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(col, total=2, batch_size=2)
     assert all_ids == ["id1", "id2"]
     assert all_docs == ["doc1", "doc2"]
     assert all_metas == [{"wing": "a", "room": "1"}, {"wing": "b", "room": "2"}]
@@ -150,9 +148,7 @@ def test_extract_drawers_sanitization_preserves_alignment():
         "documents": ["d1", "d2", "d3", "d4"],
         "metadatas": [None, {"k": "v"}, {}, None],
     }
-    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(
-        col, total=4, batch_size=4
-    )
+    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(col, total=4, batch_size=4)
     assert len(all_ids) == len(all_docs) == len(all_metas) == 4
     assert all_ids == ["id1", "id2", "id3", "id4"]
     assert all_metas[0] == {"_repaired_empty_meta": True}
@@ -170,9 +166,7 @@ def test_extract_drawers_multiple_batches():
         {"ids": ["id3"], "documents": ["d3"], "metadatas": [{}]},
         {"ids": [], "documents": [], "metadatas": []},
     ]
-    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(
-        col, total=3, batch_size=2
-    )
+    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(col, total=3, batch_size=2)
     assert all_ids == ["id1", "id2", "id3"]
     assert all_metas == [{"a": 1}, {"_repaired_empty_meta": True}, {"_repaired_empty_meta": True}]
     assert embeddings is None

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -2,8 +2,10 @@
 
 import os
 import sqlite3
+import struct
 from contextlib import closing
-from unittest.mock import MagicMock, call, patch
+from datetime import datetime
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
@@ -327,14 +329,13 @@ def test_rebuild_index_success(mock_backend_cls, mock_shutil, tmp_path):
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
 
-    mock_new_col = MagicMock()
-    mock_new_col.count.return_value = 2
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    mock_backend.create_collection.return_value = mock_temp_col
 
     repair.rebuild_index(palace_path=str(tmp_path))
 
@@ -344,19 +345,238 @@ def test_rebuild_index_success(mock_backend_cls, mock_shutil, tmp_path):
 
     # Verify: deleted and recreated (cosine is the backend default)
     assert mock_backend.create_collection.call_args_list == [
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
-        call(str(tmp_path), "mempalace_drawers"),
+        call(str(tmp_path), ANY),
     ]
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
         call(str(tmp_path), "mempalace_drawers"),
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
     ]
-
     # Verify: used upsert not add
     mock_temp_col.upsert.assert_called_once()
-    mock_new_col.upsert.assert_called_once()
-    mock_new_col.add.assert_not_called()
+    mock_temp_col.modify.assert_called_once_with(name="mempalace_drawers")
+    mock_temp_col.add.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_rebuild_index_releases_write_lock_on_backup_failure(mock_backend_cls, tmp_path):
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    sqlite_path.write_text("fake")
+    lock = MagicMock()
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    _install_mock_backend(mock_backend_cls, mock_col)
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        patch("mempalace.repair.palace_write_lock", return_value=lock),
+        patch("mempalace.repair.shutil.copy2", side_effect=OSError("copy failed")),
+        pytest.raises(OSError, match="copy failed"),
+    ):
+        repair.rebuild_index(palace_path=str(tmp_path))
+
+    lock.__enter__.assert_called_once_with()
+    lock.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_extract_drawers_includes_embeddings_when_available():
+    col = MagicMock()
+    col.get.return_value = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+    }
+
+    ids, docs, metas, embeddings = repair._extract_drawers(
+        col, total=2, batch_size=10, include_embeddings=True
+    )
+
+    assert ids == ["id1", "id2"]
+    assert docs == ["doc1", "doc2"]
+    assert metas == [{"wing": "a"}, {"wing": "b"}]
+    assert embeddings == [[0.1, 0.2], [0.3, 0.4]]
+    col.get.assert_called_once_with(
+        limit=10,
+        offset=0,
+        include=["documents", "metadatas", "embeddings"],
+    )
+
+
+def test_extract_drawers_can_skip_embeddings_for_reembed():
+    col = MagicMock()
+    col.get.return_value = {
+        "ids": ["id1"],
+        "documents": ["doc1"],
+        "metadatas": [{"wing": "a"}],
+    }
+
+    ids, docs, metas, embeddings = repair._extract_drawers(
+        col, total=1, batch_size=10, include_embeddings=False
+    )
+
+    assert ids == ["id1"]
+    assert docs == ["doc1"]
+    assert metas == [{"wing": "a"}]
+    assert embeddings is None
+    col.get.assert_called_once_with(
+        limit=10,
+        offset=0,
+        include=["documents", "metadatas"],
+    )
+
+
+def test_extract_drawers_skips_embeddings_by_default():
+    col = MagicMock()
+    col.get.return_value = {
+        "ids": ["id1"],
+        "documents": ["doc1"],
+        "metadatas": [{"wing": "a"}],
+    }
+
+    ids, docs, metas, embeddings = repair._extract_drawers(col, total=1, batch_size=10)
+
+    assert ids == ["id1"]
+    assert docs == ["doc1"]
+    assert metas == [{"wing": "a"}]
+    assert embeddings is None
+    col.get.assert_called_once_with(
+        limit=10,
+        offset=0,
+        include=["documents", "metadatas"],
+    )
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_rebuild_collection_via_temp_reuses_extracted_embeddings(mock_backend_cls):
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 2
+    mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
+    mock_backend.create_collection.return_value = mock_temp_col
+
+    repair._rebuild_collection_via_temp(
+        mock_backend,
+        "/palace",
+        ["id1", "id2"],
+        ["doc1", "doc2"],
+        [{"wing": "a"}, {"wing": "b"}],
+        batch_size=10,
+        all_embeddings=[[0.1, 0.2], [0.3, 0.4]],
+        progress=lambda *args, **kwargs: None,
+    )
+
+    expected_kwargs = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+    }
+    mock_temp_col.upsert.assert_called_once_with(**expected_kwargs)
+    mock_temp_col.modify.assert_called_once_with(name="mempalace_drawers")
+
+
+def test_stage_collection_restarts_without_embeddings_when_batch_incomplete():
+    backend = MagicMock()
+    first_temp = MagicMock()
+    second_temp = MagicMock()
+    second_temp.count.return_value = 2
+    backend.create_collection.side_effect = [first_temp, second_temp]
+
+    source_col = MagicMock()
+    source_col.get.side_effect = [
+        {
+            "ids": ["id1", "id2"],
+            "documents": ["doc1", "doc2"],
+            "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        },
+        {
+            "ids": ["id1", "id2"],
+            "documents": ["doc1", "doc2"],
+            "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        },
+    ]
+
+    temp_col, temp_name, staged = repair._stage_collection_from_source(
+        backend,
+        "/palace",
+        source_col,
+        total=2,
+        batch_size=10,
+        collection_name="mempalace_drawers",
+        include_embeddings=True,
+        progress=lambda *args, **kwargs: None,
+    )
+
+    assert temp_col is second_temp
+    assert temp_name.startswith("mempalace_drawers__repair_tmp__")
+    assert staged == 2
+    first_temp.upsert.assert_not_called()
+    second_temp.upsert.assert_called_once_with(
+        ids=["id1", "id2"],
+        documents=["doc1", "doc2"],
+        metadatas=[{"wing": "a"}, {"wing": "b"}],
+    )
+    assert source_col.get.call_args_list == [
+        call(
+            limit=10,
+            offset=0,
+            include=["documents", "metadatas", "embeddings"],
+        ),
+        call(limit=10, offset=0, include=["documents", "metadatas"]),
+    ]
+
+
+def test_stage_collection_cleans_temp_when_source_read_fails():
+    backend = MagicMock()
+    temp_col = MagicMock()
+    backend.create_collection.return_value = temp_col
+    source_col = MagicMock()
+    source_col.get.side_effect = RuntimeError("source read failed")
+
+    with pytest.raises(RuntimeError, match="source read failed"):
+        repair._stage_collection_from_source(
+            backend,
+            "/palace",
+            source_col,
+            total=2,
+            batch_size=10,
+            collection_name="mempalace_drawers",
+            include_embeddings=False,
+            temp_name="mempalace_drawers__repair_tmp__test",
+            progress=lambda *args, **kwargs: None,
+        )
+
+    backend.delete_collection.assert_any_call("/palace", "mempalace_drawers__repair_tmp__test")
+
+
+def test_stage_collection_cleans_temp_when_upsert_fails():
+    backend = MagicMock()
+    temp_col = MagicMock()
+    temp_col.upsert.side_effect = RuntimeError("upsert failed")
+    backend.create_collection.return_value = temp_col
+    source_col = MagicMock()
+    source_col.get.return_value = {
+        "ids": ["id1"],
+        "documents": ["doc1"],
+        "metadatas": [{"wing": "a"}],
+    }
+
+    with pytest.raises(RuntimeError, match="upsert failed"):
+        repair._stage_collection_from_source(
+            backend,
+            "/palace",
+            source_col,
+            total=1,
+            batch_size=10,
+            collection_name="mempalace_drawers",
+            include_embeddings=False,
+            temp_name="mempalace_drawers__repair_tmp__test",
+            progress=lambda *args, **kwargs: None,
+        )
+
+    backend.delete_collection.assert_any_call("/palace", "mempalace_drawers__repair_tmp__test")
 
 
 @patch("mempalace.repair.shutil")
@@ -379,14 +599,13 @@ def test_rebuild_index_ignores_missing_temp_collection_at_start(
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
 
-    mock_new_col = MagicMock()
-    mock_new_col.count.return_value = 2
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    mock_backend.create_collection.return_value = mock_temp_col
     mock_backend.delete_collection.side_effect = [
         ValueError("Collection [mempalace_drawers__repair_tmp] does not exist"),
         None,
@@ -397,9 +616,9 @@ def test_rebuild_index_ignores_missing_temp_collection_at_start(
 
     assert mock_shutil.copy2.call_count == 1
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
         call(str(tmp_path), "mempalace_drawers"),
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
     ]
 
 
@@ -500,6 +719,64 @@ def test_sqlite_drawer_count_returns_none_on_unreadable_schema(tmp_path):
     assert repair.sqlite_drawer_count(str(tmp_path)) is None
 
 
+def test_sqlite_drawer_count_uses_metadata_segment_count(tmp_path):
+    """The truncation guard should count the metadata rows Chroma can
+    direct-extract, not scan every embedding row through collection joins.
+    """
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE segments (
+                id TEXT PRIMARY KEY,
+                collection TEXT NOT NULL,
+                scope TEXT NOT NULL
+            );
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                segment_id TEXT NOT NULL,
+                embedding_id TEXT NOT NULL,
+                seq_id BLOB NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (segment_id, embedding_id)
+            );
+            """
+        )
+        conn.execute("INSERT INTO collections (id, name) VALUES ('c1', 'mempalace_drawers')")
+        conn.executemany(
+            "INSERT INTO segments (id, collection, scope) VALUES (?, 'c1', ?)",
+            [("seg-meta", "METADATA"), ("seg-vector", "VECTOR")],
+        )
+        conn.executemany(
+            "INSERT INTO embeddings (segment_id, embedding_id, seq_id) VALUES (?, ?, X'01')",
+            [
+                ("seg-meta", "drawer_1"),
+                ("seg-meta", "drawer_2"),
+                ("seg-vector", "vector_sidecar"),
+            ],
+        )
+        conn.commit()
+
+        segment_id = repair._sqlite_metadata_segment_id(conn, "mempalace_drawers")
+        plan = "\n".join(
+            row[-1]
+            for row in conn.execute(
+                "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM embeddings WHERE segment_id = ?",
+                (segment_id,),
+            )
+        )
+    finally:
+        conn.close()
+
+    assert repair.sqlite_drawer_count(str(tmp_path), "mempalace_drawers") == 2
+    assert "sqlite_autoindex_embeddings_1" in plan
+
+
 @patch("mempalace.repair.shutil")
 @patch("mempalace.repair.ChromaBackend")
 def test_rebuild_index_default_uses_configured_collection(mock_backend_cls, mock_shutil, tmp_path):
@@ -511,13 +788,12 @@ def test_rebuild_index_default_uses_configured_collection(mock_backend_cls, mock
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
-    mock_new_col = MagicMock()
-    mock_new_col.count.return_value = 2
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    mock_backend.create_collection.return_value = mock_temp_col
 
     with (
         patch("mempalace.repair._drawers_collection_name", return_value="custom_drawers"),
@@ -525,17 +801,10 @@ def test_rebuild_index_default_uses_configured_collection(mock_backend_cls, mock
     ):
         repair.rebuild_index(palace_path=str(tmp_path))
 
-    mock_backend.get_collection.assert_called_once_with(str(tmp_path), "custom_drawers")
+    assert mock_backend.get_collection.call_args_list[0] == call(str(tmp_path), "custom_drawers")
     count.assert_called_once_with(str(tmp_path), "custom_drawers")
-    assert mock_backend.create_collection.call_args_list == [
-        call(str(tmp_path), "custom_drawers__repair_tmp"),
-        call(str(tmp_path), "custom_drawers"),
-    ]
-    assert mock_backend.delete_collection.call_args_list == [
-        call(str(tmp_path), "custom_drawers__repair_tmp"),
-        call(str(tmp_path), "custom_drawers"),
-        call(str(tmp_path), "custom_drawers__repair_tmp"),
-    ]
+    assert call(str(tmp_path), "custom_drawers") in mock_backend.delete_collection.call_args_list
+    assert call(str(tmp_path), ANY) in mock_backend.create_collection.call_args_list
 
 
 def test_status_default_uses_configured_drawer_collection(tmp_path):
@@ -553,18 +822,288 @@ def test_status_default_uses_configured_drawer_collection(tmp_path):
                 "message": "",
             },
             {
-                "sqlite_count": 0,
-                "hnsw_count": 0,
+                "sqlite_count": 1,
+                "hnsw_count": 1,
                 "divergence": 0,
                 "diverged": False,
                 "status": "ok",
                 "message": "",
             },
         ]
-        repair.status(palace_path=str(tmp_path))
+        result = repair.status(palace_path=str(tmp_path))
 
     assert capacity_status.call_args_list[0].args == (str(tmp_path), "custom_drawers")
     assert capacity_status.call_args_list[1].args == (str(tmp_path), "mempalace_closets")
+    assert result["status"] == "ok"
+    assert result["message"] == ""
+
+def _status_info():
+    return {
+        "sqlite_count": 1,
+        "hnsw_count": 1,
+        "divergence": 0,
+        "diverged": False,
+        "status": "ok",
+        "message": "",
+    }
+
+
+def _seed_status_collection_sqlite(palace_path, collection_name, rows):
+    sqlite_path = palace_path / "chroma.sqlite3"
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE collections (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE);
+            CREATE TABLE segments (
+                id TEXT PRIMARY KEY,
+                collection TEXT NOT NULL,
+                scope TEXT NOT NULL
+            );
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                segment_id TEXT NOT NULL,
+                embedding_id TEXT NOT NULL
+            );
+            """
+        )
+        for collection_index, (name, count) in enumerate(rows):
+            collection_id = f"collection-{collection_index}"
+            segment_id = f"segment-{collection_index}"
+            conn.execute("INSERT INTO collections (id, name) VALUES (?, ?)", (collection_id, name))
+            conn.execute(
+                "INSERT INTO segments (id, collection, scope) VALUES (?, ?, 'METADATA')",
+                (segment_id, collection_id),
+            )
+            conn.executemany(
+                "INSERT INTO embeddings (segment_id, embedding_id) VALUES (?, ?)",
+                [(segment_id, f"{name}-{i}") for i in range(count)],
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_status_reports_stale_repair_temp_collections(tmp_path, capsys):
+    unique_temp = "mempalace_drawers__repair_tmp__20260502120000000000__123__abcdef12"
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [
+            ("mempalace_drawers", 3),
+            (unique_temp, 2),
+        ],
+    )
+
+    with patch(
+        "mempalace.repair.hnsw_capacity_status", side_effect=[_status_info(), _status_info()]
+    ):
+        result = repair.status(palace_path=str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert result["status"] == "artifacts"
+    assert result["repair_artifacts"] == {unique_temp: 2}
+    assert f"{unique_temp}: 2 rows" in out
+    assert f"mempalace --palace {str(tmp_path)} repair-status --cleanup-temp --yes" in out
+
+
+def test_status_does_not_treat_user_collection_with_temp_substring_as_artifact(tmp_path, capsys):
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [
+            ("mempalace_drawers", 3),
+            ("mempalace_drawers__repair_tmp", 2),
+        ],
+    )
+
+    with patch(
+        "mempalace.repair.hnsw_capacity_status", side_effect=[_status_info(), _status_info()]
+    ):
+        result = repair.status(palace_path=str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert result["repair_artifacts"] == {}
+    assert "[repair artifacts]" in out
+    assert "none found" in out
+
+
+def test_status_reports_unique_repair_temp_collections(tmp_path, capsys):
+    unique_temp = "mempalace_drawers__repair_tmp__20260502120000000000__123__abcdef12"
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [
+            ("mempalace_drawers", 3),
+            (unique_temp, 4),
+        ],
+    )
+
+    with patch(
+        "mempalace.repair.hnsw_capacity_status", side_effect=[_status_info(), _status_info()]
+    ):
+        result = repair.status(palace_path=str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert result["repair_artifacts"] == {unique_temp: 4}
+    assert f"{unique_temp}: 4 rows" in out
+
+
+def test_status_does_not_mask_live_divergence_with_temp_artifacts(tmp_path, capsys):
+    unique_temp = "mempalace_drawers__repair_tmp__20260502120000000000__123__abcdef12"
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [
+            ("mempalace_drawers", 3),
+            (unique_temp, 2),
+        ],
+    )
+    diverged = {
+        "sqlite_count": 3,
+        "hnsw_count": 1,
+        "divergence": 2,
+        "diverged": True,
+        "status": "needs_repair",
+        "message": "HNSW behind sqlite",
+    }
+
+    with patch("mempalace.repair.hnsw_capacity_status", side_effect=[diverged, _status_info()]):
+        result = repair.status(palace_path=str(tmp_path))
+
+    capsys.readouterr()
+    assert result["status"] == "needs_repair"
+    assert result["repair_artifacts"] == {unique_temp: 2}
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_status_cleanup_temp_requires_yes(mock_backend_cls, tmp_path, capsys):
+    unique_temp = "mempalace_drawers__repair_tmp__20260502121212121212__999__feedface"
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [(unique_temp, 2)],
+    )
+
+    with patch(
+        "mempalace.repair.hnsw_capacity_status", side_effect=[_status_info(), _status_info()]
+    ):
+        result = repair.status(palace_path=str(tmp_path), cleanup_temp=True, assume_yes=False)
+
+    out = capsys.readouterr().out
+    assert result["cleanup"] == {}
+    assert "cleanup skipped" in out
+    mock_backend_cls.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_status_cleanup_temp_deletes_reported_artifacts(mock_backend_cls, tmp_path, capsys):
+    unique_temp = "mempalace_drawers__repair_tmp__20260502121212121212__999__feedface"
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [(unique_temp, 2)],
+    )
+    mock_backend = MagicMock()
+    mock_backend_cls.return_value = mock_backend
+
+    with patch(
+        "mempalace.repair.hnsw_capacity_status", side_effect=[_status_info(), _status_info()]
+    ):
+        result = repair.status(palace_path=str(tmp_path), cleanup_temp=True, assume_yes=True)
+
+    out = capsys.readouterr().out
+    assert result["cleanup"] == {unique_temp: "deleted"}
+    assert result["repair_artifacts"] == {}
+    assert f"cleanup {unique_temp}: deleted" in out
+    mock_backend.delete_collection.assert_called_once_with(str(tmp_path), unique_temp)
+    mock_backend.close.assert_called_once_with()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_status_cleanup_temp_refuses_when_write_lock_active(mock_backend_cls, tmp_path, capsys):
+    unique_temp = "mempalace_drawers__repair_tmp__20260502121212121212__999__feedface"
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [(unique_temp, 2)],
+    )
+
+    def locked(*args, **kwargs):
+        raise repair.PalaceWriteAlreadyRunning("locked by repair")
+
+    with (
+        patch("mempalace.repair.palace_write_lock", locked),
+        patch(
+            "mempalace.repair.hnsw_capacity_status",
+            side_effect=[_status_info(), _status_info()],
+        ),
+    ):
+        result = repair.status(palace_path=str(tmp_path), cleanup_temp=True, assume_yes=True)
+
+    out = capsys.readouterr().out
+    assert result["cleanup"] == {unique_temp: "refused: locked by repair"}
+    assert f"cleanup {unique_temp}: refused: locked by repair" in out
+    mock_backend_cls.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_status_cleanup_temp_deletes_unique_temp_artifacts(mock_backend_cls, tmp_path, capsys):
+    unique_temp = "mempalace_drawers__repair_tmp__20260502121212121212__999__feedface"
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [(unique_temp, 2)],
+    )
+    mock_backend = MagicMock()
+    mock_backend_cls.return_value = mock_backend
+
+    with patch(
+        "mempalace.repair.hnsw_capacity_status", side_effect=[_status_info(), _status_info()]
+    ):
+        result = repair.status(palace_path=str(tmp_path), cleanup_temp=True, assume_yes=True)
+
+    out = capsys.readouterr().out
+    assert result["cleanup"] == {unique_temp: "deleted"}
+    assert f"cleanup {unique_temp}: deleted" in out
+    mock_backend.delete_collection.assert_called_once_with(str(tmp_path), unique_temp)
+    mock_backend.close.assert_called_once_with()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_status_cleanup_temp_reports_delete_failures(mock_backend_cls, tmp_path, capsys):
+    unique_temp = "mempalace_drawers__repair_tmp__20260502121212121212__999__feedface"
+    _seed_status_collection_sqlite(
+        tmp_path,
+        "mempalace_drawers",
+        [(unique_temp, 2)],
+    )
+    mock_backend = MagicMock()
+    mock_backend.delete_collection.side_effect = RuntimeError("locked")
+    mock_backend_cls.return_value = mock_backend
+
+    with patch(
+        "mempalace.repair.hnsw_capacity_status", side_effect=[_status_info(), _status_info()]
+    ):
+        result = repair.status(palace_path=str(tmp_path), cleanup_temp=True, assume_yes=True)
+
+    out = capsys.readouterr().out
+    assert result["cleanup"] == {unique_temp: "failed: locked"}
+    assert result["repair_artifacts"] == {unique_temp: 2}
+    assert f"cleanup {unique_temp}: failed: locked" in out
+    mock_backend.close.assert_called_once_with()
+
+
+def test_status_missing_palace_returns_standard_shape(tmp_path, capsys):
+    missing = tmp_path / "missing"
+
+    result = repair.status(palace_path=str(missing))
+
+    assert result["status"] == "unknown"
+    assert result["drawers"]["status"] == "unknown"
+    assert result["closets"]["status"] == "unknown"
+    assert result["repair_artifacts"] == {}
+    assert result["cleanup"] == {}
 
 
 @patch("mempalace.repair.shutil")
@@ -581,18 +1120,25 @@ def test_rebuild_index_aborts_on_truncation_signal(mock_backend_cls, mock_shutil
             "ids": [f"id{i}" for i in range(10_000)],
             "documents": ["x"] * 10_000,
             "metadatas": [{}] * 10_000,
+            "embeddings": [[0.1, 0.2]] * 10_000,
         },
         {"ids": [], "documents": [], "metadatas": []},
     ]
     mock_backend.get_collection.return_value = mock_col
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 10_000
+    mock_backend.create_collection.return_value = mock_temp_col
     mock_backend_cls.return_value = mock_backend
 
     with patch("mempalace.repair.sqlite_drawer_count", return_value=67_580):
         repair.rebuild_index(palace_path=str(tmp_path))
 
-    # Guard fired: nothing destructive happened
-    mock_backend.delete_collection.assert_not_called()
-    mock_backend.create_collection.assert_not_called()
+    # Guard fired after staging: live collection was never deleted.
+    assert mock_backend.delete_collection.call_args_list == [
+        call(str(tmp_path), ANY),
+        call(str(tmp_path), ANY),
+    ]
+    mock_backend.create_collection.assert_called_once_with(str(tmp_path), ANY)
     mock_shutil.copy2.assert_not_called()
 
 
@@ -608,24 +1154,23 @@ def test_rebuild_index_proceeds_with_override(mock_backend_cls, mock_shutil, tmp
             "ids": [f"id{i}" for i in range(10_000)],
             "documents": ["x"] * 10_000,
             "metadatas": [{}] * 10_000,
+            "embeddings": [[0.1, 0.2]] * 10_000,
         },
         {"ids": [], "documents": [], "metadatas": []},
     ]
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 10_000
-    mock_new_col = MagicMock()
-    mock_new_col.count.return_value = 10_000
     mock_backend.get_collection.return_value = mock_col
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    mock_backend.create_collection.return_value = mock_temp_col
     mock_backend_cls.return_value = mock_backend
 
     with patch("mempalace.repair.sqlite_drawer_count", return_value=67_580):
         repair.rebuild_index(palace_path=str(tmp_path), confirm_truncation_ok=True)
 
     assert mock_backend.delete_collection.call_count == 3
-    assert mock_backend.create_collection.call_count == 2
+    assert mock_backend.create_collection.call_count == 1
     mock_temp_col.upsert.assert_called()
-    mock_new_col.upsert.assert_called()
+    mock_temp_col.modify.assert_called_once_with(name="mempalace_drawers")
 
 
 @patch("mempalace.repair.shutil")
@@ -642,6 +1187,7 @@ def test_rebuild_index_stage_failure_leaves_live_collection_untouched(
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 1
@@ -654,8 +1200,8 @@ def test_rebuild_index_stage_failure_leaves_live_collection_untouched(
     assert excinfo.value.live_replaced is False
     assert mock_shutil.copy2.call_count == 1
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
+        call(str(tmp_path), ANY),
     ]
 
 
@@ -677,14 +1223,14 @@ def test_rebuild_index_live_failure_restores_backup(mock_backend_cls, mock_shuti
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
-    mock_new_col = MagicMock()
-    mock_new_col.upsert.side_effect = RuntimeError("live upsert failed")
+    mock_temp_col.modify.side_effect = RuntimeError("live rename failed")
     active_backend = MagicMock()
     active_backend.get_collection.return_value = mock_col
-    active_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    active_backend.create_collection.return_value = mock_temp_col
     helper_backend = MagicMock()
     mock_backend_cls.side_effect = [active_backend, helper_backend]
 
@@ -694,13 +1240,107 @@ def test_rebuild_index_live_failure_restores_backup(mock_backend_cls, mock_shuti
     assert excinfo.value.live_replaced is True
     assert mock_shutil.copy2.call_count == 2
     assert active_backend.delete_collection.call_args_list == [
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
         call(str(tmp_path), "mempalace_drawers"),
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
         call(str(tmp_path), "mempalace_drawers"),
     ]
     active_backend.close_palace.assert_called_once_with(str(tmp_path))
     helper_backend.close_palace.assert_not_called()
+
+
+@patch("mempalace.repair.shutil")
+@patch("mempalace.repair.ChromaBackend")
+def test_rebuild_index_pre_swap_delete_failure_does_not_restore_backup(
+    mock_backend_cls, mock_shutil, tmp_path, capsys
+):
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    sqlite_path.write_text("fake")
+
+    def _fake_copy2(src, dst):
+        with open(dst, "w") as handle:
+            handle.write("backup")
+
+    mock_shutil.copy2.side_effect = _fake_copy2
+
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_col.get.return_value = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+    }
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 2
+    mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
+    mock_backend.create_collection.return_value = mock_temp_col
+    mock_backend.delete_collection.side_effect = [
+        None,
+        RuntimeError("delete failed before live replacement"),
+    ]
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        pytest.raises(repair.RebuildCollectionError) as excinfo,
+    ):
+        repair.rebuild_index(palace_path=str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert excinfo.value.live_replaced is False
+    assert "Restoring from backup" not in out
+    assert "Live collection was not replaced" in out
+    mock_backend.close_palace.assert_not_called()
+    assert mock_shutil.copy2.call_count == 1
+    assert mock_backend.delete_collection.call_args_list == [
+        call(str(tmp_path), ANY),
+        call(str(tmp_path), "mempalace_drawers"),
+        call(str(tmp_path), ANY),
+    ]
+
+
+@patch("mempalace.repair.shutil")
+@patch("mempalace.repair.ChromaBackend")
+def test_rebuild_index_rejects_extra_live_rows_after_recreate(
+    mock_backend_cls, mock_shutil, tmp_path, capsys
+):
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    sqlite_path.write_text("fake")
+
+    def _fake_copy2(src, dst):
+        with open(dst, "w") as handle:
+            handle.write("backup")
+
+    mock_shutil.copy2.side_effect = _fake_copy2
+
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_col.get.return_value = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+    }
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 2
+    mock_new_col = MagicMock()
+    mock_new_col.count.return_value = 4
+    mock_backend = MagicMock()
+    mock_backend.get_collection.side_effect = [mock_col, mock_new_col]
+    mock_backend.create_collection.return_value = mock_temp_col
+    mock_backend_cls.return_value = mock_backend
+
+    with (
+        patch("mempalace.repair.sqlite_integrity_errors", return_value=[]),
+        pytest.raises(repair.RebuildCollectionError) as excinfo,
+    ):
+        repair.rebuild_index(palace_path=str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert excinfo.value.live_replaced is True
+    assert "count mismatch" in str(excinfo.value)
+    assert "Restoring from backup" in out
+    assert mock_shutil.copy2.call_count == 2
 
 
 @patch("mempalace.repair.shutil")
@@ -723,11 +1363,13 @@ def test_rebuild_index_live_delete_missing_still_restores_backup(
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
+    mock_temp_col.modify.side_effect = RuntimeError("rename failed")
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, RuntimeError("create failed")]
+    mock_backend.create_collection.return_value = mock_temp_col
     mock_backend.delete_collection.side_effect = [
         None,
         None,
@@ -741,9 +1383,9 @@ def test_rebuild_index_live_delete_missing_still_restores_backup(
     assert excinfo.value.live_replaced is True
     assert mock_shutil.copy2.call_count == 2
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
         call(str(tmp_path), "mempalace_drawers"),
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
         call(str(tmp_path), "mempalace_drawers"),
     ]
 
@@ -770,13 +1412,13 @@ def test_rebuild_index_restore_failure_preserves_original_error(
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
-    mock_new_col = MagicMock()
-    mock_new_col.upsert.side_effect = RuntimeError("live upsert failed")
+    mock_temp_col.modify.side_effect = RuntimeError("live rename failed")
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    mock_backend.create_collection.return_value = mock_temp_col
 
     with pytest.raises(repair.RebuildCollectionError) as excinfo:
         repair.rebuild_index(palace_path=str(tmp_path))
@@ -784,7 +1426,7 @@ def test_rebuild_index_restore_failure_preserves_original_error(
     out = capsys.readouterr().out
     assert "locked sqlite" in out
     assert "Manual restore required" in out
-    assert "live upsert failed" in str(excinfo.value)
+    assert "live rename failed" in str(excinfo.value)
 
 
 @patch("mempalace.repair.ChromaBackend")
@@ -796,7 +1438,8 @@ def test_rebuild_collection_via_temp_keeps_original_error_when_cleanup_fails(
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, RuntimeError("live build failed")]
+    mock_backend.create_collection.return_value = mock_temp_col
+    mock_temp_col.modify.side_effect = RuntimeError("live rename failed")
     mock_backend.delete_collection.side_effect = [
         None,
         None,
@@ -814,13 +1457,40 @@ def test_rebuild_collection_via_temp_keeps_original_error_when_cleanup_fails(
             progress=lambda *args, **kwargs: None,
         )
 
-    assert "live build failed" in str(excinfo.value)
+    assert "live rename failed" in str(excinfo.value)
     assert excinfo.value.live_replaced is True
     assert mock_backend.delete_collection.call_args_list == [
-        call("/palace", "mempalace_drawers__repair_tmp"),
+        call("/palace", ANY),
+        call("/palace", "mempalace_drawers"),
+        call("/palace", ANY),
+    ]
+
+
+def test_swap_temp_collection_cleans_temp_when_live_delete_fails():
+    backend = MagicMock()
+    temp_col = MagicMock()
+    backend.delete_collection.side_effect = [
+        RuntimeError("live delete failed"),
+        None,
+    ]
+
+    with pytest.raises(repair.RebuildCollectionError) as excinfo:
+        repair._swap_temp_collection_into_live(
+            backend,
+            "/palace",
+            temp_col,
+            "mempalace_drawers__repair_tmp",
+            "mempalace_drawers",
+            2,
+            progress=lambda *args, **kwargs: None,
+        )
+
+    assert excinfo.value.live_replaced is False
+    assert backend.delete_collection.call_args_list == [
         call("/palace", "mempalace_drawers"),
         call("/palace", "mempalace_drawers__repair_tmp"),
     ]
+    temp_col.modify.assert_not_called()
 
 
 @patch("mempalace.repair.shutil")
@@ -843,13 +1513,12 @@ def test_rebuild_index_ignores_temp_cleanup_failure_after_success(
         "ids": ["id1", "id2"],
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a"}, {"wing": "b"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
-    mock_new_col = MagicMock()
-    mock_new_col.count.return_value = 2
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    mock_backend.create_collection.return_value = mock_temp_col
     mock_backend.delete_collection.side_effect = [
         None,
         None,
@@ -860,9 +1529,9 @@ def test_rebuild_index_ignores_temp_cleanup_failure_after_success(
 
     assert mock_shutil.copy2.call_count == 1
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
         call(str(tmp_path), "mempalace_drawers"),
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
+        call(str(tmp_path), ANY),
     ]
 
 
@@ -1378,6 +2047,37 @@ def test_rebuild_index_repairs_poisoned_max_seq_id_before_collection_rebuild(tmp
     assert "non-destructive max_seq_id repair" in out
 
 
+def test_rebuild_index_releases_lock_when_max_seq_id_preflight_short_circuits(tmp_path, monkeypatch):
+    palace = str(tmp_path / "palace")
+    os.makedirs(palace)
+    lock = MagicMock()
+    monkeypatch.setattr(repair, "palace_write_lock", MagicMock(return_value=lock))
+    monkeypatch.setattr(
+        repair,
+        "maybe_repair_poisoned_max_seq_id_before_rebuild",
+        MagicMock(return_value={"segment_repaired": True}),
+    )
+
+    repair.rebuild_index(palace)
+
+    lock.__enter__.assert_called_once_with()
+    lock.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_rebuild_index_releases_lock_when_sqlite_integrity_preflight_aborts(tmp_path, monkeypatch):
+    palace = str(tmp_path / "palace")
+    os.makedirs(palace)
+    lock = MagicMock()
+    monkeypatch.setattr(repair, "palace_write_lock", MagicMock(return_value=lock))
+    monkeypatch.setattr(repair, "sqlite_integrity_errors", MagicMock(return_value=["bad page"]))
+    monkeypatch.setattr(repair, "print_sqlite_integrity_abort", MagicMock())
+
+    repair.rebuild_index(palace)
+
+    lock.__enter__.assert_called_once_with()
+    lock.__exit__.assert_called_once_with(None, None, None)
+
+
 # ── extract_via_sqlite + rebuild_from_sqlite (#1308) ──────────────────
 #
 # These tests build real chromadb palaces in tmp_path rather than mocking
@@ -1524,6 +2224,515 @@ def test_extract_via_sqlite_missing_palace_yields_nothing(tmp_path):
     assert list(repair.extract_via_sqlite(str(empty), "mempalace_drawers")) == []
 
 
+def test_extract_via_sqlite_skips_rows_missing_document_metadata(tmp_path):
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE collections (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE);
+            CREATE TABLE segments (id TEXT PRIMARY KEY, collection TEXT NOT NULL, scope TEXT NOT NULL);
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                segment_id TEXT NOT NULL,
+                embedding_id TEXT NOT NULL
+            );
+            CREATE TABLE embedding_metadata (
+                id INTEGER,
+                key TEXT NOT NULL,
+                string_value TEXT,
+                int_value INTEGER,
+                float_value REAL,
+                bool_value INTEGER,
+                PRIMARY KEY (id, key)
+            );
+            """
+        )
+        conn.execute("INSERT INTO collections (id, name) VALUES ('c1', 'mempalace_drawers')")
+        conn.execute(
+            "INSERT INTO segments (id, collection, scope) VALUES ('seg1', 'c1', 'METADATA')"
+        )
+        conn.execute(
+            "INSERT INTO embeddings (id, segment_id, embedding_id) VALUES (1, 'seg1', 'd1')"
+        )
+        conn.execute(
+            """
+            INSERT INTO embedding_metadata
+                (id, key, string_value, int_value, float_value, bool_value)
+            VALUES (1, 'wing', 'w', NULL, NULL, NULL)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert list(repair.extract_via_sqlite(str(tmp_path), "mempalace_drawers")) == []
+
+
+def test_extract_via_sqlite_uses_existing_chroma_indexes(tmp_path):
+    """The SQLite recovery scan should not need a temp sort. Chroma already
+    creates a unique index on ``embeddings(segment_id, embedding_id)`` and a
+    primary-key index on ``embedding_metadata(id, key)``; the extractor query
+    should follow those indexes so large palaces stream from disk instead of
+    building a temp B-tree.
+    """
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE segments (
+                id TEXT PRIMARY KEY,
+                collection TEXT NOT NULL,
+                scope TEXT NOT NULL
+            );
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                segment_id TEXT NOT NULL,
+                embedding_id TEXT NOT NULL,
+                seq_id BLOB NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (segment_id, embedding_id)
+            );
+            CREATE TABLE embedding_metadata (
+                id INTEGER REFERENCES embeddings(id),
+                key TEXT NOT NULL,
+                string_value TEXT,
+                int_value INTEGER,
+                float_value REAL,
+                bool_value INTEGER,
+                PRIMARY KEY (id, key)
+            );
+            """
+        )
+        conn.execute("INSERT INTO collections (id, name) VALUES ('c1', 'mempalace_drawers')")
+        conn.execute(
+            "INSERT INTO segments (id, collection, scope) VALUES ('seg1', 'c1', 'METADATA')"
+        )
+        conn.execute(
+            "INSERT INTO embeddings (id, segment_id, embedding_id, seq_id) "
+            "VALUES (1, 'seg1', 'drawer_z', X'01'), (2, 'seg1', 'drawer_a', X'02')"
+        )
+        conn.executemany(
+            """
+            INSERT INTO embedding_metadata
+                (id, key, string_value, int_value, float_value, bool_value)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, "chroma:document", "body z", None, None, None),
+                (1, "wing", "w", None, None, None),
+                (2, "chroma:document", "body a", None, None, None),
+                (2, "wing", "w", None, None, None),
+            ],
+        )
+        plan = "\n".join(
+            row[-1]
+            for row in conn.execute(
+                "EXPLAIN QUERY PLAN " + repair._SQLITE_EXTRACT_ROWS_SQL, ("seg1",)
+            )
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert "USE TEMP B-TREE" not in plan
+    assert list(repair.extract_via_sqlite(str(tmp_path), "mempalace_drawers")) == [
+        ("drawer_a", "body a", {"wing": "w"}),
+        ("drawer_z", "body z", {"wing": "w"}),
+    ]
+
+
+def test_load_sqlite_vectors_reads_latest_float32_vectors(tmp_path):
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE embeddings_queue (
+                seq_id INTEGER PRIMARY KEY,
+                operation INTEGER NOT NULL,
+                topic TEXT NOT NULL,
+                id TEXT NOT NULL,
+                vector BLOB,
+                encoding TEXT,
+                metadata TEXT,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        topic = "persistent://default/default/col-drawers"
+        conn.execute(
+            "INSERT INTO collections (id, name) VALUES ('col-drawers', 'mempalace_drawers')"
+        )
+        conn.executemany(
+            """
+            INSERT INTO embeddings_queue
+                (seq_id, operation, topic, id, vector, encoding, metadata)
+            VALUES (?, 2, ?, ?, ?, 'FLOAT32', '{}')
+            """,
+            [
+                (1, topic, "drawer_1", struct.pack("<ff", 1.0, 2.0)),
+                (2, topic, "drawer_2", struct.pack("<ff", 3.0, 4.0)),
+                (3, topic, "drawer_1", struct.pack("<ff", 5.0, 6.0)),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    vectors = repair._load_sqlite_vectors(str(tmp_path), "mempalace_drawers")
+
+    assert set(vectors) == {"drawer_1", "drawer_2"}
+    assert vectors["drawer_1"].tolist() == [5.0, 6.0]
+    assert vectors["drawer_2"].tolist() == [3.0, 4.0]
+
+
+def test_load_sqlite_vectors_raises_on_unreadable_vector_tables(tmp_path):
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(sqlite_path)
+    conn.execute("CREATE TABLE unrelated (id TEXT)")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(sqlite3.OperationalError):
+        repair._load_sqlite_vectors(str(tmp_path), "mempalace_drawers")
+
+
+def test_rebuild_one_collection_reuses_complete_stored_vectors(tmp_path):
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE embeddings_queue (
+                seq_id INTEGER PRIMARY KEY,
+                operation INTEGER NOT NULL,
+                topic TEXT NOT NULL,
+                id TEXT NOT NULL,
+                vector BLOB,
+                encoding TEXT,
+                metadata TEXT,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO collections (id, name) VALUES ('col-drawers', 'mempalace_drawers')"
+        )
+        conn.execute(
+            """
+            INSERT INTO embeddings_queue
+                (seq_id, operation, topic, id, vector, encoding, metadata)
+            VALUES (1, 2, 'persistent://default/default/col-drawers',
+                    'drawer_with_vector', ?, 'FLOAT32', '{}')
+            """,
+            (struct.pack("<ff", 0.25, 0.75),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    backend = MagicMock()
+    col = MagicMock()
+    col.count.return_value = 1
+    backend.create_collection.return_value = col
+
+    with (
+        patch(
+            "mempalace.repair.extract_via_sqlite",
+            return_value=iter([("drawer_with_vector", "doc 1", {"wing": "w"})]),
+        ),
+        patch(
+            "mempalace.repair._sqlite_embedding_ids",
+            return_value=["drawer_with_vector"],
+        ),
+    ):
+        upserted = repair._rebuild_one_collection(
+            backend=backend,
+            source_palace=str(tmp_path),
+            dest_palace=str(tmp_path / "dest"),
+            collection_name="mempalace_drawers",
+            batch_size=10,
+            archive_path=None,
+            counts_so_far={},
+        )
+
+    assert upserted == 1
+    col.upsert.assert_called_once()
+    assert col.upsert.call_args.kwargs["ids"] == ["drawer_with_vector"]
+    assert col.upsert.call_args.kwargs["embeddings"][0].tolist() == [0.25, 0.75]
+
+
+def test_rebuild_one_collection_reembeds_when_stored_vectors_incomplete(tmp_path):
+    backend = MagicMock()
+    col = MagicMock()
+    col.count.return_value = 2
+    backend.create_collection.return_value = col
+
+    with (
+        patch(
+            "mempalace.repair._load_sqlite_vectors",
+            return_value={"drawer_with_vector": [0.25, 0.75]},
+        ),
+        patch(
+            "mempalace.repair._sqlite_embedding_ids",
+            return_value=["drawer_with_vector", "drawer_without_vector"],
+        ),
+        patch(
+            "mempalace.repair.extract_via_sqlite",
+            return_value=iter(
+                [
+                    ("drawer_with_vector", "doc 1", {"wing": "w"}),
+                    ("drawer_without_vector", "doc 2", {"wing": "w"}),
+                ]
+            ),
+        ),
+    ):
+        upserted = repair._rebuild_one_collection(
+            backend=backend,
+            source_palace=str(tmp_path),
+            dest_palace=str(tmp_path / "dest"),
+            collection_name="mempalace_drawers",
+            batch_size=10,
+            archive_path=None,
+            counts_so_far={},
+            reembed=True,
+        )
+
+    assert upserted == 2
+    col.upsert.assert_called_once_with(
+        ids=["drawer_with_vector", "drawer_without_vector"],
+        documents=["doc 1", "doc 2"],
+        metadatas=[{"wing": "w"}, {"wing": "w"}],
+    )
+
+
+def test_rebuild_one_collection_fails_when_extraction_skips_source_rows(tmp_path):
+    backend = MagicMock()
+    col = MagicMock()
+    col.count.return_value = 1
+    backend.create_collection.return_value = col
+
+    with (
+        patch("mempalace.repair._load_sqlite_vectors", return_value={}),
+        patch(
+            "mempalace.repair._sqlite_embedding_ids",
+            return_value=["drawer_with_metadata", "drawer_missing_metadata"],
+        ),
+        patch(
+            "mempalace.repair.extract_via_sqlite",
+            return_value=iter([("drawer_with_metadata", "doc 1", {"wing": "w"})]),
+        ),
+    ):
+        with pytest.raises(repair.RebuildPartialError) as excinfo:
+            repair._rebuild_one_collection(
+                backend=backend,
+                source_palace=str(tmp_path),
+                dest_palace=str(tmp_path / "dest"),
+                collection_name="mempalace_drawers",
+                batch_size=10,
+                archive_path=None,
+                counts_so_far={},
+            )
+
+    assert excinfo.value.failed_collection == "mempalace_drawers"
+    assert "source/extracted count mismatch" in str(excinfo.value)
+
+
+def test_rebuild_one_collection_fails_when_source_document_metadata_missing(tmp_path):
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE collections (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE);
+            CREATE TABLE segments (id TEXT PRIMARY KEY, collection TEXT NOT NULL, scope TEXT NOT NULL);
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                segment_id TEXT NOT NULL,
+                embedding_id TEXT NOT NULL
+            );
+            CREATE TABLE embedding_metadata (
+                id INTEGER,
+                key TEXT NOT NULL,
+                string_value TEXT,
+                int_value INTEGER,
+                float_value REAL,
+                bool_value INTEGER,
+                PRIMARY KEY (id, key)
+            );
+            """
+        )
+        conn.execute("INSERT INTO collections (id, name) VALUES ('c1', 'mempalace_drawers')")
+        conn.execute(
+            "INSERT INTO segments (id, collection, scope) VALUES ('seg1', 'c1', 'METADATA')"
+        )
+        conn.execute(
+            "INSERT INTO embeddings (id, segment_id, embedding_id) VALUES (1, 'seg1', 'd1')"
+        )
+        conn.execute(
+            """
+            INSERT INTO embedding_metadata
+                (id, key, string_value, int_value, float_value, bool_value)
+            VALUES (1, 'wing', 'w', NULL, NULL, NULL)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    backend = MagicMock()
+    col = MagicMock()
+    col.count.return_value = 0
+    backend.create_collection.return_value = col
+
+    with pytest.raises(repair.RebuildPartialError) as excinfo:
+        repair._rebuild_one_collection(
+            backend=backend,
+            source_palace=str(tmp_path),
+            dest_palace=str(tmp_path / "dest"),
+            collection_name="mempalace_drawers",
+            batch_size=10,
+            archive_path=None,
+            counts_so_far={},
+            reembed=True,
+        )
+
+    assert "source/extracted count mismatch" in str(excinfo.value)
+    col.upsert.assert_not_called()
+
+
+def test_rebuild_one_collection_reembed_skips_stored_vectors(tmp_path):
+    backend = MagicMock()
+    col = MagicMock()
+    col.count.return_value = 1
+    backend.create_collection.return_value = col
+
+    with (
+        patch(
+            "mempalace.repair.extract_via_sqlite",
+            return_value=iter([("drawer_with_vector", "doc 1", {"wing": "w"})]),
+        ),
+        patch("mempalace.repair._load_sqlite_vectors") as load_vectors,
+    ):
+        upserted = repair._rebuild_one_collection(
+            backend=backend,
+            source_palace=str(tmp_path),
+            dest_palace=str(tmp_path / "dest"),
+            collection_name="mempalace_drawers",
+            batch_size=10,
+            archive_path=None,
+            counts_so_far={},
+            reembed=True,
+        )
+
+    assert upserted == 1
+    load_vectors.assert_not_called()
+    col.upsert.assert_called_once_with(
+        ids=["drawer_with_vector"],
+        documents=["doc 1"],
+        metadatas=[{"wing": "w"}],
+    )
+
+
+def test_rebuild_one_collection_wraps_create_collection_failure(tmp_path):
+    backend = MagicMock()
+    backend.create_collection.side_effect = RuntimeError("create failed")
+
+    with pytest.raises(repair.RebuildPartialError) as excinfo:
+        repair._rebuild_one_collection(
+            backend=backend,
+            source_palace=str(tmp_path),
+            dest_palace=str(tmp_path / "dest"),
+            collection_name="mempalace_drawers",
+            batch_size=10,
+            archive_path=str(tmp_path / "archive"),
+            counts_so_far={},
+        )
+
+    assert "during creating destination collection" in excinfo.value.message
+    assert "create failed" in excinfo.value.message
+    assert excinfo.value.archive_path == str(tmp_path / "archive")
+    assert excinfo.value.partial_counts == {"mempalace_drawers": 0}
+
+
+def test_rebuild_one_collection_recovery_hint_includes_dest_and_source(tmp_path):
+    backend = MagicMock()
+    col = MagicMock()
+    col.upsert.side_effect = RuntimeError("upsert failed")
+    backend.create_collection.return_value = col
+    archive_path = str(tmp_path / "archive")
+    dest_path = str(tmp_path / "dest")
+
+    with (
+        patch("mempalace.repair._load_sqlite_vectors", return_value={}),
+        patch("mempalace.repair._sqlite_embedding_ids", return_value=["d1"]),
+        patch(
+            "mempalace.repair.extract_via_sqlite",
+            return_value=iter([("d1", "doc 1", {"wing": "w"})]),
+        ),
+        pytest.raises(repair.RebuildPartialError) as excinfo,
+    ):
+        repair._rebuild_one_collection(
+            backend=backend,
+            source_palace=str(tmp_path / "source"),
+            dest_palace=dest_path,
+            collection_name="mempalace_drawers",
+            batch_size=10,
+            archive_path=archive_path,
+            counts_so_far={},
+        )
+
+    assert f"mempalace --palace {dest_path} repair --mode from-sqlite" in excinfo.value.message
+    assert f"--source {archive_path}" in excinfo.value.message
+    assert "during extracting and upserting rows" in excinfo.value.message
+
+
+def test_rebuild_one_collection_validates_destination_count(tmp_path):
+    backend = MagicMock()
+    col = MagicMock()
+    col.count.return_value = 1
+    backend.create_collection.return_value = col
+
+    with (
+        patch(
+            "mempalace.repair.extract_via_sqlite",
+            return_value=iter(
+                [
+                    ("d1", "doc 1", {"wing": "w"}),
+                    ("d2", "doc 2", {"wing": "w"}),
+                ]
+            ),
+        ),
+        pytest.raises(repair.RebuildPartialError) as excinfo,
+    ):
+        repair._rebuild_one_collection(
+            backend=backend,
+            source_palace=str(tmp_path),
+            dest_palace=str(tmp_path / "dest"),
+            collection_name="mempalace_drawers",
+            batch_size=10,
+            archive_path=None,
+            counts_so_far={},
+        )
+
+    assert "count mismatch" in excinfo.value.message
+    assert excinfo.value.partial_counts == {"mempalace_drawers": 2}
+
+
 def test_rebuild_from_sqlite_roundtrips_via_real_chromadb(tmp_path):
     """End-to-end: seed source palace, rebuild into a fresh dest, then
     open dest with a fresh ChromaBackend and verify ``count()`` and
@@ -1577,6 +2786,356 @@ def test_rebuild_from_sqlite_roundtrips_via_real_chromadb(tmp_path):
     assert closet_row["metadatas"][0] == {"wing": "alpha"}
 
 
+def test_rebuild_from_sqlite_uses_configured_drawer_collection(tmp_path):
+    from mempalace.backends.chroma import ChromaBackend
+
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+
+    _seed_palace(source, "custom_drawers", [("custom_1", "body", {"wing": "alpha"})])
+    _seed_palace(source, "mempalace_closets", [("closet_x", "ptr", {"wing": "alpha"})])
+
+    counts = repair.rebuild_from_sqlite(
+        str(source),
+        str(dest),
+        collection_name="custom_drawers",
+    )
+
+    assert counts == {"custom_drawers": 1, "mempalace_closets": 1}
+    backend = ChromaBackend()
+    custom = backend.get_collection(str(dest), "custom_drawers")
+    assert custom.get(ids=["custom_1"], include=["documents"])["documents"] == ["body"]
+    with pytest.raises(Exception):
+        backend.get_collection(str(dest), "mempalace_drawers")
+
+
+def test_rebuild_from_sqlite_preserves_extra_first_party_collections(tmp_path):
+    from mempalace.backends.chroma import ChromaBackend
+
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+
+    _seed_palace(source, "mempalace_drawers", [("d1", "drawer", {"wing": "w"})])
+    _seed_palace(source, "mempalace_compressed", [("c1", "compressed", {"wing": "w"})])
+
+    counts = repair.rebuild_from_sqlite(str(source), str(dest))
+
+    assert counts["mempalace_drawers"] == 1
+    assert counts["mempalace_compressed"] == 1
+    compressed = ChromaBackend().get_collection(str(dest), "mempalace_compressed")
+    row = compressed.get(ids=["c1"], include=["documents", "metadatas"])
+    assert row["documents"] == ["compressed"]
+    assert row["metadatas"] == [{"wing": "w"}]
+
+
+def test_unique_temp_collection_names_include_internal_marker():
+    first = repair._unique_temp_collection_name("mempalace_drawers")
+    second = repair._unique_temp_collection_name("mempalace_drawers")
+
+    assert first != second
+    assert first.startswith("mempalace_drawers__repair_tmp__")
+    assert repair._is_repair_internal_collection(first)
+    assert not repair._is_repair_internal_collection("mempalace_drawers__repair_tmp")
+
+
+def test_rebuild_from_sqlite_fails_on_missing_chroma_document(tmp_path):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _seed_palace(source, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+
+    conn = sqlite3.connect(source / "chroma.sqlite3")
+    try:
+        row = conn.execute(
+            """
+            SELECT e.id
+            FROM embeddings e
+            JOIN embedding_metadata em ON em.id = e.id
+            WHERE em.key = 'chroma:document'
+            LIMIT 1
+            """
+        ).fetchone()
+        conn.execute(
+            "DELETE FROM embedding_metadata WHERE id = ? AND key = 'chroma:document'",
+            (row[0],),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(RuntimeError, match="missing chroma:document"):
+        repair.rebuild_from_sqlite(str(source), str(dest))
+    assert not dest.exists()
+
+
+def test_rebuild_from_sqlite_content_audit_is_opt_in(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _seed_palace(source, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+
+    audit = MagicMock()
+    monkeypatch.setattr(repair, "_audit_collection_content", audit)
+
+    repair.rebuild_from_sqlite(str(source), str(dest))
+    audit.assert_not_called()
+
+    source2 = tmp_path / "source2"
+    dest2 = tmp_path / "dest2"
+    _seed_palace(source2, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+    repair.rebuild_from_sqlite(str(source2), str(dest2), audit_content=True)
+    audit.assert_called_once_with(str(source2.resolve()), str(dest2.resolve()), "mempalace_drawers")
+
+
+def test_validate_destination_inventory_rejects_extra_rows():
+    expected = repair.CollectionInventory("mempalace_drawers", 1, frozenset({"d1"}), frozenset())
+    actual = repair.CollectionInventory(
+        "mempalace_drawers", 2, frozenset({"d1", "d2"}), frozenset()
+    )
+
+    with pytest.raises(RuntimeError, match="count mismatch"):
+        repair._validate_destination_inventory(expected, actual)
+
+
+def test_validate_destination_inventory_rejects_same_count_id_mismatch():
+    expected = repair.CollectionInventory("mempalace_drawers", 1, frozenset({"d1"}), frozenset())
+    actual = repair.CollectionInventory("mempalace_drawers", 1, frozenset({"d2"}), frozenset())
+
+    with pytest.raises(RuntimeError, match="ID set mismatch"):
+        repair._validate_destination_inventory(expected, actual)
+
+
+def test_validate_destination_inventory_rejects_missing_destination_documents():
+    expected = repair.CollectionInventory("mempalace_drawers", 1, frozenset({"d1"}), frozenset())
+    actual = repair.CollectionInventory(
+        "mempalace_drawers", 1, frozenset({"d1"}), frozenset({"d1"})
+    )
+
+    with pytest.raises(RuntimeError, match="missing chroma:document"):
+        repair._validate_destination_inventory(expected, actual)
+
+
+def test_sqlite_inventories_skips_generated_internal_temp_collections(monkeypatch):
+    seen = []
+
+    def fake_inventory(palace_path, collection_name):
+        seen.append((palace_path, collection_name))
+        return repair.CollectionInventory(collection_name, 0, frozenset(), frozenset())
+
+    monkeypatch.setattr(repair, "_sqlite_collection_inventory", fake_inventory)
+
+    result = repair._sqlite_inventories(
+        "/palace",
+        (
+            "mempalace_drawers",
+            "mempalace_drawers__repair_tmp",
+            "mempalace_drawers__repair_tmp__20260502121212121212__999__feedface",
+        ),
+    )
+
+    assert list(result) == ["mempalace_drawers", "mempalace_drawers__repair_tmp"]
+    assert seen == [
+        ("/palace", "mempalace_drawers"),
+        ("/palace", "mempalace_drawers__repair_tmp"),
+    ]
+
+
+def test_audit_collection_content_detects_changed_document(tmp_path):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _seed_palace(source, "mempalace_drawers", [("d1", "original", {"wing": "w"})])
+    _seed_palace(dest, "mempalace_drawers", [("d1", "changed", {"wing": "w"})])
+
+    with pytest.raises(RuntimeError, match="content audit failed"):
+        repair._audit_collection_content(str(source), str(dest), "mempalace_drawers")
+
+
+def test_audit_collection_content_detects_missing_document(tmp_path):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _seed_palace(source, "mempalace_drawers", [("d1", "original", {"wing": "w"})])
+    _seed_palace(dest, "mempalace_drawers", [("d2", "extra", {"wing": "w"})])
+
+    with pytest.raises(RuntimeError, match="missing docs: d1"):
+        repair._audit_collection_content(str(source), str(dest), "mempalace_drawers")
+
+
+def test_audit_collection_content_detects_extra_document(tmp_path):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _seed_palace(source, "mempalace_drawers", [("d1", "original", {"wing": "w"})])
+    _seed_palace(
+        dest,
+        "mempalace_drawers",
+        [("d1", "original", {"wing": "w"}), ("d2", "extra", {"wing": "w"})],
+    )
+
+    with pytest.raises(RuntimeError, match="extra docs: d2"):
+        repair._audit_collection_content(str(source), str(dest), "mempalace_drawers")
+
+
+def test_rebuild_from_sqlite_restores_archive_on_post_rebuild_validation_failure(
+    tmp_path, monkeypatch
+):
+    palace = tmp_path / "palace"
+    _seed_palace(palace, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+
+    calls = {"count": 0}
+    real_validate = repair._validate_destination_inventory
+
+    def fail_once(expected, actual):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("simulated validation failure")
+        return real_validate(expected, actual)
+
+    monkeypatch.setattr(repair, "_validate_destination_inventory", fail_once)
+
+    with pytest.raises(RuntimeError, match="simulated validation failure"):
+        repair.rebuild_from_sqlite(str(palace), str(palace), archive_existing_dest=True)
+
+    assert (palace / "chroma.sqlite3").exists()
+    assert len(list(repair.extract_via_sqlite(str(palace), "mempalace_drawers"))) == 1
+    assert not [p for p in tmp_path.iterdir() if p.name.startswith("palace.pre-rebuild-")]
+
+
+def test_rebuild_from_sqlite_restores_archive_on_dest_setup_failure(tmp_path, monkeypatch):
+    palace = tmp_path / "palace"
+    _seed_palace(palace, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+    real_makedirs = os.makedirs
+
+    def fail_makedirs(path, *args, **kwargs):
+        if path == os.path.realpath(str(palace)):
+            raise OSError("simulated setup failure")
+        return real_makedirs(path, *args, **kwargs)
+
+    monkeypatch.setattr(repair.os, "makedirs", fail_makedirs)
+
+    with pytest.raises(OSError, match="simulated setup failure"):
+        repair.rebuild_from_sqlite(str(palace), str(palace), archive_existing_dest=True)
+
+    assert (palace / "chroma.sqlite3").exists()
+    assert len(list(repair.extract_via_sqlite(str(palace), "mempalace_drawers"))) == 1
+    assert not [p for p in tmp_path.iterdir() if p.name.startswith("palace.pre-rebuild-")]
+
+
+def test_rebuild_from_sqlite_restores_archive_on_backend_setup_failure(tmp_path, monkeypatch):
+    palace = tmp_path / "palace"
+    _seed_palace(palace, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+
+    def fail_backend():
+        raise RuntimeError("simulated backend setup failure")
+
+    monkeypatch.setattr(repair, "ChromaBackend", fail_backend)
+
+    with pytest.raises(RuntimeError, match="simulated backend setup failure"):
+        repair.rebuild_from_sqlite(str(palace), str(palace), archive_existing_dest=True)
+
+    assert (palace / "chroma.sqlite3").exists()
+    assert len(list(repair.extract_via_sqlite(str(palace), "mempalace_drawers"))) == 1
+    assert not [p for p in tmp_path.iterdir() if p.name.startswith("palace.pre-rebuild-")]
+
+
+def test_rebuild_from_sqlite_refuses_when_write_lock_active(tmp_path, monkeypatch, capsys):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _seed_palace(source, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+
+    def locked(*args, **kwargs):
+        raise repair.PalaceWriteAlreadyRunning("locked by test")
+
+    monkeypatch.setattr(repair, "palace_write_lock", locked)
+
+    counts = repair.rebuild_from_sqlite(str(source), str(dest))
+
+    out = capsys.readouterr().out
+    assert counts == {}
+    assert "ABORT: locked by test" in out
+    assert not dest.exists()
+
+
+def test_rebuild_from_sqlite_releases_lock_on_existing_dest_refusal(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    _seed_palace(source, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+    dest_lock = MagicMock()
+    source_lock = MagicMock()
+    lock_factory = MagicMock(side_effect=[dest_lock, source_lock])
+    monkeypatch.setattr(repair, "palace_write_lock", lock_factory)
+
+    counts = repair.rebuild_from_sqlite(str(source), str(dest))
+
+    assert counts == {}
+    assert lock_factory.call_args_list == [
+        call(os.path.realpath(str(dest)), operation="repair"),
+        call(os.path.realpath(str(source)), operation="repair source"),
+    ]
+    dest_lock.__enter__.assert_called_once_with()
+    source_lock.__enter__.assert_called_once_with()
+    source_lock.__exit__.assert_called_once_with(None, None, None)
+    dest_lock.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_rebuild_from_sqlite_releases_dest_lock_when_source_lock_active(
+    tmp_path, monkeypatch, capsys
+):
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _seed_palace(source, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+    dest_lock = MagicMock()
+
+    def lock_factory(path, *, operation):
+        if operation == "repair source":
+            raise repair.PalaceWriteAlreadyRunning("source busy")
+        return dest_lock
+
+    monkeypatch.setattr(repair, "palace_write_lock", lock_factory)
+
+    counts = repair.rebuild_from_sqlite(str(source), str(dest))
+
+    out = capsys.readouterr().out
+    assert counts == {}
+    assert "ABORT: source busy" in out
+    dest_lock.__enter__.assert_called_once_with()
+    dest_lock.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_recoverable_collection_names_orders_primary_and_ignores_empty(tmp_path):
+    from mempalace.backends.chroma import ChromaBackend
+
+    palace = tmp_path / "source"
+    _seed_palace(palace, "custom_drawers", [("d1", "drawer", {"wing": "w"})])
+    _seed_palace(palace, "mempalace_closets", [("c1", "closet", {"wing": "w"})])
+    _seed_palace(palace, "mempalace_compressed", [("z1", "compressed", {"wing": "w"})])
+    _seed_palace(palace, "custom_drawers__repair_tmp", [("tmp1", "tmp", {"wing": "w"})])
+    ChromaBackend().create_collection(str(palace), "empty_collection")
+
+    assert repair._recoverable_collection_names(str(palace), "custom_drawers") == (
+        "custom_drawers",
+        "mempalace_closets",
+        "custom_drawers__repair_tmp",
+        "mempalace_compressed",
+    )
+
+
+def test_rebuild_from_sqlite_refuses_zero_primary_collection_before_archive(tmp_path):
+    palace = tmp_path / "palace"
+    _seed_palace(palace, "mempalace_drawers", [("d1", "doc", {"wing": "w"})])
+    sqlite_before = (palace / "chroma.sqlite3").stat().st_size
+
+    counts = repair.rebuild_from_sqlite(
+        str(palace),
+        str(palace),
+        archive_existing_dest=True,
+        collection_name="custom_drawers",
+    )
+
+    assert counts == {}
+    assert palace.exists()
+    assert (palace / "chroma.sqlite3").stat().st_size == sqlite_before
+    archives = [p for p in tmp_path.iterdir() if "pre-rebuild" in p.name]
+    assert archives == []
+
+
 def test_rebuild_from_sqlite_refuses_existing_dest(tmp_path):
     """Refuse to write into a directory that already exists when source
     and dest differ. Without this, an unattended re-run would silently
@@ -1624,6 +3183,73 @@ def test_rebuild_from_sqlite_in_place_archives_when_opted_in(tmp_path):
 
     rebuilt = ChromaBackend().get_collection(str(palace), "mempalace_drawers")
     assert rebuilt.count() == 15
+
+
+def test_rebuild_from_sqlite_treats_symlinked_dest_as_in_place(tmp_path):
+    """A symlink alias to the same palace must take the in-place archive path.
+
+    Without canonicalization, repair sees source != dest, then refuses because
+    the destination path already exists. That blocks the safe archive/rebuild
+    path for users invoking repair through a symlinked palace location.
+    """
+    palace = tmp_path / "palace"
+    palace_link = tmp_path / "palace-link"
+    rows = [(f"d{i}", f"body {i}", {"wing": "w", "room": "r"}) for i in range(3)]
+    _seed_palace(palace, "mempalace_drawers", rows)
+    try:
+        palace_link.symlink_to(palace, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    counts = repair.rebuild_from_sqlite(
+        str(palace),
+        str(palace_link),
+        archive_existing_dest=True,
+    )
+
+    assert counts["mempalace_drawers"] == 3
+    archives = [p for p in tmp_path.iterdir() if p.name.startswith("palace.pre-rebuild-")]
+    assert len(archives) == 1
+    assert len(list(repair.extract_via_sqlite(str(palace), "mempalace_drawers"))) == 3
+    assert len(list(repair.extract_via_sqlite(str(archives[0]), "mempalace_drawers"))) == 3
+
+
+def test_unique_archive_path_skips_existing_collision(tmp_path, monkeypatch):
+    class FixedDatetime:
+        @staticmethod
+        def now():
+            return datetime.strptime("20260502-155501-123456", "%Y%m%d-%H%M%S-%f")
+
+    palace = tmp_path / "palace"
+    first = tmp_path / "palace.pre-rebuild-20260502-155501-123456"
+    first.mkdir()
+    monkeypatch.setattr(repair, "datetime", FixedDatetime)
+
+    assert repair._unique_archive_path(str(palace)) == str(first) + "-2"
+
+
+def test_rebuild_from_sqlite_in_place_skips_archive_collision(tmp_path, monkeypatch):
+    class FixedDatetime:
+        @staticmethod
+        def now():
+            return datetime.strptime("20260502-155501-123456", "%Y%m%d-%H%M%S-%f")
+
+    palace = tmp_path / "palace"
+    first_archive = tmp_path / "palace.pre-rebuild-20260502-155501-123456"
+    first_archive.mkdir()
+    (first_archive / "marker.txt").write_text("preexisting archive")
+    rows = [(f"d{i}", f"body {i}", {"wing": "w", "room": "r"}) for i in range(3)]
+    _seed_palace(palace, "mempalace_drawers", rows)
+    monkeypatch.setattr(repair, "datetime", FixedDatetime)
+
+    counts = repair.rebuild_from_sqlite(str(palace), str(palace), archive_existing_dest=True)
+
+    second_archive = tmp_path / "palace.pre-rebuild-20260502-155501-123456-2"
+    assert counts["mempalace_drawers"] == 3
+    assert (first_archive / "marker.txt").read_text() == "preexisting archive"
+    assert not (first_archive / "palace").exists()
+    assert (second_archive / "chroma.sqlite3").exists()
+    assert len(list(repair.extract_via_sqlite(str(second_archive), "mempalace_drawers"))) == 3
 
 
 def test_rebuild_from_sqlite_in_place_refuses_without_archive_flag(tmp_path):
@@ -1675,11 +3301,10 @@ def test_rebuild_from_sqlite_in_place_validates_source_before_archiving(tmp_path
 
 
 def test_rebuild_from_sqlite_raises_on_upsert_failure(tmp_path, monkeypatch):
-    """Mid-batch upsert failure must raise ``RebuildPartialError`` and
-    surface the failed collection + archive path so the user can recover.
-    Without this, an unattended script gets exit-code-zero on a partial
-    rebuild and the user discovers the data loss only when search starts
-    returning fewer hits.
+    """Mid-batch in-place upsert failure must restore the archived palace
+    and raise ``RebuildPartialError``. Without this, an unattended script
+    gets exit-code-zero on a partial rebuild and the user discovers the
+    data loss only when search starts returning fewer hits.
     """
     palace = tmp_path / "palace"
     rows = [(f"d{i}", f"body {i}", {"wing": "w", "room": "r"}) for i in range(5)]
@@ -1704,9 +3329,13 @@ def test_rebuild_from_sqlite_raises_on_upsert_failure(tmp_path, monkeypatch):
     err = excinfo.value
     assert err.failed_collection == "mempalace_drawers"
     assert err.partial_counts.get("mempalace_drawers") == 0
-    assert err.archive_path is not None
-    assert os.path.isfile(os.path.join(err.archive_path, "chroma.sqlite3"))
+    assert err.archive_path is None
+    assert os.path.isfile(palace / "chroma.sqlite3")
+    restored_rows = list(repair.extract_via_sqlite(str(palace), "mempalace_drawers"))
+    assert len(restored_rows) == 5
     assert err.dest_palace == os.path.abspath(str(palace))
+    assert "Original palace restored" in err.message
+    assert not [p for p in tmp_path.iterdir() if p.name.startswith("palace.pre-rebuild-")]
 
 
 def test_rebuild_from_sqlite_honors_configured_drawer_collection_name(tmp_path, monkeypatch):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,6 +1,7 @@
 """Tests for mempalace.repair — scan, prune, and rebuild HNSW index."""
 
 import os
+import shlex
 import sqlite3
 import struct
 from contextlib import closing
@@ -89,10 +90,13 @@ def test_extract_drawers_preserves_valid_metadata():
         "documents": ["doc1", "doc2"],
         "metadatas": [{"wing": "a", "room": "1"}, {"wing": "b", "room": "2"}],
     }
-    all_ids, all_docs, all_metas = repair._extract_drawers(col, total=2, batch_size=2)
+    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(
+        col, total=2, batch_size=2
+    )
     assert all_ids == ["id1", "id2"]
     assert all_docs == ["doc1", "doc2"]
     assert all_metas == [{"wing": "a", "room": "1"}, {"wing": "b", "room": "2"}]
+    assert embeddings is None
 
 
 def test_extract_drawers_sanitizes_none_metadata():
@@ -108,10 +112,11 @@ def test_extract_drawers_sanitizes_none_metadata():
         "documents": ["doc1", "doc2", "doc3"],
         "metadatas": [{"wing": "a"}, None, {"wing": "c"}],
     }
-    _, _, all_metas = repair._extract_drawers(col, total=3, batch_size=3)
+    _, _, all_metas, embeddings = repair._extract_drawers(col, total=3, batch_size=3)
     assert all_metas[0] == {"wing": "a"}
     assert all_metas[1] == {"_repaired_empty_meta": True}
     assert all_metas[2] == {"wing": "c"}
+    assert embeddings is None
 
 
 def test_extract_drawers_sanitizes_empty_dict_metadata():
@@ -126,9 +131,10 @@ def test_extract_drawers_sanitizes_empty_dict_metadata():
         "documents": ["doc1", "doc2"],
         "metadatas": [{}, {"wing": "b"}],
     }
-    _, _, all_metas = repair._extract_drawers(col, total=2, batch_size=2)
+    _, _, all_metas, embeddings = repair._extract_drawers(col, total=2, batch_size=2)
     assert all_metas[0] == {"_repaired_empty_meta": True}
     assert all_metas[1] == {"wing": "b"}
+    assert embeddings is None
 
 
 def test_extract_drawers_sanitization_preserves_alignment():
@@ -144,13 +150,16 @@ def test_extract_drawers_sanitization_preserves_alignment():
         "documents": ["d1", "d2", "d3", "d4"],
         "metadatas": [None, {"k": "v"}, {}, None],
     }
-    all_ids, all_docs, all_metas = repair._extract_drawers(col, total=4, batch_size=4)
+    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(
+        col, total=4, batch_size=4
+    )
     assert len(all_ids) == len(all_docs) == len(all_metas) == 4
     assert all_ids == ["id1", "id2", "id3", "id4"]
     assert all_metas[0] == {"_repaired_empty_meta": True}
     assert all_metas[1] == {"k": "v"}
     assert all_metas[2] == {"_repaired_empty_meta": True}
     assert all_metas[3] == {"_repaired_empty_meta": True}
+    assert embeddings is None
 
 
 def test_extract_drawers_multiple_batches():
@@ -161,9 +170,12 @@ def test_extract_drawers_multiple_batches():
         {"ids": ["id3"], "documents": ["d3"], "metadatas": [{}]},
         {"ids": [], "documents": [], "metadatas": []},
     ]
-    all_ids, all_docs, all_metas = repair._extract_drawers(col, total=3, batch_size=2)
+    all_ids, all_docs, all_metas, embeddings = repair._extract_drawers(
+        col, total=3, batch_size=2
+    )
     assert all_ids == ["id1", "id2", "id3"]
     assert all_metas == [{"a": 1}, {"_repaired_empty_meta": True}, {"_repaired_empty_meta": True}]
+    assert embeddings is None
 
 
 # ── scan_palace ───────────────────────────────────────────────────────
@@ -376,7 +388,9 @@ def test_rebuild_index_releases_write_lock_on_backup_failure(mock_backend_cls, t
         repair.rebuild_index(palace_path=str(tmp_path))
 
     lock.__enter__.assert_called_once_with()
-    lock.__exit__.assert_called_once_with(None, None, None)
+    assert lock.__exit__.call_count == 1
+    assert lock.__exit__.call_args.args[0] is OSError
+    assert str(lock.__exit__.call_args.args[1]) == "copy failed"
 
 
 def test_extract_drawers_includes_embeddings_when_available():
@@ -837,6 +851,7 @@ def test_status_default_uses_configured_drawer_collection(tmp_path):
     assert result["status"] == "ok"
     assert result["message"] == ""
 
+
 def _status_info():
     return {
         "sqlite_count": 1,
@@ -904,7 +919,9 @@ def test_status_reports_stale_repair_temp_collections(tmp_path, capsys):
     assert result["status"] == "artifacts"
     assert result["repair_artifacts"] == {unique_temp: 2}
     assert f"{unique_temp}: 2 rows" in out
-    assert f"mempalace --palace {str(tmp_path)} repair-status --cleanup-temp --yes" in out
+    assert (
+        f"mempalace --palace {shlex.quote(str(tmp_path))} repair-status --cleanup-temp --yes" in out
+    )
 
 
 def test_status_does_not_treat_user_collection_with_temp_substring_as_artifact(tmp_path, capsys):
@@ -2047,7 +2064,9 @@ def test_rebuild_index_repairs_poisoned_max_seq_id_before_collection_rebuild(tmp
     assert "non-destructive max_seq_id repair" in out
 
 
-def test_rebuild_index_releases_lock_when_max_seq_id_preflight_short_circuits(tmp_path, monkeypatch):
+def test_rebuild_index_releases_lock_when_max_seq_id_preflight_short_circuits(
+    tmp_path, monkeypatch
+):
     palace = str(tmp_path / "palace")
     os.makedirs(palace)
     lock = MagicMock()
@@ -2076,6 +2095,26 @@ def test_rebuild_index_releases_lock_when_sqlite_integrity_preflight_aborts(tmp_
 
     lock.__enter__.assert_called_once_with()
     lock.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_rebuild_index_releases_lock_when_max_seq_id_preflight_raises(tmp_path, monkeypatch):
+    palace = str(tmp_path / "palace")
+    os.makedirs(palace)
+    lock = MagicMock()
+    monkeypatch.setattr(repair, "palace_write_lock", MagicMock(return_value=lock))
+    monkeypatch.setattr(
+        repair,
+        "maybe_repair_poisoned_max_seq_id_before_rebuild",
+        MagicMock(side_effect=RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        repair.rebuild_index(palace)
+
+    lock.__enter__.assert_called_once_with()
+    assert lock.__exit__.call_count == 1
+    assert lock.__exit__.call_args.args[0] is RuntimeError
+    assert str(lock.__exit__.call_args.args[1]) == "boom"
 
 
 # ── extract_via_sqlite + rebuild_from_sqlite (#1308) ──────────────────
@@ -2696,8 +2735,11 @@ def test_rebuild_one_collection_recovery_hint_includes_dest_and_source(tmp_path)
             counts_so_far={},
         )
 
-    assert f"mempalace --palace {dest_path} repair --mode from-sqlite" in excinfo.value.message
-    assert f"--source {archive_path}" in excinfo.value.message
+    assert (
+        f"mempalace --palace {shlex.quote(dest_path)} repair --mode from-sqlite"
+        in excinfo.value.message
+    )
+    assert f"--source {shlex.quote(archive_path)}" in excinfo.value.message
     assert "during extracting and upserting rows" in excinfo.value.message
 
 
@@ -3097,6 +3139,21 @@ def test_rebuild_from_sqlite_releases_dest_lock_when_source_lock_active(
     assert "ABORT: source busy" in out
     dest_lock.__enter__.assert_called_once_with()
     dest_lock.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_rebuild_from_sqlite_releases_lock_on_archive_move_failure(tmp_path, monkeypatch):
+    palace = tmp_path / "palace"
+    _seed_palace(palace, "mempalace_drawers", [("d1", "body", {"wing": "w"})])
+    lock = MagicMock()
+    monkeypatch.setattr(repair, "palace_write_lock", MagicMock(return_value=lock))
+    monkeypatch.setattr(repair.shutil, "move", MagicMock(side_effect=OSError("archive failed")))
+
+    with pytest.raises(OSError, match="archive failed"):
+        repair.rebuild_from_sqlite(str(palace), str(palace), archive_existing_dest=True)
+
+    lock.__enter__.assert_called_once_with()
+    lock.__exit__.assert_called_once_with(None, None, None)
+    assert (palace / "chroma.sqlite3").exists()
 
 
 def test_recoverable_collection_names_orders_primary_and_ignores_empty(tmp_path):

--- a/tests/test_save_hook_mines.py
+++ b/tests/test_save_hook_mines.py
@@ -112,9 +112,7 @@ class TestShellHookTranscriptValidation:
             end = src.index("\n}\n", start) + 2
             func_src = src[start:end]
             script = tmp_path / "v.sh"
-            script.write_text(
-                f"{func_src}\n" 'is_valid_transcript_path "$1" && echo OK || echo NO\n'
-            )
+            script.write_text(f'{func_src}\nis_valid_transcript_path "$1" && echo OK || echo NO\n')
 
             def run(arg: str) -> str:
                 return subprocess.run(

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -102,6 +102,56 @@ class TestSearchMemories:
             create=False,
         )
 
+    def test_search_memories_accepts_explicit_candidate_strategy(self):
+        """Regression: ``candidate_strategy`` must remain in the API
+        signature so callers can opt into the BM25-union candidate pool
+        without hitting a ``NameError`` inside ``search_memories``."""
+        mock_col = MagicMock()
+        mock_col.query.return_value = {
+            "documents": [[]],
+            "metadatas": [[]],
+            "distances": [[]],
+            "ids": [[]],
+        }
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+            patch("mempalace.searcher.get_closets_collection", return_value=mock_col),
+        ):
+            result = search_memories(
+                "test",
+                "/fake/path",
+                candidate_strategy="union",
+            )
+
+        assert result["results"] == []
+
+    def test_search_memories_preserves_candidate_strategy_positional_order(self):
+        mock_col = MagicMock()
+        mock_col.query.return_value = {
+            "documents": [[]],
+            "metadatas": [[]],
+            "distances": [[]],
+            "ids": [[]],
+        }
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+            patch("mempalace.searcher.get_closets_collection", return_value=mock_col),
+        ):
+            result = search_memories(
+                "test",
+                "/fake/path",
+                None,
+                None,
+                5,
+                0.0,
+                False,
+                "union",
+            )
+
+        assert result["results"] == []
+
     def test_search_memories_filters_in_result(self, palace_path, seeded_collection):
         result = search_memories("test", palace_path, wing="project", room="backend")
         assert result["filters"]["wing"] == "project"
@@ -327,9 +377,9 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         first_block, _, _ = captured.out.partition("[2]")
         # Lexical match must rank first
-        assert (
-            "b.md" in first_block
-        ), f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        assert "b.md" in first_block, (
+            f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        )
         # Non-zero bm25 reported
         assert "bm25=" in first_block
         assert "bm25=0.0" not in first_block

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -237,10 +237,9 @@ class TestSearchMemories:
             assert (
                 0.0 <= h["similarity"] <= 1.0
             ), f"similarity out of range: {h['similarity']} for {h['source_file']}"
-            assert 0.0 <= h["effective_distance"] <= 2.0, (
-                f"effective_distance out of range: {h['effective_distance']} "
-                f"for {h['source_file']}"
-            )
+            assert (
+                0.0 <= h["effective_distance"] <= 2.0
+            ), f"effective_distance out of range: {h['effective_distance']} for {h['source_file']}"
 
         # With the clamp, the closet-boosted a.md still ranks ahead of b.md —
         # the boost still wins, but it no longer flips the ranking.
@@ -377,9 +376,9 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         first_block, _, _ = captured.out.partition("[2]")
         # Lexical match must rank first
-        assert "b.md" in first_block, (
-            f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
-        )
+        assert (
+            "b.md" in first_block
+        ), f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
         # Non-zero bm25 reported
         assert "bm25=" in first_block
         assert "bm25=0.0" not in first_block

--- a/tools/render_jsonl.py
+++ b/tools/render_jsonl.py
@@ -70,7 +70,7 @@ def main():
     ]
     out.write("\n".join(header))
     for ts, role, text in turns:
-        out.write(f"\n[{ts}] {role.upper()}\n{text}\n\n{'-'*72}\n")
+        out.write(f"\n[{ts}] {role.upper()}\n{text}\n\n{'-' * 72}\n")
     if out is not sys.stdout:
         out.close()
         print(f"Wrote {len(turns)} turns to {sys.argv[2]}")


### PR DESCRIPTION
## What does this PR do?

This PR hardens MemPalace repair and recovery for damaged Chroma palaces and reduces rebuild time on the common recovery path.

Rebased on 2026-05-15 onto `upstream/develop` at `bb31396`. Since the original PR, upstream has already landed overlapping repair hardening for rebuild progress/ETA and empty-metadata sanitization. This PR now focuses on the remaining repair-performance and writer-safety pieces that are still unique to this branch.

## Current delta after rebase

- Harden Chroma startup preflight/reconnect behavior so invalid HNSW metadata and stale HNSW state are handled consistently after palace replacement or reconnect.
- Make repair and recovery honor the configured primary collection name instead of assuming `mempalace_drawers`.
- Speed up legacy and from-SQLite rebuilds by reusing stored embeddings when complete, staging into a temporary collection, swapping by rename, and validating source/destination inventory before reporting success.
- Add a shared per-palace write boundary so `repair`, `mine`, repair cleanup, MCP write tools, and direct backend mutators do not race rebuild/swap paths. MemPalace-managed writes against the same palace no longer write the HNSW index concurrently.
- Fold in review followups around repair-lock release, rebuild/swap failure boundaries, migration no-op behavior, and tests for the above flows.

## User-visible outcomes

- repair/recovery succeeds against more corrupted-palace states without silently dropping rows
- custom collection names survive rebuilds correctly
- healthy palaces do not prompt for destructive migration confirmation when no rebuild is needed
- reconnect paths are more resilient to newly-invalid HNSW metadata
- live writers no longer race repair/rebuild work
- rebuilds can avoid expensive re-embedding when stored vectors are complete

## Verification

After the rebase:

```bash
.venv/bin/python -m ruff check mempalace/config.py mempalace/palace.py mempalace/repair.py mempalace/mcp_server.py tests/test_repair.py
.venv/bin/python -m pytest tests/test_repair.py tests/test_palace_locks.py tests/test_mcp_server.py -q
```

Result: `272 passed`; targeted ruff check clean.

## Broader test plan

- `uv run pytest tests/test_backends.py tests/test_searcher.py tests/test_repair.py tests/test_migrate.py tests/test_cli.py tests/test_mcp_server.py tests/test_miner.py -q`
- Optional manual spot checks:
  - run `mempalace repair` against a palace with a non-default configured collection name
  - run `mempalace migrate` against a healthy readable palace and confirm it exits successfully without prompting for destructive confirmation
  - verify MCP writes queue/refuse appropriately while repair is active

## Checklist

- [x] Targeted tests pass after rebase
- [x] Targeted linter check passes after rebase
- [x] No hardcoded paths
