### PR TITLE
fix(tests): use spawn instead of fork for lock-test subprocesses

### DIFF
--- a/tests/test_chroma_collection_lock.py
+++ b/tests/test_chroma_collection_lock.py
@@ -36,9 +36,13 @@ from mempalace.palace import MineAlreadyRunning, mine_palace_lock
 
 
 def _get_mp_context():
-    """Same start-method picker as test_palace_locks.py."""
-    start_method = "spawn" if os.name == "nt" else "fork"
-    return multiprocessing.get_context(start_method)
+    """Same start-method picker as test_palace_locks.py — ``spawn`` everywhere.
+
+    ``fork`` deadlocks under Python 3.13 when the parent is multi-threaded
+    (pytest + chromadb + onnxruntime), and macOS forbids fork-without-exec via
+    CoreFoundation. ``spawn`` is slower (re-imports) but safe.
+    """
+    return multiprocessing.get_context("spawn")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -23,15 +23,17 @@ from mempalace.palace import (
 
 
 def _get_mp_context():
-    """Pick a start method that works on every CI runner.
+    """Always use ``spawn`` — ``fork`` deadlocks under modern Python.
 
-    `fork` is cheaper (no re-import) but is unavailable on Windows, so we fall
-    back to `spawn` there. `spawn` inherits ``os.environ`` (including the
-    monkeypatched ``HOME``) and re-imports the ``mempalace`` package in the
-    child, which is sufficient for the lock-file semantics exercised here.
+    The parent (pytest + chromadb + onnxruntime) is multi-threaded by the time
+    these tests run. ``fork`` snapshots that state into the child without the
+    threads that hold the locks, which Python 3.13 explicitly warns about and
+    which deadlocks the CI runners. macOS additionally forbids
+    fork-without-exec via CoreFoundation. ``spawn`` re-imports the package in
+    the child (slower, but safe) and inherits ``os.environ`` — including the
+    monkeypatched ``HOME`` — which is all these lock-file tests need.
     """
-    start_method = "spawn" if os.name == "nt" else "fork"
-    return multiprocessing.get_context(start_method)
+    return multiprocessing.get_context("spawn")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Recent CI runs have been hanging on **Linux 3.13** and **macOS** while **Linux 3.9 / 3.11** and **Windows** finish normally. Same hang signature on every PR (#1396, #1430): `pytest` step starts, jobs run for 33+ minutes with no progress, get cancelled.

The cause is in two test files that explicitly request the `fork` start method for `multiprocessing`:

```python
# tests/test_palace_locks.py and tests/test_chroma_collection_lock.py
start_method = "spawn" if os.name == "nt" else "fork"
return multiprocessing.get_context(start_method)
```

By the time these tests run, the pytest parent is multi-threaded — `chromadb` and `onnxruntime` both spawn background threads on import. When `fork` snapshots that state into a child without the threads themselves, any lock held by another thread at fork time stays locked in the child forever. Python 3.13 explicitly warns about this (we saw the `DeprecationWarning` 10 times in a local 3.13 run), and the timing window where Python's own internal threads hold locks widened in 3.13 enough to make the deadlock reproducible.

macOS hits a parallel issue: Apple's CoreFoundation forbids fork-without-exec. Anything ONNX/Obj-C-bridge-touching that loaded in the parent will silently hang the moment the forked child touches the same library — independent of Python version.

## Change

Switch both `_get_mp_context()` helpers to use `multiprocessing.get_context("spawn")` unconditionally. Lock-file semantics are unchanged: `spawn` inherits `os.environ` (including monkeypatched `HOME`), which is all these tests need from the parent. Trade-off is per-Process import overhead (~0.5s on Linux), bounded by the small number of subprocesses these tests fork (10 across both files).

## Test plan

- [x] `uv run --python 3.13 pytest tests/test_chroma_collection_lock.py tests/test_palace_locks.py -v` → 14 passed in 6.58s
- [x] `ruff check` and `ruff format --check` (CI-pinned `ruff>=0.4.0,<0.5`) → clean
- [ ] CI green on Linux 3.9/3.11/3.13, Windows, macOS, lint
- [ ] Linux 3.13 + macOS no longer hang

## Notes

- The test docstrings claimed `fork` was preferred for speed; that reasoning is now obsolete (or rather, was always at risk). The new docstrings explain why `spawn` is required.
- This is independent of #1430 (sqlite cleanup). They can land in either order.