### PR TITLE
fix(kg): symmetric inversion guard on invalidate (#1371)

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -230,7 +230,14 @@ class KnowledgeGraph:
         return triple_id
 
     def invalidate(self, subject: str, predicate: str, obj: str, ended: str = None):
-        """Mark a relationship as no longer valid (set valid_to date)."""
+        """Mark a relationship as no longer valid (set valid_to date).
+
+        Rejects calls that would create an inverted interval — ``ended``
+        strictly before any matched row's ``valid_from``. Such a row would
+        never satisfy ``valid_from <= as_of AND valid_to >= as_of``, so it
+        would be invisible to every query — silently corrupt. Mirrors the
+        guard in :meth:`add_triple`.
+        """
         sub_id = self._entity_id(subject)
         obj_id = self._entity_id(obj)
         pred = predicate.lower().replace(" ", "_")
@@ -239,6 +246,21 @@ class KnowledgeGraph:
         with self._lock:
             conn = self._conn()
             with conn:
+                # Reject inverted intervals before the UPDATE. SELECT and
+                # UPDATE run in the same transaction so a concurrent insert
+                # cannot race a row past the guard.
+                rows = conn.execute(
+                    "SELECT valid_from FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
+                    (sub_id, pred, obj_id),
+                ).fetchall()
+                for row in rows:
+                    vf = row["valid_from"]
+                    if vf is not None and ended < vf:
+                        raise ValueError(
+                            f"ended={ended!r} is before valid_from={vf!r}; "
+                            "an inverted interval would be invisible to every KG query"
+                        )
+
                 conn.execute(
                     "UPDATE triples SET valid_to=? WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
                     (ended, sub_id, pred, obj_id),

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -79,6 +79,41 @@ class TestTripleOperations:
         tid2 = kg.add_triple("Alice", "knew", "Bob", valid_to="2026-03-01")
         assert tid2.startswith("t_alice_knew_bob_")
 
+    def test_invalidate_rejects_ended_before_valid_from(self, kg):
+        # Mirror of test_add_triple_rejects_inverted_interval but on the
+        # invalidate path: closing a relationship with `ended` strictly
+        # before its `valid_from` produces the same invisible-to-query
+        # state add_triple already rejects. #1371.
+        kg.add_triple("Alice", "knows", "Bob", valid_from="2026-01-01")
+        with pytest.raises(ValueError, match="before valid_from"):
+            kg.invalidate("Alice", "knows", "Bob", ended="2020-01-01")
+        # The original row must remain open after the rejection.
+        results = kg.query_entity("Alice", direction="outgoing")
+        rows = [r for r in results if r["predicate"] == "knows"]
+        assert len(rows) == 1
+        assert rows[0]["valid_to"] is None
+
+    def test_invalidate_accepts_ended_equal_to_valid_from(self, kg):
+        # Same-day close is a legitimate point-in-time fact, mirroring
+        # test_add_triple_accepts_equal_dates.
+        kg.add_triple("Alice", "joined", "Acme", valid_from="2026-03-15")
+        kg.invalidate("Alice", "joined", "Acme", ended="2026-03-15")
+        results = kg.query_entity("Alice", direction="outgoing")
+        rows = [r for r in results if r["predicate"] == "joined"]
+        assert len(rows) == 1
+        assert rows[0]["valid_to"] == "2026-03-15"
+
+    def test_invalidate_passes_through_open_intervals(self, kg):
+        # A row added with no valid_from cannot be inverted by any `ended`,
+        # so the guard does not fire. Non-regression for the original
+        # invalidate contract.
+        kg.add_triple("Alice", "works_at", "Acme")
+        kg.invalidate("Alice", "works_at", "Acme", ended="2020-01-01")
+        results = kg.query_entity("Alice", direction="outgoing")
+        rows = [r for r in results if r["predicate"] == "works_at"]
+        assert len(rows) == 1
+        assert rows[0]["valid_to"] == "2020-01-01"
+
 
 class TestQueries:
     def test_query_outgoing(self, seeded_kg):


### PR DESCRIPTION
## What and Why

#1214 added an inverted-interval guard to `KnowledgeGraph.add_triple()` so a row with `valid_to < valid_from` cannot be persisted on the create path. The same foot-gun was reachable through `invalidate()`: a caller passing `ended=\"2020-01-01\"` against an open row with `valid_from=\"2026-01-01\"` silently produced the same inverted state — invisible to every `query_entity` / `query_relationship` / `timeline` call (because the `as_of` filter `valid_from <= ? AND valid_to >= ?` can never be satisfied), durable in SQLite forever.

@igorls flagged this in #1371 during review of #1214.

## Root Cause

`mempalace/knowledge_graph.py:232-245` (pre-fix) — `invalidate()` issued an `UPDATE triples SET valid_to=?` with no comparison against the existing `valid_from`. The asymmetry with `add_triple()`'s line-177 guard meant the same invariant was enforced on creation but not on closure.

## Reproduction

```python
kg.add_triple('Alice', 'knows', 'Bob', valid_from='2026-01-01')
kg.invalidate('Alice', 'knows', 'Bob', ended='2020-01-01')

# Before this PR: silently succeeds. The row now has
# valid_from='2026-01-01', valid_to='2020-01-01' — invisible to every query.
results = kg.query_entity('Alice', as_of='2025-01-01')  # → []
results = kg.query_entity('Alice', as_of='2026-06-01')  # → []
# The relationship is gone from the graph permanently.

# After this PR:
# ValueError: ended='2020-01-01' is before valid_from='2026-01-01';
# an inverted interval would be invisible to every KG query
```

## Change Summary

- `mempalace/knowledge_graph.py:232-264` — `invalidate()` now `SELECT`s `valid_from` for all matched open rows before the `UPDATE`. If `ended < valid_from` for any matched row, raise `ValueError` with the same message format as `add_triple()`. The `SELECT` and `UPDATE` share one `with conn:` transaction so a concurrent insert cannot race a row past the guard.
- `ended == valid_from` is allowed (point-in-time fact, mirrors `test_add_triple_accepts_equal_dates`).
- Rows with `valid_from IS NULL` (open intervals) pass through — the original `invalidate()` contract for date-less triples is preserved.
- The guard fires if **any** matched row would become inverted (subject/predicate/object can repeat across time, so a single call may target multiple open rows; rejecting on any one prevents partial corruption).

## Test Plan

- [x] New `test_invalidate_rejects_ended_before_valid_from` — exercises the rejection path and asserts the row stays open after the failed call.
- [x] New `test_invalidate_accepts_ended_equal_to_valid_from` — same-day point-in-time close still works.
- [x] New `test_invalidate_passes_through_open_intervals` — non-regression: rows without `valid_from` invalidate normally.
- [x] All existing tests pass: `test_invalidate_sets_valid_to` (seeded_kg has `valid_from=\"2024-06-01\"`, ended `\"2026-01-01\"` — guard does not fire), `test_invalidated_triple_allows_re_add`, `test_add_triple_allows_only_one_bound`.
- [x] Full `tests/test_knowledge_graph.py`: 27 passed (24 existing + 3 new).
- [x] `ruff check .` and `ruff format --check .` clean on both files.

Closes #1371. Surfaced by @igorls during review of #1214.