### PR TITLE
fix(convo_miner): auto-quarantine stale HNSW before opening palace

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -416,6 +416,9 @@ def mine_convos(
         print("  DRY RUN — nothing will be filed")
     print(f"{'-' * 55}\n")
 
+    if not dry_run:
+        from .backends.chroma import quarantine_stale_hnsw
+        quarantine_stale_hnsw(palace_path, stale_seconds=900)
     collection = get_collection(palace_path) if not dry_run else None
 
     total_drawers = 0


### PR DESCRIPTION
## Problem

Running `mempalace mine --mode convos` alongside a running MemPalace MCP
server crashes with SIGSEGV (exit 139).

Root cause: after any mine run, `chroma.sqlite3` is updated but HNSW
segment files (`data_level0.bin`) are not flushed immediately. When a
second process opens the same palace, ChromaDB 1.5.x's Rust HNSW walk
dereferences dangling neighbor pointers and segfaults.

`quarantine_stale_hnsw()` already exists in `backends/chroma.py` for
exactly this — but is **never called automatically**. The existing 3600 s
default threshold is also too conservative: 15-minute drift between
`chroma.sqlite3` and `data_level0.bin` is sufficient to trigger the crash.

## Fix

Call `quarantine_stale_hnsw(palace_path, stale_seconds=900)` in
`mine_convos()` before `get_collection()` opens ChromaDB.

## Tested on

Windows 11, Python 3.14, ChromaDB 1.5.x — 14 Cowork sessions → 1175
drawers filed, 0 segfaults after this patch.