### PR TITLE
feat(i18n): wire closet extraction to locale regex patterns

### DIFF
--- a/mempalace/i18n/__init__.py
+++ b/mempalace/i18n/__init__.py
@@ -270,6 +270,77 @@ def get_entity_patterns(languages=("en",)) -> dict:
     return merged
 
 
+def get_closet_regex(languages=("en",)) -> dict:
+    """Return merged regex patterns for closet extraction across languages.
+
+    Closet extraction uses ``action_pattern``, ``quote_pattern``, and
+    ``stop_words`` from each locale's ``regex`` section.  This function
+    merges them so ``build_closet_lines`` works for multilingual content.
+
+    Returns dict with keys:
+      - ``action_patterns``: list of compiled regex objects
+      - ``quote_patterns``: list of compiled regex objects
+      - ``stop_words``: frozenset of lowercase stop words
+    """
+    import re as _re
+
+    if not languages:
+        languages = ("en",)
+    languages = tuple(_canonical_lang(lang) or lang for lang in languages)
+
+    action_pats = []
+    quote_pats = []
+    stop_words: set = set()
+
+    found_any = False
+    for lang in languages:
+        canonical = _canonical_lang(lang) if lang != _canonical_lang(lang) else lang
+        lang_file = _LANG_DIR / f"{canonical or lang}.json"
+        try:
+            data = json.loads(lang_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        regex_sec = data.get("regex", {})
+        if not regex_sec:
+            continue
+        found_any = True
+        if regex_sec.get("action_pattern"):
+            try:
+                action_pats.append(_re.compile(regex_sec["action_pattern"], _re.IGNORECASE))
+            except _re.error:
+                pass
+        if regex_sec.get("quote_pattern"):
+            try:
+                quote_pats.append(_re.compile(regex_sec["quote_pattern"]))
+            except _re.error:
+                pass
+        for w in regex_sec.get("stop_words", "").split():
+            stop_words.add(w.lower())
+
+    if not found_any:
+        en_file = _LANG_DIR / "en.json"
+        data = json.loads(en_file.read_text(encoding="utf-8"))
+        regex_sec = data.get("regex", {})
+        if regex_sec.get("action_pattern"):
+            try:
+                action_pats.append(_re.compile(regex_sec["action_pattern"], _re.IGNORECASE))
+            except _re.error:
+                pass
+        if regex_sec.get("quote_pattern"):
+            try:
+                quote_pats.append(_re.compile(regex_sec["quote_pattern"]))
+            except _re.error:
+                pass
+        for w in regex_sec.get("stop_words", "").split():
+            stop_words.add(w.lower())
+
+    return {
+        "action_patterns": action_pats,
+        "quote_patterns": quote_pats,
+        "stop_words": frozenset(stop_words),
+    }
+
+
 def _dedupe(items: list) -> list:
     """Remove duplicates while preserving first-occurrence order."""
     seen = set()

--- a/mempalace/i18n/__init__.py
+++ b/mempalace/i18n/__init__.py
@@ -288,22 +288,19 @@ def get_closet_regex(languages=("en",)) -> dict:
         languages = ("en",)
     languages = tuple(_canonical_lang(lang) or lang for lang in languages)
 
-    action_pats = []
-    quote_pats = []
+    action_pats: list = []
+    quote_pats: list = []
     stop_words: set = set()
 
-    found_any = False
-    for lang in languages:
-        canonical = _canonical_lang(lang) if lang != _canonical_lang(lang) else lang
-        lang_file = _LANG_DIR / f"{canonical or lang}.json"
+    def _collect(lang_code: str) -> bool:
+        lang_file = _LANG_DIR / f"{lang_code}.json"
         try:
             data = json.loads(lang_file.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
-            continue
+            return False
         regex_sec = data.get("regex", {})
         if not regex_sec:
-            continue
-        found_any = True
+            return False
         if regex_sec.get("action_pattern"):
             try:
                 action_pats.append(_re.compile(regex_sec["action_pattern"], _re.IGNORECASE))
@@ -316,23 +313,14 @@ def get_closet_regex(languages=("en",)) -> dict:
                 pass
         for w in regex_sec.get("stop_words", "").split():
             stop_words.add(w.lower())
+        return True
 
+    found_any = False
+    for lang in languages:
+        if _collect(lang):
+            found_any = True
     if not found_any:
-        en_file = _LANG_DIR / "en.json"
-        data = json.loads(en_file.read_text(encoding="utf-8"))
-        regex_sec = data.get("regex", {})
-        if regex_sec.get("action_pattern"):
-            try:
-                action_pats.append(_re.compile(regex_sec["action_pattern"], _re.IGNORECASE))
-            except _re.error:
-                pass
-        if regex_sec.get("quote_pattern"):
-            try:
-                quote_pats.append(_re.compile(regex_sec["quote_pattern"]))
-            except _re.error:
-                pass
-        for w in regex_sec.get("stop_words", "").split():
-            stop_words.add(w.lower())
+        _collect("en")
 
     return {
         "action_patterns": action_pats,

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -234,7 +234,9 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     # Extract key phrases via i18n action patterns
     topics = []
     for rx in closet_rx["action_patterns"]:
-        topics.extend(rx.findall(window))
+        for m in rx.finditer(window):
+            t = next((g for g in m.groups() if g), m.group(0))
+            topics.append(t)
     # Also grab section headers if present
     for header in re.findall(r"^#{1,3}\s+(.{5,60})$", window, re.MULTILINE):
         topics.append(header.strip())
@@ -246,7 +248,7 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     for rx in closet_rx["quote_patterns"]:
         for m in rx.finditer(window):
             # quote_pattern may have multiple groups (e.g. Chinese + English quotes)
-            q = next((g for g in m.groups() if g), None)
+            q = next((g for g in m.groups() if g), m.group(0))
             if q and 15 <= len(q) <= 150:
                 quotes.append(q)
 

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -142,6 +142,8 @@ _ENTITY_STOPLIST = frozenset(
 
 
 _CANDIDATE_RX_CACHE = None
+_CLOSET_REGEX_CACHE = None
+_ENTITY_STOP_CACHE = None
 
 
 def _candidate_entity_words(text: str) -> list:
@@ -170,6 +172,30 @@ def _candidate_entity_words(text: str) -> list:
     return words
 
 
+def _get_closet_regex() -> dict:
+    """Return cached closet regex patterns (action + quote) for configured languages."""
+    global _CLOSET_REGEX_CACHE
+    if _CLOSET_REGEX_CACHE is None:
+        from .config import MempalaceConfig
+        from .i18n import get_closet_regex
+
+        _CLOSET_REGEX_CACHE = get_closet_regex(MempalaceConfig().entity_languages)
+    return _CLOSET_REGEX_CACHE
+
+
+def _get_entity_stoplist() -> frozenset:
+    """Return entity stoplist combining built-in English words and locale stopwords."""
+    global _ENTITY_STOP_CACHE
+    if _ENTITY_STOP_CACHE is None:
+        from .config import MempalaceConfig
+        from .i18n import get_entity_patterns
+
+        patterns = get_entity_patterns(MempalaceConfig().entity_languages)
+        locale_stops = frozenset(patterns.get("stopwords", []))
+        _ENTITY_STOP_CACHE = _ENTITY_STOPLIST | locale_stops
+    return _ENTITY_STOP_CACHE
+
+
 def build_closet_lines(source_file, drawer_ids, content, wing, room):
     """Build compact closet pointer lines from drawer content.
 
@@ -177,6 +203,10 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     pointer — never split across closets.
 
     Format: topic|entities|→drawer_ids
+
+    Uses i18n-aware patterns for topic extraction, quote detection, and
+    entity filtering so non-English content (e.g. Chinese) is also indexed.
+    Configure ``entity_languages`` in config.json to enable additional locales.
     """
     import re
     from pathlib import Path
@@ -184,12 +214,15 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     drawer_ref = ",".join(drawer_ids[:3])
     window = content[:CLOSET_EXTRACT_WINDOW]
 
+    closet_rx = _get_closet_regex()
+    stop = _get_entity_stoplist()
+
     # Extract proper nouns (2+ occurrences). Uses i18n-aware patterns so
     # non-Latin names (Cyrillic, accented Latin, etc.) are also detected.
     words = _candidate_entity_words(window)
     word_freq = {}
     for w in words:
-        if w in _ENTITY_STOPLIST:
+        if w in stop:
             continue
         word_freq[w] = word_freq.get(w, 0) + 1
     entities = sorted(
@@ -198,20 +231,24 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     )[:5]
     entity_str = ";".join(entities) if entities else ""
 
-    # Extract key phrases — action verbs + context
+    # Extract key phrases via i18n action patterns
     topics = []
-    for pattern in [
-        r"(?:built|fixed|wrote|added|pushed|tested|created|decided|migrated|reviewed|deployed|configured|removed|updated)\s+[\w\s]{3,40}",
-    ]:
-        topics.extend(re.findall(pattern, window, re.IGNORECASE))
+    for rx in closet_rx["action_patterns"]:
+        topics.extend(rx.findall(window))
     # Also grab section headers if present
     for header in re.findall(r"^#{1,3}\s+(.{5,60})$", window, re.MULTILINE):
         topics.append(header.strip())
     # Dedupe preserving order
     topics = list(dict.fromkeys(t.strip().lower() for t in topics))[:12]
 
-    # Extract quotes
-    quotes = re.findall(r'"([^"]{15,150})"', window)
+    # Extract quotes via i18n quote patterns
+    quotes = []
+    for rx in closet_rx["quote_patterns"]:
+        for m in rx.finditer(window):
+            # quote_pattern may have multiple groups (e.g. Chinese + English quotes)
+            q = next((g for g in m.groups() if g), None)
+            if q and 15 <= len(q) <= 150:
+                quotes.append(q)
 
     # Build pointer lines — each one is atomic, never split
     lines = []

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -140,9 +140,9 @@ class TestMineLock:
         # Sort by entry time and verify the second entry is after the first exit.
         intervals.sort(key=lambda iv: iv[1])
         (_, enter_a, exit_a), (_, enter_b, exit_b) = intervals
-        assert (
-            enter_a < exit_a <= enter_b < exit_b
-        ), f"critical sections overlapped — lock failed to serialize: {intervals}"
+        assert enter_a < exit_a <= enter_b < exit_b, (
+            f"critical sections overlapped — lock failed to serialize: {intervals}"
+        )
 
 
 # ── build_closet_lines ─────────────────────────────────────────────────
@@ -217,6 +217,71 @@ class TestBuildClosetLines:
         ids = [f"drawer_{i}" for i in range(10)]
         lines = build_closet_lines("/x.md", ids, "# A\n# B", "w", "r")
         assert all("→drawer_0,drawer_1,drawer_2" in line for line in lines)
+
+
+class TestBuildClosetLinesI18n:
+    """Closet extraction for non-English content when zh-CN is enabled."""
+
+    def _enable_zh(self, monkeypatch):
+        """Configure entity_languages to include zh-CN."""
+        import mempalace.palace as _palace
+
+        monkeypatch.setattr(_palace, "_CANDIDATE_RX_CACHE", None)
+        monkeypatch.setattr(_palace, "_CLOSET_REGEX_CACHE", None)
+        monkeypatch.setattr(_palace, "_ENTITY_STOP_CACHE", None)
+        monkeypatch.setenv("MEMPALACE_ENTITY_LANGUAGES", "en,zh-CN")
+
+    def test_chinese_action_verbs_extracted(self, monkeypatch):
+        self._enable_zh(monkeypatch)
+        content = "我们创建了新的数据库模型。团队修复了部署问题。最后更新了配置文件。"
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined = "\n".join(lines).lower()
+        assert any(kw in joined for kw in ["创建", "修复", "更新"]), (
+            f"Chinese action verbs not found in: {lines}"
+        )
+
+    def test_chinese_quotes_extracted(self, monkeypatch):
+        self._enable_zh(monkeypatch)
+        content = "他说“这个方案需要重新设计和评审才能上线”，然后我们开始讨论替代方案。"
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        found_quote = any("“" in line or "这个方案" in line for line in lines)
+        assert found_quote, f"Chinese quoted phrase not found in: {lines}"
+
+    def test_chinese_entity_stoplist_filters(self, monkeypatch):
+        self._enable_zh(monkeypatch)
+        content = "我们今天讨论了方案。我们明天继续讨论。我们后天做总结。"
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        entity_segments = [line.split("|")[1] for line in lines]
+        for seg in entity_segments:
+            tokens = set(seg.split(";")) if seg else set()
+            assert "我们" not in tokens, "Common Chinese pronoun should be filtered"
+            assert "今天" not in tokens, "Common Chinese time word should be filtered"
+
+    def test_mixed_content_extracts_both_languages(self, monkeypatch):
+        self._enable_zh(monkeypatch)
+        content = (
+            "# API Design\n\n"
+            "Built the REST endpoints for user management. "
+            "我们创建了新的认证模块。Igor reviewed the code."
+        )
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined = "\n".join(lines).lower()
+        assert "api design" in joined, "English header should be extracted"
+        has_en_or_zh = ("built the rest" in joined) or ("创建" in joined)
+        assert has_en_or_zh, f"Neither EN nor ZH action extracted from: {lines}"
+
+    def test_default_english_still_works_without_zh(self, monkeypatch):
+        """Ensure the refactored code doesn't break when only English is configured."""
+        import mempalace.palace as _palace
+
+        monkeypatch.setattr(_palace, "_CANDIDATE_RX_CACHE", None)
+        monkeypatch.setattr(_palace, "_CLOSET_REGEX_CACHE", None)
+        monkeypatch.setattr(_palace, "_ENTITY_STOP_CACHE", None)
+        monkeypatch.setenv("MEMPALACE_ENTITY_LANGUAGES", "en")
+        content = "Built the prototype with WebAuthn. Reviewed the API surface."
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        joined = "\n".join(lines).lower()
+        assert "built the prototype" in joined
 
 
 # ── upsert_closet_lines ───────────────────────────────────────────────
@@ -315,15 +380,15 @@ class TestMinerClosetRebuild:
         second_docs = "\n".join(second_pass["documents"]).lower()
         assert "only topic now" in second_docs
         for i in range(15):
-            assert (
-                f"topic {i}\n" not in second_docs
-            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+            assert f"topic {i}\n" not in second_docs, (
+                f"stale 'Topic {i}' from first mine survived the rebuild"
+            )
         # Numbered closets that existed only in the larger first run must be gone.
         leftover = first_ids - set(second_pass["ids"])
         for stale_id in leftover:
-            assert not col.get(ids=[stale_id])[
-                "ids"
-            ], f"orphan closet {stale_id} from larger first run survived purge"
+            assert not col.get(ids=[stale_id])["ids"], (
+                f"orphan closet {stale_id} from larger first run survived purge"
+            )
 
 
 # ── _extract_drawer_ids_from_closet ───────────────────────────────────
@@ -702,9 +767,9 @@ class TestDiaryIngest:
 
         # No state file inside the user's diary dir.
         for entry in diary_dir.iterdir():
-            assert (
-                "diary_ingest" not in entry.name
-            ), f"state file leaked into user diary dir: {entry}"
+            assert "diary_ingest" not in entry.name, (
+                f"state file leaked into user diary dir: {entry}"
+            )
 
         # State file does exist under ~/.mempalace/state/.
         state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
@@ -905,7 +970,7 @@ class TestTunnels:
         assert not errors, f"worker raised: {errors}"
         tunnels = list_tunnels()
         assert len(tunnels) == 5, (
-            f"expected 5 concurrent tunnels, got {len(tunnels)} — " "write race dropped some"
+            f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
         )
 
     def test_created_at_is_timezone_aware(self):


### PR DESCRIPTION
## Summary

`build_closet_lines()` hardcodes English verb/quote regexes, so non-English content is never indexed in closets — even though locale files like `zh-CN.json` already ship `action_pattern`, `quote_pattern`, and `stopwords` in their `regex` section.

This PR wires up the existing i18n infrastructure:

- **`mempalace/i18n/__init__.py`** — adds `get_closet_regex(languages)` that loads and merges `action_pattern`, `quote_pattern`, and `stop_words` from each locale's `regex` section, returning compiled regex objects. Falls back to English when no requested language has data.
- **`mempalace/palace.py`** — rewires `build_closet_lines()` to use `get_closet_regex()` instead of hardcoded patterns:
  - Topic extraction iterates all locale action regexes
  - Quote extraction iterates locale quote regexes (handles multi-group patterns for Chinese `"…"` quotes)
  - Entity stoplist merges built-in English words with locale stopwords from `get_entity_patterns()`
- **`tests/test_closets.py`** — adds `TestBuildClosetLinesI18n` with 5 tests:
  - Chinese action verb extraction (创建/修复/更新)
  - Chinese quote extraction (`"…"`)
  - Chinese stopword filtering (我们/今天)
  - Mixed EN+ZH content extraction
  - English-only regression test

All 1731 existing tests continue to pass. No new dependencies.

## Motivation

Users with `entity_languages: ["en", "zh-CN"]` configured get entity detection in Chinese but closet indexing remains English-only. The locale data was already there — it just wasn't being read by `build_closet_lines()`.

## Test plan

- [x] `uv run pytest tests/test_closets.py -v` — all pass including 5 new i18n tests
- [x] `uv run pytest tests/ -v --ignore=tests/benchmarks` — full suite (1731 tests) green
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] Verified English-only config (`MEMPALACE_ENTITY_LANGUAGES=en`) still works identically

🤖 Generated with [Claude Code](https://claude.ai/claude-code)