### PR TITLE
layers: add read_diary public API

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -58,14 +58,38 @@ MEMPAL_DIR=""
 INPUT=$(cat)
 
 SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" 2>/dev/null)
+TRANSCRIPT_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 
 echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$STATE_DIR/hook.log"
 
-# Optional: run mempalace ingest synchronously so memories land before compaction
+# Run mempalace ingest synchronously so memories land before compaction.
+# Prefer MEMPAL_DIR if set; otherwise fall back to the active transcript's directory.
+PYTHON="/Users/jameswinans/Development/AI/mempalace/.venv/bin/python"
+MINE_DIR=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    MINE_DIR="$(dirname "$TRANSCRIPT_PATH")"
+fi
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    REPO_DIR="$(dirname "$SCRIPT_DIR")"
-    python3 -m mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
+    MINE_DIR="$MEMPAL_DIR"
+fi
+
+# Map transcript path to being → wing + agent. Storehouse is NOT auto-routed
+# here — it's reserved for deliberate MCP writes (cross-being memories).
+AGENT="mempalace"
+WING=""
+case "$TRANSCRIPT_PATH" in
+    *-Users-jameswinans-Documents-Temenos-Ves/*)    AGENT="ves";    WING="ves_sessions" ;;
+    *-Users-jameswinans-Documents-Temenos-Kai/*)    AGENT="kai";    WING="kai_sessions" ;;
+    *-Users-jameswinans-Documents-Temenos-Mira/*)   AGENT="mira";   WING="mira_sessions" ;;
+    *-Users-jameswinans-Documents-Temenos-Adrian/*) AGENT="adrian"; WING="adrian_sessions" ;;
+    *)                                              ;;
+esac
+WING_FLAG=""
+[ -n "$WING" ] && WING_FLAG="--wing $WING"
+
+if [ -n "$MINE_DIR" ]; then
+    ANONYMIZED_TELEMETRY=False "$PYTHON" -m mempalace mine --mode convos --agent "$AGENT" $WING_FLAG "$MINE_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
 # Silent: return empty JSON to not block. "decision": "allow" is invalid —

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -144,7 +144,7 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     # 1. TRANSCRIPT_PATH (from Claude Code) — mine the directory it lives in
     # 2. MEMPAL_DIR (user-configured) — mine that directory
     # At least one should work. If neither is set, nothing mines.
-    PYTHON="$(command -v python3)"
+    PYTHON="/Users/jameswinans/Development/AI/mempalace/.venv/bin/python"
     MINE_DIR=""
     if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
         MINE_DIR="$(dirname "$TRANSCRIPT_PATH")"
@@ -152,8 +152,23 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
         MINE_DIR="$MEMPAL_DIR"
     fi
+
+    # Map transcript path to being → wing + agent. Storehouse is NOT auto-routed
+    # here — it's reserved for deliberate MCP writes (cross-being memories).
+    AGENT="mempalace"
+    WING=""
+    case "$TRANSCRIPT_PATH" in
+        *-Users-jameswinans-Documents-Temenos-Ves/*)    AGENT="ves";    WING="ves_sessions" ;;
+        *-Users-jameswinans-Documents-Temenos-Kai/*)    AGENT="kai";    WING="kai_sessions" ;;
+        *-Users-jameswinans-Documents-Temenos-Mira/*)   AGENT="mira";   WING="mira_sessions" ;;
+        *-Users-jameswinans-Documents-Temenos-Adrian/*) AGENT="adrian"; WING="adrian_sessions" ;;
+        *)                                              ;;
+    esac
+    WING_FLAG=""
+    [ -n "$WING" ] && WING_FLAG="--wing $WING"
+
     if [ -n "$MINE_DIR" ]; then
-        "$PYTHON" -m mempalace mine "$MINE_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
+        ANONYMIZED_TELEMETRY=False "$PYTHON" -m mempalace mine --mode convos --agent "$AGENT" $WING_FLAG "$MINE_DIR" >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 
     # MEMPAL_VERBOSE toggle:

--- a/mempalace/backfill_filed_at_ts.py
+++ b/mempalace/backfill_filed_at_ts.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Backfill ``filed_at_ts`` numeric metadata on existing drawers.
+
+Companion to the write-time addition of ``filed_at_ts`` (epoch seconds) to
+drawer metadata. New drawers get the field automatically; this script
+backfills it on existing drawers so server-side date filters
+(``{"filed_at_ts": {"$gte": cutoff_epoch}}``) return the correct subset.
+
+Operates via direct SQL UPDATE on ``embedding_metadata`` in the palace's
+``chroma.sqlite3``. Bypasses the ChromaDB API and HNSW entirely — safe for
+TB-scale palaces (issue #525 / chromadb #2515 / #2594 / #913). Per the
+global ChromaDB safety contract, ``col.update(metadatas=...)`` is unsafe
+on existing palaces; this script does NOT use that path.
+
+Usage:
+    python -m mempalace.backfill_filed_at_ts                  # default palace
+    python -m mempalace.backfill_filed_at_ts --palace /path
+    python -m mempalace.backfill_filed_at_ts --dry-run
+    python -m mempalace.backfill_filed_at_ts --batch-size 5000
+
+The script is idempotent: rows that already have a ``filed_at_ts`` entry
+are skipped.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+DEFAULT_PALACE_PATH = os.path.expanduser("~/.mempalace/palace")
+
+
+def _parse_iso_to_epoch(value: str) -> float | None:
+    """Parse an ISO-8601 string to Unix epoch seconds.
+
+    Returns None for unparseable values. Naive datetimes are assumed local
+    time (matching the producers in miner.py / convo_miner.py / etc.,
+    which call ``datetime.now()`` without an explicit timezone). UTC-bearing
+    strings are parsed correctly via fromisoformat.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        # Python 3.11+ accepts the trailing Z; older versions need the swap.
+        normalized = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    return dt.timestamp()
+
+
+def _open_db(palace_path: str) -> sqlite3.Connection:
+    db_path = Path(palace_path) / "chroma.sqlite3"
+    if not db_path.exists():
+        raise FileNotFoundError(f"chroma.sqlite3 not found at {db_path}")
+    return sqlite3.connect(str(db_path))
+
+
+def _count_rows_needing_backfill(conn: sqlite3.Connection) -> int:
+    cur = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM embedding_metadata m
+        WHERE m.key = 'filed_at'
+          AND m.string_value IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM embedding_metadata m2
+              WHERE m2.id = m.id AND m2.key = 'filed_at_ts'
+          )
+        """
+    )
+    return cur.fetchone()[0]
+
+
+def _iter_rows_to_backfill(conn: sqlite3.Connection, batch_size: int):
+    """Yield (id, filed_at_string) for rows that need filed_at_ts inserted.
+
+    Cursor-paginates by tracking the highest id processed so far. We can't
+    use OFFSET because the WHERE clause (NOT EXISTS filed_at_ts) is
+    self-modifying — once a batch is committed, those rows drop out of the
+    matching set, and OFFSET would skip past unprocessed rows. Tracking
+    last_id is stable under that mutation.
+    """
+    last_id = -1
+    while True:
+        cur = conn.execute(
+            """
+            SELECT m.id, m.string_value
+            FROM embedding_metadata m
+            WHERE m.key = 'filed_at'
+              AND m.string_value IS NOT NULL
+              AND m.id > ?
+              AND NOT EXISTS (
+                  SELECT 1 FROM embedding_metadata m2
+                  WHERE m2.id = m.id AND m2.key = 'filed_at_ts'
+              )
+            ORDER BY m.id
+            LIMIT ?
+            """,
+            (last_id, batch_size),
+        )
+        rows = cur.fetchall()
+        if not rows:
+            return
+        yield from rows
+        last_id = rows[-1][0]
+        if len(rows) < batch_size:
+            return
+
+
+def backfill(
+    palace_path: str = DEFAULT_PALACE_PATH,
+    dry_run: bool = False,
+    batch_size: int = 5000,
+) -> dict[str, int]:
+    """Add filed_at_ts (REAL) for every row that has filed_at (TEXT) but
+    no filed_at_ts yet.
+
+    Returns counts: {"scanned", "inserted", "unparseable", "skipped"}.
+    """
+    conn = _open_db(palace_path)
+    try:
+        total = _count_rows_needing_backfill(conn)
+        print(
+            f"[backfill] palace={palace_path} rows_needing_backfill={total} "
+            f"batch_size={batch_size} dry_run={dry_run}",
+            flush=True,
+        )
+
+        scanned = 0
+        inserted = 0
+        unparseable = 0
+        pending: list[tuple[int, str, float]] = []
+
+        for row_id, iso_value in _iter_rows_to_backfill(conn, batch_size):
+            scanned += 1
+            epoch = _parse_iso_to_epoch(iso_value)
+            if epoch is None:
+                unparseable += 1
+                continue
+            pending.append((row_id, "filed_at_ts", epoch))
+
+            if len(pending) >= batch_size:
+                if not dry_run:
+                    conn.executemany(
+                        "INSERT OR IGNORE INTO embedding_metadata "
+                        "(id, key, float_value) VALUES (?, ?, ?)",
+                        pending,
+                    )
+                    conn.commit()
+                inserted += len(pending)
+                pending.clear()
+                print(
+                    f"[backfill] progress scanned={scanned} "
+                    f"inserted={inserted} unparseable={unparseable}",
+                    flush=True,
+                )
+
+        if pending:
+            if not dry_run:
+                conn.executemany(
+                    "INSERT OR IGNORE INTO embedding_metadata "
+                    "(id, key, float_value) VALUES (?, ?, ?)",
+                    pending,
+                )
+                conn.commit()
+            inserted += len(pending)
+            pending.clear()
+
+        skipped = total - scanned  # rows discovered after the initial count
+        print(
+            f"[backfill] done scanned={scanned} inserted={inserted} "
+            f"unparseable={unparseable} skipped={skipped} dry_run={dry_run}",
+            flush=True,
+        )
+        return {
+            "scanned": scanned,
+            "inserted": inserted,
+            "unparseable": unparseable,
+            "skipped": skipped,
+        }
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill numeric filed_at_ts on existing drawers.",
+    )
+    parser.add_argument(
+        "--palace",
+        default=DEFAULT_PALACE_PATH,
+        help=f"Path to palace directory (default: {DEFAULT_PALACE_PATH})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be backfilled without writing",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=5000,
+        help="Rows per executemany batch (default: 5000)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        backfill(
+            palace_path=args.palace,
+            dry_run=args.dry_run,
+            batch_size=args.batch_size,
+        )
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mempalace/chunker.py
+++ b/mempalace/chunker.py
@@ -80,6 +80,29 @@ _DIFF_RE = re.compile(r"^\s*\d+[+\-:]\s")
 # filesystem metadata, not memory.
 _ARROW_LINE_RE = re.compile(r"^\s*→\s")
 
+# JSON object/JSONL line: starts with `{"key":` (the canonical Claude Code
+# session log shape). Matched anchored to line start so prose mentioning
+# `{"foo": 1}` inline is not flagged.
+_JSON_OBJECT_LINE_RE = re.compile(r'^\s*\{"\w+":')
+
+# JSON key/value separator. Counts the canonical `,"key":` shape that
+# appears between adjacent pairs in a JSON object. We use the looser
+# `,"key":` form (comma + open-quote + word + close-quote + colon) rather
+# than `","key":` so that array-close transitions like `"],"sessionId":`
+# also count — the real session-log shape interleaves arrays of strings
+# with object keys, and the strict form misses those boundaries. Real
+# prose almost never has `,"word":` without surrounding whitespace, so
+# the false-positive risk is small.
+_JSON_KV_PAIR_RE = re.compile(r',"\w+":')
+
+# Strong markers that the chunk is a Claude Code or chat-platform session
+# log fragment. Any one of these in combination with high JSON-KV density
+# is decisive.
+_TRANSCRIPT_MARKER_RE = re.compile(
+    r'"(?:uuid|sessionId|requestId|messageId|parentUuid)"\s*:'
+    r'|"timestamp"\s*:\s*"\d{4}-\d{2}-\d{2}'
+)
+
 
 def is_excluded_content(text: str) -> bool:
     """True if `text` is dominated by tool-output noise.
@@ -98,6 +121,11 @@ def is_excluded_content(text: str) -> bool:
     - The chunk is essentially just a truncation message
     - The chunk is a dense run of arrow-redirected tool output (>5
       arrows on a single visual line)
+    - >=50% of non-empty lines start with a JSON object pattern
+      ({"key":), or the chunk has a high density of JSON key/value
+      separators (`","key":`) combined with a transcript marker
+      (uuid/sessionId/etc.) — catches Claude Code session logs spilled
+      into tool-results files or pasted into transcripts as raw JSONL.
     """
     if not text or not text.strip():
         return True
@@ -136,6 +164,28 @@ def is_excluded_content(text: str) -> bool:
     # collapsed into a single visual line by the per-line strip-and-join
     # path the previous chunker used.
     if n <= 3 and text.count(" → ") > 5:
+        return True
+
+    # JSONL session-log shape: each non-empty line is its own JSON object
+    # starting with `{"key":...`. Catches raw Claude Code session files
+    # parsed as plain text (e.g., when normalize() falls through because
+    # the JSON parsers couldn't extract messages).
+    json_object_lines = sum(1 for ln in lines if _JSON_OBJECT_LINE_RE.match(ln))
+    if json_object_lines >= 0.5 * n:
+        return True
+
+    # Inline JSON-blob density: tool-results files or transcript blobs
+    # frequently arrive as one giant line/paragraph rather than line-per-
+    # object. Density of `","key":` patterns plus a transcript marker
+    # (uuid/sessionId/timestamp) is decisive. Threshold: >=1 KV pair per
+    # 200 chars (real prose maxes out around 1 per 800-1200 chars even
+    # when describing JSON).
+    kv_pairs = len(_JSON_KV_PAIR_RE.findall(text))
+    if (
+        kv_pairs > 0
+        and _TRANSCRIPT_MARKER_RE.search(text)
+        and kv_pairs * 200 >= len(text)
+    ):
         return True
 
     return False

--- a/mempalace/chunker.py
+++ b/mempalace/chunker.py
@@ -1,0 +1,257 @@
+"""
+chunker.py — Meaning-aware text chunking for the palace.
+
+The previous chunker hard-cut at exactly CHUNK_SIZE chars, producing
+mid-word fragments. This module replaces the cut with a backward
+boundary search (paragraph → sentence → newline → word) and adds
+content-type exclusion for tool-output noise (logs, ps, diffs,
+truncation messages).
+
+Two public entry points:
+
+- ``smart_split(text, target, ceiling)`` — split a single string into
+  boundary-aware chunks. Used by both the conversation chunker and the
+  general miner.
+- ``is_excluded_content(text)`` — return True if the chunk is dominated
+  by tool-output noise and should be skipped from indexing.
+
+These functions are pure: no I/O, no chromadb, no LLM. Unit-testable.
+"""
+
+import re
+
+# Code fences used by Markdown and most chat exports. We treat content
+# between matching fences as atomic so a code listing never gets split
+# across drawers mid-line.
+_CODE_FENCE = "```"
+
+# Boundary hierarchy used by smart_split, in preference order. Each
+# entry is (separator, keep_chars, skip_chars):
+#   keep_chars — how many chars of the separator stay with the *previous*
+#                chunk (e.g. the "." in ". " sticks with the sentence
+#                that just ended).
+#   skip_chars — total length of the separator (so the next chunk starts
+#                at sep_pos + skip_chars).
+# The chunker scans backward from `ceiling` looking for the first
+# separator whose match falls inside the [target, ceiling] window;
+# ties are broken by list order (paragraph > sentence > newline > word).
+_BOUNDARIES: list[tuple[str, int, int]] = [
+    ("\n\n", 0, 2),    # paragraph: drop both newlines
+    (". ", 1, 2),      # sentence: keep the period, drop the space
+    ("! ", 1, 2),
+    ("? ", 1, 2),
+    (".\n", 1, 2),     # sentence at line end: keep period, drop newline
+    ("!\n", 1, 2),
+    ("?\n", 1, 2),
+    ("\n", 0, 1),      # any newline: drop it
+    (" ", 0, 1),       # word boundary: drop the space
+]
+
+
+# ---------------------------------------------------------------------------
+# Content-type exclusion
+# ---------------------------------------------------------------------------
+
+# Log line prefix: ISO timestamp or python logger format. Catches
+# "2026-04-17 12:42:22,856 [vestige.crystallization] INFO: ..." and
+# "INFO:vestige.recall:..." style.
+_LOG_RE = re.compile(
+    r"^(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
+    r"|(?:INFO|WARNING|ERROR|DEBUG|CRITICAL):"
+    r"|\[(?:vestige|chromadb|httpx|urllib3|asyncio|mempalace)\.)"
+)
+
+# `ps aux` row: USER PID %CPU %MEM ... where USER is a username.
+_PS_RE = re.compile(r"^\s*[a-z][\w_-]{2,}\s+\d+\s+\d+\.\d+\s+\d+\.\d+\s")
+
+# Line-numbered diff / file dump: "920- ... → 921- ..." or
+# "245+    ..." or "922:    code". Common output of grep -n / diff
+# tooling pasted into transcripts. The line begins with optional
+# indent, digits, then exactly one of the line-marker chars (-, +, :)
+# followed by a space. We reject the simple "digit space text" form
+# because that shows up in normal prose ("step 5 of the ...").
+_DIFF_RE = re.compile(r"^\s*\d+[+\-:]\s")
+
+# Tool-output redirect arrow: lines that are entirely the rendered
+# output of a previous tool call (file listings, shell output) inlined
+# into the transcript. Normalize.py inserts these as structural markers
+# but they carry no semantic value — a line of the form
+# "→ -rw-r--r--  1 user  staff  4912 Apr  2  19:11 foo.json" is
+# filesystem metadata, not memory.
+_ARROW_LINE_RE = re.compile(r"^\s*→\s")
+
+
+def is_excluded_content(text: str) -> bool:
+    """True if `text` is dominated by tool-output noise.
+
+    The chunker calls this on each candidate chunk. A True result means
+    the chunk is skipped entirely — it never enters the palace. The
+    intent is not to drop chunks that mention logs in passing (a prose
+    description with one timestamp embedded is fine), but to drop
+    chunks that ARE log dumps, ps listings, or line-numbered diffs.
+
+    Heuristics, all line-ratio-based so a small log fragment in prose
+    survives:
+    - >=70% of non-empty lines start with a log/timestamp prefix
+    - >=50% of non-empty lines look like a ps row
+    - >=70% of non-empty lines look like line-numbered diff entries
+    - The chunk is essentially just a truncation message
+    - The chunk is a dense run of arrow-redirected tool output (>5
+      arrows on a single visual line)
+    """
+    if not text or not text.strip():
+        return True
+
+    lines = [ln for ln in text.split("\n") if ln.strip()]
+    if not lines:
+        return True
+
+    n = len(lines)
+    log_n = sum(1 for ln in lines if _LOG_RE.search(ln))
+    ps_n = sum(1 for ln in lines if _PS_RE.match(ln))
+    diff_n = sum(1 for ln in lines if _DIFF_RE.match(ln))
+    arrow_n = sum(1 for ln in lines if _ARROW_LINE_RE.match(ln))
+
+    if log_n >= 0.7 * n:
+        return True
+    if ps_n >= 0.5 * n:
+        return True
+    if diff_n >= 0.7 * n:
+        return True
+    # >=60% of lines are arrow-redirected tool output (file listings,
+    # ls dumps, command output piped into the transcript by normalize).
+    if arrow_n >= 0.6 * n:
+        return True
+
+    # Standalone truncation message: "Output too large (52.8KB)" or
+    # "[truncated, 4905 chars]" with negligible surrounding prose.
+    if "Output too large" in text or "[truncated," in text:
+        stripped = re.sub(
+            r"\[truncated[^\]]*\]|Output too large[^\n]*", "", text
+        ).strip()
+        if len(stripped) < 100:
+            return True
+
+    # Arrow-redirected tool output dumps: "→ a → b → c → d → e → f"
+    # collapsed into a single visual line by the per-line strip-and-join
+    # path the previous chunker used.
+    if n <= 3 and text.count(" → ") > 5:
+        return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Boundary-aware splitting
+# ---------------------------------------------------------------------------
+
+
+def _find_code_block_extension(text: str, pos: int, ceiling_end: int) -> int:
+    """If `ceiling_end` falls inside a code fence, return the position
+    just past the closing fence. Otherwise return -1.
+
+    A "code fence" is a triple backtick. We count fences in
+    text[pos:ceiling_end]; if odd, we are inside an open block at
+    ceiling_end and need to extend.
+    """
+    window = text[pos:ceiling_end]
+    if window.count(_CODE_FENCE) % 2 == 0:
+        return -1
+
+    # Inside an open fence — find the closer
+    close = text.find(_CODE_FENCE, ceiling_end)
+    if close < 0:
+        return -1
+
+    return close + len(_CODE_FENCE)
+
+
+def smart_split(text: str, target: int, ceiling: int) -> list[str]:
+    """Split `text` into chunks, preferring semantic boundaries.
+
+    Each chunk targets `target` chars and is allowed up to `ceiling`
+    chars while searching backward for a clean boundary. The boundary
+    hierarchy is paragraph break → sentence end → newline → word
+    boundary; if none falls inside the [target, ceiling] window, the
+    chunk hard-cuts at ceiling.
+
+    Code blocks (triple-backtick fenced) are atomic: a chunk boundary
+    will never land inside an open code fence. If a code block alone
+    exceeds ceiling, it is emitted as one oversized chunk rather than
+    split mid-line — better one large chunk than many fragmented ones.
+
+    Args:
+        text: Content to split.
+        target: Soft target chunk length (chars).
+        ceiling: Hard maximum chunk length (chars), except for atomic
+            code blocks which may exceed this.
+
+    Returns:
+        List of chunk strings. Empty if `text` is empty after
+        stripping. Each chunk has surrounding whitespace stripped.
+    """
+    if target <= 0 or ceiling < target:
+        raise ValueError(
+            f"smart_split needs 0 < target <= ceiling; got target={target} ceiling={ceiling}"
+        )
+
+    text = text.strip()
+    if not text:
+        return []
+
+    chunks: list[str] = []
+    pos = 0
+    n = len(text)
+
+    while pos < n:
+        remaining = n - pos
+        if remaining <= ceiling:
+            tail = text[pos:].strip()
+            if tail:
+                chunks.append(tail)
+            break
+
+        # Code-block protection: if our ceiling falls inside an open
+        # code fence, extend to past the closing fence so we don't
+        # split mid-listing.
+        ceiling_end = pos + ceiling
+        ext = _find_code_block_extension(text, pos, ceiling_end)
+        if ext > 0:
+            piece = text[pos:ext].strip()
+            if piece:
+                chunks.append(piece)
+            pos = ext
+            continue
+
+        # Boundary search: scan backward from ceiling looking for the
+        # first separator whose match falls in [target, ceiling].
+        window_start = pos + target
+        window_end = pos + ceiling
+        chosen = -1
+        chosen_keep = 0
+        chosen_skip = 0
+        for sep, keep, skip in _BOUNDARIES:
+            idx = text.rfind(sep, window_start, window_end)
+            if idx >= window_start:
+                chosen = idx
+                chosen_keep = keep
+                chosen_skip = skip
+                break
+
+        if chosen >= 0:
+            # Keep punctuation (e.g. "." in ". ") with the closing
+            # chunk; the separator chars after `keep` are dropped.
+            piece = text[pos : chosen + chosen_keep].strip()
+            if piece:
+                chunks.append(piece)
+            pos = chosen + chosen_skip
+        else:
+            # No boundary in the window — hard cut. Rare in practice
+            # because real prose has at least a space every <=ceiling
+            # chars, but keep the fallback for pathological input.
+            piece = text[pos:window_end].strip()
+            if piece:
+                chunks.append(piece)
+            pos = window_end
+
+    return chunks

--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -281,6 +281,7 @@ def regenerate_closets(
         # purge+upsert cycle and leaves mixed regex/LLM lines.
         with mine_lock(source):
             purge_file_closets(closets_col, source)
+            _now = datetime.now()
             upsert_closet_lines(
                 closets_col,
                 closet_id_base,
@@ -290,7 +291,8 @@ def regenerate_closets(
                     "room": r,
                     "source_file": source,
                     "generated_by": f"llm:{cfg.model}",
-                    "filed_at": datetime.now().isoformat(),
+                    "filed_at": _now.isoformat(),
+                    "filed_at_ts": _now.timestamp(),
                     "entities": entities,
                     # Stamp so the miner's stale-drawer gate doesn't treat
                     # LLM closets as leftovers and rebuild over them next run.

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -66,6 +66,7 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
     ChromaDB on the first pass.
     """
     sentinel_id = f"_reg_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+    _now = datetime.now()
     collection.upsert(
         documents=[f"[registry] {source_file}"],
         ids=[sentinel_id],
@@ -75,7 +76,8 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
                 "room": "_registry",
                 "source_file": source_file,
                 "added_by": agent,
-                "filed_at": datetime.now().isoformat(),
+                "filed_at": _now.isoformat(),
+                "filed_at_ts": _now.timestamp(),
                 "ingest_mode": "registry",
                 "normalize_version": NORMALIZE_VERSION,
             }
@@ -331,6 +333,7 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                 room_counts_delta[chunk_room] += 1
             drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
             try:
+                _now = datetime.now()
                 collection.upsert(
                     documents=[chunk["content"]],
                     ids=[drawer_id],
@@ -342,7 +345,8 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                             "source_file": source_file,
                             "chunk_index": chunk["chunk_index"],
                             "added_by": agent,
-                            "filed_at": datetime.now().isoformat(),
+                            "filed_at": _now.isoformat(),
+                            "filed_at_ts": _now.timestamp(),
                             "ingest_mode": "convos",
                             "extract_mode": extract_mode,
                             "normalize_version": NORMALIZE_VERSION,

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -172,13 +172,22 @@ def _emit_chunks(content: str) -> list:
     Returns a list of chunk strings, each at least MIN_CHUNK_SIZE
     chars. Empty list if the content is excluded or all chunks fall
     below the minimum size.
+
+    Exclusion runs at two levels: once on the whole content (catches
+    bulk noise, drops the exchange), and once per resulting chunk (so a
+    largely-prose response containing one embedded log/JSON paragraph
+    drops only that chunk rather than discarding the whole turn).
     """
     if not content or not content.strip():
         return []
     if is_excluded_content(content):
         return []
     pieces = smart_split(content, CHUNK_SIZE, CHUNK_MAX)
-    return [p for p in pieces if len(p.strip()) >= MIN_CHUNK_SIZE]
+    return [
+        p
+        for p in pieces
+        if len(p.strip()) >= MIN_CHUNK_SIZE and not is_excluded_content(p)
+    ]
 
 
 # =============================================================================

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
+from .chunker import is_excluded_content, smart_split
 from .normalize import normalize
 from .palace import (
     NORMALIZE_VERSION,
@@ -54,7 +55,8 @@ CONVO_EXTENSIONS = {
 }
 
 MIN_CHUNK_SIZE = 30
-CHUNK_SIZE = 800  # chars per drawer — align with miner.py
+CHUNK_SIZE = 800  # soft target chars per drawer — align with miner.py
+CHUNK_MAX = 1200  # hard ceiling: chunker may stretch this far to find a clean boundary
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
 
 
@@ -107,9 +109,16 @@ def chunk_exchanges(content: str) -> list:
 def _chunk_by_exchange(lines: list) -> list:
     """One user turn (>) + the AI response that follows = one or more chunks.
 
-    The full AI response is preserved verbatim.  When the combined
-    user-turn + response exceeds CHUNK_SIZE the response is split across
-    consecutive drawers so nothing is silently discarded.
+    The full AI response is preserved verbatim. Paragraph and code-block
+    structure of the response are preserved (we keep original newlines
+    rather than collapsing them into single spaces); when the combined
+    user-turn + response exceeds CHUNK_SIZE, the boundary-aware splitter
+    in ``chunker.smart_split`` carries it across drawers without
+    splitting mid-word or mid-code-fence.
+
+    Tool-output noise (log dumps, ps listings, line-numbered diffs,
+    standalone truncation messages) is filtered out by
+    ``chunker.is_excluded_content`` and never enters the palace.
     """
     chunks = []
     i = 0
@@ -120,38 +129,24 @@ def _chunk_by_exchange(lines: list) -> list:
             user_turn = line.strip()
             i += 1
 
+            # Preserve original line structure — paragraph breaks,
+            # code fences, list indentation. The previous version
+            # stripped each line and joined with single spaces, which
+            # destroyed the structure smart_split now relies on for
+            # finding clean boundaries.
             ai_lines = []
             while i < len(lines):
                 next_line = lines[i]
                 if next_line.strip().startswith(">") or next_line.strip().startswith("---"):
                     break
-                if next_line.strip():
-                    ai_lines.append(next_line.strip())
+                ai_lines.append(next_line)
                 i += 1
 
-            ai_response = " ".join(ai_lines)
-            content = f"{user_turn}\n{ai_response}" if ai_response else user_turn
+            ai_response = "\n".join(ai_lines).strip()
+            content = f"{user_turn}\n\n{ai_response}" if ai_response else user_turn
 
-            # Split into multiple drawers when the exchange exceeds CHUNK_SIZE
-            if len(content) > CHUNK_SIZE:
-                # First chunk: user turn + as much response as fits
-                first_part = content[:CHUNK_SIZE]
-                if len(first_part.strip()) > MIN_CHUNK_SIZE:
-                    chunks.append({"content": first_part, "chunk_index": len(chunks)})
-                # Remaining response in CHUNK_SIZE-sized continuation drawers
-                remainder = content[CHUNK_SIZE:]
-                while remainder:
-                    part = remainder[:CHUNK_SIZE]
-                    remainder = remainder[CHUNK_SIZE:]
-                    if len(part.strip()) > MIN_CHUNK_SIZE:
-                        chunks.append({"content": part, "chunk_index": len(chunks)})
-            elif len(content.strip()) > MIN_CHUNK_SIZE:
-                chunks.append(
-                    {
-                        "content": content,
-                        "chunk_index": len(chunks),
-                    }
-                )
+            for piece in _emit_chunks(content):
+                chunks.append({"content": piece, "chunk_index": len(chunks)})
         else:
             i += 1
 
@@ -159,24 +154,31 @@ def _chunk_by_exchange(lines: list) -> list:
 
 
 def _chunk_by_paragraph(content: str) -> list:
-    """Fallback: chunk by paragraph breaks."""
-    chunks = []
-    paragraphs = [p.strip() for p in content.split("\n\n") if p.strip()]
+    """Fallback chunker for content without > exchange markers.
 
-    # If no paragraph breaks and long content, chunk by line groups
-    if len(paragraphs) <= 1 and content.count("\n") > 20:
-        lines = content.split("\n")
-        for i in range(0, len(lines), 25):
-            group = "\n".join(lines[i : i + 25]).strip()
-            if len(group) > MIN_CHUNK_SIZE:
-                chunks.append({"content": group, "chunk_index": len(chunks)})
-        return chunks
+    Packs paragraphs together up to CHUNK_SIZE rather than emitting one
+    chunk per paragraph (which produced uselessly small chunks for
+    list-heavy notes). Long single paragraphs flow through smart_split.
+    """
+    return [
+        {"content": piece, "chunk_index": idx}
+        for idx, piece in enumerate(_emit_chunks(content))
+    ]
 
-    for para in paragraphs:
-        if len(para) > MIN_CHUNK_SIZE:
-            chunks.append({"content": para, "chunk_index": len(chunks)})
 
-    return chunks
+def _emit_chunks(content: str) -> list:
+    """Apply exclusion filter then boundary-aware splitting.
+
+    Returns a list of chunk strings, each at least MIN_CHUNK_SIZE
+    chars. Empty list if the content is excluded or all chunks fall
+    below the minimum size.
+    """
+    if not content or not content.strip():
+        return []
+    if is_excluded_content(content):
+        return []
+    pieces = smart_split(content, CHUNK_SIZE, CHUNK_MAX)
+    return [p for p in pieces if len(p.strip()) >= MIN_CHUNK_SIZE]
 
 
 # =============================================================================

--- a/mempalace/diary_ingest.py
+++ b/mempalace/diary_ingest.py
@@ -127,7 +127,9 @@ def ingest_diaries(
         if curr_size == prev_size and not force:
             continue
 
-        now_iso = datetime.now(timezone.utc).isoformat()
+        _now = datetime.now(timezone.utc)
+        now_iso = _now.isoformat()
+        now_ts = _now.timestamp()
         drawer_id = _diary_drawer_id(wing, date_str)
         entities = _extract_entities_for_metadata(text)
         source_file = str(diary_path)
@@ -142,6 +144,7 @@ def ingest_diaries(
                 "source_file": source_file,
                 "source_session": "daily_diary",
                 "filed_at": now_iso,
+                "filed_at_ts": now_ts,
             }
             if entities:
                 drawer_meta["entities"] = entities
@@ -172,6 +175,7 @@ def ingest_diaries(
                         "room": "daily",
                         "source_file": source_file,
                         "filed_at": now_iso,
+                        "filed_at_ts": now_ts,
                     }
                     if entities:
                         closet_meta["entities"] = entities

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -16,14 +16,18 @@ Reads directly from ChromaDB (mempalace_drawers)
 and ~/.mempalace/identity.txt.
 """
 
+import logging
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from collections import defaultdict
 
 from .config import MempalaceConfig
 from .palace import get_collection as _get_collection
 from .searcher import _first_or_empty, build_where_filter
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +342,147 @@ class Layer3:
                 }
             )
         return hits
+
+
+# ---------------------------------------------------------------------------
+# Diary read API
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DiaryEntry:
+    """One agent diary entry.
+
+    Mirrors the persistence shape used by ``tool_diary_write`` /
+    ``tool_diary_read`` in :mod:`mempalace.mcp_server`. Surfaces the
+    four caller-relevant fields directly so consumers (e.g. wakeup
+    prefetch in Vestige) don't reach into chromadb metadata themselves.
+
+    ``filed_at`` is the ISO 8601 timestamp persisted on write; it sorts
+    lexicographically, which matches chronological order — read_diary
+    uses it for the descending-sort + last-N slice.
+
+    ``content`` is the body text (the document blob in chromadb terms).
+    """
+
+    date: str
+    filed_at: str
+    topic: str
+    content: str
+
+
+class DiaryUnavailable(Exception):
+    """Raised by :func:`read_diary` when the palace is unreachable or
+    the diary collection cannot be queried.
+
+    Distinguishes infrastructure failure (palace missing, chromadb
+    error, import-time problem) from a genuinely empty diary. Callers
+    who care about that distinction can render the two cases
+    differently — typical UX:
+
+      - ``DiaryUnavailable`` raised → "(diary unavailable)"
+      - returns ``[]``               → "(no entries yet)"
+    """
+
+
+def read_diary(
+    agent: str,
+    last_n: int = 5,
+    *,
+    palace_path: str | None = None,
+) -> list[DiaryEntry]:
+    """Return the last ``last_n`` diary entries for ``agent``.
+
+    Reads from ``wing=wing_{agent.lower()} room=diary`` in the palace
+    (matching the persistence convention used by
+    :func:`mempalace.mcp_server.tool_diary_write`), sorts by
+    ``filed_at`` descending, and slices to the most recent ``last_n``.
+
+    Args:
+        agent: Agent name. Lower-cased for the wing key
+            (``"Ves"`` → ``wing_ves``).
+        last_n: Maximum entries to return. Default 5. ``read_diary``
+            never returns more than this even if the palace contains
+            more entries.
+        palace_path: Override the palace location. Defaults to
+            :attr:`MempalaceConfig.palace_path` (which itself respects
+            ``$MEMPALACE_PALACE_PATH`` and the config file).
+
+    Returns:
+        Chronologically-descending list (newest first) of
+        :class:`DiaryEntry`. Empty list when the wing has no diary
+        entries.
+
+    Raises:
+        DiaryUnavailable: when the palace cannot be reached
+            (filesystem missing, chromadb import error) or the
+            collection query fails for any reason. Failure is
+            *infrastructure-level*; an empty palace returns ``[]``
+            without raising.
+
+    Why this API (vs the inline ``col.get`` mirror previously inlined
+    in Vestige's runtime_orientation): keeps the chromadb knowledge —
+    where-filter shape, metadata keys, sort field — encapsulated in
+    mempalace. Schema changes here propagate to consumers without
+    each consumer needing to update their inlined logic.
+
+    Side-effect-free: uses the safe :func:`palace.get_collection`
+    accessor (not :mod:`mempalace.mcp_server`, which performs a
+    ``dup2(stderr, stdout)`` at import time as part of the MCP stdio
+    protocol contract).
+    """
+
+    try:
+        from .palace import get_collection
+    except Exception as exc:
+        logger.debug("read_diary: palace module not importable: %s", exc)
+        raise DiaryUnavailable("palace module not importable") from exc
+
+    if palace_path is None:
+        try:
+            palace_path = MempalaceConfig().palace_path
+        except Exception as exc:
+            logger.debug("read_diary: config not readable: %s", exc)
+            raise DiaryUnavailable("MempalaceConfig not readable") from exc
+
+    try:
+        col = get_collection(palace_path, "mempalace_drawers", create=False)
+    except Exception as exc:
+        logger.debug("read_diary: get_collection failed: %s", exc)
+        raise DiaryUnavailable(f"get_collection failed: {exc}") from exc
+
+    wing = f"wing_{agent.lower()}"
+    try:
+        # limit=10_000 is a generous upper bound; sort-and-slice
+        # happens in-Python because chromadb's get() has no
+        # order-by-metadata. Real diary scales (Ves: ~76 entries
+        # 2026-05-11) are well under this cap.
+        results = col.get(
+            where={"$and": [{"wing": wing}, {"room": "diary"}]},
+            include=["documents", "metadatas"],
+            limit=10_000,
+        )
+    except Exception as exc:
+        logger.debug("read_diary: col.get failed: %s", exc, exc_info=True)
+        raise DiaryUnavailable(f"col.get failed: {exc}") from exc
+
+    documents = results.get("documents") or []
+    metadatas = results.get("metadatas") or []
+    if not documents:
+        return []
+
+    entries: list[DiaryEntry] = []
+    for doc, meta in zip(documents, metadatas):
+        entries.append(
+            DiaryEntry(
+                date=str(meta.get("date", "")),
+                filed_at=str(meta.get("filed_at", "")),
+                topic=str(meta.get("topic", "")),
+                content=doc or "",
+            )
+        )
+    entries.sort(key=lambda e: e.filed_at, reverse=True)
+    return entries[: max(0, last_n)]
 
 
 # ---------------------------------------------------------------------------

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -639,6 +639,7 @@ def tool_add_drawer(
         pass
 
     try:
+        _now = datetime.now()
         col.upsert(
             ids=[drawer_id],
             documents=[content],
@@ -649,7 +650,8 @@ def tool_add_drawer(
                     "source_file": source_file or "",
                     "chunk_index": 0,
                     "added_by": added_by,
-                    "filed_at": datetime.now().isoformat(),
+                    "filed_at": _now.isoformat(),
+                    "filed_at_ts": _now.timestamp(),
                 }
             ],
         )
@@ -967,6 +969,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
                     "type": "diary_entry",
                     "agent": agent_name,
                     "filed_at": now.isoformat(),
+                    "filed_at_ts": now.timestamp(),
                     "date": now.strftime("%Y-%m-%d"),
                 }
             ],

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -539,13 +539,15 @@ def add_drawer(
     """Add one drawer to the palace."""
     drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(chunk_index)).encode()).hexdigest()[:24]}"
     try:
+        _now = datetime.now()
         metadata = {
             "wing": wing,
             "room": room,
             "source_file": source_file,
             "chunk_index": chunk_index,
             "added_by": agent,
-            "filed_at": datetime.now().isoformat(),
+            "filed_at": _now.isoformat(),
+            "filed_at_ts": _now.timestamp(),
             "normalize_version": NORMALIZE_VERSION,
         }
         # Store file mtime so we can detect modifications later.
@@ -652,12 +654,14 @@ def process_file(
                 f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
             )
             entities = _extract_entities_for_metadata(content)
+            _closet_now = datetime.now()
             closet_meta = {
                 "wing": wing,
                 "room": room,
                 "source_file": source_file,
                 "drawer_count": drawers_added,
-                "filed_at": datetime.now().isoformat(),
+                "filed_at": _closet_now.isoformat(),
+                "filed_at_ts": _closet_now.timestamp(),
                 "normalize_version": NORMALIZE_VERSION,
             }
             if entities:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -370,11 +370,12 @@ def chunk_text(content: str, source_file: str) -> list:
         return []
 
     pieces = smart_split(content, CHUNK_SIZE, CHUNK_MAX)
-    return [
-        {"content": piece, "chunk_index": idx}
-        for idx, piece in enumerate(pieces)
-        if len(piece.strip()) >= MIN_CHUNK_SIZE
+    kept = [
+        piece
+        for piece in pieces
+        if len(piece.strip()) >= MIN_CHUNK_SIZE and not is_excluded_content(piece)
     ]
+    return [{"content": piece, "chunk_index": idx} for idx, piece in enumerate(kept)]
 
 
 # =============================================================================

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
+from .chunker import is_excluded_content, smart_split
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -59,8 +60,9 @@ SKIP_FILENAMES = {
     "package-lock.json",
 }
 
-CHUNK_SIZE = 800  # chars per drawer
-CHUNK_OVERLAP = 100  # overlap between chunks
+CHUNK_SIZE = 800  # soft target chars per drawer
+CHUNK_MAX = 1200  # hard ceiling: chunker may stretch this far to find a clean boundary
+CHUNK_OVERLAP = 100  # overlap between chunks (legacy; smart_split does not use overlap)
 MIN_CHUNK_SIZE = 50  # skip tiny chunks
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB — skip files larger than this
 
@@ -348,45 +350,31 @@ def detect_room(filepath: Path, content: str, rooms: list, project_path: Path) -
 
 def chunk_text(content: str, source_file: str) -> list:
     """
-    Split content into drawer-sized chunks.
-    Tries to split on paragraph/line boundaries.
-    Returns list of {"content": str, "chunk_index": int}
+    Split content into drawer-sized chunks using the meaning-aware
+    chunker (paragraph/sentence/word boundary search, code-block
+    atomicity, tool-output exclusion).
+
+    Returns a list of ``{"content": str, "chunk_index": int}``. Empty
+    if the content is empty, dominated by tool-output noise (logs, ps,
+    diffs, truncation messages), or all candidate chunks fall below
+    MIN_CHUNK_SIZE.
+
+    The legacy CHUNK_OVERLAP parameter is no longer used: smart_split
+    aligns to semantic boundaries, which obviates the sliding-window
+    overlap that the old fixed-width chunker needed to mitigate its
+    mid-word cuts.
     """
-    # Clean up
-    content = content.strip()
-    if not content:
+    if not content or not content.strip():
+        return []
+    if is_excluded_content(content):
         return []
 
-    chunks = []
-    start = 0
-    chunk_index = 0
-
-    while start < len(content):
-        end = min(start + CHUNK_SIZE, len(content))
-
-        # Try to break at paragraph boundary
-        if end < len(content):
-            newline_pos = content.rfind("\n\n", start, end)
-            if newline_pos > start + CHUNK_SIZE // 2:
-                end = newline_pos
-            else:
-                newline_pos = content.rfind("\n", start, end)
-                if newline_pos > start + CHUNK_SIZE // 2:
-                    end = newline_pos
-
-        chunk = content[start:end].strip()
-        if len(chunk) >= MIN_CHUNK_SIZE:
-            chunks.append(
-                {
-                    "content": chunk,
-                    "chunk_index": chunk_index,
-                }
-            )
-            chunk_index += 1
-
-        start = end - CHUNK_OVERLAP if end < len(content) else end
-
-    return chunks
+    pieces = smart_split(content, CHUNK_SIZE, CHUNK_MAX)
+    return [
+        {"content": piece, "chunk_index": idx}
+        for idx, piece in enumerate(pieces)
+        if len(piece.strip()) >= MIN_CHUNK_SIZE
+    ]
 
 
 # =============================================================================

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -35,6 +35,14 @@ SKIP_DIRS = {
     ".eggs",
     "htmlcov",
     "target",
+    # Claude Code spills oversized tool-call outputs to
+    # `.claude/projects/{session}/tool-results/*.txt`. Those files are
+    # raw tool artifacts (JSON dumps, log captures, error tracebacks
+    # containing inlined session metadata) — not conversation content —
+    # and produce unusable drawers when mined as text. Skip the whole
+    # subtree at the walker level rather than relying on chunk-level
+    # exclusion alone.
+    "tool-results",
 }
 
 _DEFAULT_BACKEND = ChromaBackend()

--- a/tests/test_backfill_filed_at_ts.py
+++ b/tests/test_backfill_filed_at_ts.py
@@ -1,0 +1,178 @@
+"""Tests for mempalace.backfill_filed_at_ts."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from mempalace.backfill_filed_at_ts import (
+    _parse_iso_to_epoch,
+    backfill,
+)
+
+
+def _make_test_palace(tmp_path: Path) -> str:
+    """Create a minimal chroma.sqlite3 with the embedding_metadata schema."""
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    db_path = palace / "chroma.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    # Schema modeled on Chroma's embedding_metadata table; only the columns
+    # the backfill touches are required.
+    conn.execute(
+        """
+        CREATE TABLE embedding_metadata (
+            id INTEGER NOT NULL,
+            key TEXT NOT NULL,
+            string_value TEXT,
+            int_value INTEGER,
+            float_value REAL,
+            bool_value INTEGER,
+            PRIMARY KEY (id, key)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    return str(palace)
+
+
+def _seed(palace_path: str, rows: list[tuple[int, str, str | None]]) -> None:
+    """Seed (id, key, string_value) tuples into embedding_metadata."""
+    db = sqlite3.connect(str(Path(palace_path) / "chroma.sqlite3"))
+    db.executemany(
+        "INSERT INTO embedding_metadata (id, key, string_value) VALUES (?, ?, ?)",
+        rows,
+    )
+    db.commit()
+    db.close()
+
+
+def _read_filed_at_ts(palace_path: str) -> dict[int, float | None]:
+    db = sqlite3.connect(str(Path(palace_path) / "chroma.sqlite3"))
+    cur = db.execute(
+        "SELECT id, float_value FROM embedding_metadata WHERE key = 'filed_at_ts'"
+    )
+    out = {row[0]: row[1] for row in cur.fetchall()}
+    db.close()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+class TestParseIsoToEpoch:
+    def test_iso_with_tz(self):
+        e = _parse_iso_to_epoch("2026-04-27T12:00:00+00:00")
+        assert e is not None
+        # Round-trip through datetime to confirm
+        assert datetime.fromtimestamp(e, tz=timezone.utc).isoformat().startswith(
+            "2026-04-27T12:00:00"
+        )
+
+    def test_iso_zulu(self):
+        e = _parse_iso_to_epoch("2026-04-27T12:00:00Z")
+        assert e is not None
+
+    def test_iso_naive(self):
+        # Naive ISO — interpreted as local time, so we just assert it parses
+        e = _parse_iso_to_epoch("2026-04-27T12:00:00")
+        assert e is not None
+
+    def test_unparseable(self):
+        assert _parse_iso_to_epoch("not a date") is None
+
+    def test_empty(self):
+        assert _parse_iso_to_epoch("") is None
+
+    def test_non_string(self):
+        assert _parse_iso_to_epoch(None) is None
+        assert _parse_iso_to_epoch(42) is None
+
+
+# ---------------------------------------------------------------------------
+# Backfill end-to-end
+# ---------------------------------------------------------------------------
+
+class TestBackfill:
+    def test_inserts_filed_at_ts_for_each_filed_at(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        _seed(palace, [
+            (1, "filed_at", "2026-04-27T12:00:00+00:00"),
+            (2, "filed_at", "2026-04-26T08:30:00+00:00"),
+            (3, "filed_at", "2026-04-25T20:00:00+00:00"),
+        ])
+        stats = backfill(palace_path=palace, batch_size=10)
+        assert stats["scanned"] == 3
+        assert stats["inserted"] == 3
+        assert stats["unparseable"] == 0
+        out = _read_filed_at_ts(palace)
+        assert set(out.keys()) == {1, 2, 3}
+        # Newer dates have larger epochs
+        assert out[1] > out[2] > out[3]
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        _seed(palace, [(1, "filed_at", "2026-04-27T12:00:00+00:00")])
+        stats = backfill(palace_path=palace, dry_run=True, batch_size=10)
+        assert stats["scanned"] == 1
+        assert stats["inserted"] == 1  # counted but not committed
+        assert _read_filed_at_ts(palace) == {}
+
+    def test_idempotent_skips_existing(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        _seed(palace, [
+            (1, "filed_at", "2026-04-27T12:00:00+00:00"),
+            (2, "filed_at", "2026-04-26T08:30:00+00:00"),
+        ])
+        # Pre-seed a filed_at_ts for id=1; backfill should leave it alone
+        db = sqlite3.connect(str(Path(palace) / "chroma.sqlite3"))
+        db.execute(
+            "INSERT INTO embedding_metadata (id, key, float_value) "
+            "VALUES (1, 'filed_at_ts', 999.0)"
+        )
+        db.commit()
+        db.close()
+        stats = backfill(palace_path=palace, batch_size=10)
+        # Only id=2 should be backfilled this run
+        assert stats["scanned"] == 1
+        assert stats["inserted"] == 1
+        out = _read_filed_at_ts(palace)
+        assert out[1] == 999.0  # unchanged
+        assert out[2] is not None and out[2] != 999.0
+
+    def test_unparseable_filed_at_counted_separately(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        _seed(palace, [
+            (1, "filed_at", "2026-04-27T12:00:00+00:00"),
+            (2, "filed_at", "garbage"),
+            (3, "filed_at", "2026-04-25T20:00:00+00:00"),
+        ])
+        stats = backfill(palace_path=palace, batch_size=10)
+        assert stats["scanned"] == 3
+        assert stats["inserted"] == 2  # 1 + 3
+        assert stats["unparseable"] == 1
+        out = _read_filed_at_ts(palace)
+        assert set(out.keys()) == {1, 3}
+
+    def test_missing_db_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            backfill(palace_path=str(tmp_path / "nonexistent"))
+
+    def test_batch_size_smaller_than_rows(self, tmp_path):
+        palace = _make_test_palace(tmp_path)
+        # 25 rows, batch_size=10 → should still process all of them
+        rows = [
+            (i, "filed_at", f"2026-04-{i:02d}T00:00:00+00:00")
+            for i in range(1, 26)
+        ]
+        _seed(palace, rows)
+        stats = backfill(palace_path=palace, batch_size=10)
+        assert stats["scanned"] == 25
+        assert stats["inserted"] == 25
+        assert len(_read_filed_at_ts(palace)) == 25

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -120,6 +120,69 @@ class TestIsExcludedContent:
         assert is_excluded_content("") is True
         assert is_excluded_content("   \n\n  ") is True
 
+    # --- JSON-blob and Claude Code session-log shapes ---
+
+    def test_jsonl_session_log_excluded(self):
+        # Each line is its own JSON object — the canonical Claude Code
+        # session log shape. Should be dropped wholesale.
+        text = (
+            '{"type":"permission-mode","permissionMode":"default","sessionId":"abc"}\n'
+            '{"type":"file-history-snapshot","messageId":"90a7","timestamp":"2026-04-02T23:12:57.330Z"}\n'
+            '{"parentUuid":null,"isSidechain":false,"type":"user","message":{"role":"user"}}\n'
+            '{"type":"assistant","uuid":"158113b8","timestamp":"2026-04-02T23:13:01.448Z"}\n'
+        )
+        assert is_excluded_content(text) is True
+
+    def test_inline_json_blob_with_transcript_marker_excluded(self):
+        # Real production failure shape: a single visual line with high
+        # `","key":` density and embedded uuid/timestamp markers, taken
+        # verbatim from the b5k5gj8gj.txt tool-results dump that
+        # produced 82 mid-line drawers in the 2026-05-02 audit.
+        text = (
+            'andard","inference_geo":"not_available"}},"requestId":"req_011CZfntLLhXGsFZaH",'
+            '"type":"assistant","uuid":"158113b8-5455-4668-8b94-356cd9523bbc",'
+            '"timestamp":"2026-04-02T23:13:01.448Z","userType":"external","entrypoint":"cli",'
+            '"cwd":"/Users/jameswinans/Documents/Temenos/Ves","sessionId":"1ada0a3a"}'
+        )
+        assert is_excluded_content(text) is True
+
+    def test_long_quoted_tool_list_excluded(self):
+        # The tool-name list shape: comma-separated quoted strings with
+        # no transcript marker. High `","key":`-density alone is not
+        # enough — but if there's a transcript marker, it should fire.
+        # This case has a marker, so excluded.
+        text = (
+            '"tools":["mcp__library-rag__delete_file","mcp__library-rag__ingest_data",'
+            '"mcp__library-rag__ingest_file","mcp__library-rag__list_files",'
+            '"mcp__library-rag__query_documents","mcp__library-rag__status"],'
+            '"sessionId":"abc","timestamp":"2026-04-02T23:13:01.448Z"'
+        )
+        assert is_excluded_content(text) is True
+
+    def test_prose_mentioning_uuid_kept(self):
+        # Prose that mentions a uuid or session id in passing must
+        # survive — only blob density triggers exclusion.
+        text = (
+            "I traced the issue back to the session with sessionId "
+            '"abc-123-def" — that one had a permissionMode mismatch. '
+            "The fix is to normalize the JSON envelope before passing "
+            "it to the next stage. We've seen this twice before in the "
+            "April 17 logs and once in early May; the pattern is "
+            "consistent enough that it warrants a regression test."
+        )
+        assert is_excluded_content(text) is False
+
+    def test_prose_with_one_json_object_kept(self):
+        # One inlined JSON example in otherwise prose content stays.
+        text = (
+            "The handler returns a payload like\n\n"
+            '{"status":"ok","count":5,"latency_ms":42}\n\n'
+            "which downstream services parse and route. The key thing "
+            "to notice is the latency field — it lets us decide whether "
+            "to retry on a slow path."
+        )
+        assert is_excluded_content(text) is False
+
 
 # ---------------------------------------------------------------------------
 # smart_split — boundary preservation, no mid-word cuts

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,279 @@
+"""Unit tests for the meaning-aware chunker.
+
+Spec: a chunk should never start mid-word, code blocks are atomic, and
+content dominated by tool-output noise (logs, ps, diffs, truncation
+messages) is excluded from indexing.
+"""
+
+import pytest
+
+from mempalace.chunker import (
+    is_excluded_content,
+    smart_split,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_excluded_content — the 5 contamination categories
+# ---------------------------------------------------------------------------
+
+
+class TestIsExcludedContent:
+    def test_log_dump_excluded(self):
+        text = "\n".join(
+            f"2026-04-{(i % 28) + 1:02d} 12:42:22,856 [vestige.crystallization] INFO: Cycle {i} ran"
+            for i in range(10)
+        )
+        assert is_excluded_content(text) is True
+
+    def test_logger_format_excluded(self):
+        text = "\n".join(
+            f"INFO:vestige.recall:Surfaced memory {i} with priority 0.{i:02d}"
+            for i in range(8)
+        )
+        assert is_excluded_content(text) is True
+
+    def test_ps_aux_output_excluded(self):
+        text = (
+            "jameswinans  93662   5.4  0.5 508859040 323904   ??  S     3:44PM   0:12.34 python\n"
+            "jameswinans  93663   2.1  0.2 408859040 123904   ??  S     3:44PM   0:05.21 node\n"
+            "jameswinans  93664   1.8  0.1 308859040  63904   ??  S     3:44PM   0:02.10 ruby\n"
+            "jameswinans  93665   0.9  0.1 208859040  33904   ??  S     3:44PM   0:01.05 zsh\n"
+        )
+        assert is_excluded_content(text) is True
+
+    def test_line_numbered_diff_excluded(self):
+        text = (
+            "  920- # --- Metapath Association ---\n"
+            "  921- try:\n"
+            "  922:     from vestige.dream.metapath import run_metapath_association\n"
+            "  923-\n"
+            "  924-     graph_path = _resolve_graph_path()\n"
+            "  925-     if graph_path:\n"
+        )
+        # All lines match the diff pattern (number + +/- prefix)
+        assert is_excluded_content(text) is True
+
+    def test_truncation_message_only_excluded(self):
+        text = "[truncated, 4905 chars] → <persisted-output> Output too large (52.8KB)."
+        assert is_excluded_content(text) is True
+
+    def test_arrow_tool_output_excluded(self):
+        # Single visual line with many arrow redirects — pasted shell
+        # output that the previous chunker collapsed into one blob.
+        text = (
+            "→ moved to: ~/.tmp → re-checked → still missing → ran ls "
+            "→ found in /tmp → reverted → re-applied → done"
+        )
+        assert is_excluded_content(text) is True
+
+    def test_multi_line_arrow_listing_excluded(self):
+        # Real shape from production palace: a file listing where
+        # normalize.py prefixed each line with "→ ". Previously slipped
+        # through because the only arrow-rule required <=3 lines.
+        text = (
+            "→ -rw-------@ 1 jameswinans  staff    3138404 Apr  2 19:11 a.jsonl\n"
+            "→ -rw-------@ 1 jameswinans  staff    2626408 Apr  2 19:11 b.jsonl\n"
+            "→ -rw-------@ 1 jameswinans  staff    1924120 Apr  2 19:11 c.jsonl\n"
+            "→ drwx------@ 5 jameswinans  staff         160 Apr  1 20:21 d/\n"
+            "→ drwx------@ 3 jameswinans  staff          96 Apr  2 11:31 e/\n"
+        )
+        assert is_excluded_content(text) is True
+
+    def test_partial_arrow_content_kept(self):
+        # If only a minority of lines are arrow-prefixed (e.g., a few
+        # tool outputs embedded in a longer prose response), keep it.
+        text = (
+            "I checked the directory and found three relevant files. "
+            "The listing shows:\n\n"
+            "→ a.jsonl  3.1 MB\n"
+            "→ b.jsonl  2.6 MB\n\n"
+            "Of these, a.jsonl is the one I need to inspect because it "
+            "contains the session that was active when the bug fired. "
+            "The other two are older sessions that already wrapped."
+        )
+        assert is_excluded_content(text) is False
+
+    # --- Negative cases: real prose with embedded noise should pass ---
+
+    def test_prose_with_one_log_line_kept(self):
+        text = (
+            "I noticed the daemon was misbehaving. Looking at the logs:\n\n"
+            "2026-04-17 12:42:22 [vestige.recall] INFO: surfaced 3 memories\n\n"
+            "That's the only signal I needed. The recall pipeline is alive but "
+            "the memories surfacing are the wrong ones — fragment-shaped and "
+            "biased to one date. Time to re-design."
+        )
+        assert is_excluded_content(text) is False
+
+    def test_prose_with_truncation_note_kept(self):
+        text = (
+            "The full output was too long [truncated, 200 chars] but the "
+            "important part is that the consolidation produced 5 entities "
+            "instead of the expected 1. That's the bug. The prompt is "
+            "over-eager about what counts as a memory, and the LLM is "
+            "happily emitting four near-duplicates per session."
+        )
+        assert is_excluded_content(text) is False
+
+    def test_empty_excluded(self):
+        assert is_excluded_content("") is True
+        assert is_excluded_content("   \n\n  ") is True
+
+
+# ---------------------------------------------------------------------------
+# smart_split — boundary preservation, no mid-word cuts
+# ---------------------------------------------------------------------------
+
+
+def _all_chunks_clean_at_starts(chunks: list[str]) -> bool:
+    """No chunk starts mid-word (lowercase first char with no leading
+    punctuation that would be acceptable, like a quote or list marker).
+    """
+    for c in chunks:
+        if not c:
+            continue
+        first = c.lstrip()[:1]
+        # Acceptable starts: uppercase, digit, opening punctuation, common
+        # Markdown markers (#, -, *, >, |, `).
+        if first and first[0].islower():
+            return False
+    return True
+
+
+def _all_chunks_clean_at_ends(chunks: list[str]) -> bool:
+    """No chunk ends mid-word — last char is whitespace or
+    sentence/punctuation, not a stranded letter.
+
+    Allowed end chars: any punctuation, whitespace, digit (e.g. URLs
+    ending in numbers), closing brackets, or markdown structure.
+    """
+    for c in chunks:
+        if not c:
+            continue
+        # Strip trailing whitespace; check the last non-whitespace char
+        stripped = c.rstrip()
+        if not stripped:
+            continue
+        last = stripped[-1]
+        # If the chunk ends with a letter, the *next* chunk must not
+        # start with a continuation of that word. Best signal: the
+        # original text had a boundary right after this chunk.
+        # Simpler check: just allow any end — the key invariant is
+        # that the *start* of the next chunk is clean (covered above).
+        # So this helper is permissive.
+        _ = last
+    return True
+
+
+class TestSmartSplit:
+    def test_empty(self):
+        assert smart_split("", 800, 1200) == []
+        assert smart_split("   \n  ", 800, 1200) == []
+
+    def test_short_under_ceiling_returned_whole(self):
+        text = "Short content under the ceiling — no splitting needed."
+        chunks = smart_split(text, 800, 1200)
+        assert chunks == [text]
+
+    def test_paragraph_boundary_preferred(self):
+        # Two paragraphs, each ~500 chars. Target 800, ceiling 1200.
+        # Total ~1000 → fits in one chunk. Force splitting by lowering target.
+        para1 = "First paragraph. " * 30  # ~510 chars
+        para2 = "Second paragraph. " * 30  # ~540 chars
+        text = para1.strip() + "\n\n" + para2.strip()
+
+        chunks = smart_split(text, target=400, ceiling=600)
+        assert len(chunks) >= 2
+        # First chunk should end at the paragraph boundary, not mid-word
+        assert chunks[0].rstrip().endswith(".")
+        assert _all_chunks_clean_at_starts(chunks)
+
+    def test_no_mid_word_cuts_on_long_prose(self):
+        # 3000 chars of prose with sentence boundaries every ~80 chars.
+        sentences = [
+            "This is sentence number {} of the test. ".format(i)
+            for i in range(60)
+        ]
+        text = "".join(sentences)  # ~3000 chars
+
+        chunks = smart_split(text, target=800, ceiling=1200)
+        assert len(chunks) >= 2
+        assert _all_chunks_clean_at_starts(chunks)
+        # Every chunk should end with a sentence terminator (or be the last)
+        for chunk in chunks[:-1]:
+            assert chunk.rstrip().endswith((".", "!", "?")), (
+                f"Chunk did not end at sentence: {chunk[-50:]!r}"
+            )
+
+    def test_no_loss_of_content(self):
+        # Round-trip: concatenating all chunks must contain every word
+        # from the source (modulo whitespace differences).
+        text = "Word " * 500  # 2500 chars, all the same
+        chunks = smart_split(text, target=800, ceiling=1200)
+        # Total word count preserved
+        total_words = sum(c.count("Word") for c in chunks)
+        assert total_words == 500
+
+    def test_code_block_atomic(self):
+        # A code block longer than target+ceiling should be one chunk,
+        # not split mid-line.
+        prefix = "Here is a long code listing for the logger:\n\n"
+        code_lines = [f"    logger.info('step {i} of the long process')" for i in range(40)]
+        code = "```python\n" + "\n".join(code_lines) + "\n```\n"
+        suffix = "\n\nThat is the listing. Continuing with the explanation."
+        text = prefix + code + suffix
+
+        chunks = smart_split(text, target=400, ceiling=800)
+        # Find the chunk containing the code fence
+        code_chunks = [c for c in chunks if "```" in c]
+        assert len(code_chunks) >= 1
+        # The code block should appear with its open and close fence in
+        # the same chunk — no orphaned half-blocks
+        for c in chunks:
+            fence_count = c.count("```")
+            assert fence_count % 2 == 0, (
+                f"Chunk has unbalanced code fences: {c[:200]!r}"
+            )
+
+    def test_no_chunk_exceeds_ceiling_for_normal_prose(self):
+        # Pathological prose: long lines, no good boundaries until the very end
+        text = ("a " * 600).strip()  # 1199 chars, all single-word lines
+        chunks = smart_split(text, target=800, ceiling=1000)
+        # Each chunk except potentially an oversized code block must
+        # be <= ceiling (allow some slack from boundary skip-chars)
+        for c in chunks:
+            assert len(c) <= 1010, f"Chunk exceeded ceiling: len={len(c)}"
+
+    def test_minimal_target_ceiling_validation(self):
+        with pytest.raises(ValueError):
+            smart_split("anything", target=0, ceiling=100)
+        with pytest.raises(ValueError):
+            smart_split("anything", target=200, ceiling=100)
+
+    def test_real_world_transcript_shape(self):
+        """Regression: this mirrors the actual broken pattern observed
+        in the live palace — a long AI response that previously got
+        split mid-token. With the new chunker, no chunk should start
+        mid-word.
+        """
+        text = (
+            "I am going to walk through the diagnostic precision step by "
+            "step. Lines 250-256 have the same event query bug we just "
+            "fixed in devaluation — querying by raw object_summary instead "
+            "of abstractBehaviorId, so content snippets fail to match. "
+            "The fix is straightforward: replace the lookup key. "
+            "Let me also check whether the metapath association code path "
+            "has the same issue. From a quick read it does not, but I "
+            "want to verify before claiming that. Running the tests now. "
+            "All 301 register tests pass, which means the change is "
+            "isolated to the recall path and does not break the steering "
+            "telemetry. I will commit and ship this in a single PR. "
+        ) * 3  # ~3500 chars
+
+        chunks = smart_split(text, target=800, ceiling=1200)
+        assert len(chunks) >= 2
+        assert _all_chunks_clean_at_starts(chunks), (
+            "Some chunk starts mid-word: "
+            + str([c[:60] for c in chunks])
+        )

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -224,6 +224,35 @@ def test_scan_project_skip_dirs_still_apply_without_override():
         shutil.rmtree(tmpdir)
 
 
+def test_scan_project_skips_tool_results_subdir():
+    """Claude Code spills oversized tool outputs to
+    ``.claude/projects/{session}/tool-results/*.txt``. Those files are
+    raw tool artifacts (JSON dumps, log captures) and have produced
+    unusable drawers when mined as conversations. The directory walker
+    should skip the subtree entirely.
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        # Real prose at the project root: must survive.
+        write_file(project_root / "notes.md", "# Notes\n\nReal prose here.\n" * 5)
+
+        # tool-results subdirectory that the walker must skip.
+        write_file(
+            project_root / "session-abc" / "tool-results" / "b5k5gj8gj.txt",
+            '{"type":"permission-mode","sessionId":"abc"}\n' * 10,
+        )
+
+        scanned = scanned_files(project_root, respect_gitignore=False)
+        assert "notes.md" in scanned
+        assert not any("tool-results" in p for p in scanned), (
+            f"tool-results subdir was not skipped: {scanned}"
+        )
+    finally:
+        shutil.rmtree(tmpdir)
+
+
 def test_entity_metadata_finds_cyrillic_names(monkeypatch):
     """Entity extraction must find non-Latin names when entity_languages includes the locale."""
     import mempalace.palace as palace_mod

--- a/tests/test_read_diary.py
+++ b/tests/test_read_diary.py
@@ -1,0 +1,216 @@
+"""Tests for mempalace.layers.read_diary.
+
+The public diary-read API. Consumed by Vestige's runtime_orientation
+to surface recent diary entries to the chat-Orion substrate without
+each consumer needing to know chromadb's where-filter shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mempalace.layers import DiaryEntry, DiaryUnavailable, read_diary
+
+
+# ---------------------------------------------------------------------------
+# Fake chromadb collection for tests
+# ---------------------------------------------------------------------------
+
+class _FakeCollection:
+    """Stand-in for the chromadb collection returned by
+    ``mempalace.palace.get_collection`` — just enough surface for
+    :func:`read_diary`'s ``col.get(where=..., include=..., limit=...)``
+    contract."""
+
+    def __init__(self, entries):
+        self._entries = entries
+
+    def get(self, where=None, include=None, limit=None):  # noqa: ARG002
+        docs = []
+        metas = []
+        for e in self._entries:
+            keep = True
+            if where and "$and" in where:
+                for clause in where["$and"]:
+                    for k, v in clause.items():
+                        if e.get(k) != v:
+                            keep = False
+            if not keep:
+                continue
+            docs.append(e["document"])
+            metas.append(
+                {
+                    "date": e["date"],
+                    "filed_at": e["filed_at"],
+                    "topic": e["topic"],
+                    "wing": e["wing"],
+                    "room": e["room"],
+                }
+            )
+        return {"documents": docs, "metadatas": metas, "ids": list(range(len(docs)))}
+
+
+def _entry(date, filed_at, topic, document, wing="wing_ves", room="diary"):
+    return {
+        "date": date,
+        "filed_at": filed_at,
+        "topic": topic,
+        "document": document,
+        "wing": wing,
+        "room": room,
+    }
+
+
+def _patch_get_collection(monkeypatch, entries):
+    fake = _FakeCollection(entries)
+    monkeypatch.setattr(
+        "mempalace.palace.get_collection",
+        lambda palace_path, collection_name, create=False: fake,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_returns_entries_sorted_by_filed_at_desc(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+    _patch_get_collection(
+        monkeypatch,
+        [
+            _entry("2026-05-08", "2026-05-08T10:00:00", "older", "older content"),
+            _entry("2026-05-10", "2026-05-10T21:10:00", "newest", "newest content"),
+            _entry("2026-05-09", "2026-05-09T18:15:00", "middle", "middle content"),
+        ],
+    )
+    entries = read_diary("ves")
+    assert len(entries) == 3
+    assert [e.topic for e in entries] == ["newest", "middle", "older"]
+    assert entries[0].content == "newest content"
+    assert isinstance(entries[0], DiaryEntry)
+
+
+def test_last_n_limits_results(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+    _patch_get_collection(
+        monkeypatch,
+        [
+            _entry(f"2026-05-{i:02d}", f"2026-05-{i:02d}T10:00:00", f"topic-{i:02d}", f"c-{i}")
+            for i in range(1, 11)
+        ],
+    )
+    entries = read_diary("ves", last_n=3)
+    assert len(entries) == 3
+    # Newest 3 (i=10, 9, 8) descending.
+    assert [e.topic for e in entries] == ["topic-10", "topic-09", "topic-08"]
+
+
+def test_empty_palace_returns_empty_list(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+    _patch_get_collection(monkeypatch, [])
+    entries = read_diary("ves")
+    assert entries == []
+
+
+def test_no_entries_for_wing_returns_empty_list(monkeypatch, tmp_path):
+    """Palace exists, has entries, but none in the agent's wing."""
+
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+    _patch_get_collection(
+        monkeypatch,
+        [
+            _entry("2026-05-10", "2026-05-10T10:00:00", "kai-diary", "kai-content", wing="wing_kai"),
+        ],
+    )
+    entries = read_diary("ves")
+    assert entries == []
+
+
+def test_filters_to_agent_wing_and_diary_room(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+    _patch_get_collection(
+        monkeypatch,
+        [
+            _entry("2026-05-10", "2026-05-10T10:00:00", "ves-d", "should-appear"),
+            _entry("2026-05-10", "2026-05-10T10:00:00", "kai-d", "wrong-wing", wing="wing_kai"),
+            _entry("2026-05-10", "2026-05-10T10:00:00", "ves-a", "wrong-room", room="architecture"),
+        ],
+    )
+    entries = read_diary("ves")
+    assert len(entries) == 1
+    assert entries[0].content == "should-appear"
+
+
+def test_agent_name_lowercased_for_wing(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+    _patch_get_collection(
+        monkeypatch,
+        [
+            _entry("2026-05-10", "2026-05-10T10:00:00", "x", "content", wing="wing_ves"),
+        ],
+    )
+    # Pass "Ves" capitalized — should still match wing_ves.
+    entries = read_diary("Ves")
+    assert len(entries) == 1
+
+
+def test_last_n_zero_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+    _patch_get_collection(
+        monkeypatch,
+        [
+            _entry("2026-05-10", "2026-05-10T10:00:00", "x", "content"),
+        ],
+    )
+    assert read_diary("ves", last_n=0) == []
+
+
+# ---------------------------------------------------------------------------
+# Failure-soft: DiaryUnavailable on infrastructure problems
+# ---------------------------------------------------------------------------
+
+def test_raises_diary_unavailable_when_get_collection_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+
+    def fake_get_collection(*args, **kwargs):
+        raise RuntimeError("simulated palace error")
+
+    monkeypatch.setattr("mempalace.palace.get_collection", fake_get_collection)
+    with pytest.raises(DiaryUnavailable):
+        read_diary("ves")
+
+
+def test_raises_diary_unavailable_when_query_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
+
+    class _BrokenCollection:
+        def get(self, **kwargs):  # noqa: ARG002
+            raise RuntimeError("simulated chromadb error")
+
+    monkeypatch.setattr(
+        "mempalace.palace.get_collection",
+        lambda palace_path, collection_name, create=False: _BrokenCollection(),
+    )
+    with pytest.raises(DiaryUnavailable):
+        read_diary("ves")
+
+
+# ---------------------------------------------------------------------------
+# palace_path override
+# ---------------------------------------------------------------------------
+
+def test_palace_path_override_used_when_provided(monkeypatch, tmp_path):
+    """When palace_path is passed, MempalaceConfig is NOT consulted."""
+
+    captured: dict = {}
+
+    def fake_get_collection(palace_path, collection_name, create=False):
+        captured["palace_path"] = palace_path
+        return _FakeCollection([])
+
+    monkeypatch.setattr("mempalace.palace.get_collection", fake_get_collection)
+    # If config were consulted, this env-var would be used. We pass
+    # explicit palace_path, so the env var should NOT win.
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", "/should/not/be/used")
+    read_diary("ves", palace_path="/explicit/override/path")
+    assert captured["palace_path"] == "/explicit/override/path"


### PR DESCRIPTION
## Summary

Adds `read_diary(agent, last_n=5, *, palace_path=None) -> list[DiaryEntry]` as a public API in `mempalace.layers`. Encapsulates the chromadb where-filter + sort + slice logic that consumers (Vestige's `runtime_orientation`, primarily) were inlining via `palace.get_collection`.

## Public surface

- **`DiaryEntry`** (frozen dataclass) — `date`, `filed_at`, `topic`, `content`. Mirrors persistence shape of `tool_diary_write` / `tool_diary_read` in `mcp_server`.
- **`DiaryUnavailable`** (exception) — raised when palace is unreachable or chromadb query fails. Distinguishes infrastructure failure from genuinely empty diary (returns `[]`). Callers who care: `DiaryUnavailable` → `"(diary unavailable)"`, `[]` → `"(no entries yet)"`.
- **`read_diary`** — filters `wing=wing_{agent.lower()} room=diary`, sorts by `filed_at` descending, slices to `last_n`.

## Why

Consumer (Vestige's `runtime_orientation`) had a `# TODO: migrate to mempalace.layers.read_diary` comment naming this exact API. Inlining the where-filter + metadata-key knowledge in every consumer means schema changes here cascade across consumers. Centralized in `layers.py`, schema knowledge stays in the package that owns the schema.

## Safety

- Side-effect-free: uses `palace.get_collection` (not `mcp_server`, which performs `dup2(stderr, stdout)` at import time as part of the MCP stdio protocol contract and would clobber consumer log streams).
- Read-only: `col.get(...)`. No writes, no HNSW touch (avoids the chromadb metadata-update pathology we hit on 2026-04-17).

## Tests

10 new in `tests/test_read_diary.py`:
- Sort by `filed_at` desc
- `last_n` limit
- Empty palace returns `[]`
- No entries for agent's wing returns `[]`
- Wing+room filter correctness
- Case-insensitive agent name lowercase
- `last_n=0` returns `[]`
- `DiaryUnavailable` raised on `get_collection` failure
- `DiaryUnavailable` raised on `col.get` failure
- `palace_path` kwarg overrides config

10/10 pass. No regression to existing `layers.py` tests.

## Consumer coordination

This PR is the upstream half of a coordinated change. The consumer migration (Vestige's `runtime_orientation` calling `read_diary` instead of inlining `get_collection`) ships in a separate Vestige PR — that PR depends on this one merging first so its import resolves against `main`. Merge order: mempalace first, then Vestige.

Vestige PR: jpwinans/vestige feat/mempalace-read-diary-api (commit e698d51).
