### PR TITLE
feat(search): add candidate_strategy="contains" for substring union (#1125)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -31,10 +31,20 @@ class SearchError(Exception):
 
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 
-# Upper bound on the per-query candidate fetch from the vector index.
-# Short queries widen the over-fetch (see issue #1125) up to this cap so
-# the cost of the underlying ChromaDB ``.query()`` and downstream BM25
-# rerank stays bounded on large ``n_results`` requests.
+# Over-fetch tuning for the vector candidate pool (see issue #1125).
+#
+# Short queries — proper nouns and 1–3 token names — produce weak
+# embeddings relative to longer narrative drawers. The default 3× over-
+# fetch can drop name-bearing drawers below the candidate cutoff before
+# BM25 rerank ever sees them. The wider multiplier kicks in for queries
+# with ``len(_tokenize(query)) <= _SHORT_QUERY_TOKEN_THRESHOLD``.
+#
+# ``_OVERFETCH_MAX`` bounds the candidate fetch so latency stays sane on
+# large ``n_results`` requests; ``n_results`` itself acts as a floor so
+# the clamp never returns fewer candidates than the caller asked for.
+_SHORT_QUERY_TOKEN_THRESHOLD = 3
+_SHORT_QUERY_OVERFETCH_MULTIPLIER = 10
+_DEFAULT_OVERFETCH_MULTIPLIER = 3
 _OVERFETCH_MAX = 200
 
 
@@ -818,9 +828,19 @@ def search_memories(
     # Widen the pool for short queries so rerank can do its job; clamp
     # to 200 so the candidate fetch stays bounded on large n_results
     # requests. See issue #1125.
-    token_count = len(_TOKEN_RE.findall(query))
-    overfetch_multiplier = 10 if token_count <= 3 else 3
-    overfetch_n = min(n_results * overfetch_multiplier, _OVERFETCH_MAX)
+    # ``_tokenize`` handles the ``None``/empty cases that ``_TOKEN_RE.findall``
+    # would raise on, and uses the same regex as BM25 — keep token counting
+    # behaviourally identical to rerank tokenisation.
+    token_count = len(_tokenize(query))
+    overfetch_multiplier = (
+        _SHORT_QUERY_OVERFETCH_MULTIPLIER
+        if token_count <= _SHORT_QUERY_TOKEN_THRESHOLD
+        else _DEFAULT_OVERFETCH_MULTIPLIER
+    )
+    # Floor at ``n_results`` so a large request never returns fewer
+    # candidates than asked for; ceiling at ``_OVERFETCH_MAX`` so the
+    # vector ``.query()`` latency stays bounded.
+    overfetch_n = max(n_results, min(n_results * overfetch_multiplier, _OVERFETCH_MAX))
 
     try:
         dkwargs = {

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -629,6 +629,23 @@ def _bm25_only_via_sqlite(
     }
 
 
+def _chunk_precise_dedup_key(entry: dict):
+    """Stable dedup key for hits crossing the vector / BM25 / contains
+    pools. Uses ``(_source_file_full, _chunk_index)`` so two files
+    sharing a basename in different directories don't collide and a
+    vector hit on chunk N of a source doesn't block another path from
+    contributing chunk M of the same source. Falls back to
+    ``source_file`` only when richer metadata is missing — avoids
+    silently dropping candidates on legacy data while still giving
+    chunk-precise dedup whenever the metadata is present.
+    """
+    full = entry.get("_source_file_full")
+    ci = entry.get("_chunk_index")
+    if full and ci is not None:
+        return (full, ci)
+    return entry.get("source_file")
+
+
 def _merge_bm25_union_candidates(
     hits: list,
     query: str,
@@ -678,19 +695,9 @@ def _merge_bm25_union_candidates(
         logger.debug("candidate_strategy=union: BM25 fetch failed", exc_info=True)
         return
 
-    def _dedup_key(entry: dict):
-        full = entry.get("_source_file_full")
-        ci = entry.get("_chunk_index")
-        if full and ci is not None:
-            return (full, ci)
-        # Fall back to basename only when richer metadata is missing —
-        # avoids silently dropping candidates on legacy data while still
-        # giving chunk-precise dedup whenever the metadata is present.
-        return entry.get("source_file")
-
-    seen = {_dedup_key(h) for h in hits}
+    seen = {_chunk_precise_dedup_key(h) for h in hits}
     for bh in bm25_extra:
-        key = _dedup_key(bh)
+        key = _chunk_precise_dedup_key(bh)
         if not key or key == "?" or key in seen:
             continue
         bh["distance"] = None
@@ -742,10 +749,9 @@ def _merge_contains_union_candidates(
         return
 
     try:
-        if collection_name is not None:
-            drawers_col = get_collection(palace_path, collection_name=collection_name, create=False)
-        else:
-            drawers_col = get_collection(palace_path, create=False)
+        # ``get_collection`` resolves ``collection_name=None`` itself via
+        # ``get_configured_collection_name`` — no need to branch here.
+        drawers_col = get_collection(palace_path, collection_name=collection_name, create=False)
     except Exception:
         logger.debug("candidate_strategy=contains: collection fetch failed", exc_info=True)
         return
@@ -768,14 +774,7 @@ def _merge_contains_union_candidates(
     docs = contains_results.documents or []
     metas = contains_results.metadatas or []
 
-    def _dedup_key(entry: dict):
-        full = entry.get("_source_file_full")
-        ci = entry.get("_chunk_index")
-        if full and ci is not None:
-            return (full, ci)
-        return entry.get("source_file")
-
-    seen = {_dedup_key(h) for h in hits}
+    seen = {_chunk_precise_dedup_key(h) for h in hits}
     for doc, meta in zip(docs, metas):
         if doc is None or meta is None:
             continue
@@ -794,7 +793,7 @@ def _merge_contains_union_candidates(
             "_source_file_full": full_source,
             "_chunk_index": meta.get("chunk_index"),
         }
-        key = _dedup_key(entry)
+        key = _chunk_precise_dedup_key(entry)
         if not key or key == "?" or key in seen:
             continue
         hits.append(entry)

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -944,14 +944,19 @@ def search_memories(
         query_terms = set(_tokenize(query))
         best_idx, best_score = 0, -1
         for idx, d in enumerate(ordered_docs):
-            d_lower = d.lower()
+            # Tolerate ``None`` documents — Chroma returns ``None`` in the
+            # ``documents`` field for drawers inserted with embeddings only
+            # (legacy mines, partial restores, no-text entries). Treat as
+            # empty so the keyword scan continues rather than raising
+            # ``AttributeError`` mid-search (issue #1125).
+            d_lower = (d or "").lower()
             s = sum(1 for t in query_terms if t in d_lower)
             if s > best_score:
                 best_score, best_idx = s, idx
 
         start = max(0, best_idx - 1)
         end = min(len(ordered_docs), best_idx + 2)
-        expanded = "\n\n".join(ordered_docs[start:end])
+        expanded = "\n\n".join(d or "" for d in ordered_docs[start:end])
         if len(expanded) > MAX_HYDRATION_CHARS:
             expanded = (
                 expanded[:MAX_HYDRATION_CHARS]

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -31,6 +31,12 @@ class SearchError(Exception):
 
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 
+# Upper bound on the per-query candidate fetch from the vector index.
+# Short queries widen the over-fetch (see issue #1125) up to this cap so
+# the cost of the underlying ChromaDB ``.query()`` and downstream BM25
+# rerank stays bounded on large ``n_results`` requests.
+_OVERFETCH_MAX = 200
+
 
 def _first_or_empty(results, key: str) -> list:
     """Return the first inner list of a query result field, or [].
@@ -805,10 +811,21 @@ def search_memories(
     # This avoids the "weak-closets regression" where narrative content
     # produces low-signal closets (regex extraction matches few topics)
     # and closet-first routing hides drawers that direct search would find.
+    # Short queries — particularly proper nouns and 1-3 token names —
+    # produce weak embeddings relative to longer narrative drawers. The
+    # default ``n_results * 3`` over-fetch can drop name-bearing drawers
+    # below the candidate cutoff before BM25 rerank ever sees them.
+    # Widen the pool for short queries so rerank can do its job; clamp
+    # to 200 so the candidate fetch stays bounded on large n_results
+    # requests. See issue #1125.
+    token_count = len(_TOKEN_RE.findall(query))
+    overfetch_multiplier = 10 if token_count <= 3 else 3
+    overfetch_n = min(n_results * overfetch_multiplier, _OVERFETCH_MAX)
+
     try:
         dkwargs = {
             "query_texts": [query],
-            "n_results": n_results * 3,  # over-fetch for re-ranking
+            "n_results": overfetch_n,  # over-fetch for re-ranking
             "include": ["documents", "metadatas", "distances"],
         }
         if where:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -637,6 +637,7 @@ def _merge_bm25_union_candidates(
     room: str,
     n_results: int,
     max_distance: float = 0.0,
+    collection_name: str = None,
 ) -> None:
     """Append top-K BM25-only candidates from sqlite into ``hits`` in place.
 
@@ -671,6 +672,7 @@ def _merge_bm25_union_candidates(
             room=room,
             n_results=n_results * 3,
             _include_internal=True,
+            collection_name=collection_name,
         ).get("results", [])
     except Exception:
         logger.debug("candidate_strategy=union: BM25 fetch failed", exc_info=True)
@@ -698,12 +700,114 @@ def _merge_bm25_union_candidates(
         seen.add(key)
 
 
+def _merge_contains_union_candidates(
+    hits: list,
+    query: str,
+    palace_path: str,
+    wing: str,
+    room: str,
+    n_results: int,
+    max_distance: float = 0.0,
+    collection_name: str = None,
+) -> None:
+    """Append drawers whose ``documents`` contain ``query`` as a literal
+    substring (Chroma ``where_document={"$contains": query}``) into
+    ``hits`` in place.
+
+    Used by ``search_memories(..., candidate_strategy="contains")`` to
+    catch proper-noun and exact-string matches whose embeddings fall
+    below the vector candidate cutoff. The vector path can over-fetch a
+    larger pool (see ``_OVERFETCH_MAX`` and the short-query widening),
+    but rare or single-token proper-noun queries still produce
+    embeddings too weak to clear the rerank window. A direct substring
+    fetch guarantees those drawers reach BM25 rerank. See issue #1125.
+
+    Dedup is chunk-precise: same key as ``_merge_bm25_union_candidates``
+    so two files sharing a basename in different directories don't
+    collide and a vector hit on chunk N doesn't block contains from
+    contributing chunk M of the same file.
+
+    Contains-only additions carry ``distance=None`` so ``_hybrid_rank``
+    scores them on BM25 contribution alone — mirrors the BM25-only
+    union path.
+
+    Skipped when ``max_distance > 0.0`` for the same reason as the BM25
+    union path: a strict vector-distance threshold has no meaning for
+    candidates that never ran a vector query, and silently injecting
+    them would break the existing ``max_distance`` guarantee.
+    """
+    if max_distance > 0.0:
+        return
+    if not query.strip():
+        return
+
+    try:
+        if collection_name is not None:
+            drawers_col = get_collection(palace_path, collection_name=collection_name, create=False)
+        else:
+            drawers_col = get_collection(palace_path, create=False)
+    except Exception:
+        logger.debug("candidate_strategy=contains: collection fetch failed", exc_info=True)
+        return
+
+    where = build_where_filter(wing, room)
+    get_kwargs = {
+        "where_document": {"$contains": query},
+        "limit": min(n_results * 3, _OVERFETCH_MAX),
+        "include": ["documents", "metadatas"],
+    }
+    if where:
+        get_kwargs["where"] = where
+
+    try:
+        contains_results = drawers_col.get(**get_kwargs)
+    except Exception:
+        logger.debug("candidate_strategy=contains: where_document fetch failed", exc_info=True)
+        return
+
+    docs = contains_results.documents or []
+    metas = contains_results.metadatas or []
+
+    def _dedup_key(entry: dict):
+        full = entry.get("_source_file_full")
+        ci = entry.get("_chunk_index")
+        if full and ci is not None:
+            return (full, ci)
+        return entry.get("source_file")
+
+    seen = {_dedup_key(h) for h in hits}
+    for doc, meta in zip(docs, metas):
+        if doc is None or meta is None:
+            continue
+        full_source = meta.get("source_file", "") or ""
+        entry = {
+            "text": doc,
+            "wing": meta.get("wing", "unknown"),
+            "room": meta.get("room", "unknown"),
+            "source_file": Path(full_source).name if full_source else "?",
+            "created_at": meta.get("filed_at", "unknown"),
+            "similarity": None,
+            "distance": None,
+            "effective_distance": None,
+            "closet_boost": 0.0,
+            "matched_via": "contains",
+            "_source_file_full": full_source,
+            "_chunk_index": meta.get("chunk_index"),
+        }
+        key = _dedup_key(entry)
+        if not key or key == "?" or key in seen:
+            continue
+        hits.append(entry)
+        seen.add(key)
+
+
 # Strategy dispatch — keeps search_memories' branch count under the
 # project's complexity ceiling (C901 max-complexity=25). New strategies
 # register here.
 _CANDIDATE_MERGERS = {
     "vector": None,  # default no-op
     "union": _merge_bm25_union_candidates,
+    "contains": _merge_contains_union_candidates,
 }
 
 
@@ -729,6 +833,7 @@ def _apply_candidate_strategy(
     room: str,
     n_results: int,
     max_distance: float = 0.0,
+    collection_name: str = None,
 ) -> None:
     """Dispatch to the registered merger for ``strategy``.
 
@@ -737,7 +842,16 @@ def _apply_candidate_strategy(
     """
     merger = _CANDIDATE_MERGERS[strategy]
     if merger is not None:
-        merger(hits, query, palace_path, wing, room, n_results, max_distance=max_distance)
+        merger(
+            hits,
+            query,
+            palace_path,
+            wing,
+            room,
+            n_results,
+            max_distance=max_distance,
+            collection_name=collection_name,
+        )
 
 
 def search_memories(
@@ -1019,6 +1133,7 @@ def search_memories(
         room,
         n_results,
         max_distance=max_distance,
+        collection_name=collection_name,
     )
 
     # BM25 hybrid re-rank within the final candidate set, then trim back

--- a/tests/test_hybrid_candidate_union.py
+++ b/tests/test_hybrid_candidate_union.py
@@ -9,9 +9,19 @@ The ``"union"`` strategy also pulls top-K BM25-only candidates from sqlite
 FTS5 and merges them into the rerank pool. Both signal sources contribute
 candidates; the hybrid rerank picks the best from a richer pool.
 
+The ``"contains"`` strategy additionally injects drawers whose document
+text contains the query as a literal substring (Chroma
+``where_document={"$contains": query}``). This catches proper-noun and
+exact-string matches that produce embeddings too weak to clear the
+vector candidate cutoff — issue #1125.
+
 Default behavior is unchanged ("vector") — these tests exercise opt-in
-"union" mode.
+modes.
 """
+
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from mempalace.palace import get_collection
 from mempalace.searcher import search_memories
@@ -79,8 +89,7 @@ class TestCandidateUnion:
         result = search_memories(_NARRATIVE_QUERY, palace, n_results=5, candidate_strategy="union")
         ids = [h["source_file"] for h in result["results"]]
         assert "brand_voice_D4.md" in ids, (
-            "union mode must surface BM25-strong docs even when vector signal "
-            f"is weak; got {ids}"
+            f"union mode must surface BM25-strong docs even when vector signal is weak; got {ids}"
         )
 
     def test_union_preserves_vector_hits(self, tmp_path):
@@ -138,9 +147,9 @@ class TestCandidateUnion:
         # 4-doc corpus, n_results=2 → union pool can grow to ~8 candidates,
         # rerank reorders them, but final list must respect the cap.
         result = search_memories(_NARRATIVE_QUERY, palace, n_results=2, candidate_strategy="union")
-        assert (
-            len(result["results"]) <= 2
-        ), f"union must trim to n_results=2; got {len(result['results'])} results"
+        assert len(result["results"]) <= 2, (
+            f"union must trim to n_results=2; got {len(result['results'])} results"
+        )
 
     def test_union_skipped_when_max_distance_set(self, tmp_path):
         """``max_distance`` is a vector-distance threshold; BM25-only
@@ -212,6 +221,232 @@ class TestCandidateUnion:
         assert readme_count >= 2, (
             f"union must surface both README.md files from different dirs "
             f"(basename collision would drop one); got sources={sources}"
+        )
+
+
+# ── candidate_strategy="contains" (#1125) ──────────────────────────────
+
+
+def _make_mocked_collection(vector_hits=None, contains_hits=None):
+    """Build a mock collection whose ``.query()`` and ``.get()`` return
+    fully-controlled candidates. Lets the contains-strategy tests pin
+    each path's contribution independently — small live corpora are too
+    permissive (vector returns all candidates) to discriminate which
+    strategy surfaced a result."""
+
+    def _doc_payload(hits):
+        if not hits:
+            return {"documents": [[]], "metadatas": [[]], "distances": [[]], "ids": [[]]}
+        return {
+            "documents": [[h["document"] for h in hits]],
+            "metadatas": [[h["metadata"] for h in hits]],
+            "distances": [[h.get("distance", 0.1) for h in hits]],
+            "ids": [[h["id"] for h in hits]],
+        }
+
+    def _get_payload(hits):
+        hits = hits or []
+        return MagicMock(
+            documents=[h["document"] for h in hits],
+            metadatas=[h["metadata"] for h in hits],
+            ids=[h["id"] for h in hits],
+        )
+
+    mock_col = MagicMock()
+    mock_col.metadata = {"hnsw:space": "cosine"}
+    mock_col.query.return_value = _doc_payload(vector_hits)
+
+    def fake_get(**kwargs):
+        # The closet path (if any) goes through ``query`` not ``get``;
+        # only the contains merger uses ``get(where_document=...)``.
+        # Other ``.get`` callers receive an empty result.
+        if "where_document" in kwargs:
+            return _get_payload(contains_hits)
+        return _get_payload([])
+
+    mock_col.get.side_effect = fake_get
+    return mock_col
+
+
+def _hit(*, id, source, document, wing="ops", room="infra", chunk_index=0):
+    return {
+        "id": id,
+        "document": document,
+        "metadata": {
+            "wing": wing,
+            "room": room,
+            "source_file": source,
+            "chunk_index": chunk_index,
+            "filed_at": "2026-01-01T00:00:00",
+        },
+    }
+
+
+class TestContainsStrategy:
+    """``contains`` strategy pulls drawers whose ``documents`` contain the
+    query as a literal substring and unions them into the rerank pool.
+
+    Tests use mocked collections rather than live ChromaDB so we can pin
+    each retrieval path's contribution and prove the strategy actually
+    does work — a small live corpus over-fetches every drawer into the
+    candidate pool anyway, masking which path surfaced a result.
+    """
+
+    def test_invalid_strategy_still_raises(self):
+        with pytest.raises(ValueError, match="bogus"):
+            with patch(
+                "mempalace.searcher.get_collection",
+                return_value=_make_mocked_collection(),
+            ):
+                search_memories("anything", "/fake/path", candidate_strategy="bogus")
+
+    def test_default_vector_strategy_unchanged_after_contains_added(self):
+        vector_only = [_hit(id="V1", source="rev_plan.md", document="quarterly revenue")]
+        with patch(
+            "mempalace.searcher.get_collection",
+            return_value=_make_mocked_collection(vector_hits=vector_only),
+        ):
+            without = search_memories("revenue", "/fake/path", n_results=2)
+            explicit = search_memories(
+                "revenue", "/fake/path", n_results=2, candidate_strategy="vector"
+            )
+        assert [h["source_file"] for h in without["results"]] == [
+            h["source_file"] for h in explicit["results"]
+        ], "explicit candidate_strategy='vector' must match default"
+
+    def test_contains_surfaces_substring_match_vector_misses(self):
+        """Vector returns unrelated drawers; only the contains path
+        surfaces the literal-substring drawer. Strategy must merge it
+        into the rerank pool."""
+        vector_hits = [
+            _hit(id="V1", source="rev_plan.md", document="quarterly revenue planning"),
+            _hit(id="V2", source="db_migration.md", document="postgres migration log"),
+        ]
+        contains_hits = [
+            _hit(
+                id="C1",
+                source="procurement.md",
+                document="Xerathon-7 chassis arrives Tuesday",
+            ),
+        ]
+        with patch(
+            "mempalace.searcher.get_collection",
+            return_value=_make_mocked_collection(
+                vector_hits=vector_hits, contains_hits=contains_hits
+            ),
+        ):
+            result = search_memories(
+                "Xerathon-7",
+                "/fake/path",
+                n_results=3,
+                candidate_strategy="contains",
+            )
+        sources = [h["source_file"] for h in result["results"]]
+        assert "procurement.md" in sources, (
+            f"contains strategy must merge the where_document substring "
+            f"match into the rerank pool; got sources={sources}"
+        )
+
+    def test_contains_invokes_where_document_filter(self):
+        """Contract test — the merger calls ``.get`` exactly once with
+        ``where_document={"$contains": query}``. Any drift breaks the
+        issue-#1125 promise."""
+        mock_col = _make_mocked_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories(
+                "Alice",
+                "/fake/path",
+                n_results=5,
+                candidate_strategy="contains",
+            )
+
+        where_doc_calls = [c for c in mock_col.get.call_args_list if "where_document" in c.kwargs]
+        assert len(where_doc_calls) == 1, (
+            f"contains must call .get with where_document exactly once; "
+            f"got {len(where_doc_calls)} calls"
+        )
+        kwargs = where_doc_calls[0].kwargs
+        assert kwargs["where_document"] == {"$contains": "Alice"}
+        # ``limit`` must be a positive int — exact value is the merger's
+        # tuning knob, but it must be set to avoid full-collection scans.
+        assert isinstance(kwargs.get("limit"), int) and kwargs["limit"] > 0, (
+            f"contains must pass a positive int limit to bound the fetch; "
+            f"got limit={kwargs.get('limit')!r}"
+        )
+
+    def test_contains_dedup_does_not_dupe_vector_hits(self):
+        """Same drawer surfaced by BOTH vector and contains paths must
+        appear exactly once in the merged pool. Without dedup the count
+        would be 2."""
+        shared = _hit(
+            id="SHARED",
+            source="procurement.md",
+            document="Xerathon-7 chassis arrives Tuesday",
+        )
+        with patch(
+            "mempalace.searcher.get_collection",
+            return_value=_make_mocked_collection(vector_hits=[shared], contains_hits=[shared]),
+        ):
+            result = search_memories(
+                "Xerathon-7",
+                "/fake/path",
+                n_results=4,
+                candidate_strategy="contains",
+            )
+        sources = [h["source_file"] for h in result["results"]]
+        assert sources.count("procurement.md") == 1, (
+            f"shared drawer must dedup to exactly one entry; got sources={sources}"
+        )
+
+    def test_contains_respects_wing_room_filters(self):
+        """The ``where`` filter (wing/room) must be forwarded to the
+        ``.get()`` call — otherwise the strategy leaks cross-room
+        candidates that the vector path filters out at query time."""
+        mock_col = _make_mocked_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories(
+                "Alice",
+                "/fake/path",
+                n_results=4,
+                wing="ops",
+                room="sales",
+                candidate_strategy="contains",
+            )
+
+        where_doc_calls = [c for c in mock_col.get.call_args_list if "where_document" in c.kwargs]
+        assert where_doc_calls, "contains must call .get with where_document"
+        passed_where = where_doc_calls[0].kwargs.get("where")
+        # Implementation may pass a single-key dict or a $and combination;
+        # the contract is only that wing AND room are both expressed.
+        flat = str(passed_where)
+        assert "ops" in flat and "sales" in flat, (
+            f"wing/room must be forwarded to the contains .get(); got where={passed_where!r}"
+        )
+
+    def test_contains_forwards_collection_name(self):
+        """Explicit ``collection_name`` (e.g. a tenant-prefixed collection)
+        must be forwarded into the contains merger's ``get_collection``
+        call so multi-collection deployments don't silently fall back to
+        the default collection."""
+        captured = {}
+
+        def fake_get_collection(palace_path, *, collection_name=None, create=True):
+            captured.setdefault("calls", []).append(collection_name)
+            mock_col = _make_mocked_collection()
+            return mock_col
+
+        with patch("mempalace.searcher.get_collection", side_effect=fake_get_collection):
+            search_memories(
+                "Alice",
+                "/fake/path",
+                n_results=2,
+                collection_name="tenant_abc_drawers",
+                candidate_strategy="contains",
+            )
+
+        assert "tenant_abc_drawers" in captured["calls"], (
+            f"contains merger must forward collection_name to get_collection; "
+            f"saw calls={captured['calls']}"
         )
 
 

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -131,3 +131,70 @@ class TestClosetMetadata:
             assert h["matched_via"] == "drawer"
             assert "closet_preview" not in h
             assert h["closet_boost"] == 0.0
+
+
+# ── chunk-hydration robustness (#1125) ───────────────────────────────────
+
+
+class TestChunkHydrationNoneDocument:
+    """Drawer-grep enrichment must tolerate sibling drawers with no document
+    text. Chroma returns ``documents=None`` for entries inserted with only
+    embeddings (legacy mines, partial restores, no-text drawers), which
+    crashed the ``.lower()`` scan inside the enrichment loop.
+
+    Issue: https://github.com/MemPalace/mempalace/issues/1125
+    """
+
+    def test_closet_boosted_hit_with_none_sibling_does_not_crash(self, tmp_path):
+        palace = str(tmp_path / "palace")
+        col = get_collection(palace, create=True)
+        # D1: textual sibling — the drawer the closet boost surfaces.
+        col.upsert(
+            ids=["D1"],
+            documents=["JWT authentication tokens with a 24-hour session expiry."],
+            metadatas=[
+                {
+                    "wing": "backend",
+                    "room": "auth",
+                    "source_file": "auth.md",
+                    "chunk_index": 0,
+                }
+            ],
+        )
+        # D2: same source, embeddings-only — Chroma returns documents=None
+        # for it, which is the failure mode reported in #1125. No public
+        # MemPalace API for documentless inserts; raw chromadb access required.
+        embedding_dim = len(col._collection._embedding_function(["probe"])[0])
+        col._collection.add(
+            ids=["D2"],
+            embeddings=[[0.1] * embedding_dim],
+            metadatas=[
+                {
+                    "wing": "backend",
+                    "room": "auth",
+                    "source_file": "auth.md",
+                    "chunk_index": 1,
+                }
+            ],
+        )
+
+        _seed_strong_closet_for(
+            palace,
+            drawer_id="D1",
+            source_file="auth.md",
+            topics=["JWT auth tokens", "session expiry", "authentication service"],
+        )
+
+        # Currently raises AttributeError: 'NoneType' object has no attribute
+        # 'lower' inside the drawer-grep enrichment loop (issue #1125).
+        result = search_memories("JWT auth tokens expiry", palace, n_results=3)
+
+        assert "results" in result, "search must not crash on None doc siblings"
+        # Anchor: the closet boost must fire, otherwise the enrichment loop
+        # never runs and this test would pass vacuously without exercising
+        # the crash site.
+        assert any(h["matched_via"] == "drawer+closet" for h in result["results"]), (
+            "closet boost must fire so drawer-grep enrichment runs"
+        )
+        sources = [h["source_file"] for h in result["results"]]
+        assert "auth.md" in sources, "D1 must surface despite D2 having no text"

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -486,3 +486,17 @@ class TestShortQueryOverfetch:
             "10× n_results must clamp to 200 so large n_results requests "
             "do not blow up candidate-fetch latency"
         )
+
+    def test_overfetch_never_below_n_results(self):
+        """Floor: if the caller asks for ``n_results > _OVERFETCH_MAX``,
+        the clamp must not return fewer candidates than requested —
+        otherwise the function returns less than the caller asked for
+        and the contract breaks. Floor at ``n_results``, ceiling at
+        ``_OVERFETCH_MAX``, so the clamp can never be below the floor."""
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("Bob", "/fake/path", n_results=300)
+        assert self._captured_n_results(mock_col) == 300, (
+            "n_results=300 (above _OVERFETCH_MAX=200): overfetch must "
+            "floor at n_results, not clamp below it"
+        )

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -184,12 +184,11 @@ class TestSearchMemories:
 
         # Invariants on every hit.
         for h in hits:
-            assert (
-                0.0 <= h["similarity"] <= 1.0
-            ), f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            assert 0.0 <= h["similarity"] <= 1.0, (
+                f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            )
             assert 0.0 <= h["effective_distance"] <= 2.0, (
-                f"effective_distance out of range: {h['effective_distance']} "
-                f"for {h['source_file']}"
+                f"effective_distance out of range: {h['effective_distance']} for {h['source_file']}"
             )
 
         # With the clamp, the closet-boosted a.md still ranks ahead of b.md —
@@ -327,9 +326,9 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         first_block, _, _ = captured.out.partition("[2]")
         # Lexical match must rank first
-        assert (
-            "b.md" in first_block
-        ), f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        assert "b.md" in first_block, (
+            f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        )
         # Non-zero bm25 reported
         assert "bm25=" in first_block
         assert "bm25=0.0" not in first_block
@@ -399,3 +398,91 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         assert "[1]" in captured.out
         assert "[2]" in captured.out
+
+
+# ── short-query overfetch widening (#1125) ─────────────────────────────
+
+
+class TestShortQueryOverfetch:
+    """Proper-noun and short queries produce weak embeddings relative to
+    longer narrative drawers; the default ``n_results * 3`` over-fetch
+    window can drop name-bearing drawers before BM25 rerank ever sees
+    them. Widen the candidate pool for short queries so the rerank stage
+    can do its job.
+
+    Issue: https://github.com/MemPalace/mempalace/issues/1125
+    """
+
+    def _capturing_collection(self, return_empty=True):
+        mock_col = MagicMock()
+        mock_col.metadata = {"hnsw:space": "cosine"}
+        empty = {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+        mock_col.query.return_value = empty if return_empty else None
+        return mock_col
+
+    def _captured_n_results(self, mock_col):
+        return mock_col.query.call_args.kwargs.get("n_results")
+
+    def test_single_token_query_widens_to_10x(self):
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("Alice", "/fake/path", n_results=5)
+        assert self._captured_n_results(mock_col) == 50, (
+            "single-token queries must widen over-fetch to 10× n_results"
+        )
+
+    def test_three_token_query_widens_to_10x(self):
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("Jane Marie Doe", "/fake/path", n_results=5)
+        assert self._captured_n_results(mock_col) == 50, (
+            "three-token queries must still widen — proper-noun full names fit in this band"
+        )
+
+    def test_four_token_query_keeps_3x_overfetch(self):
+        # ``_TOKEN_RE`` matches ``\w{2,}`` so every word here is 1 token.
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories(
+                "configure authentication module users",  # 4 tokens
+                "/fake/path",
+                n_results=5,
+            )
+        assert self._captured_n_results(mock_col) == 15, (
+            "queries with more than 3 tokens must keep the existing 3× window"
+        )
+
+    def test_three_vs_four_token_boundary_is_inclusive(self):
+        """Boundary lock: ``<= 3`` widens, ``> 3`` does not. Same
+        ``n_results`` so any future off-by-one in the comparison flips
+        exactly one of the two assertions."""
+        for tokens, expected in [("alpha beta gamma", 50), ("alpha beta gamma delta", 15)]:
+            mock_col = self._capturing_collection()
+            with patch("mempalace.searcher.get_collection", return_value=mock_col):
+                search_memories(tokens, "/fake/path", n_results=5)
+            assert self._captured_n_results(mock_col) == expected, (
+                f"query={tokens!r} expected n_results={expected}, "
+                f"got {self._captured_n_results(mock_col)}"
+            )
+
+    def test_zero_token_query_uses_widened_overfetch(self):
+        """Empty / whitespace-only / punctuation-only queries produce
+        ``token_count = 0`` (``_TOKEN_RE`` requires ``\\w{2,}``). These fall
+        into the ``<= 3`` band and widen to 10× — documenting the
+        behaviour so a later "guard for empty query" change is a
+        deliberate decision, not an accident."""
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("??", "/fake/path", n_results=5)
+        assert self._captured_n_results(mock_col) == 50, (
+            "0-token queries route through the wide overfetch path"
+        )
+
+    def test_overfetch_clamped_to_200(self):
+        mock_col = self._capturing_collection()
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search_memories("Bob", "/fake/path", n_results=25)
+        assert self._captured_n_results(mock_col) == 200, (
+            "10× n_results must clamp to 200 so large n_results requests "
+            "do not blow up candidate-fetch latency"
+        )


### PR DESCRIPTION
## Summary

Final piece of issue #1125: opt-in `candidate_strategy="contains"` that runs `drawers_col.get(where_document={"$contains": query}, ...)` in parallel to the vector query and unions the substring-match drawers into the rerank pool. Picks up the proper-noun and exact-string matches whose embeddings sit outside even the widened vector window from PR #1480.

**PR C of three** for #1125. Stacked on:
- PR #1479 — `fix(search): tolerate None documents in chunk-hydration loop` (mandatory; wider candidate pools surface None docs that crashed the enrichment loop)
- PR #1480 — `feat(search): widen vector over-fetch for short queries`

Each PR is independently mergeable. This one is the **preferred** fix from #1125's design discussion.

## Why a new strategy and not always-on

`$contains` is a cheap query but it is still a separate Chroma round-trip per `search_memories` call. Making it always-on would add latency to every search regardless of query shape. Registering it as an opt-in strategy:

- mirrors the existing `candidate_strategy="union"` (BM25-from-sqlite) precedent so the API surface stays consistent
- lets callers who care about proper-noun recall enable it without rewriting the default search path
- lets you (the maintainers) ship it conservatively and flip the default later if the production data justifies it

## Implementation

`mempalace/searcher.py` — `_merge_contains_union_candidates` mirrors `_merge_bm25_union_candidates` line-for-line where the semantics are shared (`max_distance` guard, chunk-precise dedup key, `distance=None` for contains-only adds, defensive try/except + debug log on Chroma failure). The differences are exactly what the strategy advertises:

- the merger reaches into the Chroma collection with `where_document={\"$contains\": query}` and a positive int `limit = min(n_results * 3, _OVERFETCH_MAX)` (no widening for short queries — `$contains` is exact-match, widening adds no recall)
- contains-only hits are tagged `matched_via=\"contains\"` so downstream tooling can distinguish them from `\"drawer\"`, `\"drawer+closet\"`, or `\"bm25_sqlite\"` candidates
- the merger respects the same `wing`/`room` filter the vector path applies (`build_where_filter` is reused; `where_document` and `where` combine inside Chroma)

Registered as `_CANDIDATE_MERGERS[\"contains\"]`; `\"vector\"` and `\"union\"` are unchanged.

### Adjacent fix: `collection_name` forwarding

While threading `collection_name` through `_apply_candidate_strategy` and the new contains merger for multi-collection deployments, `_merge_bm25_union_candidates` also gains the same forwarding (one extra kwarg) so an explicit non-default `collection_name` finally reaches `_bm25_only_via_sqlite`. This was a pre-existing latent gap — surfaced by review of this PR — but is included here because the new strategy framework had to thread the kwarg through anyway. If you'd prefer the BM25-side fix as a separate commit, I can split.

## Test plan

7 mock-based tests in `tests/test_hybrid_candidate_union.py::TestContainsStrategy` (designed mock-first because a small live corpus over-fetches every drawer into the candidate pool and masks which strategy surfaced a result):

- [x] invalid strategy still raises `ValueError` after registry grows
- [x] explicit `\"vector\"` matches default behaviour (no regression)
- [x] vector path misses substring drawer → contains union surfaces it
- [x] `.get` called **exactly once** with `where_document={\"$contains\": q}` and a positive int `limit`
- [x] shared drawer dedupes to one entry across both paths
- [x] wing/room `where` filter is forwarded to the contains `.get()`
- [x] explicit `collection_name` is forwarded into `get_collection`

```
$ uv run pytest tests/ --ignore=tests/benchmarks
1740 passed, 1 skipped, 1 warning in 34.23s

$ uv run ruff check . && uv run ruff format --check .
clean
```

## Open question for maintainer

Worth flipping the default to `\"contains\"` (or a new `\"vector+contains\"`) once your test fleet confirms no regression on narrative queries? Happy to follow up if you want the experiment.

Credit: @MAF33884 for the proposal and the empirical analysis on a 482-drawer palace that motivated this strategy.