### PR TITLE
feat(cli): add --room filter to compress

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -987,7 +987,12 @@ def cmd_mcp(args):
 
 
 def cmd_compress(args):
-    """Compress drawers in a wing using AAAK Dialect."""
+    """Compress drawers using AAAK Dialect.
+
+    Optionally scope to a single wing (``--wing``) and/or single room
+    (``--room``). When neither is supplied every drawer in the palace is
+    compressed (existing behavior).
+    """
     from .backends.chroma import ChromaBackend
     from .dialect import Dialect
 
@@ -1016,8 +1021,18 @@ def cmd_compress(args):
         print("  Run: mempalace init <dir> then mempalace mine <dir>")
         sys.exit(1)
 
-    # Query drawers in batches to avoid SQLite variable limit (~999)
-    where = {"wing": args.wing} if args.wing else None
+    # Query drawers in batches to avoid SQLite variable limit (~999).
+    # ``getattr`` keeps callers that build args manually (older tests,
+    # programmatic invocations) working when ``room`` is absent.
+    room = getattr(args, "room", None)
+    if args.wing and room:
+        where = {"$and": [{"wing": args.wing}, {"room": room}]}
+    elif args.wing:
+        where = {"wing": args.wing}
+    elif room:
+        where = {"room": room}
+    else:
+        where = None
     _BATCH = 500
     docs, metas, ids = [], [], []
     offset = 0
@@ -1046,16 +1061,19 @@ def cmd_compress(args):
         if len(batch_docs) < _BATCH:
             break
 
+    def _scope_label() -> str:
+        parts = []
+        if args.wing:
+            parts.append(f"wing '{args.wing}'")
+        if room:
+            parts.append(f"room '{room}'")
+        return f" in {' / '.join(parts)}" if parts else ""
+
     if not docs:
-        wing_label = f" in wing '{args.wing}'" if args.wing else ""
-        print(f"\n  No drawers found{wing_label}.")
+        print(f"\n  No drawers found{_scope_label()}.")
         return
 
-    print(
-        f"\n  Compressing {len(docs)} drawers"
-        + (f" in wing '{args.wing}'" if args.wing else "")
-        + "..."
-    )
+    print(f"\n  Compressing {len(docs)} drawers{_scope_label()}...")
     print()
 
     total_original = 0
@@ -1336,6 +1354,11 @@ def main():
         "compress", help="Compress drawers using AAAK Dialect (~30x reduction)"
     )
     p_compress.add_argument("--wing", default=None, help="Wing to compress (default: all wings)")
+    p_compress.add_argument(
+        "--room",
+        default=None,
+        help="Room to compress (default: all rooms). Combine with --wing to scope to a single wing/room.",
+    )
     p_compress.add_argument(
         "--dry-run", action="store_true", help="Preview compression without storing"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1120,6 +1120,74 @@ def test_cmd_compress_stores_results(mock_config_cls, capsys):
     assert "mempalace_closets" in out
 
 
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_compress_room_filter_scopes_query(mock_config_cls, capsys):
+    """`--room` scopes compress to one room without requiring `--wing`.
+
+    Regression guard: previously `cmd_compress` only honoured `--wing`, so
+    operators of large palaces had no way to recover a partially-failed pass
+    without recompressing every drawer.
+    """
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = argparse.Namespace(palace=None, wing=None, room="runbooks", dry_run=True, config=None)
+    mock_col = MagicMock()
+    mock_col.get.side_effect = [
+        {
+            "documents": ["runbook body"],
+            "metadatas": [{"wing": "infra", "room": "runbooks", "source_file": "deploy.md"}],
+            "ids": ["id1"],
+        },
+        {"documents": [], "metadatas": [], "ids": []},
+    ]
+    mock_backend = _mock_backend_for(col=mock_col)
+
+    mock_dialect = MagicMock()
+    mock_dialect.compress.return_value = "compressed"
+    mock_dialect.compression_stats.return_value = {
+        "original_chars": 100,
+        "summary_chars": 30,
+        "original_tokens_est": 25,
+        "summary_tokens_est": 8,
+        "size_ratio": 3.3,
+        "note": "Estimates only.",
+    }
+    mock_dialect_mod = _make_mock_dialect_module(mock_dialect)
+
+    with (
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+        patch.dict("sys.modules", {"mempalace.dialect": mock_dialect_mod}),
+    ):
+        cmd_compress(args)
+
+    # The first batch query must carry a `where` filter scoped to the room.
+    first_call_kwargs = mock_col.get.call_args_list[0].kwargs
+    assert first_call_kwargs.get("where") == {
+        "room": "runbooks"
+    }, f"expected room-only where filter, got {first_call_kwargs.get('where')!r}"
+
+    out = capsys.readouterr().out
+    assert "room 'runbooks'" in out
+    assert "Compressing 1 drawers" in out
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_compress_no_room_filter_processes_all(mock_config_cls, capsys):
+    """When neither --wing nor --room is given, compress queries with no `where`."""
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = argparse.Namespace(palace=None, wing=None, room=None, dry_run=True, config=None)
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"documents": [], "metadatas": [], "ids": []}
+    mock_backend = _mock_backend_for(col=mock_col)
+
+    with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
+        cmd_compress(args)
+
+    first_call_kwargs = mock_col.get.call_args_list[0].kwargs
+    assert (
+        "where" not in first_call_kwargs
+    ), f"expected no where filter, got {first_call_kwargs.get('where')!r}"
+
+
 def test_cmd_compress_output_readable_via_get_closets_collection(tmp_path, capsys):
     """End-to-end: cmd_compress output must be readable via the same code
     path palace.py uses (`get_closets_collection`). Regression for #1244."""


### PR DESCRIPTION
## Why
`mempalace compress` only honoured `--wing`, so operators of large palaces had no way to scope a single-room recompress (or recover a partially-failed pass) without recompressing every drawer. On a palace holding ~200k drawers this turns into an hours-long all-or-nothing run.

## What changed
- Add `--room <name>` to the `compress` subparser (mirrors existing `search --room`).
- `--room` can be used alone (every wing, one room) or combined with `--wing` (one wing, one room).
- Default behaviour unchanged: with neither flag, every drawer is still compressed.

## Implementation notes
- `getattr(args, "room", None)` keeps programmatic callers that build `argparse.Namespace` manually from breaking.
- The Chroma where-clause is built inline rather than imported from `searcher.build_where_filter`. Importing `searcher` inside `cmd_compress` would force `mempalace.palace` to load through a deferred import, and an earlier test in the suite (`test_cmd_compress_no_palace`) has `ChromaBackend` patched at that moment — loading `palace` under that patch turns `_DEFAULT_BACKEND` into a MagicMock for the rest of the session and breaks the end-to-end compress test. The duplicated 4-line filter avoids the trap.

## Tests
- `test_cmd_compress_room_filter_scopes_query` — `--room` alone produces a `{"room": ...}` where-clause and labels output with the room name.
- `test_cmd_compress_no_room_filter_processes_all` — absence of both flags keeps unfiltered behaviour.

Full suite: `uv run pytest -q` → 1728 passed, 1 skipped (pre-existing), ruff clean.