### PR TITLE
fix(search): recover from Chroma ID lookup divergence

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -25,8 +25,99 @@ _CLOSET_DRAWER_REF_RE = re.compile(r"→([\w,]+)")
 logger = logging.getLogger("mempalace_mcp")
 
 
+_CHROMA_ID_LOOKUP_MARKERS = (
+    "error finding id",
+    "finding id",
+)
+
+
 class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
+
+
+def _is_chroma_id_lookup_error(error: Exception) -> bool:
+    """Detect transient Chroma metadata/HNSW ID divergence errors."""
+    msg = str(error).lower()
+    return any(marker in msg for marker in _CHROMA_ID_LOOKUP_MARKERS)
+
+
+def _search_memories_bm25_recovery(
+    query: str,
+    palace_path: str,
+    wing: str,
+    room: str,
+    n_results: int,
+    collection_name: str,
+) -> dict:
+    result = _bm25_only_via_sqlite(
+        query,
+        palace_path,
+        wing=wing,
+        room=room,
+        n_results=n_results,
+        collection_name=collection_name,
+    )
+    if "error" not in result:
+        result["vector_disabled"] = True
+        result["vector_disabled_reason"] = (
+            "chroma-id-lookup-divergence; recovered via BM25 sqlite fallback"
+        )
+        result["fallback_reason"] = "chroma_id_lookup_divergence"
+    return result
+
+
+def _query_drawers_for_search(
+    drawers_col,
+    query: str,
+    palace_path: str,
+    where: dict,
+    wing: str,
+    room: str,
+    n_results: int,
+    collection_name: str,
+):
+    dkwargs = {
+        "query_texts": [query],
+        "n_results": n_results * 3,  # over-fetch for re-ranking
+        "include": ["documents", "metadatas", "distances"],
+    }
+    if where:
+        dkwargs["where"] = where
+    try:
+        return drawers_col.query(**dkwargs), None
+    except Exception as e:
+        if _is_chroma_id_lookup_error(e):
+            logger.warning(
+                "Chroma ID lookup divergence during drawer search; routing to BM25 fallback. "
+                "wing=%s room=%s err=%s",
+                wing,
+                room,
+                e,
+            )
+            try:
+                return None, _search_memories_bm25_recovery(
+                    query,
+                    palace_path,
+                    wing,
+                    room,
+                    n_results,
+                    collection_name,
+                )
+            except Exception:
+                logger.exception("BM25 fallback failed after Chroma ID lookup divergence")
+        return None, {"error": f"Search error: {e}"}
+
+
+def _log_chroma_id_lookup_or_debug(
+    error: Exception,
+    warning_message: str,
+    debug_message: str,
+    *args,
+) -> None:
+    if _is_chroma_id_lookup_error(error):
+        logger.warning(warning_message, *args, error)
+    else:
+        logger.debug(debug_message, *args, exc_info=True)
 
 
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
@@ -805,17 +896,18 @@ def search_memories(
     # This avoids the "weak-closets regression" where narrative content
     # produces low-signal closets (regex extraction matches few topics)
     # and closet-first routing hides drawers that direct search would find.
-    try:
-        dkwargs = {
-            "query_texts": [query],
-            "n_results": n_results * 3,  # over-fetch for re-ranking
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            dkwargs["where"] = where
-        drawer_results = drawers_col.query(**dkwargs)
-    except Exception as e:
-        return {"error": f"Search error: {e}"}
+    drawer_results, drawer_error = _query_drawers_for_search(
+        drawers_col,
+        query,
+        palace_path,
+        where,
+        wing,
+        room,
+        n_results,
+        collection_name,
+    )
+    if drawer_error is not None:
+        return drawer_error
 
     # Gather closet hits (best-per-source) to build a boost lookup.
     closet_boost_by_source: dict = {}  # source_file -> (rank, closet_dist, preview)
@@ -840,9 +932,16 @@ def search_memories(
             source = cmeta.get("source_file", "")
             if source and source not in closet_boost_by_source:
                 closet_boost_by_source[source] = (rank, cdist, cdoc[:200])
-    except Exception:
+    except Exception as e:
         # No closets yet — hybrid degrades to pure drawer search.
-        logger.debug("Closet collection unavailable; using drawer-only search", exc_info=True)
+        _log_chroma_id_lookup_or_debug(
+            e,
+            "Chroma ID lookup divergence during closet search; using drawer-only ranking. "
+            "wing=%s room=%s err=%s",
+            "Closet collection unavailable; using drawer-only search. wing=%s room=%s",
+            wing,
+            room,
+        )
 
     # Rank-based boost. The ordinal signal ("which closet matched best") is
     # more reliable than absolute distance on narrative content, where
@@ -923,8 +1022,14 @@ def search_memories(
                 where={"source_file": full_source},
                 include=["documents", "metadatas"],
             )
-        except Exception:
-            logger.debug("Neighbor fetch failed for %s", full_source, exc_info=True)
+        except Exception as e:
+            _log_chroma_id_lookup_or_debug(
+                e,
+                "Chroma ID lookup divergence during neighbor fetch; returning base drawer. "
+                "source_file=%s err=%s",
+                "Neighbor fetch failed for %s",
+                full_source,
+            )
             continue
         docs = source_drawers.documents
         metas_ = source_drawers.metadatas

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -112,12 +112,16 @@ def _log_chroma_id_lookup_or_debug(
     error: Exception,
     warning_message: str,
     debug_message: str,
-    *args,
+    context: dict[str, object] | None = None,
 ) -> None:
+    context_suffix = ""
+    if context:
+        context_suffix = " " + " ".join(f"{key}={value}" for key, value in context.items())
+
     if _is_chroma_id_lookup_error(error):
-        logger.warning(warning_message, *args, error)
+        logger.warning("%s%s err=%s", warning_message, context_suffix, error)
     else:
-        logger.debug(debug_message, *args, exc_info=True)
+        logger.debug("%s%s", debug_message, context_suffix, exc_info=True)
 
 
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
@@ -936,11 +940,9 @@ def search_memories(
         # No closets yet — hybrid degrades to pure drawer search.
         _log_chroma_id_lookup_or_debug(
             e,
-            "Chroma ID lookup divergence during closet search; using drawer-only ranking. "
-            "wing=%s room=%s err=%s",
-            "Closet collection unavailable; using drawer-only search. wing=%s room=%s",
-            wing,
-            room,
+            "Chroma ID lookup divergence during closet search; using drawer-only ranking.",
+            "Closet collection unavailable; using drawer-only search.",
+            context={"wing": wing, "room": room},
         )
 
     # Rank-based boost. The ordinal signal ("which closet matched best") is
@@ -1025,10 +1027,9 @@ def search_memories(
         except Exception as e:
             _log_chroma_id_lookup_or_debug(
                 e,
-                "Chroma ID lookup divergence during neighbor fetch; returning base drawer. "
-                "source_file=%s err=%s",
-                "Neighbor fetch failed for %s",
-                full_source,
+                "Chroma ID lookup divergence during neighbor fetch; returning base drawer.",
+                "Neighbor fetch failed.",
+                context={"source_file": full_source},
             )
             continue
         docs = source_drawers.documents

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -84,6 +84,72 @@ class TestSearchMemories:
         assert "error" in result
         assert "query failed" in result["error"]
 
+    def test_search_memories_recovers_chroma_id_lookup_error_with_bm25(self):
+        """Chroma can raise while HNSW lags metadata; MCP should still search."""
+        mock_col = MagicMock()
+        mock_col.query.side_effect = RuntimeError(
+            "Error executing plan: Internal error: Error finding id drawer_1"
+        )
+        fallback = {
+            "query": "test",
+            "filters": {"wing": "project", "room": "backend"},
+            "total_before_filter": 1,
+            "results": [{"text": "fallback hit", "wing": "project", "room": "backend"}],
+            "fallback": "bm25_only_via_sqlite",
+            "fallback_reason": "vector_search_disabled",
+        }
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+            patch("mempalace.searcher._bm25_only_via_sqlite", return_value=fallback) as bm25,
+        ):
+            result = search_memories(
+                "test",
+                "/fake/path",
+                wing="project",
+                room="backend",
+                n_results=3,
+                collection_name="custom_drawers",
+            )
+
+        bm25.assert_called_once_with(
+            "test",
+            "/fake/path",
+            wing="project",
+            room="backend",
+            n_results=3,
+            collection_name="custom_drawers",
+        )
+        assert result["results"][0]["text"] == "fallback hit"
+        assert result["vector_disabled"] is True
+        assert result["vector_disabled_reason"] == (
+            "chroma-id-lookup-divergence; recovered via BM25 sqlite fallback"
+        )
+        assert result["fallback_reason"] == "chroma_id_lookup_divergence"
+
+    def test_search_memories_keeps_drawer_results_when_closet_id_lookup_fails(self, caplog):
+        """Closet boost failure should degrade ranking, not fail the whole search."""
+        drawers_col = MagicMock()
+        drawers_col.query.return_value = {
+            "documents": [["drawer doc"]],
+            "metadatas": [[{"source_file": "a.md", "wing": "project", "room": "backend"}]],
+            "distances": [[0.2]],
+            "ids": [["d1"]],
+        }
+        closets_col = MagicMock()
+        closets_col.query.side_effect = RuntimeError("Internal error: Error finding id closet_1")
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=drawers_col),
+            patch("mempalace.searcher.get_closets_collection", return_value=closets_col),
+            caplog.at_level("WARNING", logger="mempalace_mcp"),
+        ):
+            result = search_memories("test", "/fake/path", wing="project", room="backend")
+
+        assert result["results"][0]["text"] == "drawer doc"
+        assert result["results"][0]["matched_via"] == "drawer"
+        assert "closet search" in caplog.text
+
     def test_search_memories_vector_path_uses_explicit_collection_name(self):
         mock_col = MagicMock()
         mock_col.query.return_value = {
@@ -184,12 +250,11 @@ class TestSearchMemories:
 
         # Invariants on every hit.
         for h in hits:
-            assert (
-                0.0 <= h["similarity"] <= 1.0
-            ), f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            assert 0.0 <= h["similarity"] <= 1.0, (
+                f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            )
             assert 0.0 <= h["effective_distance"] <= 2.0, (
-                f"effective_distance out of range: {h['effective_distance']} "
-                f"for {h['source_file']}"
+                f"effective_distance out of range: {h['effective_distance']} for {h['source_file']}"
             )
 
         # With the clamp, the closet-boosted a.md still ranks ahead of b.md —
@@ -327,9 +392,9 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         first_block, _, _ = captured.out.partition("[2]")
         # Lexical match must rank first
-        assert (
-            "b.md" in first_block
-        ), f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        assert "b.md" in first_block, (
+            f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        )
         # Non-zero bm25 reported
         assert "bm25=" in first_block
         assert "bm25=0.0" not in first_block


### PR DESCRIPTION
## What does this PR do?

Fixes #1398.

When Chroma raises `Error finding id` during MCP search, the drawer search now falls back to the existing SQLite BM25 path instead of returning an error. Closet and neighbor lookups with the same error degrade gracefully to the drawer/base result and log the reduced ranking quality.

## How to test

- `uv run python -m pytest tests/ -v`
- `uv run pytest tests/test_searcher.py -v`
- `uv run pytest tests/test_mcp_server.py::TestSearchTool::test_search_retries_once_on_hnsw_flush_transient tests/test_mcp_server.py::TestSearchTool::test_search_returns_second_error_if_retry_also_fails -v`
- `uv run ruff check .`
- `uv run ruff format --check mempalace/searcher.py tests/test_searcher.py`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
