### PR TITLE
fix(search): tolerate None documents in chunk-hydration loop (#1125)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -944,14 +944,19 @@ def search_memories(
         query_terms = set(_tokenize(query))
         best_idx, best_score = 0, -1
         for idx, d in enumerate(ordered_docs):
-            d_lower = d.lower()
+            # Tolerate ``None`` documents — Chroma returns ``None`` in the
+            # ``documents`` field for drawers inserted with embeddings only
+            # (legacy mines, partial restores, no-text entries). Treat as
+            # empty so the keyword scan continues rather than raising
+            # ``AttributeError`` mid-search (issue #1125).
+            d_lower = (d or "").lower()
             s = sum(1 for t in query_terms if t in d_lower)
             if s > best_score:
                 best_score, best_idx = s, idx
 
         start = max(0, best_idx - 1)
         end = min(len(ordered_docs), best_idx + 2)
-        expanded = "\n\n".join(ordered_docs[start:end])
+        expanded = "\n\n".join(d or "" for d in ordered_docs[start:end])
         if len(expanded) > MAX_HYDRATION_CHARS:
             expanded = (
                 expanded[:MAX_HYDRATION_CHARS]

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -131,3 +131,70 @@ class TestClosetMetadata:
             assert h["matched_via"] == "drawer"
             assert "closet_preview" not in h
             assert h["closet_boost"] == 0.0
+
+
+# ── chunk-hydration robustness (#1125) ───────────────────────────────────
+
+
+class TestChunkHydrationNoneDocument:
+    """Drawer-grep enrichment must tolerate sibling drawers with no document
+    text. Chroma returns ``documents=None`` for entries inserted with only
+    embeddings (legacy mines, partial restores, no-text drawers), which
+    crashed the ``.lower()`` scan inside the enrichment loop.
+
+    Issue: https://github.com/MemPalace/mempalace/issues/1125
+    """
+
+    def test_closet_boosted_hit_with_none_sibling_does_not_crash(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        col = get_collection(palace, create=True)
+        # D1: textual sibling — the drawer the closet boost surfaces.
+        col.upsert(
+            ids=["D1"],
+            documents=["JWT authentication tokens with a 24-hour session expiry."],
+            metadatas=[
+                {
+                    "wing": "backend",
+                    "room": "auth",
+                    "source_file": "auth.md",
+                    "chunk_index": 0,
+                }
+            ],
+        )
+        # D2: same source, embeddings-only — Chroma returns documents=None
+        # for it, which is the failure mode reported in #1125. No public
+        # MemPalace API for documentless inserts; raw chromadb access required.
+        embedding_dim = len(col._collection._embedding_function(["probe"])[0])
+        col._collection.add(
+            ids=["D2"],
+            embeddings=[[0.1] * embedding_dim],
+            metadatas=[
+                {
+                    "wing": "backend",
+                    "room": "auth",
+                    "source_file": "auth.md",
+                    "chunk_index": 1,
+                }
+            ],
+        )
+
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D1",
+            source_file="auth.md",
+            topics=["JWT auth tokens", "session expiry", "authentication service"],
+        )
+
+        # Currently raises AttributeError: 'NoneType' object has no attribute
+        # 'lower' inside the drawer-grep enrichment loop (issue #1125).
+        result = search_memories("JWT auth tokens expiry", palace, n_results=3)
+
+        assert "results" in result, "search must not crash on None doc siblings"
+        # Anchor: the closet boost must fire, otherwise the enrichment loop
+        # never runs and this test would pass vacuously without exercising
+        # the crash site.
+        assert any(h["matched_via"] == "drawer+closet" for h in result["results"]), (
+            "closet boost must fire so drawer-grep enrichment runs"
+        )
+        sources = [h["source_file"] for h in result["results"]]
+        assert "auth.md" in sources, "D1 must surface despite D2 having no text"


### PR DESCRIPTION
## Summary

Closes the chunk-hydration half of #1125. The `_tokenize` site flagged in that issue (line 50 in the reporter's version) has already been guarded upstream; the second site — the drawer-grep enrichment loop's keyword scan inside `search_memories` — was still vulnerable to `AttributeError: 'NoneType' object has no attribute 'lower'`.

## Repro

Sibling drawers in the same `source_file` can have `documents=None` whenever Chroma returns them for entries inserted with embeddings only (legacy mines, partial restores, no-text drawers). When a closet boost surfaces such a source, the enrichment loop iterates `ordered_docs` and crashes at `d.lower()`.

The failure was diagnosed in detail by @MAF33884 in https://github.com/MemPalace/mempalace/issues/1125 (test palace: 482 drawers, single-token queries reliably trigger). Credit to them for narrowing the chunk-hydration site.

## Fix

Two-line guard matching the `_tokenize` idiom already used in this file (`if not text: return []` and `doc or ""` at line 343):

```python
d_lower = (d or "").lower()
# ...
expanded = "\n\n".join(d or "" for d in ordered_docs[start:end])
```

The second guard is necessary because `str.join` raises `TypeError` if any element of the slice is `None` — same root cause propagating one statement further.

## Test

`tests/test_hybrid_search.py::TestChunkHydrationNoneDocument` reproduces the crash:

1. Inserts D1 with text via the public `BaseCollection.upsert` API.
2. Inserts D2 in the same source with embeddings only via the raw `_collection.add` path (no public API for documentless inserts; comment in test notes the reason).
3. Seeds a strong closet for D1's source so the boost fires and `matched_via != "drawer"` triggers the enrichment loop.
4. Asserts `search_memories` returns results without crashing AND that the closet boost fired (anchor against vacuous pass if scoring ever drifts).

Embedding dimension is derived dynamically from `col._collection._embedding_function(["probe"])` so the test won't silently break if MemPalace swaps embedder.

```
$ uv run pytest tests/test_hybrid_search.py -v
6 passed in 5.93s

$ uv run pytest tests/ -v --ignore=tests/benchmarks
1727 passed, 1 skipped, 1 warning in 43.57s
```

Ruff clean.

## Adjacent pre-existing gap (not in this PR)

`source_drawers.documents` itself can be `None` (the whole list, not individual elements) when `include=["documents", "metadatas"]` is called on a collection with no text at all. The `if len(docs) <= 1:` check at line ~932 would raise `TypeError` on that path. That's pre-existing behaviour and sits two lines above this fix; happy to address it as a follow-up if you'd prefer, or leave for a separate PR — let me know.

## Test plan

- [x] `pytest tests/ --ignore=tests/benchmarks` — 1727 passed, 0 fail
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] Reproduced crash before fix; test fails RED at `searcher.py:947` `AttributeError`
- [x] Test GREEN after fix; no regression in `test_hybrid_search.py` (5 existing) or `test_searcher.py`