### PR TITLE
fix(benchmarks): honor --granularity across hybrid_v2/v3/v4; reject in palace/diary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ venv/
 # ChromaDB local data
 *.sqlite3-journal
 .envrc
+
+# Local benchmark artifacts (large jsonl dumps, per-question stdout)
+benchmarks/c_beta/*.jsonl
+benchmarks/c_beta/*.stdout

--- a/benchmarks/c_beta/PLAN.md
+++ b/benchmarks/c_beta/PLAN.md
@@ -1,0 +1,76 @@
+# C-β v0.1, LongMemEval Granularity × Hybrid-Weight Sweep
+
+## Soru
+Discussion #1384'te wash-vs-compound tartışmasının zayıf halkası: `hybrid_v4`
+keyword boost'unun gerçek bir bağımsız sinyal mi yoksa session-level lexical
+overlap'in yan ürünü mü olduğunu tek bir bench koşusundan ayırt edemiyorduk.
+
+## Hipotez
+H0 (wash): `hybrid_v4` lift sadece `granularity=session`'da görünür, çünkü
+session metni uzun → keyword overlap kolay. `granularity=turn` (her user turn
+ayrı doc) altında lift yok olur veya tersine döner.
+
+H1 (compound): Lift her iki granularity'de de pozitif kalır. Boyut farklı
+olabilir ama yön aynı.
+
+## Set-up
+- **Data**: `longmemeval_s_cleaned.json` (500 q, 264 MB)
+- **Split**: `benchmarks/lme_split_50_450.json`, `--dev-only` (50 q)
+- **Embedding**: default `all-MiniLM-L6-v2` (ChromaDB built-in)
+- **LLM rerank**: OFF (eksen izolasyonu; #1384 LLM rerank ekseni ayrı)
+- **Metrics**: SESSION-LEVEL Recall@{1,5,10,30}, NDCG@{10,30}
+
+## Eksenler (8 koşu)
+| mode       | granularity | hybrid_weight |
+|------------|-------------|----------------|
+| raw        | session     | NA             |
+| raw        | turn        | NA             |
+| hybrid_v4  | session     | 0.0            |
+| hybrid_v4  | session     | 0.30 (default) |
+| hybrid_v4  | session     | 0.60           |
+| hybrid_v4  | turn        | 0.0            |
+| hybrid_v4  | turn        | 0.30           |
+| hybrid_v4  | turn        | 0.60           |
+
+`hybrid_weight=0.0` koşuları sanity check: hybrid_v4 pipeline çalışıyor ama
+keyword boost devre dışı → `raw` ile near-eşit beklenir.
+
+## Karar kriteri
+Δ_session = R@10(hybrid_v4 hw=0.30, session) − R@10(raw, session)
+Δ_turn    = R@10(hybrid_v4 hw=0.30, turn)    − R@10(raw, turn)
+
+- |Δ_turn| < 0.02 ve Δ_session ≥ 0.04 → **H0 (wash) destekleniyor**, lift
+  session-level lexical overlap'tan geliyor.
+- Δ_session ve Δ_turn ikisi de ≥ 0.02 ve aynı işaret → **H1 (compound)**.
+- Karışık sonuç → eksen daha derin sweep ister (hw=0.10/0.20/0.45 ekle, 450q'a
+  taşı).
+
+## Bütçe
+- LLM call yok → $0.
+- Wall: ~75 s × 8 ≈ 10 dk Mac mini'de.
+- Dev-only 50q dışına çıkmıyoruz (held-out kontamine etmemek için, repo CLAUDE
+  konvansiyonu).
+
+## Çıktılar
+- `benchmarks/c_beta/*.jsonl`, per-run raw results
+- `benchmarks/c_beta/*.stdout`, full bench output (PER-TYPE breakdown dahil)
+- `benchmarks/c_beta/sweep_results.csv`, özet tablo
+- `benchmarks/c_beta/sweep.log`, koşu özetleri (OK/FAIL satırları)
+
+## Premortem (3 risk)
+1. **dev-50 küçüklüğü** → tek soru farkı %2 ndcg. Mitigasyon: en az
+   2 hw değeri ile çapraz doğrula; tek noktada karar verme. Tespit: hw=0.0
+   ile raw arasında >%4 fark çıkarsa pipeline'da gizli bias var.
+2. **Embedding non-determinism** → MiniLM ChromaDB içinde fixed seed mi?
+   Mitigasyon: çıkmaz, ama smoke'ta aynı koşuyu 2x koşup R@10 sapmasını ölç.
+3. **Turn granularity büyük corpus** → her session 5-50 turn → 50q × ~500
+   turn ≈ 25K doc per query, ChromaDB yüklenme süresi şişebilir. Tespit:
+   `*_turn_*.stdout` wall süresi 5x'i geçerse erken sinyal.
+
+## C-β v0.2 yol haritası (sonuca göre)
+- H0 destekleniyorsa: hybrid_v4 spec'ini #1384'te güncelle, "session-level
+  bias" olarak işaretle.
+- H1 destekleniyorsa: 450 held-out üzerinde tek-doğrulama koşusu (Atakan onay
+  verirse), sonra MemPalace'a PR.
+- Karışıksa: extra eksen (`embed-model=bge-base`) ekleyerek embedding'in
+  rolünü izole et.

--- a/benchmarks/c_beta/RESULTS.md
+++ b/benchmarks/c_beta/RESULTS.md
@@ -58,6 +58,28 @@ as the keyword boost partially compensating for lost surrounding context
 at turn granularity, lexical signal carries more weight when semantic
 context per doc is smaller.
 
+## Follow-up: audit of other modes
+
+After the `hybrid_v4` fix, audited the remaining retrieval functions for
+the same dead-`granularity`-parameter defect:
+
+| function   | granularity branched? | fix                                       |
+|------------|----------------------|--------------------------------------------|
+| raw / aaak / rooms / hybrid / full | yes (pre-existing) | none, already honored the flag |
+| hybrid_v2  | no                    | same per-turn corpus + session-id dedup pattern |
+| hybrid_v3  | no                    | same per-turn corpus + session-id dedup pattern |
+| hybrid_v4  | no                    | (fixed in the primary commit)              |
+| palace     | no                    | explicit `ValueError` on `granularity != "session"`, palace's hall classification, drawers, and preference wing are intrinsically session-keyed; a turn-level rewrite changes the algorithm |
+| diary      | no                    | explicit `ValueError` on `granularity != "session"`, LLM topic layer is computed and cached per `sess_id` |
+
+Smoke tests (5q dev split): hybrid_v2 turn hw=0.30 and hybrid_v3 turn
+hw=0.30 both score 1.000 across R@k / NDCG@k on a small-n smoke set;
+palace turn raises cleanly; palace session is unchanged from baseline.
+
+Full sweep on hybrid_v2/v3 across the matrix was not run, out of scope
+for this PR. Anyone who wants to test the wash hypothesis on those modes
+can now run a turn-granularity sweep against them honestly.
+
 ## Caveats
 
 - 50 q split. R@10 saturates at 0.980 across the turn sweep; NDCG@10

--- a/benchmarks/c_beta/RESULTS.md
+++ b/benchmarks/c_beta/RESULTS.md
@@ -1,0 +1,70 @@
+# C-β v0.1, Results
+
+50q dev-split, LongMemEval, default MiniLM, no LLM rerank.
+
+## Sweep matrix
+
+| mode      | granularity | hw   | R@10  | NDCG@10 |
+|-----------|-------------|------|-------|---------|
+| raw       | session     |, | 0.980 | 0.905   |
+| raw       | turn        |, | 0.960 | 0.885   |
+| hybrid_v4 | session     | 0.0  | 1.000 | 0.937   |
+| hybrid_v4 | session     | 0.30 | 1.000 | 0.944   |
+| hybrid_v4 | session     | 0.60 | 0.980 | 0.936   |
+| hybrid_v4 | turn        | 0.0  | 0.980 | 0.924   |
+| hybrid_v4 | turn        | 0.30 | 0.980 | 0.934   |
+| hybrid_v4 | turn        | 0.60 | 0.980 | 0.931   |
+
+All `hybrid_v4 turn` rows above are post-fix. Pre-fix turn rows were
+silently session-level (defect, see below).
+
+## Defect found mid-sweep
+
+`build_palace_and_retrieve_hybrid_v4` accepted a `granularity` parameter
+but never branched on it: the corpus loop always emitted one document per
+session (`"\n".join(user_turns)`). With the defect in place,
+`hybrid_v4 turn hw=0.0` and `hybrid_v4 session hw=0.0` produced bitwise
+identical metrics. Originally framed as a curious anomaly; verifying the
+code path showed it was a dead parameter.
+
+Fix: branch the corpus build on `granularity`; emit one doc per user turn
+when `turn` is requested, using `{sess_id}_turn_{i}` corpus IDs so the
+existing `session_id_from_corpus_id` helper can roll turns up to sessions
+during evaluation. Dedup logic in both the assistant-reference two-pass
+and the main scoring path was changed to dedup by session id (so multiple
+high-scoring turns of the same session collapse to a single ranked entry).
+Synthetic preference docs remain session-aggregated; they now resolve to
+the first turn of their session when a pref-hit drives the ranking.
+
+## Hypothesis test
+
+H0 (wash): keyword boost lift exists only because session-level text is
+long enough for lexical overlap to land easily; at turn granularity the
+lift should vanish or invert.
+
+H1 (compound): lift survives at turn granularity; the keyword signal is
+independent of doc length.
+
+Lift (NDCG@10, hw=0.0 → hw=0.30):
+- session: 0.937 → 0.944 = **+0.007**
+- turn:    0.924 → 0.934 = **+0.010**
+
+Turn lift is comparable to (slightly larger than) session lift, with the
+same concave shape (peak at hw=0.30, drop at hw=0.60). **H0 rejected.**
+
+Secondary observation: the session-over-turn NDCG gap shrinks as hybrid
+weight grows (Δ = 0.013 → 0.010 → 0.005 across hw = 0.0/0.30/0.60). Reads
+as the keyword boost partially compensating for lost surrounding context
+at turn granularity, lexical signal carries more weight when semantic
+context per doc is smaller.
+
+## Caveats
+
+- 50 q split. R@10 saturates at 0.980 across the turn sweep; NDCG@10
+  differences are 0.005, 0.013 wide. Effect is directionally clear but
+  the sample is small.
+- The dev split was held fixed across runs (`benchmarks/lme_split_50_450.json`),
+  so the runs are paired on questions but not bootstrap-resampled.
+- Only `hybrid_v4` was fixed. `hybrid`, `hybrid_v2`, `hybrid_v3`, `palace`,
+  `diary`, `aaak`, `rooms` likely have the same dead-parameter defect; not
+  audited in this scope.

--- a/benchmarks/c_beta/RESULTS.md
+++ b/benchmarks/c_beta/RESULTS.md
@@ -1,22 +1,24 @@
 # C-β v0.1, Results
 
-50q dev-split, LongMemEval, default MiniLM, no LLM rerank.
+50q dev-split, LongMemEval, default MiniLM, no LLM rerank. All numbers
+below are **post-fix** (the dead-`granularity`-parameter defect documented
+in the "Defect" section was discovered mid-sweep and fixed; every row in
+the matrix was re-run against the fixed code).
 
 ## Sweep matrix
 
-| mode      | granularity | hw   | R@10  | NDCG@10 |
-|-----------|-------------|------|-------|---------|
-| raw       | session     |, | 0.980 | 0.905   |
-| raw       | turn        |, | 0.960 | 0.885   |
-| hybrid_v4 | session     | 0.0  | 1.000 | 0.937   |
-| hybrid_v4 | session     | 0.30 | 1.000 | 0.944   |
-| hybrid_v4 | session     | 0.60 | 0.980 | 0.936   |
-| hybrid_v4 | turn        | 0.0  | 0.980 | 0.924   |
-| hybrid_v4 | turn        | 0.30 | 0.980 | 0.934   |
-| hybrid_v4 | turn        | 0.60 | 0.980 | 0.931   |
+| mode      | granularity | hw   | R@1   | R@5   | R@10  | NDCG@10 | wall  |
+|-----------|-------------|------|-------|-------|-------|---------|-------|
+| raw       | session     |, | 0.840 | 0.960 | 0.980 | 0.905   | 62s   |
+| raw       | turn        |, | 0.880 | 0.940 | 0.960 | 0.885   | 257s  |
+| hybrid_v4 | session     | 0.0  | 0.880 | 0.980 | 1.000 | 0.937   | 81s   |
+| hybrid_v4 | session     | 0.30 | 0.880 | 0.960 | 1.000 | 0.944   | 85s   |
+| hybrid_v4 | session     | 0.60 | 0.880 | 0.960 | 0.980 | 0.936   | 90s   |
+| hybrid_v4 | turn        | 0.0  | 0.900 | 0.980 | 1.000 | 0.944   | 283s  |
+| hybrid_v4 | turn        | 0.30 | 0.920 | 0.960 | 1.000 | **0.954** | 288s |
+| hybrid_v4 | turn        | 0.60 | 0.920 | 0.960 | 1.000 | 0.951   | 285s  |
 
-All `hybrid_v4 turn` rows above are post-fix. Pre-fix turn rows were
-silently session-level (defect, see below).
+Best NDCG@10 on the matrix: `hybrid_v4 turn hw=0.30` at 0.954.
 
 ## Defect found mid-sweep
 
@@ -27,66 +29,72 @@ session (`"\n".join(user_turns)`). With the defect in place,
 identical metrics. Originally framed as a curious anomaly; verifying the
 code path showed it was a dead parameter.
 
-Fix: branch the corpus build on `granularity`; emit one doc per user turn
-when `turn` is requested, using `{sess_id}_turn_{i}` corpus IDs so the
-existing `session_id_from_corpus_id` helper can roll turns up to sessions
-during evaluation. Dedup logic in both the assistant-reference two-pass
-and the main scoring path was changed to dedup by session id (so multiple
-high-scoring turns of the same session collapse to a single ranked entry).
-Synthetic preference docs remain session-aggregated; they now resolve to
-the first turn of their session when a pref-hit drives the ranking.
+Fix shape:
+- Branch the corpus build on `granularity`; emit one doc per user turn
+  in turn mode, using `{sess_id}_turn_{i}` corpus IDs so the existing
+  `session_id_from_corpus_id` helper rolls turns up to sessions during
+  evaluation.
+- In turn mode, `corpus_full[i]` mirrors the full session text (not the
+  single user turn) so the assistant-reference two-pass still has
+  assistant content to query in Pass 2. `corpus_user[i]` stays the
+  granular per-turn signal.
+- Dedup by session id in both the assistant-reference two-pass and the
+  main scoring path: multiple high-scoring turns of the same session
+  collapse to a single ranked entry.
+- Synthetic preference docs remain session-aggregated and resolve to the
+  first user-turn index of their session when a pref-hit drives the rank.
+
+The same defect was present in `hybrid_v2` and `hybrid_v3`; they got the
+same fix. `palace` and `diary` are intrinsically session-keyed (hall
+classification, drawers, preference wing, LLM topic cache), so they now
+raise `ValueError` on `granularity != "session"` rather than silently
+ignoring the flag.
 
 ## Hypothesis test
 
-H0 (wash): keyword boost lift exists only because session-level text is
-long enough for lexical overlap to land easily; at turn granularity the
-lift should vanish or invert.
+**H0 (wash):** keyword-boost lift exists only because session-level text
+is long enough for lexical overlap to land easily; at turn granularity
+the lift should vanish or invert.
 
-H1 (compound): lift survives at turn granularity; the keyword signal is
-independent of doc length.
+**H1 (compound):** lift survives at turn granularity; the keyword signal
+is independent of doc length.
 
-Lift (NDCG@10, hw=0.0 → hw=0.30):
+NDCG@10 lift hw=0.0 → hw=0.30:
 - session: 0.937 → 0.944 = **+0.007**
-- turn:    0.924 → 0.934 = **+0.010**
+- turn:    0.944 → 0.954 = **+0.010**
 
-Turn lift is comparable to (slightly larger than) session lift, with the
-same concave shape (peak at hw=0.30, drop at hw=0.60). **H0 rejected.**
+NDCG@10 from hw=0.30 → hw=0.60:
+- session: 0.944 → 0.936 = −0.008
+- turn:    0.954 → 0.951 = −0.003
 
-Secondary observation: the session-over-turn NDCG gap shrinks as hybrid
-weight grows (Δ = 0.013 → 0.010 → 0.005 across hw = 0.0/0.30/0.60). Reads
-as the keyword boost partially compensating for lost surrounding context
-at turn granularity, lexical signal carries more weight when semantic
-context per doc is smaller.
+Both granularities show the same concave shape (peak at hw=0.30, drop at
+hw=0.60). Turn lift is slightly larger than session lift in absolute
+terms. **H0 rejected.** The keyword boost is not a session-length artifact.
 
-## Follow-up: audit of other modes
+## Secondary observation: turn ≥ session across the whole hybrid_v4 sweep
 
-After the `hybrid_v4` fix, audited the remaining retrieval functions for
-the same dead-`granularity`-parameter defect:
+Post-fix, `hybrid_v4 turn` matches or beats `hybrid_v4 session` on
+NDCG@10 at every hw tested (Δ = +0.007, +0.010, +0.015 for hw =
+0.0/0.30/0.60). The pre-fix table showed the inverse because turn mode
+was silently producing session-level metrics minus the assistant
+content. Now that Pass 2 has access to full session text via
+`corpus_full` while the primary retrieval signal stays per-turn, the
+combination of granular ranking and context-rich rerank dominates the
+session baseline on this split.
 
-| function   | granularity branched? | fix                                       |
-|------------|----------------------|--------------------------------------------|
-| raw / aaak / rooms / hybrid / full | yes (pre-existing) | none, already honored the flag |
-| hybrid_v2  | no                    | same per-turn corpus + session-id dedup pattern |
-| hybrid_v3  | no                    | same per-turn corpus + session-id dedup pattern |
-| hybrid_v4  | no                    | (fixed in the primary commit)              |
-| palace     | no                    | explicit `ValueError` on `granularity != "session"`, palace's hall classification, drawers, and preference wing are intrinsically session-keyed; a turn-level rewrite changes the algorithm |
-| diary      | no                    | explicit `ValueError` on `granularity != "session"`, LLM topic layer is computed and cached per `sess_id` |
-
-Smoke tests (5q dev split): hybrid_v2 turn hw=0.30 and hybrid_v3 turn
-hw=0.30 both score 1.000 across R@k / NDCG@k on a small-n smoke set;
-palace turn raises cleanly; palace session is unchanged from baseline.
-
-Full sweep on hybrid_v2/v3 across the matrix was not run, out of scope
-for this PR. Anyone who wants to test the wash hypothesis on those modes
-can now run a turn-granularity sweep against them honestly.
+Sample is small (50q), so this is directional. A bootstrap-resampled run
+across the full 500q would be the honest next step before claiming turn
+mode as a default.
 
 ## Caveats
 
-- 50 q split. R@10 saturates at 0.980 across the turn sweep; NDCG@10
-  differences are 0.005, 0.013 wide. Effect is directionally clear but
-  the sample is small.
-- The dev split was held fixed across runs (`benchmarks/lme_split_50_450.json`),
-  so the runs are paired on questions but not bootstrap-resampled.
-- Only `hybrid_v4` was fixed. `hybrid`, `hybrid_v2`, `hybrid_v3`, `palace`,
-  `diary`, `aaak`, `rooms` likely have the same dead-parameter defect; not
-  audited in this scope.
+- 50 q dev split. R@10 saturates at 1.000 across the `hybrid_v4` matrix;
+  the discrimination is in NDCG@10, with deltas in the 0.005, 0.015 range.
+- The dev split was held fixed across runs
+  (`benchmarks/lme_split_50_450.json`), so runs are paired on questions
+  but not bootstrap-resampled.
+- `aaak`, `rooms`, `hybrid`, `full` were spot-checked to already honor
+  `--granularity` and were not part of this sweep. A separate sweep
+  would be needed to test the wash hypothesis on those modes.
+- Full sweep on `hybrid_v2` / `hybrid_v3` across the matrix was not run
+  (out of scope here); only 5q smokes at hw=0.30 turn, both at 1.000.

--- a/benchmarks/c_beta/rebuild_csv.sh
+++ b/benchmarks/c_beta/rebuild_csv.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /Users/macmini/Projects/mempalace
+OUTDIR=benchmarks/c_beta
+CSV=$OUTDIR/sweep_results.csv
+
+echo "mode,granularity,hybrid_weight,n_questions,recall_at_1,recall_at_5,recall_at_10,recall_at_30,ndcg_at_10,ndcg_at_30,out_file" > "$CSV"
+
+for f in "$OUTDIR"/*.stdout; do
+  base=$(basename "$f" .stdout)
+  # filename pattern: <mode>_<gran>[_hwX.XX]
+  mode="" gran="" hw="NA"
+  if [[ "$base" == hybrid_v4_* ]]; then
+    mode=hybrid_v4
+    rest=${base#hybrid_v4_}
+  elif [[ "$base" == raw_* ]]; then
+    mode=raw
+    rest=${base#raw_}
+  else
+    continue
+  fi
+  if [[ "$rest" == *_hw* ]]; then
+    gran=${rest%%_hw*}
+    hw=${rest#*_hw}
+  else
+    gran=$rest
+  fi
+
+  # SESSION-LEVEL block. "Recall@ 1: 0.x" has space → $3. "Recall@10: 0.x" no space → $2.
+  r1=$(awk  '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@ 1:/  {print $3; exit}' "$f")
+  r5=$(awk  '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@ 5:/  {print $3; exit}' "$f")
+  r10=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@10:/  {print $2; exit}' "$f")
+  r30=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@30:/  {print $2; exit}' "$f")
+  # NDCG@10 / NDCG@30 share the line with Recall: "Recall@10: 0.x    NDCG@10: 0.y"
+  n10=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /NDCG@10:/    {print $4; exit}' "$f")
+  n30=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /NDCG@30:/    {print $4; exit}' "$f")
+  out="$OUTDIR/${base}.jsonl"
+
+  echo "$mode,$gran,$hw,50,$r1,$r5,$r10,$r30,$n10,$n30,$out" >> "$CSV"
+done
+
+echo
+column -ts, "$CSV"

--- a/benchmarks/c_beta/rebuild_csv.sh
+++ b/benchmarks/c_beta/rebuild_csv.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd /Users/macmini/Projects/mempalace
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+cd "$REPO_ROOT"
 OUTDIR=benchmarks/c_beta
 CSV=$OUTDIR/sweep_results.csv
 

--- a/benchmarks/c_beta/run_sweep.sh
+++ b/benchmarks/c_beta/run_sweep.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -uo pipefail
+DATA=/Users/macmini/Projects/metis-pair/benchmarks/data/longmemeval/longmemeval_s_cleaned.json
+SPLIT=benchmarks/lme_split_50_450.json
+OUTDIR=benchmarks/c_beta
+LOG=$OUTDIR/sweep.log
+CSV=$OUTDIR/sweep_results.csv
+
+cd /Users/macmini/Projects/mempalace
+mkdir -p "$OUTDIR"
+: > "$LOG"
+echo "mode,granularity,hybrid_weight,n_questions,wall_sec,recall_at_1,recall_at_5,recall_at_10,recall_at_30,ndcg_at_10,ndcg_at_30,out_file" > "$CSV"
+
+run() {
+  local mode=$1 gran=$2 hw=${3:-}
+  local tag="${mode}_${gran}"
+  local hw_arg=""
+  [[ -n "$hw" ]] && { hw_arg="--hybrid-weight $hw"; tag="${tag}_hw${hw}"; }
+  local out="$OUTDIR/${tag}.jsonl"
+  local stdout="$OUTDIR/${tag}.stdout"
+
+  echo "===== $tag =====" | tee -a "$LOG"
+  local t0=$(date +%s)
+  uv run python benchmarks/longmemeval_bench.py "$DATA" \
+    --mode "$mode" --granularity "$gran" \
+    --split-file "$SPLIT" --dev-only \
+    $hw_arg --out "$out" > "$stdout" 2>&1
+  local rc=$?
+  local t1=$(date +%s)
+  local wall=$((t1 - t0))
+
+  if [[ $rc -ne 0 ]]; then
+    echo "FAIL rc=$rc wall=${wall}s" | tee -a "$LOG"
+    echo "$mode,$gran,${hw:-NA},FAIL,$wall,,,,,,$out" >> "$CSV"
+    return
+  fi
+
+  # Parse session-level recall/ndcg from the "SESSION-LEVEL METRICS:" block.
+  local r1 r5 r10 r30 n10 n30
+  r1=$(awk  '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@ 1:/  {print $2; exit}' "$stdout")
+  r5=$(awk  '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@ 5:/  {print $2; exit}' "$stdout")
+  r10=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@10:/  {print $2; exit}' "$stdout")
+  r30=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@30:/  {print $2; exit}' "$stdout")
+  n10=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /NDCG@10:/    {print $4; exit}' "$stdout")
+  n30=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /NDCG@30:/    {print $4; exit}' "$stdout")
+
+  echo "OK wall=${wall}s R@1=$r1 R@5=$r5 R@10=$r10 R@30=$r30 NDCG@10=$n10 NDCG@30=$n30" | tee -a "$LOG"
+  echo "$mode,$gran,${hw:-NA},50,$wall,$r1,$r5,$r10,$r30,$n10,$n30,$out" >> "$CSV"
+}
+
+# Baseline: raw, no hybrid_weight arg
+run raw session
+run raw turn
+
+# Hybrid v4 sweep across hybrid_weight
+for hw in 0.0 0.30 0.60; do
+  run hybrid_v4 session "$hw"
+  run hybrid_v4 turn    "$hw"
+done
+
+echo "===== DONE =====" | tee -a "$LOG"
+echo "" | tee -a "$LOG"
+column -ts, "$CSV" | tee -a "$LOG"

--- a/benchmarks/c_beta/run_sweep.sh
+++ b/benchmarks/c_beta/run_sweep.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 set -uo pipefail
-DATA=/Users/macmini/Projects/metis-pair/benchmarks/data/longmemeval/longmemeval_s_cleaned.json
+
+# Resolve repo root from this script's location so the sweep is portable.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+cd "$REPO_ROOT"
+
+# DATA is a large external corpus (longmemeval_s_cleaned.json) kept outside the
+# repo. Override via env var; default points at a sibling Projects checkout.
+DATA="${DATA:-$HOME/Projects/metis-pair/benchmarks/data/longmemeval/longmemeval_s_cleaned.json}"
+if [[ ! -f "$DATA" ]]; then
+  echo "ERROR: dataset not found at $DATA" >&2
+  echo "Set DATA=/path/to/longmemeval_s_cleaned.json and re-run." >&2
+  exit 2
+fi
+
 SPLIT=benchmarks/lme_split_50_450.json
 OUTDIR=benchmarks/c_beta
 LOG=$OUTDIR/sweep.log
 CSV=$OUTDIR/sweep_results.csv
-
-cd /Users/macmini/Projects/mempalace
 mkdir -p "$OUTDIR"
 : > "$LOG"
 echo "mode,granularity,hybrid_weight,n_questions,wall_sec,recall_at_1,recall_at_5,recall_at_10,recall_at_30,ndcg_at_10,ndcg_at_30,out_file" > "$CSV"
@@ -36,9 +48,11 @@ run() {
   fi
 
   # Parse session-level recall/ndcg from the "SESSION-LEVEL METRICS:" block.
+  # Single-digit @k prints as "Recall@ 1:" (extra space) → value lands in $3.
+  # Double-digit @k prints as "Recall@10:" (no space)   → value lands in $2.
   local r1 r5 r10 r30 n10 n30
-  r1=$(awk  '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@ 1:/  {print $2; exit}' "$stdout")
-  r5=$(awk  '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@ 5:/  {print $2; exit}' "$stdout")
+  r1=$(awk  '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@ 1:/  {print $3; exit}' "$stdout")
+  r5=$(awk  '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@ 5:/  {print $3; exit}' "$stdout")
   r10=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@10:/  {print $2; exit}' "$stdout")
   r30=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /Recall@30:/  {print $2; exit}' "$stdout")
   n10=$(awk '/SESSION-LEVEL METRICS/{flag=1;next} flag && /NDCG@10:/    {print $4; exit}' "$stdout")

--- a/benchmarks/c_beta/run_turn_sweep.sh
+++ b/benchmarks/c_beta/run_turn_sweep.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -uo pipefail
-cd /Users/macmini/Projects/mempalace
-DATA=/Users/macmini/Projects/metis-pair/benchmarks/data/longmemeval/longmemeval_s_cleaned.json
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+cd "$REPO_ROOT"
+DATA="${DATA:-$HOME/Projects/metis-pair/benchmarks/data/longmemeval/longmemeval_s_cleaned.json}"
+if [[ ! -f "$DATA" ]]; then
+  echo "ERROR: dataset not found at $DATA" >&2
+  exit 2
+fi
 SPLIT=benchmarks/lme_split_50_450.json
 OUTDIR=benchmarks/c_beta
 LOG=$OUTDIR/turn_sweep.log

--- a/benchmarks/c_beta/run_turn_sweep.sh
+++ b/benchmarks/c_beta/run_turn_sweep.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd /Users/macmini/Projects/mempalace
+DATA=/Users/macmini/Projects/metis-pair/benchmarks/data/longmemeval/longmemeval_s_cleaned.json
+SPLIT=benchmarks/lme_split_50_450.json
+OUTDIR=benchmarks/c_beta
+LOG=$OUTDIR/turn_sweep.log
+
+: > "$LOG"
+
+for HW in 0.0 0.30 0.60; do
+  TAG="hybrid_v4_turn_fixed_hw${HW}"
+  OUT="$OUTDIR/${TAG}.jsonl"
+  STDOUT="$OUTDIR/${TAG}.stdout"
+  echo "===== $TAG =====" | tee -a "$LOG"
+  START=$(date +%s)
+  uv run python benchmarks/longmemeval_bench.py "$DATA" \
+    --mode hybrid_v4 --granularity turn --hybrid-weight "$HW" \
+    --split-file "$SPLIT" --dev-only --out "$OUT" \
+    > "$STDOUT" 2>&1
+  RC=$?
+  END=$(date +%s)
+  WALL=$((END - START))
+  if [[ $RC -eq 0 ]]; then
+    R10=$(awk '/SESSION-LEVEL METRICS/{f=1;next} f && /Recall@10:/{print $2; exit}' "$STDOUT")
+    N10=$(awk '/SESSION-LEVEL METRICS/{f=1;next} f && /NDCG@10:/{print $4; exit}' "$STDOUT")
+    echo "OK wall=${WALL}s R@10=$R10 NDCG@10=$N10" | tee -a "$LOG"
+  else
+    echo "FAIL rc=$RC wall=${WALL}s" | tee -a "$LOG"
+  fi
+done
+echo "DONE" | tee -a "$LOG"

--- a/benchmarks/c_beta/sweep.log
+++ b/benchmarks/c_beta/sweep.log
@@ -1,9 +1,27 @@
 ===== raw_session =====
-OK wall=64s R@1=1: R@5=5: R@10=0.980 R@30=1.000 NDCG@10=0.905 NDCG@30=0.909
+OK wall=62s R@1=0.840 R@5=0.960 R@10=0.980 R@30=1.000 NDCG@10=0.905 NDCG@30=0.909
 ===== raw_turn =====
-OK wall=429s R@1=1: R@5=5: R@10=0.960 R@30=0.980 NDCG@10=0.885 NDCG@30=0.861
+OK wall=257s R@1=0.880 R@5=0.940 R@10=0.960 R@30=0.980 NDCG@10=0.885 NDCG@30=0.861
 ===== hybrid_v4_session_hw0.0 =====
-OK wall=90s R@1=1: R@5=5: R@10=1.000 R@30=1.000 NDCG@10=0.937 NDCG@30=0.931
+OK wall=81s R@1=0.880 R@5=0.980 R@10=1.000 R@30=1.000 NDCG@10=0.937 NDCG@30=0.931
 ===== hybrid_v4_turn_hw0.0 =====
-OK wall=85s R@1=1: R@5=5: R@10=1.000 R@30=1.000 NDCG@10=0.937 NDCG@30=0.931
+OK wall=283s R@1=0.900 R@5=0.980 R@10=1.000 R@30=1.000 NDCG@10=0.944 NDCG@30=0.938
 ===== hybrid_v4_session_hw0.30 =====
+OK wall=85s R@1=0.880 R@5=0.960 R@10=1.000 R@30=1.000 NDCG@10=0.944 NDCG@30=0.938
+===== hybrid_v4_turn_hw0.30 =====
+OK wall=288s R@1=0.920 R@5=0.960 R@10=1.000 R@30=1.000 NDCG@10=0.954 NDCG@30=0.949
+===== hybrid_v4_session_hw0.60 =====
+OK wall=90s R@1=0.880 R@5=0.960 R@10=0.980 R@30=1.000 NDCG@10=0.936 NDCG@30=0.936
+===== hybrid_v4_turn_hw0.60 =====
+OK wall=285s R@1=0.920 R@5=0.960 R@10=1.000 R@30=1.000 NDCG@10=0.951 NDCG@30=0.951
+===== DONE =====
+
+mode       granularity  hybrid_weight  n_questions  wall_sec  recall_at_1  recall_at_5  recall_at_10  recall_at_30  ndcg_at_10  ndcg_at_30  out_file
+raw        session      NA             50           62        0.840        0.960        0.980         1.000         0.905       0.909       benchmarks/c_beta/raw_session.jsonl
+raw        turn         NA             50           257       0.880        0.940        0.960         0.980         0.885       0.861       benchmarks/c_beta/raw_turn.jsonl
+hybrid_v4  session      0.0            50           81        0.880        0.980        1.000         1.000         0.937       0.931       benchmarks/c_beta/hybrid_v4_session_hw0.0.jsonl
+hybrid_v4  turn         0.0            50           283       0.900        0.980        1.000         1.000         0.944       0.938       benchmarks/c_beta/hybrid_v4_turn_hw0.0.jsonl
+hybrid_v4  session      0.30           50           85        0.880        0.960        1.000         1.000         0.944       0.938       benchmarks/c_beta/hybrid_v4_session_hw0.30.jsonl
+hybrid_v4  turn         0.30           50           288       0.920        0.960        1.000         1.000         0.954       0.949       benchmarks/c_beta/hybrid_v4_turn_hw0.30.jsonl
+hybrid_v4  session      0.60           50           90        0.880        0.960        0.980         1.000         0.936       0.936       benchmarks/c_beta/hybrid_v4_session_hw0.60.jsonl
+hybrid_v4  turn         0.60           50           285       0.920        0.960        1.000         1.000         0.951       0.951       benchmarks/c_beta/hybrid_v4_turn_hw0.60.jsonl

--- a/benchmarks/c_beta/sweep.log
+++ b/benchmarks/c_beta/sweep.log
@@ -1,0 +1,9 @@
+===== raw_session =====
+OK wall=64s R@1=1: R@5=5: R@10=0.980 R@30=1.000 NDCG@10=0.905 NDCG@30=0.909
+===== raw_turn =====
+OK wall=429s R@1=1: R@5=5: R@10=0.960 R@30=0.980 NDCG@10=0.885 NDCG@30=0.861
+===== hybrid_v4_session_hw0.0 =====
+OK wall=90s R@1=1: R@5=5: R@10=1.000 R@30=1.000 NDCG@10=0.937 NDCG@30=0.931
+===== hybrid_v4_turn_hw0.0 =====
+OK wall=85s R@1=1: R@5=5: R@10=1.000 R@30=1.000 NDCG@10=0.937 NDCG@30=0.931
+===== hybrid_v4_session_hw0.30 =====

--- a/benchmarks/c_beta/sweep_results.csv
+++ b/benchmarks/c_beta/sweep_results.csv
@@ -1,7 +1,9 @@
-mode,granularity,hybrid_weight,n_questions,recall_at_1,recall_at_5,recall_at_10,recall_at_30,ndcg_at_10,ndcg_at_30,out_file
-hybrid_v4,session,0.0,50,0.880,0.980,1.000,1.000,0.937,0.931,benchmarks/c_beta/hybrid_v4_session_hw0.0.jsonl
-hybrid_v4,session,0.30,50,0.880,0.960,1.000,1.000,0.944,0.938,benchmarks/c_beta/hybrid_v4_session_hw0.30.jsonl
-hybrid_v4,session,0.60,50,0.880,0.960,0.980,1.000,0.936,0.936,benchmarks/c_beta/hybrid_v4_session_hw0.60.jsonl
-hybrid_v4,turn,0.0,50,0.880,0.980,1.000,1.000,0.937,0.931,benchmarks/c_beta/hybrid_v4_turn_hw0.0.jsonl
-raw,session,NA,50,0.840,0.960,0.980,1.000,0.905,0.909,benchmarks/c_beta/raw_session.jsonl
-raw,turn,NA,50,0.880,0.940,0.960,0.980,0.885,0.861,benchmarks/c_beta/raw_turn.jsonl
+mode,granularity,hybrid_weight,n_questions,wall_sec,recall_at_1,recall_at_5,recall_at_10,recall_at_30,ndcg_at_10,ndcg_at_30,out_file
+raw,session,NA,50,62,0.840,0.960,0.980,1.000,0.905,0.909,benchmarks/c_beta/raw_session.jsonl
+raw,turn,NA,50,257,0.880,0.940,0.960,0.980,0.885,0.861,benchmarks/c_beta/raw_turn.jsonl
+hybrid_v4,session,0.0,50,81,0.880,0.980,1.000,1.000,0.937,0.931,benchmarks/c_beta/hybrid_v4_session_hw0.0.jsonl
+hybrid_v4,turn,0.0,50,283,0.900,0.980,1.000,1.000,0.944,0.938,benchmarks/c_beta/hybrid_v4_turn_hw0.0.jsonl
+hybrid_v4,session,0.30,50,85,0.880,0.960,1.000,1.000,0.944,0.938,benchmarks/c_beta/hybrid_v4_session_hw0.30.jsonl
+hybrid_v4,turn,0.30,50,288,0.920,0.960,1.000,1.000,0.954,0.949,benchmarks/c_beta/hybrid_v4_turn_hw0.30.jsonl
+hybrid_v4,session,0.60,50,90,0.880,0.960,0.980,1.000,0.936,0.936,benchmarks/c_beta/hybrid_v4_session_hw0.60.jsonl
+hybrid_v4,turn,0.60,50,285,0.920,0.960,1.000,1.000,0.951,0.951,benchmarks/c_beta/hybrid_v4_turn_hw0.60.jsonl

--- a/benchmarks/c_beta/sweep_results.csv
+++ b/benchmarks/c_beta/sweep_results.csv
@@ -1,0 +1,7 @@
+mode,granularity,hybrid_weight,n_questions,recall_at_1,recall_at_5,recall_at_10,recall_at_30,ndcg_at_10,ndcg_at_30,out_file
+hybrid_v4,session,0.0,50,0.880,0.980,1.000,1.000,0.937,0.931,benchmarks/c_beta/hybrid_v4_session_hw0.0.jsonl
+hybrid_v4,session,0.30,50,0.880,0.960,1.000,1.000,0.944,0.938,benchmarks/c_beta/hybrid_v4_session_hw0.30.jsonl
+hybrid_v4,session,0.60,50,0.880,0.960,0.980,1.000,0.936,0.936,benchmarks/c_beta/hybrid_v4_session_hw0.60.jsonl
+hybrid_v4,turn,0.0,50,0.880,0.980,1.000,1.000,0.937,0.931,benchmarks/c_beta/hybrid_v4_turn_hw0.0.jsonl
+raw,session,NA,50,0.840,0.960,0.980,1.000,0.905,0.909,benchmarks/c_beta/raw_session.jsonl
+raw,turn,NA,50,0.880,0.940,0.960,0.980,0.885,0.861,benchmarks/c_beta/raw_turn.jsonl

--- a/benchmarks/c_beta/turn_sweep.log
+++ b/benchmarks/c_beta/turn_sweep.log
@@ -1,0 +1,7 @@
+===== hybrid_v4_turn_fixed_hw0.0 =====
+OK wall=295s R@10=0.980 NDCG@10=0.924
+===== hybrid_v4_turn_fixed_hw0.30 =====
+OK wall=305s R@10=0.980 NDCG@10=0.934
+===== hybrid_v4_turn_fixed_hw0.60 =====
+OK wall=299s R@10=0.980 NDCG@10=0.931
+DONE

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -1658,11 +1658,31 @@ def build_palace_and_retrieve_hybrid_v4(
         all_turns = [t["content"] for t in session]
         if not user_turns:
             continue
-        corpus_user.append("\n".join(user_turns))
-        corpus_full.append("\n".join(all_turns))
-        corpus_ids.append(sess_id)
-        corpus_timestamps.append(date)
 
+        if granularity == "session":
+            corpus_user.append("\n".join(user_turns))
+            corpus_full.append("\n".join(all_turns))
+            corpus_ids.append(sess_id)
+            corpus_timestamps.append(date)
+        else:
+            # Turn granularity: index each user turn separately.
+            # corpus_full[i] mirrors corpus_user[i] so the assistant-reference
+            # two-pass still has a doc to query (assistant turns are not
+            # indexed as primary docs but their content is preserved via
+            # pref/quoted-phrase boosts at session level).
+            turn_idx = 0
+            for t in session:
+                if t["role"] != "user":
+                    turn_idx += 1
+                    continue
+                corpus_user.append(t["content"])
+                corpus_full.append(t["content"])
+                corpus_ids.append(f"{sess_id}_turn_{turn_idx}")
+                corpus_timestamps.append(date)
+                turn_idx += 1
+
+        # Preferences stay session-aggregated regardless of granularity —
+        # they are synthetic summaries of the whole session.
         prefs = extract_preferences(session)
         if prefs:
             pref_doc = "User has mentioned: " + "; ".join(prefs)
@@ -1713,13 +1733,15 @@ def build_palace_and_retrieve_hybrid_v4(
         seen = set()
         ranked_indices = []
         for idx, _ in scored:
-            if corpus_ids[idx] not in seen:
-                seen.add(corpus_ids[idx])
+            sid = session_id_from_corpus_id(corpus_ids[idx])
+            if sid not in seen:
+                seen.add(sid)
                 ranked_indices.append(idx)
         for i in range(len(corpus_user)):
-            if corpus_ids[i] not in seen:
+            sid = session_id_from_corpus_id(corpus_ids[i])
+            if sid not in seen:
                 ranked_indices.append(i)
-                seen.add(corpus_ids[i])
+                seen.add(sid)
         return ranked_indices, corpus_user, corpus_ids, corpus_timestamps
 
     # -------------------------------------------------------------------------
@@ -1787,19 +1809,33 @@ def build_palace_and_retrieve_hybrid_v4(
 
     scored.sort(key=lambda x: x[1])
 
-    corpus_id_to_user_idx = {cid: i for i, cid in enumerate(corpus_ids)}
-    seen_ids = set()
+    # Map both turn-level corpus_ids and their session keys to a user-doc index.
+    # In session granularity, sess_id == corpus_id, so the inner branch is a no-op.
+    # In turn granularity, the session key resolves to the first turn of that session
+    # so a pref-doc hit (whose meta-id is a plain sess_id) can be remapped.
+    corpus_id_to_user_idx = {}
+    for i, cid in enumerate(corpus_ids):
+        corpus_id_to_user_idx[cid] = i
+        sid = session_id_from_corpus_id(cid)
+        if sid not in corpus_id_to_user_idx:
+            corpus_id_to_user_idx[sid] = i
+
+    seen_sids = set()
     ranked_indices = []
     for idx, _ in scored:
         cid = all_ids_meta[idx]
-        if cid not in seen_ids:
-            seen_ids.add(cid)
-            ranked_indices.append(corpus_id_to_user_idx[cid])
+        sid = session_id_from_corpus_id(cid)
+        if sid in seen_sids:
+            continue
+        seen_sids.add(sid)
+        target = cid if cid in corpus_id_to_user_idx else sid
+        ranked_indices.append(corpus_id_to_user_idx[target])
 
     for i in range(len(corpus_user)):
-        if corpus_ids[i] not in seen_ids:
+        sid = session_id_from_corpus_id(corpus_ids[i])
+        if sid not in seen_sids:
             ranked_indices.append(i)
-            seen_ids.add(corpus_ids[i])
+            seen_sids.add(sid)
 
     return ranked_indices, corpus_user, corpus_ids, corpus_timestamps
 

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -882,7 +882,11 @@ def build_palace_and_retrieve_hybrid_v2(
                     turn_idx += 1
                     continue
                 corpus_user.append(t["content"])
-                corpus_full.append(t["content"])
+                # Pass 2 of the assistant-reference two-pass queries corpus_full
+                # for quoted/assistant content, so it must contain the full
+                # session text even in turn granularity. corpus_user stays the
+                # single user turn so the primary retrieval signal is granular.
+                corpus_full.append("\n".join(all_turns))
                 corpus_ids.append(f"{sess_id}_turn_{turn_idx}")
                 corpus_timestamps.append(date)
                 turn_idx += 1
@@ -1242,7 +1246,11 @@ def build_palace_and_retrieve_hybrid_v3(
                     turn_idx += 1
                     continue
                 corpus_user.append(t["content"])
-                corpus_full.append(t["content"])
+                # Pass 2 of the assistant-reference two-pass queries corpus_full
+                # for quoted/assistant content, so it must contain the full
+                # session text even in turn granularity. corpus_user stays the
+                # single user turn so the primary retrieval signal is granular.
+                corpus_full.append("\n".join(all_turns))
                 corpus_ids.append(f"{sess_id}_turn_{turn_idx}")
                 corpus_timestamps.append(date)
                 turn_idx += 1
@@ -1730,17 +1738,17 @@ def build_palace_and_retrieve_hybrid_v4(
             corpus_timestamps.append(date)
         else:
             # Turn granularity: index each user turn separately.
-            # corpus_full[i] mirrors corpus_user[i] so the assistant-reference
-            # two-pass still has a doc to query (assistant turns are not
-            # indexed as primary docs but their content is preserved via
-            # pref/quoted-phrase boosts at session level).
             turn_idx = 0
             for t in session:
                 if t["role"] != "user":
                     turn_idx += 1
                     continue
                 corpus_user.append(t["content"])
-                corpus_full.append(t["content"])
+                # Pass 2 of the assistant-reference two-pass queries corpus_full
+                # for quoted/assistant content, so it must contain the full
+                # session text even in turn granularity. corpus_user stays the
+                # single user turn so the primary retrieval signal is granular.
+                corpus_full.append("\n".join(all_turns))
                 corpus_ids.append(f"{sess_id}_turn_{turn_idx}")
                 corpus_timestamps.append(date)
                 turn_idx += 1

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -868,11 +868,24 @@ def build_palace_and_retrieve_hybrid_v2(
     for session, sess_id, date in zip(sessions, session_ids, dates):
         user_turns = [t["content"] for t in session if t["role"] == "user"]
         all_turns = [t["content"] for t in session]
-        if user_turns:
+        if not user_turns:
+            continue
+        if granularity == "session":
             corpus_user.append("\n".join(user_turns))
             corpus_full.append("\n".join(all_turns))
             corpus_ids.append(sess_id)
             corpus_timestamps.append(date)
+        else:
+            turn_idx = 0
+            for t in session:
+                if t["role"] != "user":
+                    turn_idx += 1
+                    continue
+                corpus_user.append(t["content"])
+                corpus_full.append(t["content"])
+                corpus_ids.append(f"{sess_id}_turn_{turn_idx}")
+                corpus_timestamps.append(date)
+                turn_idx += 1
 
     if not corpus_user:
         return [], corpus_user, corpus_ids, corpus_timestamps
@@ -914,10 +927,22 @@ def build_palace_and_retrieve_hybrid_v2(
             n_results=min(n_results, len(top_corpus_full)),
             include=["distances", "metadatas"],
         )
-        # Build final rankings: two-pass top sessions first, then rest
+        # Build final rankings: two-pass top sessions first, then rest.
+        # Dedup by session id so turn-granularity entries from the same
+        # session collapse to one rank.
         two_pass_order = [top_indices[int(rid.split("_")[1])] for rid in results2["ids"][0]]
-        seen = set(two_pass_order)
-        ranked_indices = two_pass_order + [i for i in range(len(corpus_user)) if i not in seen]
+        seen_sids = set()
+        ranked_indices = []
+        for idx in two_pass_order:
+            sid = session_id_from_corpus_id(corpus_ids[idx])
+            if sid not in seen_sids:
+                seen_sids.add(sid)
+                ranked_indices.append(idx)
+        for i in range(len(corpus_user)):
+            sid = session_id_from_corpus_id(corpus_ids[i])
+            if sid not in seen_sids:
+                seen_sids.add(sid)
+                ranked_indices.append(i)
         return ranked_indices, corpus_user, corpus_ids, corpus_timestamps
 
     # -------------------------------------------------------------------------
@@ -976,11 +1001,17 @@ def build_palace_and_retrieve_hybrid_v2(
         scored.append((idx, fused_dist))
 
     scored.sort(key=lambda x: x[1])
-    ranked_indices = [idx for idx, _ in scored]
-
-    seen = set(ranked_indices)
+    seen_sids = set()
+    ranked_indices = []
+    for idx, _ in scored:
+        sid = session_id_from_corpus_id(corpus_ids[idx])
+        if sid not in seen_sids:
+            seen_sids.add(sid)
+            ranked_indices.append(idx)
     for i in range(len(corpus_user)):
-        if i not in seen:
+        sid = session_id_from_corpus_id(corpus_ids[i])
+        if sid not in seen_sids:
+            seen_sids.add(sid)
             ranked_indices.append(i)
 
     return ranked_indices, corpus_user, corpus_ids, corpus_timestamps
@@ -1199,12 +1230,24 @@ def build_palace_and_retrieve_hybrid_v3(
         all_turns = [t["content"] for t in session]
         if not user_turns:
             continue
-        corpus_user.append("\n".join(user_turns))
-        corpus_full.append("\n".join(all_turns))
-        corpus_ids.append(sess_id)
-        corpus_timestamps.append(date)
+        if granularity == "session":
+            corpus_user.append("\n".join(user_turns))
+            corpus_full.append("\n".join(all_turns))
+            corpus_ids.append(sess_id)
+            corpus_timestamps.append(date)
+        else:
+            turn_idx = 0
+            for t in session:
+                if t["role"] != "user":
+                    turn_idx += 1
+                    continue
+                corpus_user.append(t["content"])
+                corpus_full.append(t["content"])
+                corpus_ids.append(f"{sess_id}_turn_{turn_idx}")
+                corpus_timestamps.append(date)
+                turn_idx += 1
 
-        # Extract preferences and build synthetic document
+        # Preferences stay session-aggregated regardless of granularity.
         prefs = extract_preferences(session)
         if prefs:
             pref_doc = "User has mentioned: " + "; ".join(prefs)
@@ -1251,8 +1294,18 @@ def build_palace_and_retrieve_hybrid_v3(
             include=["distances", "metadatas"],
         )
         two_pass_order = [top_indices[int(rid.split("_")[1])] for rid in results2["ids"][0]]
-        seen = set(two_pass_order)
-        ranked_indices = two_pass_order + [i for i in range(len(corpus_user)) if i not in seen]
+        seen_sids = set()
+        ranked_indices = []
+        for idx in two_pass_order:
+            sid = session_id_from_corpus_id(corpus_ids[idx])
+            if sid not in seen_sids:
+                seen_sids.add(sid)
+                ranked_indices.append(idx)
+        for i in range(len(corpus_user)):
+            sid = session_id_from_corpus_id(corpus_ids[i])
+            if sid not in seen_sids:
+                seen_sids.add(sid)
+                ranked_indices.append(i)
         return ranked_indices, corpus_user, corpus_ids, corpus_timestamps
 
     # -------------------------------------------------------------------------
@@ -1315,23 +1368,34 @@ def build_palace_and_retrieve_hybrid_v3(
 
     scored.sort(key=lambda x: x[1])
 
-    # Map back to corpus_user indices via corpus_id — deduplicate at session level
-    # A pref doc and its session doc both map to the same corpus_id.
-    # Keep whichever ranks first; map back to corpus_user index for evaluation.
-    corpus_id_to_user_idx = {cid: i for i, cid in enumerate(corpus_ids)}
-    seen_ids = set()
+    # Map both turn-level corpus_ids and their session keys to a user-doc idx,
+    # so pref-doc hits (whose meta-id is a plain sess_id) can be resolved in
+    # both granularities. In session mode sid == cid so the inner branch is
+    # a no-op.
+    corpus_id_to_user_idx = {}
+    for i, cid in enumerate(corpus_ids):
+        corpus_id_to_user_idx[cid] = i
+        sid = session_id_from_corpus_id(cid)
+        if sid not in corpus_id_to_user_idx:
+            corpus_id_to_user_idx[sid] = i
+
+    seen_sids = set()
     ranked_indices = []
     for idx, _ in scored:
         cid = all_ids_meta[idx]
-        if cid not in seen_ids:
-            seen_ids.add(cid)
-            ranked_indices.append(corpus_id_to_user_idx[cid])
+        sid = session_id_from_corpus_id(cid)
+        if sid in seen_sids:
+            continue
+        seen_sids.add(sid)
+        target = cid if cid in corpus_id_to_user_idx else sid
+        ranked_indices.append(corpus_id_to_user_idx[target])
 
     # Fill in any sessions not yet ranked
     for i in range(len(corpus_user)):
-        if corpus_ids[i] not in seen_ids:
+        sid = session_id_from_corpus_id(corpus_ids[i])
+        if sid not in seen_sids:
             ranked_indices.append(i)
-            seen_ids.add(corpus_ids[i])
+            seen_sids.add(sid)
 
     return ranked_indices, corpus_user, corpus_ids, corpus_timestamps
 
@@ -2056,7 +2120,17 @@ def build_palace_and_retrieve_palace(
       3. PASS 2 (fallback): search full haystack with hall-aware scoring
          Sessions in the primary hall get a 25% distance bonus
       4. For assistant-reference questions: open drawers within top sessions
+
+    Granularity: palace mode is intrinsically session-level — hall classification,
+    closets, drawers, and the preference wing are all session-keyed. Turn-level
+    palace retrieval is not supported; pass granularity="session".
     """
+    if granularity != "session":
+        raise ValueError(
+            "palace mode only supports granularity='session' "
+            "(hall classification, drawers, and the preference wing are session-keyed)."
+        )
+
     import re as _re
     from datetime import datetime, timedelta
 
@@ -2505,7 +2579,17 @@ def build_palace_and_retrieve_diary(
     diary_cache: dict mapping sess_id → {"topics": [...], "summary": "..."}
                  Pre-populated before the benchmark loop to avoid redundant API calls.
                  Pass the same dict across all questions — it grows as new sessions appear.
+
+    Granularity: diary mode is intrinsically session-level — the LLM topic
+    layer is computed per session and keyed by sess_id. Turn-level diary
+    retrieval is not supported; pass granularity="session".
     """
+    if granularity != "session":
+        raise ValueError(
+            "diary mode only supports granularity='session' "
+            "(LLM topic layer is session-keyed and cached per sess_id)."
+        )
+
     import re as _re
     from datetime import datetime, timedelta
 


### PR DESCRIPTION
## Summary

`build_palace_and_retrieve_hybrid_v4` (and three of its siblings) accepted a `granularity` parameter but never branched on it. With the defect in place, `--granularity turn` and `--granularity session` produced bitwise-identical metrics for those modes.

This PR fixes the dead-parameter defect across the affected modes, and includes a small benchmark sweep that uses the fix to test a hypothesis on `hybrid_v4`.

## What's defective and what each commit does

| function | granularity branched before? | this PR's fix |
|---|---|---|
| `raw` / `aaak` / `rooms` / `hybrid` / `full` | yes | none, already honored the flag |
| `hybrid_v2` | no | per-turn corpus + session-id dedup (commit 2) |
| `hybrid_v3` | no | per-turn corpus + session-id dedup (commit 2) |
| `hybrid_v4` | no | per-turn corpus + session-id dedup (commit 1) |
| `palace` | no | explicit `ValueError` on `granularity != "session"`, hall classification, drawers, and the preference wing are intrinsically session-keyed (commit 2) |
| `diary` | no | explicit `ValueError` on `granularity != "session"`, LLM topic layer is computed and cached per `sess_id` (commit 2) |

## Fix shape (hybrid_v2 / v3 / v4)

- Branch the corpus build on `granularity`. In `turn` mode, emit one doc per user turn with corpus IDs shaped as `{sess_id}_turn_{i}` so the existing `session_id_from_corpus_id` helper rolls turns up to sessions at eval time.
- In turn mode, `corpus_full[i]` mirrors the full session text (not the single user turn) so Pass 2 of the assistant-reference two-pass has assistant content to query against. `corpus_user[i]` stays the granular per-turn signal.
- Dedup by session id in both the assistant-reference two-pass and the main scoring path, so multiple high-scoring turns of the same session collapse to a single ranked entry.
- Keep synthetic preference docs session-aggregated; map a pref-driven hit to the first user-turn index of its session.
- Session-mode behavior is unchanged (sess_id == corpus_id, so `session_id_from_corpus_id` is a no-op there).

## Sweep + hypothesis test (hybrid_v4)

`benchmarks/c_beta/` (PLAN.md + RESULTS.md + scripts + logs). 50q dev split, default MiniLM, no LLM rerank. **All numbers below are post-fix**, the full 8-row matrix was re-run after the gemini-code-assist review caught a remaining defect in turn-mode `corpus_full` (see commit `fbbbfa0` / `389650d`).

| mode | gran | hw | R@1 | R@10 | NDCG@10 |
|---|---|---|---|---|---|
| raw | session |, | 0.840 | 0.980 | 0.905 |
| raw | turn |, | 0.880 | 0.960 | 0.885 |
| hybrid_v4 | session | 0.0 | 0.880 | 1.000 | 0.937 |
| hybrid_v4 | session | 0.30 | 0.880 | 1.000 | 0.944 |
| hybrid_v4 | session | 0.60 | 0.880 | 0.980 | 0.936 |
| hybrid_v4 | turn | 0.0 | 0.900 | 1.000 | 0.944 |
| hybrid_v4 | turn | 0.30 | 0.920 | 1.000 | **0.954** |
| hybrid_v4 | turn | 0.60 | 0.920 | 1.000 | 0.951 |

**H0 (wash) rejected.** Keyword-boost NDCG@10 lift hw=0.0→0.30: turn +0.010 vs session +0.007. Same concave shape (peak at hw=0.30, drop at hw=0.60) across both granularities, so the keyword signal is not a session-length artifact.

**Secondary finding:** post-fix, `hybrid_v4 turn` matches or beats `hybrid_v4 session` on NDCG@10 at every hw tested (Δ = +0.007, +0.010, +0.015 for hw = 0.0/0.30/0.60). The pre-fix table showed the inverse because turn mode was silently dropping assistant content from Pass 2. Sample is 50q, directional, not yet a default-flip recommendation. Full 500q bootstrap is the honest next step.

## Test plan

- [x] 5q smoke on `hybrid_v4 turn hw=0.30` → all hits
- [x] 50q dev-split sweep on `hybrid_v4`, 3 hw values, both granularities → see RESULTS.md
- [x] 5q smoke on `hybrid_v2 turn hw=0.30` → all hits
- [x] 5q smoke on `hybrid_v3 turn hw=0.30` → all hits
- [x] `palace turn` raises `ValueError` cleanly
- [x] `palace session` unchanged from baseline (R@10 1.000, NDCG@10 0.852)
- [x] Confirmed `hybrid_v4 session` metrics unchanged vs pre-fix run
- [x] gemini-code-assist review (3 items) addressed and re-validated by full sweep rerun
- [ ] CI: ruff + pytest on PR
