### PR TITLE
feat(search): opt-in recency-aware ranking via exponential decay

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -60,6 +60,7 @@ def _recency_factor(filed_at_str, half_life_days: float = _RECENCY_HALF_LIFE_DAY
         return 1.0
     return 2.0 ** (-age_days / half_life_days)
 
+
 # Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
 # Multiple lines may join with newlines inside one closet document.
 _CLOSET_DRAWER_REF_RE = re.compile(r"→([\w,]+)")

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -14,9 +14,51 @@ import math
 import os
 import re
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .palace import get_closets_collection, get_collection
+
+
+# --- Recency-aware ranking config -------------------------------------------
+# Backwards compatible: with weight=0.0 (default) ``_hybrid_rank`` behaves
+# exactly as before.  Set MEMPALACE_RECENCY_WEIGHT to a value in (0, 1] to
+# blend in an exponential-decay recency factor; older drawers fade by half
+# every MEMPALACE_RECENCY_HALF_LIFE_DAYS (default 30).  Useful when a palace
+# accumulates years of session transcripts but the user is asking about
+# *current* state ("what was the latest decision on X?").
+_RECENCY_WEIGHT_DEFAULT = float(os.environ.get("MEMPALACE_RECENCY_WEIGHT", "0.0") or 0.0)
+_RECENCY_HALF_LIFE_DAYS_DEFAULT = float(
+    os.environ.get("MEMPALACE_RECENCY_HALF_LIFE_DAYS", "30") or 30
+)
+
+
+def _recency_factor(filed_at_str, half_life_days: float = _RECENCY_HALF_LIFE_DAYS_DEFAULT) -> float:
+    """Return a recency multiplier in [0, 1] for a drawer's ``filed_at`` timestamp.
+
+    Returns 1.0 for "filed now" and decays by half every ``half_life_days``.
+    Future-dated entries (clock skew) are treated as fresh (1.0).
+    Returns 0.0 when ``filed_at_str`` is missing, ``"unknown"``, or unparseable —
+    so a drawer with no timestamp can never beat a recent dated drawer
+    on the recency axis alone.
+    """
+    if not filed_at_str or filed_at_str == "unknown":
+        return 0.0
+    if not isinstance(filed_at_str, str):
+        return 0.0
+    s = filed_at_str.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return 0.0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    age_days = (datetime.now(timezone.utc) - dt).total_seconds() / 86400.0
+    if age_days <= 0 or half_life_days <= 0:
+        return 1.0
+    return 2.0 ** (-age_days / half_life_days)
 
 # Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
 # Multiple lines may join with newlines inside one closet document.
@@ -123,8 +165,11 @@ def _hybrid_rank(
     query: str,
     vector_weight: float = 0.6,
     bm25_weight: float = 0.4,
+    recency_weight: float = None,
+    half_life_days: float = None,
 ) -> list:
-    """Re-rank ``results`` by a convex combination of vector similarity and BM25.
+    """Re-rank ``results`` by a convex combination of vector similarity, BM25,
+    and (optionally) drawer recency.
 
     * Vector similarity uses absolute cosine sim ``max(0, 1 - distance)`` —
       ChromaDB's hnsw cosine distance lives in ``[0, 2]`` (0 = identical).
@@ -133,12 +178,34 @@ def _hybrid_rank(
     * BM25 is real Okapi-BM25 with corpus-relative IDF over the candidates
       themselves. Since the absolute scale is unbounded, BM25 is min-max
       normalized within the candidate set so weights are commensurable.
+    * Recency (opt-in) is an exponential-decay factor on drawer ``filed_at``;
+      half-life defaults to MEMPALACE_RECENCY_HALF_LIFE_DAYS (30).
 
-    Mutates each result dict to add ``bm25_score`` and reorders the list
-    in place. Returns the same list for convenience.
+    Final score is a weighted blend:
+        score = (1 - recency_weight) * (vector_weight * vec_sim
+                                        + bm25_weight  * bm25_norm)
+              + recency_weight       * recency_factor
+
+    With ``recency_weight=0`` (default) behavior is unchanged from before
+    this commit — it's a pure backward-compatible extension.
+
+    Mutates each result dict to add ``bm25_score`` (and ``recency_factor``
+    when recency blending is active) and reorders the list in place.
+    Returns the same list for convenience.
     """
     if not results:
         return results
+
+    if recency_weight is None:
+        recency_weight = _RECENCY_WEIGHT_DEFAULT
+    if half_life_days is None:
+        half_life_days = _RECENCY_HALF_LIFE_DAYS_DEFAULT
+
+    # Clamp recency_weight so callers can't accidentally invert the score.
+    if recency_weight < 0:
+        recency_weight = 0.0
+    elif recency_weight > 1:
+        recency_weight = 1.0
 
     docs = [r.get("text", "") for r in results]
     bm25_raw = _bm25_scores(query, docs)
@@ -149,7 +216,15 @@ def _hybrid_rank(
     for r, raw, norm in zip(results, bm25_raw, bm25_norm):
         vec_sim = max(0.0, 1.0 - r.get("distance", 1.0))
         r["bm25_score"] = round(raw, 3)
-        scored.append((vector_weight * vec_sim + bm25_weight * norm, r))
+        base = vector_weight * vec_sim + bm25_weight * norm
+        if recency_weight > 0:
+            filed_at = (r.get("metadata") or {}).get("filed_at")
+            recency = _recency_factor(filed_at, half_life_days=half_life_days)
+            r["recency_factor"] = round(recency, 3)
+            score = (1.0 - recency_weight) * base + recency_weight * recency
+        else:
+            score = base
+        scored.append((score, r))
 
     scored.sort(key=lambda pair: pair[0], reverse=True)
     results[:] = [r for _, r in scored]

--- a/tests/test_searcher_recency.py
+++ b/tests/test_searcher_recency.py
@@ -1,0 +1,198 @@
+"""
+test_searcher_recency.py -- Tests for opt-in recency-aware ranking.
+
+Pure-unit tests for ``_recency_factor`` and the recency blending path of
+``_hybrid_rank``. No ChromaDB / palace fixtures needed — both functions
+operate on plain dict lists.
+
+Covers:
+* recency_factor exponential decay (now=1.0, half-life=0.5, dead=≈0)
+* malformed / missing / None timestamps return 0.0 (so undated drawers
+  cannot win on the recency axis alone)
+* future-dated entries (clock skew) treated as fresh, not negative
+* trailing-Z (Zulu/UTC) timestamps parse correctly
+* timezone-naive timestamps assumed UTC
+* custom half_life overrides default
+* _hybrid_rank backward-compat: recency_weight=0 reproduces pre-PR ordering
+* _hybrid_rank flips order when recency dominates
+* recency_weight clamping ([0, 1])
+* empty results no-op
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from mempalace.searcher import _hybrid_rank, _recency_factor
+
+
+def _iso(days_ago: float) -> str:
+    """Return an ISO-8601 timestamp ``days_ago`` days before now (UTC)."""
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+# ── _recency_factor ────────────────────────────────────────────────────
+
+
+class TestRecencyFactor:
+    def test_now_is_one(self):
+        assert _recency_factor(_iso(0)) > 0.999
+
+    def test_at_half_life_is_half(self):
+        # Default half-life is 30 days; allow a small clock-tick tolerance.
+        assert abs(_recency_factor(_iso(30)) - 0.5) < 0.001
+
+    def test_two_half_lives_is_quarter(self):
+        assert abs(_recency_factor(_iso(60)) - 0.25) < 0.001
+
+    def test_far_past_is_near_zero(self):
+        # 365d at 30d half-life ≈ 12.17 half-lives → ~2.2e-4 (well below 0.001).
+        assert _recency_factor(_iso(365)) < 0.001
+
+    def test_unknown_string_returns_zero(self):
+        assert _recency_factor("unknown") == 0.0
+
+    def test_none_returns_zero(self):
+        assert _recency_factor(None) == 0.0
+
+    def test_empty_string_returns_zero(self):
+        assert _recency_factor("") == 0.0
+
+    def test_malformed_returns_zero(self):
+        assert _recency_factor("not-a-date") == 0.0
+        assert _recency_factor("2026-13-99T00:00:00Z") == 0.0
+
+    def test_non_string_input_returns_zero(self):
+        assert _recency_factor(12345) == 0.0
+        assert _recency_factor([]) == 0.0
+
+    def test_trailing_z_parsed(self):
+        s = _iso(0).replace("+00:00", "Z")
+        assert _recency_factor(s) > 0.999
+
+    def test_future_dated_treated_as_fresh(self):
+        # Clock-skew safety: future dates clamp to fresh, never negative.
+        assert _recency_factor(_iso(-5)) == 1.0
+
+    def test_naive_timestamp_assumed_utc(self):
+        # ``datetime.fromisoformat`` accepts naive strings; we assume UTC.
+        s = (datetime.now(timezone.utc) - timedelta(days=30)).replace(tzinfo=None).isoformat()
+        assert abs(_recency_factor(s) - 0.5) < 0.01
+
+    def test_custom_half_life(self):
+        # 90 days at half-life=10 → 9 half-lives → 2**-9 ≈ 0.00195.
+        result = _recency_factor(_iso(90), half_life_days=10)
+        assert abs(result - 0.001953125) < 0.0001
+
+    def test_zero_half_life_returns_one_for_fresh(self):
+        # Edge case: half_life_days=0 means no decay; fresh stays fresh.
+        # (Implementation returns 1.0 to avoid divide-by-zero blowup.)
+        assert _recency_factor(_iso(0), half_life_days=0) == 1.0
+
+
+# ── _hybrid_rank — backward compatibility ──────────────────────────────
+
+
+def _make_candidates() -> list:
+    """Two candidates: an older drawer with stronger base score, a newer with weaker."""
+    return [
+        {
+            "text": "older but exact lexical match for query foo bar",
+            "distance": 0.3,  # vec_sim = 0.7
+            "metadata": {"filed_at": _iso(365)},
+        },
+        {
+            "text": "newer with weaker semantic overlap",
+            "distance": 0.5,  # vec_sim = 0.5
+            "metadata": {"filed_at": _iso(1)},
+        },
+    ]
+
+
+class TestHybridRankBackwardCompat:
+    def test_recency_weight_zero_preserves_old_ordering(self):
+        results = _make_candidates()
+        _hybrid_rank(results, "query foo bar", recency_weight=0.0)
+        # Older candidate should win on pure vec+BM25 because exact lexical match.
+        assert results[0]["text"].startswith("older")
+
+    def test_default_recency_weight_is_zero(self, monkeypatch):
+        # Ensure no env-var leak from the test runner.
+        monkeypatch.delenv("MEMPALACE_RECENCY_WEIGHT", raising=False)
+        # Re-import to pick up the cleared env (module-level constant).
+        # Easier: pass explicit recency_weight to bypass the constant.
+        results = _make_candidates()
+        _hybrid_rank(results, "query foo bar")  # no recency_weight kwarg
+        # Without the kwarg AND without env, behavior should match recency=0.
+        # (Module-level _RECENCY_WEIGHT_DEFAULT defaults to 0.0.)
+        from mempalace.searcher import _RECENCY_WEIGHT_DEFAULT
+
+        if _RECENCY_WEIGHT_DEFAULT == 0.0:
+            assert results[0]["text"].startswith("older")
+
+    def test_empty_list_no_op(self):
+        results: list = []
+        out = _hybrid_rank(results, "anything", recency_weight=0.5)
+        assert out == []
+        assert results == []
+
+    def test_bm25_score_added_to_each_result(self):
+        results = _make_candidates()
+        _hybrid_rank(results, "query foo bar", recency_weight=0.0)
+        for r in results:
+            assert "bm25_score" in r
+            assert isinstance(r["bm25_score"], float)
+
+
+# ── _hybrid_rank — recency blending ────────────────────────────────────
+
+
+class TestHybridRankRecencyBlending:
+    def test_recency_flips_order_when_strong(self):
+        results = _make_candidates()
+        _hybrid_rank(results, "query foo bar", recency_weight=0.7, half_life_days=30)
+        # With strong recency weight, the 1-day-old drawer should win
+        # despite the 365-day-old one having stronger base similarity.
+        assert results[0]["text"].startswith("newer")
+
+    def test_recency_factor_added_when_active(self):
+        results = _make_candidates()
+        _hybrid_rank(results, "query foo bar", recency_weight=0.5)
+        for r in results:
+            assert "recency_factor" in r
+
+    def test_recency_factor_not_added_when_inactive(self):
+        results = _make_candidates()
+        _hybrid_rank(results, "query foo bar", recency_weight=0.0)
+        # No recency_factor key — saves payload bytes for callers
+        # that don't want recency in their MCP response.
+        for r in results:
+            assert "recency_factor" not in r
+
+    def test_missing_filed_at_does_not_crash(self):
+        results = [
+            {"text": "doc with metadata", "distance": 0.3, "metadata": {"filed_at": _iso(1)}},
+            {"text": "doc without filed_at", "distance": 0.4, "metadata": {}},
+            {"text": "doc with None metadata", "distance": 0.5, "metadata": None},
+        ]
+        # Should run cleanly, never raising; undated drawers get factor=0.0.
+        _hybrid_rank(results, "doc", recency_weight=0.5)
+        # The dated drawer should win when recency weighs heavily.
+        assert results[0]["text"] == "doc with metadata"
+
+
+# ── _hybrid_rank — clamping ────────────────────────────────────────────
+
+
+class TestRecencyWeightClamping:
+    def test_negative_clamps_to_zero(self):
+        results = _make_candidates()
+        _hybrid_rank(results, "query foo bar", recency_weight=-5.0)
+        # Clamped to 0 → behaves like backward-compat: older with strong base wins.
+        assert results[0]["text"].startswith("older")
+
+    def test_above_one_clamps_to_one(self):
+        results = _make_candidates()
+        _hybrid_rank(results, "query foo bar", recency_weight=99.0)
+        # Clamped to 1 → pure recency: 1-day-old beats 365-day-old.
+        assert results[0]["text"].startswith("newer")


### PR DESCRIPTION
## Summary

Add an optional third axis to the existing hybrid (vector + BM25) ranker in ``_hybrid_rank``: an exponential-decay recency factor on each drawer's ``filed_at`` timestamp.

This addresses the common *"what was the latest decision on X?"* failure mode where a palace accumulates years of session transcripts and an old high-similarity drawer outranks a recent, more relevant one. Pure cosine + BM25 has no notion of time, so a 12-month-old infrastructure note can mask the answer recorded in last week's session.

## Behavior

**Default (``MEMPALACE_RECENCY_WEIGHT=0.0``) is a strict no-op** — the score formula collapses to the existing convex combination:

```
score = 0.6 * vec_sim + 0.4 * bm25_norm
```

Setting ``MEMPALACE_RECENCY_WEIGHT`` to a value in ``(0, 1]`` blends in ``recency_factor``:

```
score = (1 - w) * (0.6 * vec_sim + 0.4 * bm25_norm)
      + w       *  recency_factor

recency_factor = 2 ** (-age_days / half_life_days)
age_days       = max(0, now - filed_at)
```

## Configuration

| Env var | Default | Meaning |
|---|---|---|
| ``MEMPALACE_RECENCY_WEIGHT`` | ``0.0`` | Blend factor; 0 = old behavior, 1 = pure recency |
| ``MEMPALACE_RECENCY_HALF_LIFE_DAYS`` | ``30`` | Time for ``recency_factor`` to halve |

Programmatic callers can also override per-call:

```python
_hybrid_rank(results, query, recency_weight=0.3, half_life_days=14)
```

Negative weights clamp to 0; values >1 clamp to 1 — a callsite that plumbs through user input can never invert the score direction.

## Edge cases handled

* Missing or unparseable ``filed_at`` → ``recency_factor = 0.0`` (a drawer with no timestamp can never beat a recent dated drawer on the recency axis alone)
* Future-dated entries (clock skew) → ``recency_factor = 1.0`` (treated as "just now", not negative)
* Trailing ``Z`` (Zulu/UTC) timestamps → parsed correctly via the standard ``datetime.fromisoformat`` ``+00:00`` substitution
* Timezone-naive timestamps → assumed UTC
* Empty results list → unchanged no-op

When recency blending is active, each result dict gains a ``"recency_factor"`` key alongside the existing ``"bm25_score"``, so introspection / debugging still works (CLI ``mempalace search`` can display it; MCP responses pass through arbitrary keys to the agent).

## Why opt-in by default

* Existing palaces see literally no behavior change without explicit env var
* Long-tail-stable palaces (reference docs, code patterns, identity files) usually want ``recency=0``; aging them out would be wrong
* Users with mostly session-transcript content benefit most
* Half-life of 30 days matches the "what's current?" intent of typical agent queries without aging out reference material too aggressively

## Test plan

Smoke-tested in a sanity script:

```
=== _recency_factor ===
  now           -> 1.000
  30d ago       -> 0.500   ← exact half-life
  60d ago       -> 0.250
  365d ago      -> 0.000
  unknown       -> 0.000
  None          -> 0.000
  malformed     -> 0.000
  trailing-Z    -> 1.000
  future        -> 1.000
  90d half=10   -> 0.002

=== _hybrid_rank ===
  recency_weight=0   -> top: 'older but exact match' (backward-compat ✓)
  recency_weight=.5  -> top: 'newer but weaker semantic match' (recency wins ✓)
  recency_weight=99  -> clamped to 1.0 (pure recency)
  recency_weight=-5  -> clamped to 0.0 (no effect)
  empty list         -> no-op ✓
```

## Followups (not in this PR)

These were considered but kept out for focused review; happy to open separate PRs if the maintainer is interested:

* **Embedder upgrade as opt-in** — current ``all-MiniLM-L6-v2`` is the 2019 baseline; ``BGE-base-en-v1.5`` typically gets +30-40% recall@10. Needs a re-embed migration tool because vectors are dim-incompatible (384 → 768).
* **Cross-encoder reranker on the live MCP path** — benchmark code uses LLM-as-reranker (``llm_rerank_locomo``) which is too slow / costly for production. A real cross-encoder (``bge-reranker-base``) would add ~50-200 ms per query but materially improve top-K precision; would introduce a new optional dep.