### PR TITLE
refactor(searcher): decompose search_memories and bm25_only_via_sqlite

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -437,32 +437,24 @@ def _select_bm25_candidate_ids(
 ) -> list:
     """Run the FTS5 → recency → id-ordered fallback chain.
 
-    Behavioral nuance preserved verbatim from the original inline logic:
-    a *successful but empty* FTS5 result terminates the chain — recency
-    fallback only runs when FTS5 itself raised, or when the query had no
-    usable trigram tokens. This avoids returning unrelated drawers under
-    a wing/room scope that legitimately has zero FTS5 matches.
+    Behavioral nuance preserved: a *successful but empty* FTS5 result
+    terminates the chain — recency fallback only runs when FTS5 itself
+    raised, or when the query had no usable trigram tokens. (Without this,
+    recency would surface unrelated drawers under a wing/room scope that
+    legitimately has zero FTS5 matches.)
     """
     # FTS5 MATCH expects whitespace-separated tokens. Drop tokens shorter
     # than 3 chars (the trigram tokenizer can't match them).
     tokens = [t for t in _tokenize(query) if len(t) >= 3]
-    use_recency_fallback = not tokens
     if tokens:
         fts_query = " OR ".join(tokens)
         try:
-            ids = _select_via_fts5(conn, fts_query, collection_name, wing, room, max_candidates)
+            return _select_via_fts5(conn, fts_query, collection_name, wing, room, max_candidates)
         except sqlite3.Error:
             logger.debug("FTS5 MATCH failed; using recency fallback", exc_info=True)
-            use_recency_fallback = True
-        else:
-            # Successful FTS5 — return its result, even if empty. A clean
-            # miss (especially under wing/room scope) must NOT cascade to
-            # recency, which would surface unrelated drawers.
-            return ids
 
-    if not use_recency_fallback:
-        return []
-
+    # Reached only if (a) no usable tokens or (b) FTS5 raised. Try recency,
+    # then id-ordered as the final fallback.
     try:
         return _select_via_recency(conn, collection_name, wing, room, max_candidates)
     except sqlite3.Error:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -18,10 +18,6 @@ from pathlib import Path
 
 from .palace import get_closets_collection, get_collection
 
-# Closet pointer line format: "topic|entities|→drawer_id_a,drawer_id_b"
-# Multiple lines may join with newlines inside one closet document.
-_CLOSET_DRAWER_REF_RE = re.compile(r"→([\w,]+)")
-
 logger = logging.getLogger("mempalace_mcp")
 
 
@@ -30,6 +26,18 @@ class SearchError(Exception):
 
 
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
+
+# Search tunables. Kept at module level so the dispatcher reads cleanly
+# and tests can patch these without surgery on a function body.
+CLOSET_RANK_BOOSTS = [0.40, 0.25, 0.15, 0.08, 0.04]
+CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
+MAX_HYDRATION_CHARS = 10000
+
+# Over-fetch ratios. The hybrid rerank pool is ``n_results * RATIO`` so
+# BM25/closet signals can reorder a wider candidate set than the final cut.
+_VECTOR_OVERFETCH_RATIO = 3
+_CLOSET_OVERFETCH_RATIO = 2
+_BM25_UNION_OVERFETCH_RATIO = 3
 
 
 def _first_or_empty(results, key: str) -> list:
@@ -176,84 +184,6 @@ def build_where_filter(wing: str = None, room: str = None) -> dict:
     return {}
 
 
-def _extract_drawer_ids_from_closet(closet_doc: str) -> list:
-    """Parse all `→drawer_id_a,drawer_id_b` pointers out of a closet document.
-
-    Preserves order and dedupes.
-    """
-    seen: dict = {}
-    for match in _CLOSET_DRAWER_REF_RE.findall(closet_doc):
-        for did in match.split(","):
-            did = did.strip()
-            if did and did not in seen:
-                seen[did] = None
-    return list(seen.keys())
-
-
-def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, radius: int = 1):
-    """Expand a matched drawer with its ±radius sibling chunks in the same source file.
-
-    Motivation — "drawer-grep context" feature: a closet hit returns one
-    drawer, but the chunk boundary may clip mid-thought (e.g., the matched
-    chunk says "here's a breakdown:" and the actual breakdown lives in the
-    next chunk). Fetching the small neighborhood around the match gives
-    callers enough context without forcing a follow-up ``get_drawer`` call.
-
-    Returns a dict with:
-        ``text``            combined chunks in chunk_index order
-        ``drawer_index``    the matched chunk's index in the source file
-        ``total_drawers``   total drawer count for the source file (or None)
-
-    On any ChromaDB failure or missing metadata, falls back to returning the
-    matched drawer alone so search never breaks because neighbor expansion
-    failed.
-    """
-    src = matched_meta.get("source_file")
-    chunk_idx = matched_meta.get("chunk_index")
-    if not src or not isinstance(chunk_idx, int):
-        return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
-
-    target_indexes = [chunk_idx + offset for offset in range(-radius, radius + 1)]
-    try:
-        neighbors = drawers_col.get(
-            where={
-                "$and": [
-                    {"source_file": src},
-                    {"chunk_index": {"$in": target_indexes}},
-                ]
-            },
-            include=["documents", "metadatas"],
-        )
-    except Exception:
-        return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
-
-    indexed_docs = []
-    for doc, meta in zip(neighbors.documents, neighbors.metadatas):
-        ci = meta.get("chunk_index")
-        if isinstance(ci, int):
-            indexed_docs.append((ci, doc))
-    indexed_docs.sort(key=lambda pair: pair[0])
-
-    if not indexed_docs:
-        combined_text = matched_doc
-    else:
-        combined_text = "\n\n".join(doc for _, doc in indexed_docs)
-
-    # Cheap total_drawers lookup: metadata-only scan of the source file.
-    total_drawers = None
-    try:
-        all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
-        total_drawers = len(all_meta.ids) if all_meta.ids else None
-    except Exception:
-        logger.debug("total_drawers lookup failed for %s", src, exc_info=True)
-
-    return {
-        "text": combined_text,
-        "drawer_index": chunk_idx,
-        "total_drawers": total_drawers,
-    }
-
-
 def _warn_if_legacy_metric(col) -> None:
     """Print a one-line notice if the palace was created without
     ``hnsw:space=cosine``.
@@ -374,6 +304,263 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     print()
 
 
+def _metadata_filter_sql(row_id_expr: str, wing: str, room: str) -> tuple[str, list[str]]:
+    """Build ``AND EXISTS(SELECT ... FROM embedding_metadata ...)`` clauses for wing/room.
+
+    The metadata is stored as one row per (embedding_id, key, value), so each
+    filter joins back to ``embedding_metadata`` via the row id expression
+    supplied by the caller (e.g. ``e.id`` or ``embedding_fulltext_search.rowid``).
+    Returns ``("", [])`` when neither filter is active.
+    """
+    clauses: list = []
+    params: list = []
+    for key, value in (("wing", wing), ("room", room)):
+        if not value:
+            continue
+        clauses.append(
+            f"""
+            AND EXISTS (
+                SELECT 1
+                FROM embedding_metadata mf
+                WHERE mf.id = {row_id_expr}
+                  AND mf.key = ?
+                  AND COALESCE(
+                    mf.string_value,
+                    CAST(mf.int_value AS TEXT),
+                    CAST(mf.float_value AS TEXT),
+                    CAST(mf.bool_value AS TEXT)
+                  ) = ?
+            )
+            """
+        )
+        params.extend([key, value])
+    return "".join(clauses), params
+
+
+def _select_via_fts5(
+    conn,
+    fts_query: str,
+    collection_name: str,
+    wing: str,
+    room: str,
+    max_candidates: int,
+) -> list:
+    """FTS5 MATCH selector. Returns candidate row ids.
+
+    Raises ``sqlite3.Error`` on tokenizer mismatch / syntax error so the
+    caller can distinguish "FTS5 hit nothing" (return [] and stop) from
+    "FTS5 broke" (fall through to the recency selector).
+    """
+    filter_sql, filter_params = _metadata_filter_sql("embedding_fulltext_search.rowid", wing, room)
+    rows = conn.execute(
+        f"""
+        SELECT embedding_fulltext_search.rowid
+        FROM embedding_fulltext_search
+        JOIN embeddings e ON e.id = embedding_fulltext_search.rowid
+        JOIN segments s ON e.segment_id = s.id
+        JOIN collections c ON s.collection = c.id
+        WHERE embedding_fulltext_search MATCH ?
+          AND c.name = ?
+        {filter_sql}
+        LIMIT ?
+        """,
+        (fts_query, collection_name, *filter_params, max_candidates),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _select_via_recency(
+    conn,
+    collection_name: str,
+    wing: str,
+    room: str,
+    max_candidates: int,
+) -> list:
+    """``ORDER BY created_at DESC`` selector. Raises ``sqlite3.Error`` on schema mismatch.
+
+    Used as the second fallback when there are no usable FTS tokens or
+    FTS5 itself errored.
+    """
+    filter_sql, filter_params = _metadata_filter_sql("e.id", wing, room)
+    rows = conn.execute(
+        f"""
+        SELECT e.id
+        FROM embeddings e
+        JOIN segments s ON e.segment_id = s.id
+        JOIN collections c ON s.collection = c.id
+        WHERE c.name = ?
+        {filter_sql}
+        ORDER BY e.created_at DESC
+        LIMIT ?
+        """,
+        (collection_name, *filter_params, max_candidates),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _select_via_id(
+    conn,
+    collection_name: str,
+    wing: str,
+    room: str,
+    max_candidates: int,
+) -> list:
+    """``ORDER BY e.id DESC`` selector — the final fallback.
+
+    Used when even the recency-window query errors (legacy palaces without
+    ``created_at``, partial restores missing ``segments`` rows, etc.).
+    """
+    filter_sql, filter_params = _metadata_filter_sql("e.id", wing, room)
+    rows = conn.execute(
+        f"""
+        SELECT e.id
+        FROM embeddings e
+        JOIN segments s ON e.segment_id = s.id
+        JOIN collections c ON s.collection = c.id
+        WHERE c.name = ?
+        {filter_sql}
+        ORDER BY e.id DESC
+        LIMIT ?
+        """,
+        (collection_name, *filter_params, max_candidates),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _select_bm25_candidate_ids(
+    conn,
+    query: str,
+    collection_name: str,
+    wing: str,
+    room: str,
+    max_candidates: int,
+) -> list:
+    """Run the FTS5 → recency → id-ordered fallback chain.
+
+    Behavioral nuance preserved verbatim from the original inline logic:
+    a *successful but empty* FTS5 result terminates the chain — recency
+    fallback only runs when FTS5 itself raised, or when the query had no
+    usable trigram tokens. This avoids returning unrelated drawers under
+    a wing/room scope that legitimately has zero FTS5 matches.
+    """
+    # FTS5 MATCH expects whitespace-separated tokens. Drop tokens shorter
+    # than 3 chars (the trigram tokenizer can't match them).
+    tokens = [t for t in _tokenize(query) if len(t) >= 3]
+    use_recency_fallback = not tokens
+    if tokens:
+        fts_query = " OR ".join(tokens)
+        try:
+            ids = _select_via_fts5(conn, fts_query, collection_name, wing, room, max_candidates)
+        except sqlite3.Error:
+            logger.debug("FTS5 MATCH failed; using recency fallback", exc_info=True)
+            use_recency_fallback = True
+        else:
+            # Successful FTS5 — return its result, even if empty. A clean
+            # miss (especially under wing/room scope) must NOT cascade to
+            # recency, which would surface unrelated drawers.
+            return ids
+
+    if not use_recency_fallback:
+        return []
+
+    try:
+        return _select_via_recency(conn, collection_name, wing, room, max_candidates)
+    except sqlite3.Error:
+        logger.debug("recency-window query failed; trying id-ordered fallback", exc_info=True)
+
+    try:
+        return _select_via_id(conn, collection_name, wing, room, max_candidates)
+    except sqlite3.Error:
+        logger.debug("id-ordered fallback also failed", exc_info=True)
+        return []
+
+
+def _load_drawer_metadata(conn, ids: list) -> list:
+    """Fetch ``(id, key, string_value, int_value)`` rows for the given embedding ids."""
+    if not ids:
+        return []
+    placeholders = ",".join(["?"] * len(ids))
+    return conn.execute(
+        f"""
+        SELECT id, key, string_value, int_value
+        FROM embedding_metadata
+        WHERE id IN ({placeholders})
+        """,
+        ids,
+    ).fetchall()
+
+
+def _shape_drawer_candidates(meta_rows: list, wing: str, room: str) -> list:
+    """Group flat metadata rows into per-drawer dicts, apply Python-side wing/room filter.
+
+    FTS5 candidates may include entries from other wings (the metadata
+    EXISTS-clauses restrict at JOIN time but distinct shared metadata rows
+    can still leak through), so re-checking in Python is the safety net.
+    """
+    drawers: dict = {}
+    for emb_id, key, sval, ival in meta_rows:
+        d = drawers.setdefault(emb_id, {"_id": emb_id, "metadata": {}, "text": ""})
+        if key == "chroma:document":
+            d["text"] = sval or ""
+        else:
+            d["metadata"][key] = sval if sval is not None else ival
+
+    candidates: list = []
+    for d in drawers.values():
+        meta = d["metadata"]
+        if wing and meta.get("wing") != wing:
+            continue
+        if room and meta.get("room") != room:
+            continue
+        full_source = meta.get("source_file", "") or ""
+        candidates.append(
+            {
+                "text": d["text"],
+                "wing": meta.get("wing", "unknown"),
+                "room": meta.get("room", "unknown"),
+                "source_file": Path(full_source).name if full_source else "?",
+                "created_at": meta.get("filed_at", "unknown"),
+                # No vector distance available in BM25-only mode.
+                "similarity": None,
+                "distance": None,
+                "matched_via": "bm25_sqlite",
+                # Internal: full path + chunk_index let callers (notably
+                # candidate_strategy="union") dedupe at chunk granularity
+                # rather than basename — two files in different directories
+                # may share a basename, and one source_file is split across
+                # multiple chunks. Stripped before this helper returns
+                # unless _include_internal is set.
+                "_source_file_full": full_source,
+                "_chunk_index": meta.get("chunk_index"),
+            }
+        )
+    return candidates
+
+
+def _rank_and_trim(candidates: list, query: str, n_results: int, _include_internal: bool) -> list:
+    """BM25-score candidates, sort descending, trim to ``n_results``, strip internals.
+
+    Mutates each candidate to add ``bm25_score``; uses a transient ``_score``
+    field for sorting (popped before return). Internal source-path/chunk
+    fields are stripped unless the caller opted in via ``_include_internal``
+    (the union-merge path does this for chunk-precise dedup).
+    """
+    docs = [c["text"] for c in candidates]
+    bm25_raw = _bm25_scores(query, docs)
+    max_bm25 = max(bm25_raw) if bm25_raw else 0.0
+    for c, raw in zip(candidates, bm25_raw):
+        c["bm25_score"] = round(raw, 3)
+        c["_score"] = (raw / max_bm25) if max_bm25 > 0 else 0.0
+    candidates.sort(key=lambda c: c["_score"], reverse=True)
+    hits = candidates[:n_results]
+    for h in hits:
+        h.pop("_score", None)
+        if not _include_internal:
+            h.pop("_source_file_full", None)
+            h.pop("_chunk_index", None)
+    return hits
+
+
 def _bm25_only_via_sqlite(
     query: str,
     palace_path: str,
@@ -411,119 +598,15 @@ def _bm25_only_via_sqlite(
 
         collection_name = get_configured_collection_name()
 
-    def _metadata_filter_sql(row_id_expr: str) -> tuple[str, list[str]]:
-        clauses = []
-        params = []
-        for key, value in (("wing", wing), ("room", room)):
-            if not value:
-                continue
-            clauses.append(
-                f"""
-                AND EXISTS (
-                    SELECT 1
-                    FROM embedding_metadata mf
-                    WHERE mf.id = {row_id_expr}
-                      AND mf.key = ?
-                      AND COALESCE(
-                        mf.string_value,
-                        CAST(mf.int_value AS TEXT),
-                        CAST(mf.float_value AS TEXT),
-                        CAST(mf.bool_value AS TEXT)
-                      ) = ?
-                )
-                """
-            )
-            params.extend([key, value])
-        return "".join(clauses), params
-
     try:
         conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
     except sqlite3.Error as e:
         return {"error": f"sqlite open failed: {e}"}
 
     try:
-        # FTS5 MATCH expects whitespace-separated tokens. Drop tokens
-        # shorter than 3 chars (trigram tokenizer can't match them).
-        tokens = [t for t in _tokenize(query) if len(t) >= 3]
-        candidate_ids: list[int] = []
-        use_recency_fallback = not tokens
-        if tokens:
-            fts_query = " OR ".join(tokens)
-            filter_sql, filter_params = _metadata_filter_sql("embedding_fulltext_search.rowid")
-            try:
-                rows = conn.execute(
-                    f"""
-                    SELECT embedding_fulltext_search.rowid
-                    FROM embedding_fulltext_search
-                    JOIN embeddings e ON e.id = embedding_fulltext_search.rowid
-                    JOIN segments s ON e.segment_id = s.id
-                    JOIN collections c ON s.collection = c.id
-                    WHERE embedding_fulltext_search MATCH ?
-                      AND c.name = ?
-                    {filter_sql}
-                    LIMIT ?
-                    """,
-                    (fts_query, collection_name, *filter_params, max_candidates),
-                ).fetchall()
-                candidate_ids = [r[0] for r in rows]
-            except sqlite3.Error:
-                # FTS5 tokenizer mismatch or syntax error — fall through
-                # to the recency-window selector below.
-                logger.debug("FTS5 MATCH failed; using recency fallback", exc_info=True)
-                use_recency_fallback = True
-
-        if not candidate_ids and use_recency_fallback:
-            # No usable FTS tokens, or FTS itself failed — pull the most
-            # recent rows for the drawers segment so we can BM25-rank
-            # something rather than return empty-handed. A clean FTS miss
-            # must stay empty, especially after wing/room filtering, because
-            # recency fallback would return unrelated scoped drawers.
-            # Wrapped in try/except because the schema may differ on legacy
-            # palaces (older chromadb without ``created_at``, missing
-            # ``segments`` rows after partial restore, etc.); on schema
-            # mismatch we fall back to ordering by primary-key id and finally
-            # to an empty result rather than letting search raise.
-            try:
-                filter_sql, filter_params = _metadata_filter_sql("e.id")
-                rows = conn.execute(
-                    f"""
-                    SELECT e.id
-                    FROM embeddings e
-                    JOIN segments s ON e.segment_id = s.id
-                    JOIN collections c ON s.collection = c.id
-                    WHERE c.name = ?
-                    {filter_sql}
-                    ORDER BY e.created_at DESC
-                    LIMIT ?
-                    """,
-                    (collection_name, *filter_params, max_candidates),
-                ).fetchall()
-                candidate_ids = [r[0] for r in rows]
-            except sqlite3.Error:
-                logger.debug(
-                    "recency-window query failed; trying id-ordered fallback",
-                    exc_info=True,
-                )
-                try:
-                    filter_sql, filter_params = _metadata_filter_sql("e.id")
-                    rows = conn.execute(
-                        f"""
-                        SELECT e.id
-                        FROM embeddings e
-                        JOIN segments s ON e.segment_id = s.id
-                        JOIN collections c ON s.collection = c.id
-                        WHERE c.name = ?
-                        {filter_sql}
-                        ORDER BY e.id DESC
-                        LIMIT ?
-                        """,
-                        (collection_name, *filter_params, max_candidates),
-                    ).fetchall()
-                    candidate_ids = [r[0] for r in rows]
-                except sqlite3.Error:
-                    logger.debug("id-ordered fallback also failed", exc_info=True)
-                    candidate_ids = []
-
+        candidate_ids = _select_bm25_candidate_ids(
+            conn, query, collection_name, wing, room, max_candidates
+        )
         if not candidate_ids:
             return {
                 "query": query,
@@ -532,76 +615,12 @@ def _bm25_only_via_sqlite(
                 "results": [],
                 "fallback": "bm25_only_via_sqlite",
             }
-
-        placeholders = ",".join(["?"] * len(candidate_ids))
-        meta_rows = conn.execute(
-            f"""
-            SELECT id, key, string_value, int_value
-            FROM embedding_metadata
-            WHERE id IN ({placeholders})
-            """,
-            candidate_ids,
-        ).fetchall()
+        meta_rows = _load_drawer_metadata(conn, candidate_ids)
     finally:
         conn.close()
 
-    # Group metadata rows into per-drawer dicts.
-    drawers: dict[int, dict] = {}
-    for emb_id, key, sval, ival in meta_rows:
-        d = drawers.setdefault(emb_id, {"_id": emb_id, "metadata": {}, "text": ""})
-        if key == "chroma:document":
-            d["text"] = sval or ""
-        else:
-            d["metadata"][key] = sval if sval is not None else ival
-
-    # Apply wing/room filters in Python (FTS5 candidates may include
-    # entries from other wings).
-    candidates = []
-    for d in drawers.values():
-        meta = d["metadata"]
-        if wing and meta.get("wing") != wing:
-            continue
-        if room and meta.get("room") != room:
-            continue
-        full_source = meta.get("source_file", "") or ""
-        candidates.append(
-            {
-                "text": d["text"],
-                "wing": meta.get("wing", "unknown"),
-                "room": meta.get("room", "unknown"),
-                "source_file": Path(full_source).name if full_source else "?",
-                "created_at": meta.get("filed_at", "unknown"),
-                # No vector distance available in BM25-only mode.
-                "similarity": None,
-                "distance": None,
-                "matched_via": "bm25_sqlite",
-                # Internal: full path + chunk_index let callers (notably
-                # candidate_strategy="union") dedupe at chunk granularity
-                # rather than basename — two files in different directories
-                # may share a basename, and one source_file is split across
-                # multiple chunks. Stripped before this helper returns.
-                "_source_file_full": full_source,
-                "_chunk_index": meta.get("chunk_index"),
-            }
-        )
-
-    # Local BM25 over the candidate set.
-    docs = [c["text"] for c in candidates]
-    bm25_raw = _bm25_scores(query, docs)
-    max_bm25 = max(bm25_raw) if bm25_raw else 0.0
-    for c, raw in zip(candidates, bm25_raw):
-        c["bm25_score"] = round(raw, 3)
-        c["_score"] = (raw / max_bm25) if max_bm25 > 0 else 0.0
-    candidates.sort(key=lambda c: c["_score"], reverse=True)
-    hits = candidates[:n_results]
-    for h in hits:
-        h.pop("_score", None)
-        # Strip internal fields by default so the public BM25-only fallback
-        # response stays clean. Callers that need chunk-precise dedup
-        # (notably the union-merge path) opt in via _include_internal.
-        if not _include_internal:
-            h.pop("_source_file_full", None)
-            h.pop("_chunk_index", None)
+    candidates = _shape_drawer_candidates(meta_rows, wing, room)
+    hits = _rank_and_trim(candidates, query, n_results, _include_internal)
 
     return {
         "query": query,
@@ -653,7 +672,7 @@ def _merge_bm25_union_candidates(
             palace_path,
             wing=wing,
             room=room,
-            n_results=n_results * 3,
+            n_results=n_results * _BM25_UNION_OVERFETCH_RATIO,
             _include_internal=True,
         ).get("results", [])
     except Exception:
@@ -722,6 +741,186 @@ def _apply_candidate_strategy(
     merger = _CANDIDATE_MERGERS[strategy]
     if merger is not None:
         merger(hits, query, palace_path, wing, room, n_results, max_distance=max_distance)
+
+
+def _build_closet_boost_lookup(
+    palace_path: str,
+    query: str,
+    where: dict,
+    n_results: int,
+) -> dict:
+    """Query the closets collection and return ``{source_file: (rank, dist, preview)}``.
+
+    Closets are best-effort: any failure (missing collection, query error, etc.)
+    yields an empty dict so the caller degrades to drawer-only ranking. This
+    preserves the "closets are a signal, never a gate" invariant.
+    """
+    closet_boost_by_source: dict = {}
+    try:
+        closets_col = get_closets_collection(palace_path, create=False)
+        ckwargs = {
+            "query_texts": [query],
+            "n_results": n_results * _CLOSET_OVERFETCH_RATIO,
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            ckwargs["where"] = where
+        closet_results = closets_col.query(**ckwargs)
+        for rank, (cdoc, cmeta, cdist) in enumerate(
+            zip(
+                _first_or_empty(closet_results, "documents"),
+                _first_or_empty(closet_results, "metadatas"),
+                _first_or_empty(closet_results, "distances"),
+            )
+        ):
+            cmeta = cmeta or {}
+            source = cmeta.get("source_file", "")
+            if source and source not in closet_boost_by_source:
+                closet_boost_by_source[source] = (rank, cdist, cdoc[:200])
+    except Exception:
+        logger.debug("Closet collection unavailable; using drawer-only search", exc_info=True)
+    return closet_boost_by_source
+
+
+def _score_drawer_candidates(
+    drawer_results,
+    closet_boost_by_source: dict,
+    max_distance: float,
+    n_results: int,
+) -> list:
+    """Score drawer candidates with closet boost + cosine clamp; sort and trim.
+
+    The ordinal closet signal ("which closet matched best") is more reliable
+    than absolute distance on narrative content where closet distances cluster
+    in the 1.2–1.5 range regardless of match quality. Boost is capped at
+    ``CLOSET_DISTANCE_CAP`` and follows the ``CLOSET_RANK_BOOSTS`` schedule.
+
+    Returns the top ``n_results`` hits, each carrying both public fields and
+    the internal ``_sort_key`` / ``_source_file_full`` / ``_chunk_index`` keys
+    that downstream enrichment and cleanup expect.
+    """
+    scored: list = []
+    for doc, meta, dist in zip(
+        _first_or_empty(drawer_results, "documents"),
+        _first_or_empty(drawer_results, "metadatas"),
+        _first_or_empty(drawer_results, "distances"),
+    ):
+        meta = meta or {}
+        doc = doc or ""
+        # Filter on raw distance before rounding to avoid precision loss.
+        if max_distance > 0.0 and dist > max_distance:
+            continue
+
+        source = meta.get("source_file", "") or ""
+        boost = 0.0
+        matched_via = "drawer"
+        closet_preview = None
+        if source in closet_boost_by_source:
+            c_rank, c_dist, c_preview = closet_boost_by_source[source]
+            if c_dist <= CLOSET_DISTANCE_CAP and c_rank < len(CLOSET_RANK_BOOSTS):
+                boost = CLOSET_RANK_BOOSTS[c_rank]
+                matched_via = "drawer+closet"
+                closet_preview = c_preview
+
+        # Clamp to the valid cosine-distance range [0, 2]. When a strong
+        # closet boost (up to 0.40) exceeds the raw distance, the subtraction
+        # can go negative — which (a) yields ``similarity > 1.0`` downstream
+        # and (b) makes the sort key land *below* ordinary positive distances,
+        # inverting the ranking so the best hybrid matches sort last.
+        effective_dist = max(0.0, min(2.0, dist - boost))
+        entry = {
+            "text": doc,
+            "wing": meta.get("wing", "unknown"),
+            "room": meta.get("room", "unknown"),
+            "source_file": Path(source).name if source else "?",
+            "created_at": meta.get("filed_at", "unknown"),
+            "similarity": round(max(0.0, 1 - effective_dist), 3),
+            "distance": round(dist, 4),
+            "effective_distance": round(effective_dist, 4),
+            "closet_boost": round(boost, 3),
+            "matched_via": matched_via,
+            "_sort_key": effective_dist,
+            "_source_file_full": source,
+            "_chunk_index": meta.get("chunk_index"),
+        }
+        if closet_preview:
+            entry["closet_preview"] = closet_preview
+        scored.append(entry)
+
+    scored.sort(key=lambda h: h["_sort_key"])
+    return scored[:n_results]
+
+
+def _hydrate_closet_boosted_hits(hits: list, drawers_col, query: str) -> None:
+    """Replace each closet-boosted hit's text with the keyword-best chunk + neighbors.
+
+    For every hit whose ``matched_via == "drawer+closet"``, fetch all drawers
+    from the same source file, find the chunk with the most query-term
+    matches, and join it with one neighbor on each side. The closet said
+    "this source is relevant"; vector may have picked the wrong chunk within
+    it; this picks the right one.
+
+    Mutates ``hits`` in place: sets ``text``, ``drawer_index``, and
+    ``total_drawers``. Truncates oversized hydrations to ``MAX_HYDRATION_CHARS``.
+    Skips drawer-only hits and any source with one or zero drawers.
+    """
+    for h in hits:
+        if h["matched_via"] == "drawer":
+            continue
+        full_source = h.get("_source_file_full") or ""
+        if not full_source:
+            continue
+        try:
+            source_drawers = drawers_col.get(
+                where={"source_file": full_source},
+                include=["documents", "metadatas"],
+            )
+        except Exception:
+            logger.debug("Neighbor fetch failed for %s", full_source, exc_info=True)
+            continue
+        docs = source_drawers.documents
+        metas_ = source_drawers.metadatas
+        if len(docs) <= 1:
+            continue
+
+        # Sort by chunk_index so best_idx + neighbors are positional.
+        indexed = []
+        for idx, (d, m) in enumerate(zip(docs, metas_)):
+            ci = m.get("chunk_index", idx) if isinstance(m, dict) else idx
+            if not isinstance(ci, int):
+                ci = idx
+            indexed.append((ci, d))
+        indexed.sort(key=lambda p: p[0])
+        ordered_docs = [d for _, d in indexed]
+
+        query_terms = set(_tokenize(query))
+        best_idx, best_score = 0, -1
+        for idx, d in enumerate(ordered_docs):
+            d_lower = d.lower()
+            s = sum(1 for t in query_terms if t in d_lower)
+            if s > best_score:
+                best_score, best_idx = s, idx
+
+        start = max(0, best_idx - 1)
+        end = min(len(ordered_docs), best_idx + 2)
+        expanded = "\n\n".join(ordered_docs[start:end])
+        if len(expanded) > MAX_HYDRATION_CHARS:
+            expanded = (
+                expanded[:MAX_HYDRATION_CHARS]
+                + f"\n\n[...truncated. {len(ordered_docs)} total drawers. "
+                "Use mempalace_get_drawer for full content.]"
+            )
+        h["text"] = expanded
+        h["drawer_index"] = best_idx
+        h["total_drawers"] = len(ordered_docs)
+
+
+def _strip_internal_hit_fields(hits: list) -> None:
+    """Remove the leading-underscore internal keys before returning hits."""
+    for h in hits:
+        h.pop("_sort_key", None)
+        h.pop("_source_file_full", None)
+        h.pop("_chunk_index", None)
 
 
 def search_memories(
@@ -800,15 +999,14 @@ def search_memories(
 
     # Hybrid retrieval: always query drawers directly (the floor), then use
     # closet hits to boost rankings. Closets are a ranking SIGNAL, never a
-    # GATE — direct drawer search is always the baseline.
-    #
-    # This avoids the "weak-closets regression" where narrative content
-    # produces low-signal closets (regex extraction matches few topics)
-    # and closet-first routing hides drawers that direct search would find.
+    # GATE — direct drawer search is always the baseline. This avoids the
+    # "weak-closets regression" where narrative content produces low-signal
+    # closets and closet-first routing would hide drawers that direct search
+    # would find.
     try:
         dkwargs = {
             "query_texts": [query],
-            "n_results": n_results * 3,  # over-fetch for re-ranking
+            "n_results": n_results * _VECTOR_OVERFETCH_RATIO,
             "include": ["documents", "metadatas", "distances"],
         }
         if where:
@@ -817,157 +1015,14 @@ def search_memories(
     except Exception as e:
         return {"error": f"Search error: {e}"}
 
-    # Gather closet hits (best-per-source) to build a boost lookup.
-    closet_boost_by_source: dict = {}  # source_file -> (rank, closet_dist, preview)
-    try:
-        closets_col = get_closets_collection(palace_path, create=False)
-        ckwargs = {
-            "query_texts": [query],
-            "n_results": n_results * 2,
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            ckwargs["where"] = where
-        closet_results = closets_col.query(**ckwargs)
-        for rank, (cdoc, cmeta, cdist) in enumerate(
-            zip(
-                _first_or_empty(closet_results, "documents"),
-                _first_or_empty(closet_results, "metadatas"),
-                _first_or_empty(closet_results, "distances"),
-            )
-        ):
-            cmeta = cmeta or {}
-            source = cmeta.get("source_file", "")
-            if source and source not in closet_boost_by_source:
-                closet_boost_by_source[source] = (rank, cdist, cdoc[:200])
-    except Exception:
-        # No closets yet — hybrid degrades to pure drawer search.
-        logger.debug("Closet collection unavailable; using drawer-only search", exc_info=True)
+    closet_boost_by_source = _build_closet_boost_lookup(palace_path, query, where, n_results)
+    hits = _score_drawer_candidates(drawer_results, closet_boost_by_source, max_distance, n_results)
+    _hydrate_closet_boosted_hits(hits, drawers_col, query)
 
-    # Rank-based boost. The ordinal signal ("which closet matched best") is
-    # more reliable than absolute distance on narrative content, where
-    # closet distances cluster in 1.2-1.5 range regardless of match quality.
-    CLOSET_RANK_BOOSTS = [0.40, 0.25, 0.15, 0.08, 0.04]
-    CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
-
-    scored: list = []
-    for doc, meta, dist in zip(
-        _first_or_empty(drawer_results, "documents"),
-        _first_or_empty(drawer_results, "metadatas"),
-        _first_or_empty(drawer_results, "distances"),
-    ):
-        meta = meta or {}
-        doc = doc or ""
-        # Filter on raw distance before rounding to avoid precision loss.
-        if max_distance > 0.0 and dist > max_distance:
-            continue
-
-        meta = meta or {}
-        source = meta.get("source_file", "") or ""
-        boost = 0.0
-        matched_via = "drawer"
-        closet_preview = None
-        if source in closet_boost_by_source:
-            c_rank, c_dist, c_preview = closet_boost_by_source[source]
-            if c_dist <= CLOSET_DISTANCE_CAP and c_rank < len(CLOSET_RANK_BOOSTS):
-                boost = CLOSET_RANK_BOOSTS[c_rank]
-                matched_via = "drawer+closet"
-                closet_preview = c_preview
-
-        # Clamp to the valid cosine-distance range [0, 2]. When a strong
-        # closet boost (up to 0.40) exceeds the raw distance, the subtraction
-        # can go negative — which (a) yields ``similarity > 1.0`` downstream
-        # and (b) makes the sort key land *below* ordinary positive distances,
-        # inverting the ranking so the best hybrid matches sort last.
-        effective_dist = max(0.0, min(2.0, dist - boost))
-        entry = {
-            "text": doc,
-            "wing": meta.get("wing", "unknown"),
-            "room": meta.get("room", "unknown"),
-            "source_file": Path(source).name if source else "?",
-            "created_at": meta.get("filed_at", "unknown"),
-            "similarity": round(max(0.0, 1 - effective_dist), 3),
-            "distance": round(dist, 4),
-            "effective_distance": round(effective_dist, 4),
-            "closet_boost": round(boost, 3),
-            "matched_via": matched_via,
-            # Internal: retain the full source_file path + chunk_index so the
-            # enrichment step below doesn't have to reverse-lookup via
-            # basename-suffix matching (which silently collides when two
-            # files share a basename across different directories).
-            "_sort_key": effective_dist,
-            "_source_file_full": source,
-            "_chunk_index": meta.get("chunk_index"),
-        }
-        if closet_preview:
-            entry["closet_preview"] = closet_preview
-        scored.append(entry)
-
-    scored.sort(key=lambda h: h["_sort_key"])
-    hits = scored[:n_results]
-
-    # Drawer-grep enrichment: for closet-boosted hits whose source has
-    # multiple drawers, return the keyword-best chunk + its immediate
-    # neighbors instead of just the drawer vector search landed on. The
-    # closet said "this source is relevant"; vector may have picked the
-    # wrong chunk within it; grep picks the right one.
-    MAX_HYDRATION_CHARS = 10000
-    for h in hits:
-        if h["matched_via"] == "drawer":
-            continue
-        full_source = h.get("_source_file_full") or ""
-        if not full_source:
-            continue
-        try:
-            source_drawers = drawers_col.get(
-                where={"source_file": full_source},
-                include=["documents", "metadatas"],
-            )
-        except Exception:
-            logger.debug("Neighbor fetch failed for %s", full_source, exc_info=True)
-            continue
-        docs = source_drawers.documents
-        metas_ = source_drawers.metadatas
-        if len(docs) <= 1:
-            continue
-
-        # Sort by chunk_index so best_idx + neighbors are positional.
-        indexed = []
-        for idx, (d, m) in enumerate(zip(docs, metas_)):
-            ci = m.get("chunk_index", idx) if isinstance(m, dict) else idx
-            if not isinstance(ci, int):
-                ci = idx
-            indexed.append((ci, d))
-        indexed.sort(key=lambda p: p[0])
-        ordered_docs = [d for _, d in indexed]
-
-        query_terms = set(_tokenize(query))
-        best_idx, best_score = 0, -1
-        for idx, d in enumerate(ordered_docs):
-            d_lower = d.lower()
-            s = sum(1 for t in query_terms if t in d_lower)
-            if s > best_score:
-                best_score, best_idx = s, idx
-
-        start = max(0, best_idx - 1)
-        end = min(len(ordered_docs), best_idx + 2)
-        expanded = "\n\n".join(ordered_docs[start:end])
-        if len(expanded) > MAX_HYDRATION_CHARS:
-            expanded = (
-                expanded[:MAX_HYDRATION_CHARS]
-                + f"\n\n[...truncated. {len(ordered_docs)} total drawers. "
-                "Use mempalace_get_drawer for full content.]"
-            )
-        h["text"] = expanded
-        h["drawer_index"] = best_idx
-        h["total_drawers"] = len(ordered_docs)
-
-    # Candidate strategy hook: optionally widen the rerank pool's *source*
-    # before ranking. Default ("vector") is a no-op; "union" merges top-K
-    # BM25 candidates from sqlite. See `_apply_candidate_strategy`.
-    # ``max_distance`` is forwarded so union mode can refuse to inject
-    # BM25-only (distance=None) candidates that would silently bypass the
-    # caller's strict distance threshold.
+    # Candidate strategy hook: default "vector" is a no-op; "union" merges
+    # top-K BM25 candidates from sqlite. ``max_distance`` is forwarded so
+    # union mode can refuse to inject BM25-only (distance=None) candidates
+    # that would silently bypass the caller's strict distance threshold.
     _apply_candidate_strategy(
         candidate_strategy,
         hits,
@@ -985,10 +1040,7 @@ def search_memories(
     # breaking the existing ``search_memories`` size contract that the MCP
     # ``limit`` parameter is built on.
     hits = _hybrid_rank(hits, query)[:n_results]
-    for h in hits:
-        h.pop("_sort_key", None)
-        h.pop("_source_file_full", None)
-        h.pop("_chunk_index", None)
+    _strip_internal_hit_fields(hits)
 
     return {
         "query": query,

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -12,7 +12,6 @@ Coverage map:
   * purge_file_closets — scoped to source_file.
   * Project-miner end-to-end rebuild — re-mining with fewer topics fully
     purges leftover numbered closets from a larger prior run.
-  * _extract_drawer_ids_from_closet — pointer parsing + dedup.
   * search_memories hybrid path — drawer query always the floor,
     closets boost matching source_file, matched_via reflects both signals,
     no whole-file glue, max_distance enforcement.
@@ -55,8 +54,6 @@ from mempalace.palace_graph import (
 )
 from mempalace.searcher import (
     _bm25_scores,
-    _expand_with_neighbors,
-    _extract_drawer_ids_from_closet,
     _hybrid_rank,
     search_memories,
 )
@@ -140,9 +137,9 @@ class TestMineLock:
         # Sort by entry time and verify the second entry is after the first exit.
         intervals.sort(key=lambda iv: iv[1])
         (_, enter_a, exit_a), (_, enter_b, exit_b) = intervals
-        assert (
-            enter_a < exit_a <= enter_b < exit_b
-        ), f"critical sections overlapped — lock failed to serialize: {intervals}"
+        assert enter_a < exit_a <= enter_b < exit_b, (
+            f"critical sections overlapped — lock failed to serialize: {intervals}"
+        )
 
 
 # ── build_closet_lines ─────────────────────────────────────────────────
@@ -315,35 +312,15 @@ class TestMinerClosetRebuild:
         second_docs = "\n".join(second_pass["documents"]).lower()
         assert "only topic now" in second_docs
         for i in range(15):
-            assert (
-                f"topic {i}\n" not in second_docs
-            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+            assert f"topic {i}\n" not in second_docs, (
+                f"stale 'Topic {i}' from first mine survived the rebuild"
+            )
         # Numbered closets that existed only in the larger first run must be gone.
         leftover = first_ids - set(second_pass["ids"])
         for stale_id in leftover:
-            assert not col.get(ids=[stale_id])[
-                "ids"
-            ], f"orphan closet {stale_id} from larger first run survived purge"
-
-
-# ── _extract_drawer_ids_from_closet ───────────────────────────────────
-
-
-class TestExtractDrawerIds:
-    def test_parses_single_pointer(self):
-        assert _extract_drawer_ids_from_closet("topic|;|→drawer_x") == ["drawer_x"]
-
-    def test_parses_multiple_pointers_per_line(self):
-        line = "topic|ent|→drawer_a,drawer_b,drawer_c"
-        assert _extract_drawer_ids_from_closet(line) == ["drawer_a", "drawer_b", "drawer_c"]
-
-    def test_dedupes_across_lines(self):
-        doc = "one|;|→drawer_a,drawer_b\ntwo|;|→drawer_b,drawer_c"
-        assert _extract_drawer_ids_from_closet(doc) == ["drawer_a", "drawer_b", "drawer_c"]
-
-    def test_empty_doc_returns_empty(self):
-        assert _extract_drawer_ids_from_closet("") == []
-        assert _extract_drawer_ids_from_closet("no arrows here") == []
+            assert not col.get(ids=[stale_id])["ids"], (
+                f"orphan closet {stale_id} from larger first run survived purge"
+            )
 
 
 # ── search_memories closet-first path ────────────────────────────────
@@ -702,9 +679,9 @@ class TestDiaryIngest:
 
         # No state file inside the user's diary dir.
         for entry in diary_dir.iterdir():
-            assert (
-                "diary_ingest" not in entry.name
-            ), f"state file leaked into user diary dir: {entry}"
+            assert "diary_ingest" not in entry.name, (
+                f"state file leaked into user diary dir: {entry}"
+            )
 
         # State file does exist under ~/.mempalace/state/.
         state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
@@ -905,7 +882,7 @@ class TestTunnels:
         assert not errors, f"worker raised: {errors}"
         tunnels = list_tunnels()
         assert len(tunnels) == 5, (
-            f"expected 5 concurrent tunnels, got {len(tunnels)} — " "write race dropped some"
+            f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
         )
 
     def test_created_at_is_timezone_aware(self):
@@ -919,97 +896,12 @@ class TestTunnels:
 #
 # When a closet hit lands on a drawer whose chunk boundary clips a thought
 # (matched chunk says "here's a breakdown:" and the breakdown lives in the
-# next chunk), the closet path now expands to ±1 neighbor chunks from the
-# same source file. These tests pin that behavior end-to-end and at the
-# helper level.
+# next chunk), the closet path expands across the source's chunks to pick
+# the keyword-best one plus its immediate neighbors. This test pins that
+# behavior end-to-end through search_memories.
 
 
 class TestDrawerGrepExpansion:
-    def _seed_source_file(self, palace_path, source: str, n_chunks: int):
-        """Helper: put N sequential drawers for a single source file into
-        the palace and return the drawer IDs keyed by chunk_index."""
-        col = get_collection(palace_path)
-        ids = [f"drawer_test_room_{source.replace('/', '_')}_{i:03d}" for i in range(n_chunks)]
-        docs = [f"chunk_{i} content about topic alpha" for i in range(n_chunks)]
-        metas = [
-            {
-                "wing": "test",
-                "room": "room",
-                "source_file": source,
-                "chunk_index": i,
-                "filed_at": "2026-04-13T00:00:00",
-            }
-            for i in range(n_chunks)
-        ]
-        col.upsert(ids=ids, documents=docs, metadatas=metas)
-        return col, {i: ids[i] for i in range(n_chunks)}
-
-    def test_expand_returns_matched_plus_neighbors(self, palace_path):
-        col, by_idx = self._seed_source_file(palace_path, "/proj/doc.md", n_chunks=5)
-        matched_meta = {"source_file": "/proj/doc.md", "chunk_index": 2}
-        matched_doc = "chunk_2 content about topic alpha"
-
-        out = _expand_with_neighbors(col, matched_doc, matched_meta, radius=1)
-        assert out["drawer_index"] == 2
-        assert out["total_drawers"] == 5
-        # Expect chunks 1, 2, 3 joined in chunk_index order.
-        text = out["text"]
-        assert "chunk_1" in text
-        assert "chunk_2" in text
-        assert "chunk_3" in text
-        # No leakage of non-neighbors.
-        assert "chunk_0" not in text
-        assert "chunk_4" not in text
-        # Ordering preserved — chunk_1 before chunk_2 before chunk_3.
-        assert text.index("chunk_1") < text.index("chunk_2") < text.index("chunk_3")
-
-    def test_expand_at_start_of_file_only_has_next_neighbor(self, palace_path):
-        col, _ = self._seed_source_file(palace_path, "/proj/edge_start.md", n_chunks=3)
-        out = _expand_with_neighbors(
-            col,
-            "chunk_0 content",
-            {"source_file": "/proj/edge_start.md", "chunk_index": 0},
-        )
-        assert out["drawer_index"] == 0
-        assert out["total_drawers"] == 3
-        assert "chunk_0" in out["text"]
-        assert "chunk_1" in out["text"]
-        # No chunk_-1 could exist; the expansion must not invent one.
-        assert "chunk_-1" not in out["text"]
-
-    def test_expand_at_end_of_file_only_has_prev_neighbor(self, palace_path):
-        col, _ = self._seed_source_file(palace_path, "/proj/edge_end.md", n_chunks=3)
-        out = _expand_with_neighbors(
-            col,
-            "chunk_2 content",
-            {"source_file": "/proj/edge_end.md", "chunk_index": 2},
-        )
-        assert out["drawer_index"] == 2
-        assert out["total_drawers"] == 3
-        assert "chunk_1" in out["text"]
-        assert "chunk_2" in out["text"]
-        # No chunk_3 exists.
-        assert "chunk_3" not in out["text"]
-
-    def test_expand_single_drawer_file_returns_just_matched(self, palace_path):
-        col, _ = self._seed_source_file(palace_path, "/proj/lone.md", n_chunks=1)
-        out = _expand_with_neighbors(
-            col,
-            "chunk_0 content",
-            {"source_file": "/proj/lone.md", "chunk_index": 0},
-        )
-        assert out["drawer_index"] == 0
-        assert out["total_drawers"] == 1
-        assert out["text"] == "chunk_0 content about topic alpha"
-
-    def test_expand_falls_back_when_metadata_missing(self, palace_path):
-        col = get_collection(palace_path)
-        # No source_file / chunk_index in meta — degrade gracefully.
-        out = _expand_with_neighbors(col, "matched doc", {})
-        assert out["text"] == "matched doc"
-        assert out["drawer_index"] is None
-        assert out["total_drawers"] is None
-
     def test_hybrid_search_enrichment_populates_drawer_index_and_total(self, palace_path):
         """End-to-end: when a closet boosts a source with many drawers, the
         enrichment step runs drawer-grep across all chunks of that source


### PR DESCRIPTION
## What does this PR do?

Structural-readability refactor of `mempalace/searcher.py`. Splits two long-running functions into named phase helpers and lifts magic constants to module level. **No behavior change.**

- `search_memories` (~270-line body) → ~50-line dispatcher + 4 helpers (`_build_closet_boost_lookup`, `_score_drawer_candidates`, `_hydrate_closet_boosted_hits`, `_strip_internal_hit_fields`).
- `_bm25_only_via_sqlite` (~234-line body) → ~45-line dispatcher + 7 helpers (`_metadata_filter_sql`, three selectors with explicit fallback chain in `_select_bm25_candidate_ids`, `_load_drawer_metadata`, `_shape_drawer_candidates`, `_rank_and_trim`).
- Constants `CLOSET_RANK_BOOSTS`, `CLOSET_DISTANCE_CAP`, `MAX_HYDRATION_CHARS` moved to module top; new `_VECTOR_OVERFETCH_RATIO`, `_CLOSET_OVERFETCH_RATIO`, `_BM25_UNION_OVERFETCH_RATIO` replace bare `n_results * N` arithmetic.
- Removed `_extract_drawer_ids_from_closet`, `_expand_with_neighbors`, and `_CLOSET_DRAWER_REF_RE` — orphaned by the move from closet-first retrieval to hybrid rank-boost; only tests imported them. Six matching unit tests in `tests/test_closets.py` removed; the end-to-end test of the inline drawer-grep block (now `_hydrate_closet_boosted_hits`) is preserved.

### Subtle behavior preserved

The `_bm25_only_via_sqlite` fallback chain has a load-bearing nuance: a *successful but empty* FTS5 result must NOT cascade to the recency selector — under wing/room scope, recency would surface unrelated drawers. The new `_select_bm25_candidate_ids` makes this explicit via the `else: return ids` branch after the FTS5 try/except, with a comment pinning the rule. `tests/test_hnsw_capacity.py` (27 tests) covers it.

## How to test

```bash
uv run ruff check mempalace/searcher.py tests/test_closets.py
uv run ruff format --check mempalace/searcher.py tests/test_closets.py
uv run pytest tests/ --ignore=tests/benchmarks --cov=mempalace --cov-report=term-missing
```

Targeted suites for a faster sanity check:

```bash
uv run pytest tests/test_searcher.py tests/test_hybrid_search.py \
  tests/test_closets.py tests/test_hnsw_capacity.py \
  tests/test_empty_chromadb_results.py tests/test_hybrid_candidate_union.py \
  tests/test_readme_claims.py -v
```

## Checklist
- [x] Tests pass (`uv run pytest tests/ --ignore=tests/benchmarks`) — 1714 passed, 1 skipped
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)