### PR TITLE
feat(search): widen vector over-fetch for short queries (#1125)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -31,10 +31,20 @@ class SearchError(Exception):
 
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 
-# Upper bound on the per-query candidate fetch from the vector index.
-# Short queries widen the over-fetch (see issue #1125) up to this cap so
-# the cost of the underlying ChromaDB ``.query()`` and downstream BM25
-# rerank stays bounded on large ``n_results`` requests.
+# Over-fetch tuning for the vector candidate pool (see issue #1125).
+#
+# Short queries — proper nouns and 1–3 token names — produce weak
+# embeddings relative to longer narrative drawers. The default 3× over-
+# fetch can drop name-bearing drawers below the candidate cutoff before
+# BM25 rerank ever sees them. The wider multiplier kicks in for queries
+# with ``len(_tokenize(query)) <= _SHORT_QUERY_TOKEN_THRESHOLD``.
+#
+# ``_OVERFETCH_MAX`` bounds the candidate fetch so latency stays sane on
+# large ``n_results`` requests; ``n_results`` itself acts as a floor so
+# the clamp never returns fewer candidates than the caller asked for.
+_SHORT_QUERY_TOKEN_THRESHOLD = 3
+_SHORT_QUERY_OVERFETCH_MULTIPLIER = 10
+_DEFAULT_OVERFETCH_MULTIPLIER = 3
 _OVERFETCH_MAX = 200
 
 
@@ -818,9 +828,19 @@ def search_memories(
     # Widen the pool for short queries so rerank can do its job; clamp
     # to 200 so the candidate fetch stays bounded on large n_results
     # requests. See issue #1125.
-    token_count = len(_TOKEN_RE.findall(query))
-    overfetch_multiplier = 10 if token_count <= 3 else 3
-    overfetch_n = min(n_results * overfetch_multiplier, _OVERFETCH_MAX)
+    # ``_tokenize`` handles the ``None``/empty cases that ``_TOKEN_RE.findall``
+    # would raise on, and uses the same regex as BM25 — keep token counting
+    # behaviourally identical to rerank tokenisation.
+    token_count = len(_tokenize(query))
+    overfetch_multiplier = (
+        _SHORT_QUERY_OVERFETCH_MULTIPLIER
+        if token_count <= _SHORT_QUERY_TOKEN_THRESHOLD
+        else _DEFAULT_OVERFETCH_MULTIPLIER
+    )
+    # Floor at ``n_results`` so a large request never returns fewer
+    # candidates than asked for; ceiling at ``_OVERFETCH_MAX`` so the
+    # vector ``.query()`` latency stays bounded.
+    overfetch_n = max(n_results, min(n_results * overfetch_multiplier, _OVERFETCH_MAX))
 
     try:
         dkwargs = {

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -944,14 +944,19 @@ def search_memories(
         query_terms = set(_tokenize(query))
         best_idx, best_score = 0, -1
         for idx, d in enumerate(ordered_docs):
-            d_lower = d.lower()
+            # Tolerate ``None`` documents — Chroma returns ``None`` in the
+            # ``documents`` field for drawers inserted with embeddings only
+            # (legacy mines, partial restores, no-text entries). Treat as
+            # empty so the keyword scan continues rather than raising
+            # ``AttributeError`` mid-search (issue #1125).
+            d_lower = (d or "").lower()
             s = sum(1 for t in query_terms if t in d_lower)
             if s > best_score:
                 best_score, best_idx = s, idx
 
         start = max(0, best_idx - 1)
         end = min(len(ordered_docs), best_idx + 2)
-        expanded = "\n\n".join(ordered_docs[start:end])
+        expanded = "\n\n".join(d or "" for d in ordered_docs[start:end])
         if len(expanded) > MAX_HYDRATION_CHARS:
             expanded = (
                 expanded[:MAX_HYDRATION_CHARS]

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -31,6 +31,12 @@ class SearchError(Exception):
 
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 
+# Upper bound on the per-query candidate fetch from the vector index.
+# Short queries widen the over-fetch (see issue #1125) up to this cap so
+# the cost of the underlying ChromaDB ``.query()`` and downstream BM25
+# rerank stays bounded on large ``n_results`` requests.
+_OVERFETCH_MAX = 200
+
 
 def _first_or_empty(results, key: str) -> list:
     """Return the first inner list of a query result field, or [].
@@ -805,10 +811,21 @@ def search_memories(
     # This avoids the "weak-closets regression" where narrative content
     # produces low-signal closets (regex extraction matches few topics)
     # and closet-first routing hides drawers that direct search would find.
+    # Short queries — particularly proper nouns and 1-3 token names —
+    # produce weak embeddings relative to longer narrative drawers. The
+    # default ``n_results * 3`` over-fetch can drop name-bearing drawers
+    # below the candidate cutoff before BM25 rerank ever sees them.
+    # Widen the pool for short queries so rerank can do its job; clamp
+    # to 200 so the candidate fetch stays bounded on large n_results
+    # requests. See issue #1125.
+    token_count = len(_TOKEN_RE.findall(query))
+    overfetch_multiplier = 10 if token_count <= 3 else 3
+    overfetch_n = min(n_results * overfetch_multiplier, _OVERFETCH_MAX)
+
     try:
         dkwargs = {
             "query_texts": [query],
-            "n_results": n_results * 3,  # over-fetch for re-ranking
+            "n_results": overfetch_n,  # over-fetch for re-ranking
             "include": ["documents", "metadatas", "distances"],
         }
         if where:

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -131,3 +131,70 @@ class TestClosetMetadata:
             assert h["matched_via"] == "drawer"
             assert "closet_preview" not in h
             assert h["closet_boost"] == 0.0
+
+
+# ── chunk-hydration robustness (#1125) ───────────────────────────────────
+
+
+class TestChunkHydrationNoneDocument:
+    """Drawer-grep enrichment must tolerate sibling drawers with no document
+    text. Chroma returns ``documents=None`` for entries inserted with only
+    embeddings (legacy mines, partial restores, no-text drawers), which
+    crashed the ``.lower()`` scan inside the enrichment loop.
+
+    Issue: https://github.com/MemPalace/mempalace/issues/1125
+    """
+
+    def test_closet_boosted_hit_with_none_sibling_does_not_crash(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        col = get_collection(palace, create=True)
+        # D1: textual sibling — the drawer the closet boost surfaces.
+        col.upsert(
+            ids=["D1"],
+            documents=["JWT authentication tokens with a 24-hour session expiry."],
+            metadatas=[
+                {
+                    "wing": "backend",
+                    "room": "auth",
+                    "source_file": "auth.md",
+                    "chunk_index": 0,
+                }
+            ],
+        )
+        # D2: same source, embeddings-only — Chroma returns documents=None
+        # for it, which is the failure mode reported in #1125. No public
+        # MemPalace API for documentless inserts; raw chromadb access required.
+        embedding_dim = len(col._collection._embedding_function(["probe"])[0])
+        col._collection.add(
+            ids=["D2"],
+            embeddings=[[0.1] * embedding_dim],
+            metadatas=[
+                {
+                    "wing": "backend",
+                    "room": "auth",
+                    "source_file": "auth.md",
+                    "chunk_index": 1,
+                }
+            ],
+        )
+
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D1",
+            source_file="auth.md",
+            topics=["JWT auth tokens", "session expiry", "authentication service"],
+        )
+
+        # Currently raises AttributeError: 'NoneType' object has no attribute
+        # 'lower' inside the drawer-grep enrichment loop (issue #1125).
+        result = search_memories("JWT auth tokens expiry", palace, n_results=3)
+
+        assert "results" in result, "search must not crash on None doc siblings"
+        # Anchor: the closet boost must fire, otherwise the enrichment loop
+        # never runs and this test would pass vacuously without exercising
+        # the crash site.
+        assert any(h["matched_via"] == "drawer+closet" for h in result["results"]), (
+            "closet boost must fire so drawer-grep enrichment runs"
+        )
+        sources = [h["source_file"] for h in result["results"]]
+        assert "auth.md" in sources, "D1 must surface despite D2 having no text"

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -486,3 +486,17 @@ class TestShortQueryOverfetch:
             "10× n_results must clamp to 200 so large n_results requests "
             "do not blow up candidate-fetch latency"
         )
+
+    def test_overfetch_never_below_n_results(self):
+        """Floor: if the caller asks for ``n_results > _OVERFETCH_MAX``,
+        the clamp must not return fewer candidates than requested —
+        otherwise the function returns less than the caller asked for
+        and the contract breaks. Floor at ``n_results``, ceiling at
+        ``_OVERFETCH_MAX``, so the clamp can never be below the floor."""
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("Bob", "/fake/path", n_results=300)
+        assert self._captured_n_results(mock_col) == 300, (
+            "n_results=300 (above _OVERFETCH_MAX=200): overfetch must "
+            "floor at n_results, not clamp below it"
+        )

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -184,12 +184,11 @@ class TestSearchMemories:
 
         # Invariants on every hit.
         for h in hits:
-            assert (
-                0.0 <= h["similarity"] <= 1.0
-            ), f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            assert 0.0 <= h["similarity"] <= 1.0, (
+                f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            )
             assert 0.0 <= h["effective_distance"] <= 2.0, (
-                f"effective_distance out of range: {h['effective_distance']} "
-                f"for {h['source_file']}"
+                f"effective_distance out of range: {h['effective_distance']} for {h['source_file']}"
             )
 
         # With the clamp, the closet-boosted a.md still ranks ahead of b.md —
@@ -327,9 +326,9 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         first_block, _, _ = captured.out.partition("[2]")
         # Lexical match must rank first
-        assert (
-            "b.md" in first_block
-        ), f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        assert "b.md" in first_block, (
+            f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        )
         # Non-zero bm25 reported
         assert "bm25=" in first_block
         assert "bm25=0.0" not in first_block
@@ -399,3 +398,91 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         assert "[1]" in captured.out
         assert "[2]" in captured.out
+
+
+# ── short-query overfetch widening (#1125) ─────────────────────────────
+
+
+class TestShortQueryOverfetch:
+    """Proper-noun and short queries produce weak embeddings relative to
+    longer narrative drawers; the default ``n_results * 3`` over-fetch
+    window can drop name-bearing drawers before BM25 rerank ever sees
+    them. Widen the candidate pool for short queries so the rerank stage
+    can do its job.
+
+    Issue: https://github.com/MemPalace/mempalace/issues/1125
+    """
+
+    def _capturing_collection(self, return_empty=True):
+        mock_col = MagicMock()
+        mock_col.metadata = {"hnsw:space": "cosine"}
+        empty = {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+        mock_col.query.return_value = empty if return_empty else None
+        return mock_col
+
+    def _captured_n_results(self, mock_col):
+        return mock_col.query.call_args.kwargs.get("n_results")
+
+    def test_single_token_query_widens_to_10x(self):
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("Alice", "/fake/path", n_results=5)
+        assert self._captured_n_results(mock_col) == 50, (
+            "single-token queries must widen over-fetch to 10× n_results"
+        )
+
+    def test_three_token_query_widens_to_10x(self):
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("Jane Marie Doe", "/fake/path", n_results=5)
+        assert self._captured_n_results(mock_col) == 50, (
+            "three-token queries must still widen — proper-noun full names fit in this band"
+        )
+
+    def test_four_token_query_keeps_3x_overfetch(self):
+        # ``_TOKEN_RE`` matches ``\w{2,}`` so every word here is 1 token.
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories(
+                "configure authentication module users",  # 4 tokens
+                "/fake/path",
+                n_results=5,
+            )
+        assert self._captured_n_results(mock_col) == 15, (
+            "queries with more than 3 tokens must keep the existing 3× window"
+        )
+
+    def test_three_vs_four_token_boundary_is_inclusive(self):
+        """Boundary lock: ``<= 3`` widens, ``> 3`` does not. Same
+        ``n_results`` so any future off-by-one in the comparison flips
+        exactly one of the two assertions."""
+        for tokens, expected in [("alpha beta gamma", 50), ("alpha beta gamma delta", 15)]:
+            mock_col = self._capturing_collection()
+            with patch("mempalace.searcher.get_collection", return_value=mock_col):
+                search_memories(tokens, "/fake/path", n_results=5)
+            assert self._captured_n_results(mock_col) == expected, (
+                f"query={tokens!r} expected n_results={expected}, "
+                f"got {self._captured_n_results(mock_col)}"
+            )
+
+    def test_zero_token_query_uses_widened_overfetch(self):
+        """Empty / whitespace-only / punctuation-only queries produce
+        ``token_count = 0`` (``_TOKEN_RE`` requires ``\\w{2,}``). These fall
+        into the ``<= 3`` band and widen to 10× — documenting the
+        behaviour so a later "guard for empty query" change is a
+        deliberate decision, not an accident."""
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("??", "/fake/path", n_results=5)
+        assert self._captured_n_results(mock_col) == 50, (
+            "0-token queries route through the wide overfetch path"
+        )
+
+    def test_overfetch_clamped_to_200(self):
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("Bob", "/fake/path", n_results=25)
+        assert self._captured_n_results(mock_col) == 200, (
+            "10× n_results must clamp to 200 so large n_results requests "
+            "do not blow up candidate-fetch latency"
+        )


### PR DESCRIPTION
## Summary

Cheap mitigation from #1125: widen vector `.query()` over-fetch to **10×** `n_results` for queries with **≤3 tokens**, clamp at 200. Long queries keep the existing 3× window. Restores BM25 rerank's chance to recover proper-noun drawers whose embeddings drop below the default cutoff.

This is **PR B of three** for issue #1125. PR A (#1479) lands the chunk-hydration None-guard the wider candidate pool reliably exposes. This PR (B) is the cheap mitigation. PR C will add the preferred `where_document` lexical union for the residual cases that even 10× cannot reach. Each PR is independently useful; this one is **stacked on #1479** (rebase will collapse cleanly once that merges).

## Repro / evidence

@MAF33884's testing on a 482-drawer palace ([detailed report on #1125](https://github.com/MemPalace/mempalace/issues/1125)) confirmed:

| Query | `total_before_filter` (default) | With this PR | Outcome |
|---|---|---|---|
| 1-token name | 15 | 50 | name-bearing drawer surfaces |
| 3-token short name | 15 | 50 | surfaces |
| 4+ token narrative | unchanged | unchanged | unchanged (3× kept) |

Crashes that the wider pool exposes (None-doc chunk-hydration) are covered by PR #1479. Without that PR, this one would surface more `AttributeError`s, so the stacking order matters.

## Implementation

`mempalace/searcher.py:807-826`. Two additions:

```python
# Module top (matches existing constant style)
_OVERFETCH_MAX = 200

# In search_memories, before drawer .query()
token_count = len(_TOKEN_RE.findall(query))
overfetch_multiplier = 10 if token_count <= 3 else 3
overfetch_n = min(n_results * overfetch_multiplier, _OVERFETCH_MAX)
```

Token count uses the same `_TOKEN_RE` (`\\w{2,}`) that `_tokenize` and the BM25 paths use — drift-free by construction.

## Scope notes

- **Only the vector path widens.** The BM25 union path (`_bm25_only_via_sqlite` at line ~656) keeps `n_results * 3` intentionally — FTS5 ranks by term frequency, so 1-3 token queries already get the relative BM25 advantage regardless of fetch width. Widening BM25 would fetch noise, not signal.
- **CLI `search()` is unchanged** — no rerank stage there, so over-fetching adds latency without benefit.
- Downstream filters (`max_distance`, `_hybrid_rank`, final `[:n_results]` truncation) are per-candidate and order-invariant. Only the candidate *pool* widens; the result count returned to the caller is unchanged.

## Test plan

- [x] `pytest tests/test_searcher.py::TestShortQueryOverfetch -v` — 6 passed
  - single-token → 10×
  - three-token → 10×
  - four-token → 3×
  - 3-vs-4 boundary lock (same `n_results`, off-by-one trap)
  - 0-token (`\"??\"`, whitespace) → routes through wide path (documented)
  - clamp: `n_results=25` with single-token → 200, not 250
- [x] `pytest tests/ --ignore=tests/benchmarks` — 1733 passed, 0 fail, 1 skipped
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean

Tests use `MagicMock` on the collection's `.query()` call to assert the actual `n_results` argument passed through the over-fetch math, avoiding flakiness from real ChromaDB embedding determinism.

## Open questions for maintainer

- Threshold `<= 3` and multiplier `10` are MAF33884's empirically-tuned values; should they be exposed as module constants for future production tuning, or stay inline? Codex review recommended keeping them inline since they're coupled.
- BM25 union path stays at 3× by deliberate scoping. Happy to widen there too in a follow-up if you'd prefer, but the analysis above (FTS5 invariance) suggests it shouldn't help.

Credit: @MAF33884 for the empirical analysis and the precise mitigation shape.