### PR TITLE
test(kg): cover invalidate interval bounds

### DIFF
--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -125,6 +125,43 @@ class TestInvalidation:
         assert chess[0]["valid_to"] == "2026-01-01"
         assert chess[0]["current"] is False
 
+    def test_invalidate_rejects_ended_before_valid_from(self, kg):
+        kg.add_triple(
+            "Alice",
+            "works_at",
+            "Acme",
+            valid_from="2026-01-01",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"valid_to='2020-01-01'.*valid_from='2026-01-01'",
+        ):
+            kg.invalidate("Alice", "works_at", "Acme", ended="2020-01-01")
+
+    def test_invalidate_accepts_ended_equal_to_valid_from(self, kg):
+        kg.add_triple(
+            "Alice",
+            "works_at",
+            "Acme",
+            valid_from="2026-01-01",
+        )
+
+        kg.invalidate("Alice", "works_at", "Acme", ended="2026-01-01")
+
+        results = kg.query_entity("Alice", direction="outgoing")
+        assert results[0]["valid_to"] == "2026-01-01"
+        assert results[0]["current"] is False
+
+    def test_invalidate_allows_open_start_interval(self, kg):
+        kg.add_triple("Alice", "works_at", "Acme")
+
+        kg.invalidate("Alice", "works_at", "Acme", ended="2020-01-01")
+
+        results = kg.query_entity("Alice", direction="outgoing")
+        assert results[0]["valid_from"] is None
+        assert results[0]["valid_to"] == "2020-01-01"
+
 
 class TestTimeline:
     def test_timeline_all(self, seeded_kg):

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -139,6 +139,12 @@ class TestInvalidation:
         ):
             kg.invalidate("Alice", "works_at", "Acme", ended="2020-01-01")
 
+        results = kg.query_entity("Alice", direction="outgoing")
+        assert len(results) == 1
+        assert results[0]["valid_from"] == "2026-01-01"
+        assert results[0]["valid_to"] is None
+        assert results[0]["current"] is True
+
     def test_invalidate_accepts_ended_equal_to_valid_from(self, kg):
         kg.add_triple(
             "Alice",
@@ -150,6 +156,7 @@ class TestInvalidation:
         kg.invalidate("Alice", "works_at", "Acme", ended="2026-01-01")
 
         results = kg.query_entity("Alice", direction="outgoing")
+        assert len(results) == 1
         assert results[0]["valid_to"] == "2026-01-01"
         assert results[0]["current"] is False
 
@@ -159,8 +166,10 @@ class TestInvalidation:
         kg.invalidate("Alice", "works_at", "Acme", ended="2020-01-01")
 
         results = kg.query_entity("Alice", direction="outgoing")
+        assert len(results) == 1
         assert results[0]["valid_from"] is None
         assert results[0]["valid_to"] == "2020-01-01"
+        assert results[0]["current"] is False
 
 
 class TestTimeline:


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage for #1371.

It pins the `KnowledgeGraph.invalidate()` interval cases from the issue:
- reject `ended < valid_from` with a clear `ValueError`
- allow `ended == valid_from`
- allow invalidating rows that have no `valid_from`

## How to test

- `uv run python -m pytest tests/test_knowledge_graph.py -v`
- `uv run python -m pytest tests/ -v`
- `uv run ruff check .`
- `uv run ruff format --check tests/test_knowledge_graph.py`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)