### PR TITLE
feat(backends): add sqlite-vec backend

### DIFF
--- a/mempalace/backends/__init__.py
+++ b/mempalace/backends/__init__.py
@@ -29,6 +29,7 @@ from .base import (
     UnsupportedFilterError,
 )
 from .chroma import ChromaBackend, ChromaCollection
+from .sqlite_vec import SQLiteVecBackend, SQLiteVecCollection
 from .registry import (
     available_backends,
     get_backend,
@@ -46,6 +47,8 @@ __all__ = [
     "BaseCollection",
     "ChromaBackend",
     "ChromaCollection",
+    "SQLiteVecBackend",
+    "SQLiteVecCollection",
     "DimensionMismatchError",
     "EmbedderIdentityMismatchError",
     "GetResult",

--- a/mempalace/backends/registry.py
+++ b/mempalace/backends/registry.py
@@ -178,12 +178,22 @@ def resolve_backend_for_palace(
 
 
 def _register_builtins() -> None:
-    """Register chroma as the in-tree default."""
+    """Register chroma + sqlite-vec as in-tree backends.
+
+    sqlite-vec is registered eagerly so it appears in
+    ``available_backends()``; the import is light (no network, no DB I/O).
+    The first ``get_backend('sqlite-vec')`` call inside
+    :class:`~mempalace.backends.sqlite_vec.SQLiteVecBackend` is what loads
+    the sqlite-vec extension into a per-palace connection.
+    """
     from .chroma import ChromaBackend
+    from .sqlite_vec import SQLiteVecBackend
 
     # Use setdefault semantics so a caller that pre-registered for tests wins.
     if "chroma" not in _registry:
         _registry["chroma"] = ChromaBackend
+    if "sqlite-vec" not in _registry:
+        _registry["sqlite-vec"] = SQLiteVecBackend
 
 
 _register_builtins()

--- a/mempalace/backends/sqlite_vec.py
+++ b/mempalace/backends/sqlite_vec.py
@@ -16,15 +16,19 @@ $and, $or, $contains, $gt, $gte, $lt, $lte) via SQLite json_extract.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import re
 import sqlite3
 import struct
+import threading
 from typing import Any, ClassVar, Optional
 
-import sqlite_vec as _sqlite_vec_ext
+# ``sqlite_vec`` is an optional dependency: imported lazily inside ``_open_db``
+# so the registry can advertise this backend (``available_backends()``) on
+# every install without crashing default-Chroma users at import time.
 
 from .base import (
     BackendClosedError,
@@ -55,24 +59,42 @@ _SUPPORTED_OPERATORS = _REQUIRED_OPERATORS | _OPTIONAL_OPERATORS
 
 
 def _sanitize_table_suffix(name: str) -> str:
-    """Sanitize collection name into safe SQL identifier suffix."""
-    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-    if not sanitized:
-        sanitized = "_anon"
-    elif sanitized[0].isdigit():
+    """Sanitize a collection name into a safe SQL identifier suffix.
+
+    When the input is already a clean ``[a-zA-Z_][a-zA-Z0-9_]*`` token of at
+    most 40 characters, the original name is used verbatim. Otherwise a short
+    hash of the original name is appended so that two collections whose first
+    40 sanitised characters collide still get distinct virtual-table names
+    (review feedback on PR #1525).
+    """
+    needs_hash = len(name) > 40 or not _FIELD_NAME_RE.match(name)
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", name) or "_anon"
+    if sanitized[0].isdigit():
         sanitized = f"c_{sanitized}"
-    return sanitized[:48]
+    if not needs_hash:
+        return sanitized[:48]
+    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:8]
+    return f"{sanitized[:40]}_{digest}"
+
+
+# Field names valid for direct identifier use in SQL. Everything else routes
+# through ``json_extract`` with a parameter-bound path (review feedback on
+# PR #1525: f-string interpolation of metadata keys is SQL-injection-shaped).
+_FIELD_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 
 def _pack_vec(values) -> bytes:
+    # ``sqlite-vec`` consumes 32-bit floats in little-endian regardless of
+    # host architecture; pin the format prefix so a palace remains portable
+    # across machines (review feedback on PR #1525).
     if not isinstance(values, (list, tuple)):
         values = list(values)
-    return struct.pack(f"{len(values)}f", *values)
+    return struct.pack(f"<{len(values)}f", *values)
 
 
 def _unpack_vec(blob: bytes) -> list[float]:
     n = len(blob) // 4
-    return list(struct.unpack(f"{n}f", blob))
+    return list(struct.unpack(f"<{n}f", blob))
 
 
 # ---------------------------------------------------------------------------
@@ -133,23 +155,46 @@ def _translate_node(node: Any, *, alias: str) -> tuple[str, list[Any]]:
     return " AND ".join(parts), all_params
 
 
-def _field_expr(field: str, *, alias: str) -> str:
-    """Return SQL expression for accessing field — either column or json_extract."""
+def _field_expr(field: str, *, alias: str) -> tuple[str, list[Any]]:
+    """Return SQL expression for accessing a field plus any params it needs.
+
+    ``document`` and ``id`` resolve to identifier columns. Anything else
+    routes through ``json_extract(metadata_json, ?)`` with the JSON path
+    bound as a parameter — never interpolated into the SQL string — to
+    foreclose SQL injection through user-supplied where keys (review
+    feedback on PR #1525).
+    """
     if field == "document":
-        return f"{alias}.document"
+        return f"{alias}.document", []
     if field == "id":
-        return f"{alias}.id"
-    # Default: read from metadata_json
-    return f"json_extract({alias}.metadata_json, '$.{field}')"
+        return f"{alias}.id", []
+    if not _FIELD_NAME_RE.match(field):
+        raise UnsupportedFilterError(
+            f"metadata field {field!r} must match [a-zA-Z_][a-zA-Z0-9_]* "
+            "(nested JSON paths not supported)"
+        )
+    return f"json_extract({alias}.metadata_json, ?)", [f"$.{field}"]
 
 
 def _translate_field(field: str, value: Any, *, alias: str) -> tuple[str, list[Any]]:
-    """Translate {field: value-or-operator-dict} pair."""
-    expr = _field_expr(field, alias=alias)
+    """Translate {field: value-or-operator-dict} pair.
+
+    Every emission of the field expression is paired with its parameters
+    (currently empty for column accesses, ``['$.field']`` for json_extract)
+    so the placeholder order stays consistent with the resulting SQL.
+    """
+    expr, expr_params = _field_expr(field, alias=alias)
+
+    def emit(template: str, *values: Any) -> tuple[str, list[Any]]:
+        """Replace one or two ``{expr}`` markers; emit ``expr_params`` per copy."""
+        copies = template.count("{expr}")
+        rendered = template.replace("{expr}", expr)
+        return rendered, list(expr_params) * copies + list(values)
 
     # Plain scalar → $eq
     if not isinstance(value, dict):
-        return f"{expr} = ?", [value]
+        sql, params = emit("{expr} = ?", value)
+        return sql, params
 
     # Operator dict
     parts: list[str] = []
@@ -158,38 +203,31 @@ def _translate_field(field: str, value: Any, *, alias: str) -> tuple[str, list[A
         if op not in _SUPPORTED_OPERATORS:
             raise UnsupportedFilterError(f"operator {op!r} not supported by sqlite-vec backend")
         if op == "$eq":
-            parts.append(f"{expr} = ?")
-            params.append(op_val)
+            sql, p = emit("{expr} = ?", op_val)
         elif op == "$ne":
-            parts.append(f"({expr} IS NULL OR {expr} != ?)")
-            params.append(op_val)
+            sql, p = emit("({expr} IS NULL OR {expr} != ?)", op_val)
         elif op == "$in":
             if not isinstance(op_val, (list, tuple)) or not op_val:
                 raise UnsupportedFilterError("$in requires non-empty list")
             placeholders = ",".join("?" for _ in op_val)
-            parts.append(f"{expr} IN ({placeholders})")
-            params.extend(op_val)
+            sql, p = emit(f"{{expr}} IN ({placeholders})", *op_val)
         elif op == "$nin":
             if not isinstance(op_val, (list, tuple)) or not op_val:
                 raise UnsupportedFilterError("$nin requires non-empty list")
             placeholders = ",".join("?" for _ in op_val)
-            parts.append(f"({expr} IS NULL OR {expr} NOT IN ({placeholders}))")
-            params.extend(op_val)
+            sql, p = emit(f"({{expr}} IS NULL OR {{expr}} NOT IN ({placeholders}))", *op_val)
         elif op == "$contains":
-            parts.append(f"{expr} LIKE ?")
-            params.append(f"%{op_val}%")
+            sql, p = emit("{expr} LIKE ?", f"%{op_val}%")
         elif op == "$gt":
-            parts.append(f"{expr} > ?")
-            params.append(op_val)
+            sql, p = emit("{expr} > ?", op_val)
         elif op == "$gte":
-            parts.append(f"{expr} >= ?")
-            params.append(op_val)
+            sql, p = emit("{expr} >= ?", op_val)
         elif op == "$lt":
-            parts.append(f"{expr} < ?")
-            params.append(op_val)
+            sql, p = emit("{expr} < ?", op_val)
         elif op == "$lte":
-            parts.append(f"{expr} <= ?")
-            params.append(op_val)
+            sql, p = emit("{expr} <= ?", op_val)
+        parts.append(sql)
+        params.extend(p)
     return " AND ".join(parts), params
 
 
@@ -661,8 +699,12 @@ class SQLiteVecBackend(BaseBackend):
           and by callers that pre-embed at a different layer.
         * callable — use as-is (typically a Chroma-style ``EmbeddingFunction``).
         """
-        # palace_path -> sqlite3.Connection (long-lived per palace)
+        # palace_path -> sqlite3.Connection (long-lived per palace).
+        # Connection map is shared across get_collection calls; concurrent
+        # opens of distinct palaces are common, so guard with a lock to
+        # prevent duplicate cache entries / extension-load races.
         self._connections: dict[str, sqlite3.Connection] = {}
+        self._connections_lock = threading.Lock()
         self._closed = False
         self._embedder = embedder
         self._embedder_resolved = embedder is False or callable(embedder)
@@ -684,50 +726,71 @@ class SQLiteVecBackend(BaseBackend):
     def _open_db(self, palace_path: str) -> sqlite3.Connection:
         if self._closed:
             raise BackendClosedError("backend closed")
+
+        # Double-checked locking: a hot-path get_collection should not pay
+        # the lock cost once the connection exists, but the open path must
+        # serialise so two concurrent get_collection calls don't both create
+        # the same connection and leak one.
         cached = self._connections.get(palace_path)
         if cached is not None:
             return cached
+        with self._connections_lock:
+            cached = self._connections.get(palace_path)
+            if cached is not None:
+                return cached
 
-        os.makedirs(palace_path, exist_ok=True)
-        db_path = os.path.join(palace_path, DB_FILENAME)
-        db = sqlite3.connect(db_path, check_same_thread=False)
-        db.enable_load_extension(True)
-        _sqlite_vec_ext.load(db)
-        db.enable_load_extension(False)
+            # Lazy import: ``sqlite_vec`` is declared as an optional extra so
+            # default-Chroma installs don't pay for it. Resolving the import
+            # only when an actual sqlite-vec palace is being opened keeps the
+            # registry's eager registration safe across both install shapes.
+            try:
+                import sqlite_vec as _sqlite_vec_ext  # noqa: PLC0415
+            except ImportError as exc:
+                raise BackendClosedError(
+                    "sqlite-vec backend requires the optional `sqlite-vec` package; "
+                    "install with `pip install mempalace[sqlite-vec]`"
+                ) from exc
 
-        # Bootstrap schema
-        db.execute("PRAGMA journal_mode=WAL")
-        db.execute("PRAGMA foreign_keys=ON")
-        db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS collections (
-                name TEXT PRIMARY KEY,
-                dimension INT NOT NULL,
-                embedder_name TEXT,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            os.makedirs(palace_path, exist_ok=True)
+            db_path = os.path.join(palace_path, DB_FILENAME)
+            db = sqlite3.connect(db_path, check_same_thread=False)
+            db.enable_load_extension(True)
+            _sqlite_vec_ext.load(db)
+            db.enable_load_extension(False)
+
+            # Bootstrap schema
+            db.execute("PRAGMA journal_mode=WAL")
+            db.execute("PRAGMA foreign_keys=ON")
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS collections (
+                    name TEXT PRIMARY KEY,
+                    dimension INT NOT NULL,
+                    embedder_name TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+                """
             )
-            """
-        )
-        db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS items (
-                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
-                collection TEXT NOT NULL,
-                id TEXT NOT NULL,
-                document TEXT,
-                metadata_json TEXT,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE(collection, id),
-                FOREIGN KEY (collection) REFERENCES collections(name) ON DELETE CASCADE
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS items (
+                    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                    collection TEXT NOT NULL,
+                    id TEXT NOT NULL,
+                    document TEXT,
+                    metadata_json TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(collection, id),
+                    FOREIGN KEY (collection) REFERENCES collections(name) ON DELETE CASCADE
+                )
+                """
             )
-            """
-        )
-        db.execute("CREATE INDEX IF NOT EXISTS idx_items_collection ON items(collection)")
-        db.commit()
+            db.execute("CREATE INDEX IF NOT EXISTS idx_items_collection ON items(collection)")
+            db.commit()
 
-        self._connections[palace_path] = db
-        return db
+            self._connections[palace_path] = db
+            return db
 
     def get_collection(self, *args, **kwargs) -> BaseCollection:
         if self._closed:

--- a/mempalace/backends/sqlite_vec.py
+++ b/mempalace/backends/sqlite_vec.py
@@ -1,0 +1,848 @@
+"""sqlite-vec backend for MemPalace (RFC 001).
+
+Per-palace SQLite database stored at ``<palace_path>/sqlite_vec.db`` with:
+
+* ``collections``    — registry of collections (name, dimension, embedder).
+* ``items``          — shared items table (collection, id, document, metadata_json).
+* ``items_vec_<col>`` — one vec0 virtual table per collection (dimension fixed).
+
+Embedding policy: caller MUST supply ``embeddings=`` in add/upsert and
+``query_embeddings=`` in query. ``query_texts`` is rejected — embedder
+injection is out of scope for Fase A (per base.py docstring: follow-up PR).
+
+Where translator supports MemPalace's spec operators ($eq, $ne, $in, $nin,
+$and, $or, $contains, $gt, $gte, $lt, $lte) via SQLite json_extract.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import struct
+from typing import Any, ClassVar, Optional
+
+import sqlite_vec as _sqlite_vec_ext
+
+from .base import (
+    BackendClosedError,
+    BaseBackend,
+    BaseCollection,
+    DimensionMismatchError,
+    GetResult,
+    HealthStatus,
+    PalaceNotFoundError,
+    PalaceRef,
+    QueryResult,
+    UnsupportedFilterError,
+    _IncludeSpec,
+)
+
+logger = logging.getLogger(__name__)
+
+DB_FILENAME = "sqlite_vec.db"
+
+_REQUIRED_OPERATORS = frozenset({"$eq", "$ne", "$in", "$nin", "$and", "$or", "$contains"})
+_OPTIONAL_OPERATORS = frozenset({"$gt", "$gte", "$lt", "$lte"})
+_SUPPORTED_OPERATORS = _REQUIRED_OPERATORS | _OPTIONAL_OPERATORS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_table_suffix(name: str) -> str:
+    """Sanitize collection name into safe SQL identifier suffix."""
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+    if not sanitized:
+        sanitized = "_anon"
+    elif sanitized[0].isdigit():
+        sanitized = f"c_{sanitized}"
+    return sanitized[:48]
+
+
+def _pack_vec(values) -> bytes:
+    if not isinstance(values, (list, tuple)):
+        values = list(values)
+    return struct.pack(f"{len(values)}f", *values)
+
+
+def _unpack_vec(blob: bytes) -> list[float]:
+    n = len(blob) // 4
+    return list(struct.unpack(f"{n}f", blob))
+
+
+# ---------------------------------------------------------------------------
+# Where translator (MemPalace dict → SQL via json_extract)
+# ---------------------------------------------------------------------------
+
+
+def _translate_where(where: dict, *, alias: str = "i") -> tuple[str, list[Any]]:
+    """Translate a MemPalace where dict to a parameterized SQL fragment.
+
+    Returns (sql_fragment, params). Empty dict → ('', []).
+    Raises UnsupportedFilterError for unknown operators (spec §1.4).
+    """
+    if not where:
+        return "", []
+    sql, params = _translate_node(where, alias=alias)
+    return sql, params
+
+
+def _translate_node(node: Any, *, alias: str) -> tuple[str, list[Any]]:
+    """Recursive translator. ``node`` is either a dict at filter level or
+    a key→value pair we expand. Returns ('', []) when node yields nothing."""
+    if not isinstance(node, dict):
+        raise UnsupportedFilterError(f"where expects dict, got {type(node).__name__}")
+
+    # Logical combinators at top level: {"$and": [...]} or {"$or": [...]}
+    if "$and" in node or "$or" in node:
+        if len(node) != 1:
+            raise UnsupportedFilterError(
+                f"logical operator must be the sole key, got siblings: {list(node)!r}"
+            )
+        op = "$and" if "$and" in node else "$or"
+        sub_nodes = node[op]
+        if not isinstance(sub_nodes, list) or not sub_nodes:
+            raise UnsupportedFilterError(f"{op} requires non-empty list")
+        parts: list[str] = []
+        all_params: list[Any] = []
+        for sub in sub_nodes:
+            s, p = _translate_node(sub, alias=alias)
+            if s:
+                parts.append(f"({s})")
+                all_params.extend(p)
+        joiner = " AND " if op == "$and" else " OR "
+        return joiner.join(parts), all_params
+
+    # Implicit AND across keys
+    parts: list[str] = []
+    all_params: list[Any] = []
+    for key, val in node.items():
+        if key.startswith("$"):
+            raise UnsupportedFilterError(
+                f"operator {key!r} not allowed at field level (use field: {{operator: value}})"
+            )
+        s, p = _translate_field(key, val, alias=alias)
+        if s:
+            parts.append(f"({s})")
+            all_params.extend(p)
+    return " AND ".join(parts), all_params
+
+
+def _field_expr(field: str, *, alias: str) -> str:
+    """Return SQL expression for accessing field — either column or json_extract."""
+    if field == "document":
+        return f"{alias}.document"
+    if field == "id":
+        return f"{alias}.id"
+    # Default: read from metadata_json
+    return f"json_extract({alias}.metadata_json, '$.{field}')"
+
+
+def _translate_field(field: str, value: Any, *, alias: str) -> tuple[str, list[Any]]:
+    """Translate {field: value-or-operator-dict} pair."""
+    expr = _field_expr(field, alias=alias)
+
+    # Plain scalar → $eq
+    if not isinstance(value, dict):
+        return f"{expr} = ?", [value]
+
+    # Operator dict
+    parts: list[str] = []
+    params: list[Any] = []
+    for op, op_val in value.items():
+        if op not in _SUPPORTED_OPERATORS:
+            raise UnsupportedFilterError(f"operator {op!r} not supported by sqlite-vec backend")
+        if op == "$eq":
+            parts.append(f"{expr} = ?")
+            params.append(op_val)
+        elif op == "$ne":
+            parts.append(f"({expr} IS NULL OR {expr} != ?)")
+            params.append(op_val)
+        elif op == "$in":
+            if not isinstance(op_val, (list, tuple)) or not op_val:
+                raise UnsupportedFilterError("$in requires non-empty list")
+            placeholders = ",".join("?" for _ in op_val)
+            parts.append(f"{expr} IN ({placeholders})")
+            params.extend(op_val)
+        elif op == "$nin":
+            if not isinstance(op_val, (list, tuple)) or not op_val:
+                raise UnsupportedFilterError("$nin requires non-empty list")
+            placeholders = ",".join("?" for _ in op_val)
+            parts.append(f"({expr} IS NULL OR {expr} NOT IN ({placeholders}))")
+            params.extend(op_val)
+        elif op == "$contains":
+            parts.append(f"{expr} LIKE ?")
+            params.append(f"%{op_val}%")
+        elif op == "$gt":
+            parts.append(f"{expr} > ?")
+            params.append(op_val)
+        elif op == "$gte":
+            parts.append(f"{expr} >= ?")
+            params.append(op_val)
+        elif op == "$lt":
+            parts.append(f"{expr} < ?")
+            params.append(op_val)
+        elif op == "$lte":
+            parts.append(f"{expr} <= ?")
+            params.append(op_val)
+    return " AND ".join(parts), params
+
+
+def _translate_where_document(where_document: dict, *, alias: str = "i") -> tuple[str, list[Any]]:
+    """Translate where_document — only $contains supported."""
+    if not where_document:
+        return "", []
+    if "$contains" not in where_document or len(where_document) != 1:
+        raise UnsupportedFilterError(
+            f"where_document only supports {{'$contains': str}}, got {where_document!r}"
+        )
+    return f"{alias}.document LIKE ?", [f"%{where_document['$contains']}%"]
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+class SQLiteVecCollection(BaseCollection):
+    def __init__(
+        self,
+        *,
+        db: sqlite3.Connection,
+        palace_path: str,
+        name: str,
+        dimension: int,
+        embedder=None,
+    ):
+        self._db = db
+        self._palace_path = palace_path
+        self._name = name
+        self._dimension = dimension
+        self._vec_table = f"items_vec_{_sanitize_table_suffix(name)}"
+        self._closed = False
+        # Optional embedder for query_texts / docs-only add convenience.
+        # If None, callers MUST supply embeddings explicitly.
+        self._embedder = embedder
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _check(self) -> None:
+        if self._closed:
+            raise BackendClosedError(f"collection {self._name!r} is closed")
+
+    def _ensure_dim(self, embeddings) -> None:
+        for emb in embeddings:
+            if len(emb) != self._dimension:
+                raise DimensionMismatchError(
+                    f"embedding dim {len(emb)} != collection dim {self._dimension}"
+                )
+
+    def _require_embeddings(self, embeddings, documents=None):
+        """Either embeddings are supplied or we can derive them from documents
+        via a configured embedder. Returns the resolved embeddings list."""
+        if embeddings is not None:
+            return embeddings
+        if self._embedder is not None and documents is not None:
+            return self._embedder(list(documents))
+        raise ValueError(
+            "sqlite-vec backend requires explicit embeddings; "
+            "supply embeddings= or configure the backend with an embedder"
+        )
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def add(self, *, documents, ids, metadatas=None, embeddings=None):
+        self._check()
+        embeddings = self._require_embeddings(embeddings, documents=documents)
+        if len(documents) != len(ids) or len(embeddings) != len(ids):
+            raise ValueError("documents, ids, embeddings must have the same length")
+        if metadatas is not None and len(metadatas) != len(ids):
+            raise ValueError("metadatas length must match ids")
+        self._ensure_dim(embeddings)
+
+        cur = self._db.cursor()
+        try:
+            cur.execute("BEGIN")
+            for i, (id_, doc, emb) in enumerate(zip(ids, documents, embeddings)):
+                meta_json = json.dumps(metadatas[i]) if metadatas is not None else None
+                cur.execute(
+                    "INSERT INTO items(collection, id, document, metadata_json) VALUES (?, ?, ?, ?)",
+                    (self._name, id_, doc, meta_json),
+                )
+                rowid = cur.lastrowid
+                cur.execute(
+                    f"INSERT INTO {self._vec_table}(rowid, embedding) VALUES (?, ?)",
+                    (rowid, _pack_vec(emb)),
+                )
+            cur.execute("COMMIT")
+        except Exception:
+            cur.execute("ROLLBACK")
+            raise
+
+    def upsert(self, *, documents, ids, metadatas=None, embeddings=None):
+        self._check()
+        embeddings = self._require_embeddings(embeddings, documents=documents)
+        if len(documents) != len(ids) or len(embeddings) != len(ids):
+            raise ValueError("documents, ids, embeddings must have the same length")
+        if metadatas is not None and len(metadatas) != len(ids):
+            raise ValueError("metadatas length must match ids")
+        self._ensure_dim(embeddings)
+
+        cur = self._db.cursor()
+        try:
+            cur.execute("BEGIN")
+            for i, (id_, doc, emb) in enumerate(zip(ids, documents, embeddings)):
+                meta_json = json.dumps(metadatas[i]) if metadatas is not None else None
+                row = cur.execute(
+                    "SELECT rowid FROM items WHERE collection = ? AND id = ?",
+                    (self._name, id_),
+                ).fetchone()
+                if row is not None:
+                    rowid = row[0]
+                    cur.execute(
+                        "UPDATE items SET document = ?, metadata_json = ?, updated_at = CURRENT_TIMESTAMP WHERE rowid = ?",
+                        (doc, meta_json, rowid),
+                    )
+                    cur.execute(
+                        f"DELETE FROM {self._vec_table} WHERE rowid = ?", (rowid,)
+                    )
+                    cur.execute(
+                        f"INSERT INTO {self._vec_table}(rowid, embedding) VALUES (?, ?)",
+                        (rowid, _pack_vec(emb)),
+                    )
+                else:
+                    cur.execute(
+                        "INSERT INTO items(collection, id, document, metadata_json) VALUES (?, ?, ?, ?)",
+                        (self._name, id_, doc, meta_json),
+                    )
+                    rowid = cur.lastrowid
+                    cur.execute(
+                        f"INSERT INTO {self._vec_table}(rowid, embedding) VALUES (?, ?)",
+                        (rowid, _pack_vec(emb)),
+                    )
+            cur.execute("COMMIT")
+        except Exception:
+            cur.execute("ROLLBACK")
+            raise
+
+    def update(
+        self,
+        *,
+        ids,
+        documents=None,
+        metadatas=None,
+        embeddings=None,
+    ):
+        """Atomic partial update — preserves embeddings if not supplied.
+
+        Overrides the base default (get+merge+upsert) so callers can update
+        document/metadata without re-embedding.
+        """
+        self._check()
+        if documents is None and metadatas is None and embeddings is None:
+            raise ValueError("update requires at least one of documents, metadatas, embeddings")
+
+        n = len(ids)
+        for label, value in (
+            ("documents", documents),
+            ("metadatas", metadatas),
+            ("embeddings", embeddings),
+        ):
+            if value is not None and len(value) != n:
+                raise ValueError(f"{label} length {len(value)} does not match ids length {n}")
+        if embeddings is not None:
+            self._ensure_dim(embeddings)
+
+        cur = self._db.cursor()
+        try:
+            cur.execute("BEGIN")
+            for i, id_ in enumerate(ids):
+                row = cur.execute(
+                    "SELECT rowid, document, metadata_json FROM items WHERE collection = ? AND id = ?",
+                    (self._name, id_),
+                ).fetchone()
+                if row is None:
+                    # Spec doesn't mandate behaviour for missing ids on update;
+                    # match Chroma (silent skip) rather than raising.
+                    continue
+                rowid, prev_doc, prev_meta_json = row
+
+                new_doc = documents[i] if documents is not None else prev_doc
+                if metadatas is not None:
+                    prev_meta = json.loads(prev_meta_json) if prev_meta_json else {}
+                    prev_meta.update(metadatas[i] or {})
+                    new_meta_json = json.dumps(prev_meta)
+                else:
+                    new_meta_json = prev_meta_json
+
+                cur.execute(
+                    "UPDATE items SET document = ?, metadata_json = ?, updated_at = CURRENT_TIMESTAMP WHERE rowid = ?",
+                    (new_doc, new_meta_json, rowid),
+                )
+                if embeddings is not None:
+                    cur.execute(f"DELETE FROM {self._vec_table} WHERE rowid = ?", (rowid,))
+                    cur.execute(
+                        f"INSERT INTO {self._vec_table}(rowid, embedding) VALUES (?, ?)",
+                        (rowid, _pack_vec(embeddings[i])),
+                    )
+            cur.execute("COMMIT")
+        except Exception:
+            cur.execute("ROLLBACK")
+            raise
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def query(
+        self,
+        *,
+        query_texts=None,
+        query_embeddings=None,
+        n_results: int = 10,
+        where=None,
+        where_document=None,
+        include=None,
+    ) -> QueryResult:
+        self._check()
+        if query_embeddings is None:
+            if query_texts is None:
+                raise ValueError("query requires query_embeddings or query_texts")
+            if self._embedder is None:
+                raise ValueError(
+                    "sqlite-vec backend has no embedder configured; supply query_embeddings"
+                )
+            if not query_texts:
+                raise ValueError("query input must be a non-empty list")
+            query_embeddings = self._embedder(list(query_texts))
+        if not query_embeddings:
+            raise ValueError("query input must be a non-empty list")
+
+        spec = _IncludeSpec.resolve(include, default_distances=True)
+
+        where_sql, where_params = _translate_where(where or {}, alias="i")
+        doc_sql, doc_params = _translate_where_document(where_document or {}, alias="i")
+
+        # Over-retrieve to compensate for post-filtering. vec0 MATCH+k returns
+        # top-k by distance; if we then filter with WHERE, we may end up with
+        # < n_results. Strategy: ask vec0 for max(n_results * 5, 50) candidates
+        # and LIMIT n_results after the WHERE applies.
+        over_k = max(n_results * 5, 50)
+
+        all_ids: list[list[str]] = []
+        all_docs: list[list[str]] = []
+        all_metas: list[list[dict]] = []
+        all_dists: list[list[float]] = []
+        all_embs: Optional[list[list[list[float]]]] = [] if spec.embeddings else None
+
+        for qemb in query_embeddings:
+            if len(qemb) != self._dimension:
+                raise DimensionMismatchError(
+                    f"query embedding dim {len(qemb)} != collection dim {self._dimension}"
+                )
+
+            clauses = ["v.embedding MATCH ?", "k = ?", "i.collection = ?"]
+            params: list[Any] = [_pack_vec(qemb), over_k, self._name]
+            if where_sql:
+                clauses.append(where_sql)
+                params.extend(where_params)
+            if doc_sql:
+                clauses.append(doc_sql)
+                params.extend(doc_params)
+
+            select_emb = ", v.embedding" if spec.embeddings else ", NULL AS embedding"
+            sql = f"""
+                SELECT i.id, i.document, i.metadata_json, v.distance{select_emb}
+                FROM {self._vec_table} v
+                JOIN items i ON i.rowid = v.rowid
+                WHERE {' AND '.join(clauses)}
+                ORDER BY v.distance
+                LIMIT ?
+            """
+            params.append(n_results)
+            rows = self._db.execute(sql, params).fetchall()
+
+            qids: list[str] = []
+            qdocs: list[str] = []
+            qmetas: list[dict] = []
+            qdists: list[float] = []
+            qembs: list[list[float]] = []
+            for id_, doc, meta_json, dist, emb_blob in rows:
+                qids.append(id_)
+                qdocs.append(doc or "")
+                qmetas.append(json.loads(meta_json) if meta_json else {})
+                qdists.append(float(dist))
+                if spec.embeddings:
+                    qembs.append(_unpack_vec(emb_blob) if emb_blob else [])
+
+            all_ids.append(qids)
+            all_docs.append(qdocs)
+            all_metas.append(qmetas)
+            all_dists.append(qdists)
+            if spec.embeddings:
+                all_embs.append(qembs)
+
+        # Even when caller didn't include a field, RFC 001 §1.3 says the outer
+        # shape must be preserved with empty inner lists. We populate inner
+        # lists from the rows (cheap), but only return them via the typed
+        # result when spec.<field> is True; otherwise we return shape-only
+        # placeholders. Distances default to True per QueryResult contract.
+        def _shape_only(rows_outer: list[list[str]]) -> list[list]:
+            return [[] for _ in rows_outer]
+
+        return QueryResult(
+            ids=all_ids,
+            documents=all_docs if spec.documents else _shape_only(all_ids),
+            metadatas=all_metas if spec.metadatas else _shape_only(all_ids),
+            distances=all_dists if spec.distances else _shape_only(all_ids),
+            embeddings=all_embs,
+        )
+
+    def get(
+        self,
+        *,
+        ids=None,
+        where=None,
+        where_document=None,
+        limit=None,
+        offset=None,
+        include=None,
+    ) -> GetResult:
+        self._check()
+        spec = _IncludeSpec.resolve(include, default_distances=False)
+
+        clauses = ["i.collection = ?"]
+        params: list[Any] = [self._name]
+
+        if ids:
+            placeholders = ",".join("?" for _ in ids)
+            clauses.append(f"i.id IN ({placeholders})")
+            params.extend(ids)
+        if where:
+            wsql, wparams = _translate_where(where, alias="i")
+            if wsql:
+                clauses.append(wsql)
+                params.extend(wparams)
+        if where_document:
+            dsql, dparams = _translate_where_document(where_document, alias="i")
+            if dsql:
+                clauses.append(dsql)
+                params.extend(dparams)
+
+        select_fields = ["i.id", "i.rowid"]
+        select_fields.append("i.document" if spec.documents else "NULL")
+        select_fields.append("i.metadata_json" if spec.metadatas else "NULL")
+
+        sql = f"SELECT {', '.join(select_fields)} FROM items i WHERE {' AND '.join(clauses)} ORDER BY i.rowid"
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+            if offset is not None:
+                sql += f" OFFSET {int(offset)}"
+        elif offset is not None:
+            sql += f" LIMIT -1 OFFSET {int(offset)}"
+
+        rows = self._db.execute(sql, params).fetchall()
+
+        out_ids: list[str] = []
+        out_docs: list[str] = []
+        out_metas: list[dict] = []
+        out_embs: Optional[list[list[float]]] = [] if spec.embeddings else None
+
+        for id_, rowid, doc, meta_json in rows:
+            out_ids.append(id_)
+            if spec.documents:
+                out_docs.append(doc or "")
+            if spec.metadatas:
+                out_metas.append(json.loads(meta_json) if meta_json else {})
+            if spec.embeddings:
+                emb_row = self._db.execute(
+                    f"SELECT embedding FROM {self._vec_table} WHERE rowid = ?", (rowid,)
+                ).fetchone()
+                out_embs.append(_unpack_vec(emb_row[0]) if emb_row and emb_row[0] else [])
+
+        return GetResult(
+            ids=out_ids,
+            documents=out_docs if spec.documents else [""] * len(out_ids),
+            metadatas=out_metas if spec.metadatas else [{}] * len(out_ids),
+            embeddings=out_embs,
+        )
+
+    def delete(self, *, ids=None, where=None):
+        self._check()
+        if ids is None and where is None:
+            raise ValueError("delete requires ids or where")
+
+        clauses = ["collection = ?"]
+        params: list[Any] = [self._name]
+
+        if ids is not None:
+            if not ids:
+                return
+            placeholders = ",".join("?" for _ in ids)
+            clauses.append(f"id IN ({placeholders})")
+            params.extend(ids)
+        if where:
+            # Use alias 'items' here since this query doesn't use 'i'
+            wsql, wparams = _translate_where(where, alias="items")
+            if wsql:
+                clauses.append(wsql)
+                params.extend(wparams)
+
+        cur = self._db.cursor()
+        rowids = [
+            r[0]
+            for r in cur.execute(
+                f"SELECT rowid FROM items WHERE {' AND '.join(clauses)}", params
+            ).fetchall()
+        ]
+        if not rowids:
+            return
+
+        try:
+            cur.execute("BEGIN")
+            placeholders = ",".join("?" for _ in rowids)
+            cur.execute(
+                f"DELETE FROM {self._vec_table} WHERE rowid IN ({placeholders})", rowids
+            )
+            cur.execute(f"DELETE FROM items WHERE rowid IN ({placeholders})", rowids)
+            cur.execute("COMMIT")
+        except Exception:
+            cur.execute("ROLLBACK")
+            raise
+
+    def count(self) -> int:
+        self._check()
+        row = self._db.execute(
+            "SELECT COUNT(*) FROM items WHERE collection = ?", (self._name,)
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def close(self) -> None:
+        self._closed = True
+
+    def health(self) -> HealthStatus:
+        try:
+            self._db.execute("SELECT 1").fetchone()
+            self._db.execute(f"SELECT COUNT(*) FROM {self._vec_table} LIMIT 1").fetchone()
+            return HealthStatus.healthy(detail=f"sqlite_vec collection {self._name}")
+        except Exception as e:
+            return HealthStatus.unhealthy(detail=f"sqlite_vec collection {self._name}: {e!r}")
+
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+
+
+class SQLiteVecBackend(BaseBackend):
+    name: ClassVar[str] = "sqlite-vec"
+    spec_version: ClassVar[str] = "1.0"
+    capabilities: ClassVar[frozenset[str]] = frozenset({"supports_update", "supports_filter"})
+
+    def __init__(self, embedder=None):
+        """Construct a backend.
+
+        ``embedder`` semantics:
+
+        * ``None`` (default) — lazy-resolve via
+          :func:`mempalace.embedding.get_embedding_function` on first
+          :meth:`get_collection`. Allows ``query_texts`` / docs-only ``add``.
+        * ``False`` — explicitly disable embedder. Callers MUST supply
+          ``embeddings`` / ``query_embeddings`` themselves. Used by tests
+          and by callers that pre-embed at a different layer.
+        * callable — use as-is (typically a Chroma-style ``EmbeddingFunction``).
+        """
+        # palace_path -> sqlite3.Connection (long-lived per palace)
+        self._connections: dict[str, sqlite3.Connection] = {}
+        self._closed = False
+        self._embedder = embedder
+        self._embedder_resolved = embedder is False or callable(embedder)
+
+    def _resolve_embedder(self):
+        if self._embedder_resolved:
+            # ``False`` means "no embedder by design"; collection sees None
+            # so add/query without embeddings raises ValueError.
+            return self._embedder if callable(self._embedder) else None
+        try:
+            from ..embedding import get_embedding_function
+            self._embedder = get_embedding_function()
+        except Exception:
+            logger.exception("Failed to build embedding function; query_texts will fail")
+            self._embedder = None
+        self._embedder_resolved = True
+        return self._embedder
+
+    def _open_db(self, palace_path: str) -> sqlite3.Connection:
+        if self._closed:
+            raise BackendClosedError("backend closed")
+        cached = self._connections.get(palace_path)
+        if cached is not None:
+            return cached
+
+        os.makedirs(palace_path, exist_ok=True)
+        db_path = os.path.join(palace_path, DB_FILENAME)
+        db = sqlite3.connect(db_path, check_same_thread=False)
+        db.enable_load_extension(True)
+        _sqlite_vec_ext.load(db)
+        db.enable_load_extension(False)
+
+        # Bootstrap schema
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA foreign_keys=ON")
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS collections (
+                name TEXT PRIMARY KEY,
+                dimension INT NOT NULL,
+                embedder_name TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS items (
+                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                collection TEXT NOT NULL,
+                id TEXT NOT NULL,
+                document TEXT,
+                metadata_json TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(collection, id),
+                FOREIGN KEY (collection) REFERENCES collections(name) ON DELETE CASCADE
+            )
+            """
+        )
+        db.execute("CREATE INDEX IF NOT EXISTS idx_items_collection ON items(collection)")
+        db.commit()
+
+        self._connections[palace_path] = db
+        return db
+
+    def get_collection(self, *args, **kwargs) -> BaseCollection:
+        if self._closed:
+            raise BackendClosedError("backend closed")
+
+        # Accept both new-style (palace=PalaceRef, ...) and legacy positional
+        # (palace_path_str, collection_name, create) to match ChromaBackend's
+        # transition shim.
+        if "palace" in kwargs:
+            palace: PalaceRef = kwargs.pop("palace")
+            if not isinstance(palace, PalaceRef):
+                raise TypeError("palace= must be a PalaceRef instance")
+            collection_name: str = kwargs.pop("collection_name")
+            create: bool = kwargs.pop("create", False)
+            options: Optional[dict] = kwargs.pop("options", None)
+            if kwargs or args:
+                raise TypeError(f"unexpected extra args: args={args!r} kwargs={list(kwargs)!r}")
+        else:
+            # Legacy: positional palace_path string
+            if not args:
+                raise TypeError("get_collection requires palace= or positional palace_path")
+            palace_path = args[0]
+            rest = list(args[1:])
+            collection_name = kwargs.pop("collection_name", None) or (rest.pop(0) if rest else None)
+            if collection_name is None:
+                raise TypeError("collection_name is required")
+            create = kwargs.pop("create", False)
+            if rest:
+                create = rest.pop(0)
+            options = kwargs.pop("options", None)
+            if rest or kwargs:
+                raise TypeError(f"unexpected extra args: rest={rest!r} kwargs={list(kwargs)!r}")
+            palace = PalaceRef(id=palace_path, local_path=palace_path)
+
+        if not palace.local_path:
+            raise ValueError("sqlite-vec backend requires PalaceRef.local_path")
+
+        if create:
+            os.makedirs(palace.local_path, exist_ok=True)
+        elif not os.path.isdir(palace.local_path):
+            raise PalaceNotFoundError(palace.local_path)
+
+        db = self._open_db(palace.local_path)
+
+        row = db.execute(
+            "SELECT dimension FROM collections WHERE name = ?", (collection_name,)
+        ).fetchone()
+
+        if row is None:
+            if not create:
+                raise PalaceNotFoundError(
+                    f"collection {collection_name!r} not found in {palace.local_path}"
+                )
+            opts = options or {}
+            dim = opts.get("dimension")
+            if dim is None:
+                raise ValueError(
+                    "creating a new collection requires options={'dimension': N}"
+                )
+            embedder = opts.get("embedder_name")
+            vec_table = f"items_vec_{_sanitize_table_suffix(collection_name)}"
+            with db:
+                db.execute(
+                    "INSERT INTO collections(name, dimension, embedder_name) VALUES (?, ?, ?)",
+                    (collection_name, int(dim), embedder),
+                )
+                db.execute(
+                    f"CREATE VIRTUAL TABLE IF NOT EXISTS {vec_table} USING vec0(embedding float[{int(dim)}])"
+                )
+            dimension = int(dim)
+        else:
+            dimension = int(row[0])
+
+        return SQLiteVecCollection(
+            db=db,
+            palace_path=palace.local_path,
+            name=collection_name,
+            dimension=dimension,
+            embedder=self._resolve_embedder(),
+        )
+
+    def close_palace(self, palace: PalaceRef) -> None:
+        if not palace.local_path:
+            return
+        db = self._connections.pop(palace.local_path, None)
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                logger.exception("error closing sqlite-vec db for %s", palace.local_path)
+
+    def close(self) -> None:
+        for path, db in list(self._connections.items()):
+            try:
+                db.close()
+            except Exception:
+                logger.exception("error closing sqlite-vec db for %s", path)
+        self._connections.clear()
+        self._closed = True
+
+    def health(self, palace: Optional[PalaceRef] = None) -> HealthStatus:
+        if self._closed:
+            return HealthStatus.unhealthy("backend closed")
+        if palace is None:
+            return HealthStatus.healthy(detail=f"{len(self._connections)} open dbs")
+        if not palace.local_path:
+            return HealthStatus.unhealthy("local_path required")
+        try:
+            db = self._open_db(palace.local_path)
+            db.execute("SELECT 1").fetchone()
+            return HealthStatus.healthy(detail=palace.local_path)
+        except Exception as e:
+            return HealthStatus.unhealthy(detail=f"{palace.local_path}: {e!r}")
+
+    @classmethod
+    def detect(cls, path: str) -> bool:
+        """Auto-detect sqlite-vec palace by presence of the db file."""
+        return os.path.isfile(os.path.join(path, DB_FILENAME))

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -14,6 +14,7 @@ import threading
 from typing import Optional
 
 from .backends.chroma import ChromaBackend
+from .backends.registry import get_backend, resolve_backend_for_palace
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -45,6 +46,37 @@ SKIP_DIRS = {
 
 _DEFAULT_BACKEND = ChromaBackend()
 
+
+def _select_backend(palace_path: Optional[str] = None):
+    """Resolve which backend to use for a palace operation.
+
+    Honours :func:`resolve_backend_for_palace` (RFC 001 §3.3):
+    1. ``MEMPALACE_BACKEND`` env var
+    2. Per-palace auto-detect by on-disk artifacts (``sqlite_vec.db`` vs
+       ``chroma.sqlite3``)
+    3. Default — falls through to the singleton ``ChromaBackend`` so callers
+       that never set a backend keep current behaviour exactly.
+
+    Caching: ``ChromaBackend`` keeps its own per-process client cache, so
+    returning the singleton preserves it. Non-default backends are resolved
+    through the registry, which caches one instance per backend name.
+    """
+    env_value = os.environ.get("MEMPALACE_BACKEND")
+    try:
+        name = resolve_backend_for_palace(
+            env_value=env_value, palace_path=palace_path
+        )
+    except Exception:
+        logger.exception("resolve_backend_for_palace failed; using default chroma")
+        return _DEFAULT_BACKEND
+    if name == "chroma":
+        return _DEFAULT_BACKEND
+    try:
+        return get_backend(name)
+    except Exception:
+        logger.exception("backend %r unavailable; using default chroma", name)
+        return _DEFAULT_BACKEND
+
 # Schema version for drawer normalization. Bump when the normalization
 # pipeline changes in a way that existing drawers should be rebuilt to pick up
 # (e.g., new noise-stripping rules). `file_already_mined` treats drawers with
@@ -66,7 +98,8 @@ def get_collection(
         from .config import get_configured_collection_name
 
         collection_name = get_configured_collection_name()
-    return _DEFAULT_BACKEND.get_collection(
+    backend = _select_backend(palace_path)
+    return backend.get_collection(
         palace_path,
         collection_name=collection_name,
         create=create,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ mempalace-mcp = "mempalace.mcp_server:main"
 
 [project.entry-points."mempalace.backends"]
 chroma = "mempalace.backends.chroma:ChromaBackend"
+sqlite-vec = "mempalace.backends.sqlite_vec:SQLiteVecBackend"
 
 # RFC 002 source-adapter entry-point group. Core publishes no first-party
 # adapters under this group yet; ``miner.py`` and ``convo_miner.py`` migrate
@@ -53,6 +54,10 @@ chroma = "mempalace.backends.chroma:ChromaBackend"
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]
 spellcheck = ["autocorrect>=2.0"]
+# Alternative vector backend — opt in with `pip install mempalace[sqlite-vec]`
+# then set MEMPALACE_BACKEND=sqlite-vec. See mempalace/backends/sqlite_vec.py
+# for schema and trade-offs vs the default Chroma backend.
+sqlite-vec = ["sqlite-vec>=0.1.6"]
 # Hardware acceleration for the ONNX embedding model. Install exactly one:
 #   pip install mempalace[gpu]       — NVIDIA CUDA
 #   pip install mempalace[dml]       — DirectML (Windows AMD/Intel/NVIDIA)

--- a/tests/test_sqlite_vec_backend.py
+++ b/tests/test_sqlite_vec_backend.py
@@ -424,8 +424,11 @@ def test_two_collections_isolated_in_same_palace(backend, palace_dir):
 
 def test_translate_where_eq():
     sql, params = _translate_where({"wing": "x"})
+    # json_extract(metadata_json, '$.wing') is rendered as
+    # json_extract(metadata_json, ?), with '$.wing' bound as a parameter.
+    assert "json_extract" in sql
     assert "= ?" in sql
-    assert params == ["x"]
+    assert params == ["$.wing", "x"]
 
 
 def test_translate_where_and_or_combination():
@@ -434,11 +437,24 @@ def test_translate_where_and_or_combination():
     )
     assert "AND" in sql
     assert "OR" in sql
-    # Order is implementation-defined; only the multiset of params matters.
-    assert len(params) == 3
+    # Each json_extract emission adds one path param plus the comparison value.
+    # Three field accesses (wing, score, score) → three path params.
+    assert params.count("$.wing") == 1
+    assert params.count("$.score") == 2
     assert "x" in params
     assert 1 in params
     assert 2 in params
+
+
+def test_translate_where_field_name_rejects_injection():
+    from mempalace.backends.sqlite_vec import _FIELD_NAME_RE  # type: ignore
+    assert _FIELD_NAME_RE.match("wing")
+    assert _FIELD_NAME_RE.match("tenant_id")
+    assert not _FIELD_NAME_RE.match("wing'; DROP TABLE items--")
+    assert not _FIELD_NAME_RE.match("wing.nested")
+    assert not _FIELD_NAME_RE.match("$wing")
+    with pytest.raises(UnsupportedFilterError, match="metadata field"):
+        _translate_where({"wing'; DROP TABLE items--": "x"})
 
 
 def test_translate_where_in_empty_list_raises():
@@ -463,6 +479,28 @@ def test_translate_where_document_other_op_raises():
 
 
 def test_sanitize_table_suffix_handles_special_chars():
-    assert _sanitize_table_suffix("hello-world") == "hello_world"
+    # Short cleanly-sanitised names round-trip unchanged.
+    assert _sanitize_table_suffix("hello_world") == "hello_world"
+    # Names that required substitution get a hash suffix to keep distinct
+    # originals distinguishable post-sanitisation.
+    s_dash = _sanitize_table_suffix("hello-world")
+    assert s_dash.startswith("hello_world_") and len(s_dash) == len("hello_world_") + 8
     assert _sanitize_table_suffix("123abc").startswith("c_")
-    assert _sanitize_table_suffix("") == "_anon"
+    # Empty input still produces a usable identifier (with stable hash suffix).
+    empty = _sanitize_table_suffix("")
+    assert empty.startswith("_anon_") and len(empty) == len("_anon_") + 8
+
+
+def test_sanitize_table_suffix_distinguishes_long_prefixes():
+    a = _sanitize_table_suffix("a" * 45 + "_one")
+    b = _sanitize_table_suffix("a" * 45 + "_two")
+    assert a != b, "long collection names with identical 40-char prefixes must differ"
+
+
+def test_pack_vec_uses_little_endian():
+    import struct
+    from mempalace.backends.sqlite_vec import _pack_vec, _unpack_vec  # type: ignore
+    blob = _pack_vec([1.0, 2.0, 3.0])
+    # Little-endian float32 of [1, 2, 3].
+    assert blob == struct.pack("<3f", 1.0, 2.0, 3.0)
+    assert _unpack_vec(blob) == [1.0, 2.0, 3.0]

--- a/tests/test_sqlite_vec_backend.py
+++ b/tests/test_sqlite_vec_backend.py
@@ -1,0 +1,468 @@
+"""Tests for the sqlite-vec backend.
+
+Skipped if the ``sqlite-vec`` optional dependency is not installed
+(``pip install mempalace[sqlite-vec]``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+sqlite_vec = pytest.importorskip("sqlite_vec")
+
+from mempalace.backends import (
+    BackendClosedError,
+    DimensionMismatchError,
+    GetResult,
+    PalaceNotFoundError,
+    PalaceRef,
+    QueryResult,
+    SQLiteVecBackend,
+    SQLiteVecCollection,
+    UnsupportedFilterError,
+    available_backends,
+    get_backend,
+)
+from mempalace.backends.sqlite_vec import (
+    DB_FILENAME,
+    _sanitize_table_suffix,
+    _translate_where,
+    _translate_where_document,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def palace_dir():
+    d = tempfile.mkdtemp(prefix="mp-svec-test-")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def backend():
+    b = SQLiteVecBackend()
+    yield b
+    b.close()
+
+
+@pytest.fixture
+def collection(backend, palace_dir):
+    palace = PalaceRef(id="t", local_path=palace_dir)
+    return backend.get_collection(
+        palace=palace,
+        collection_name="drawers",
+        create=True,
+        options={"dimension": 4},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_sqlite_vec_registered_as_builtin():
+    assert "sqlite-vec" in available_backends()
+
+
+def test_get_backend_returns_sqlite_vec_instance():
+    b = get_backend("sqlite-vec")
+    assert isinstance(b, SQLiteVecBackend)
+
+
+def test_detect_returns_true_when_db_present(palace_dir):
+    db_path = os.path.join(palace_dir, DB_FILENAME)
+    open(db_path, "wb").close()
+    assert SQLiteVecBackend.detect(palace_dir) is True
+
+
+def test_detect_returns_false_when_db_absent(palace_dir):
+    assert SQLiteVecBackend.detect(palace_dir) is False
+
+
+# ---------------------------------------------------------------------------
+# get_collection lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_get_collection_missing_raises_palace_not_found(backend, palace_dir):
+    palace = PalaceRef(id="t", local_path=palace_dir)
+    with pytest.raises(PalaceNotFoundError):
+        backend.get_collection(palace=palace, collection_name="missing")
+
+
+def test_create_requires_dimension(backend, palace_dir):
+    palace = PalaceRef(id="t", local_path=palace_dir)
+    with pytest.raises(ValueError, match="dimension"):
+        backend.get_collection(palace=palace, collection_name="x", create=True)
+
+
+def test_create_then_reopen_preserves_metadata(backend, palace_dir):
+    palace = PalaceRef(id="t", local_path=palace_dir)
+    c1 = backend.get_collection(
+        palace=palace,
+        collection_name="cc",
+        create=True,
+        options={"dimension": 8},
+    )
+    assert c1._dimension == 8
+    backend.close_palace(palace)
+
+    c2 = backend.get_collection(palace=palace, collection_name="cc")
+    assert c2._dimension == 8
+
+
+def test_legacy_positional_get_collection(backend, palace_dir):
+    """ChromaBackend supports legacy (palace_path, collection_name) calls;
+    SQLiteVecBackend mirrors the same shim for callers not yet migrated."""
+    c = backend.get_collection(
+        palace_dir, "drawers", create=True, options={"dimension": 4}
+    )
+    assert isinstance(c, SQLiteVecCollection)
+
+
+# ---------------------------------------------------------------------------
+# Writes
+# ---------------------------------------------------------------------------
+
+
+def test_add_requires_embeddings_when_no_embedder():
+    # Build a collection without an embedder (skip lazy resolve)
+    backend = SQLiteVecBackend(embedder=False)  # falsy disables embedder
+    d = tempfile.mkdtemp(prefix="mp-svec-noemb-")
+    try:
+        palace = PalaceRef(id="t", local_path=d)
+        c = backend.get_collection(
+            palace=palace, collection_name="x", create=True, options={"dimension": 4}
+        )
+        # _embedder is False (truthy check fails), so add without embeddings errs
+        with pytest.raises(ValueError, match="requires explicit embeddings"):
+            c.add(documents=["x"], ids=["x"])
+    finally:
+        backend.close()
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_add_dimension_mismatch_raises(collection):
+    with pytest.raises(DimensionMismatchError):
+        collection.add(
+            documents=["x"],
+            ids=["x"],
+            embeddings=[[1.0, 2.0]],  # dim 2, expected 4
+        )
+
+
+def test_add_then_count(collection):
+    collection.add(
+        documents=["a", "b"],
+        ids=["a", "b"],
+        embeddings=[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+    )
+    assert collection.count() == 2
+
+
+def test_upsert_inserts_and_updates(collection):
+    collection.add(
+        documents=["a"],
+        ids=["a"],
+        metadatas=[{"score": 1}],
+        embeddings=[[1.0, 0.0, 0.0, 0.0]],
+    )
+    collection.upsert(
+        documents=["a-new", "b"],
+        ids=["a", "b"],
+        metadatas=[{"score": 99}, {"score": 5}],
+        embeddings=[[0.9, 0.1, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+    )
+    assert collection.count() == 2
+    g = collection.get(ids=["a"])
+    assert g.documents[0] == "a-new"
+    assert g.metadatas[0]["score"] == 99
+
+
+def test_update_preserves_embeddings_when_not_supplied(collection):
+    collection.add(
+        documents=["a"],
+        ids=["a"],
+        metadatas=[{"k": "v"}],
+        embeddings=[[1.0, 0.0, 0.0, 0.0]],
+    )
+    collection.update(ids=["a"], metadatas=[{"k": "v2"}])
+    g = collection.get(ids=["a"], include=["documents", "metadatas", "embeddings"])
+    assert g.metadatas[0]["k"] == "v2"
+    # embedding round-trips
+    assert pytest.approx(g.embeddings[0][0], abs=1e-6) == 1.0
+
+
+def test_update_atomic_per_field(collection):
+    collection.add(
+        documents=["a"], ids=["a"], embeddings=[[1.0, 0.0, 0.0, 0.0]]
+    )
+    collection.update(ids=["a"], documents=["a-renamed"])
+    g = collection.get(ids=["a"])
+    assert g.documents[0] == "a-renamed"
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+def test_query_returns_typed_result(collection):
+    collection.add(
+        documents=["x", "y", "z"],
+        ids=["x", "y", "z"],
+        embeddings=[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+    )
+    r = collection.query(query_embeddings=[[1.0, 0.0, 0.0, 0.0]], n_results=2)
+    assert isinstance(r, QueryResult)
+    assert r.ids[0][0] == "x"
+    assert len(r.ids[0]) == 2
+
+
+def test_query_with_metadata_filter(collection):
+    collection.add(
+        documents=["a", "b", "c"],
+        ids=["a", "b", "c"],
+        metadatas=[{"wing": "x"}, {"wing": "y"}, {"wing": "x"}],
+        embeddings=[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+    )
+    r = collection.query(
+        query_embeddings=[[1.0, 0.0, 0.0, 0.0]],
+        n_results=5,
+        where={"wing": "x"},
+    )
+    assert set(r.ids[0]) == {"a", "c"}
+
+
+def test_query_with_in_operator(collection):
+    collection.add(
+        documents=["a", "b", "c"],
+        ids=["a", "b", "c"],
+        metadatas=[{"wing": "x"}, {"wing": "y"}, {"wing": "z"}],
+        embeddings=[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+    )
+    r = collection.query(
+        query_embeddings=[[1.0, 0.0, 0.0, 0.0]],
+        n_results=5,
+        where={"wing": {"$in": ["x", "y"]}},
+    )
+    assert set(r.ids[0]) == {"a", "b"}
+
+
+def test_query_with_and_logical(collection):
+    collection.add(
+        documents=["a", "b", "c"],
+        ids=["a", "b", "c"],
+        metadatas=[
+            {"wing": "x", "score": 1},
+            {"wing": "x", "score": 5},
+            {"wing": "y", "score": 5},
+        ],
+        embeddings=[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+    )
+    r = collection.query(
+        query_embeddings=[[1.0, 0.0, 0.0, 0.0]],
+        n_results=5,
+        where={"$and": [{"wing": "x"}, {"score": {"$gte": 5}}]},
+    )
+    assert set(r.ids[0]) == {"b"}
+
+
+def test_query_where_document_contains(collection):
+    collection.add(
+        documents=["hello world", "world series", "goodbye"],
+        ids=["a", "b", "c"],
+        embeddings=[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+    )
+    r = collection.query(
+        query_embeddings=[[1.0, 0.0, 0.0, 0.0]],
+        n_results=5,
+        where_document={"$contains": "world"},
+    )
+    assert set(r.ids[0]) == {"a", "b"}
+
+
+def test_query_unsupported_operator_raises(collection):
+    collection.add(
+        documents=["a"], ids=["a"], embeddings=[[1.0, 0.0, 0.0, 0.0]]
+    )
+    with pytest.raises(UnsupportedFilterError, match="\\$regex"):
+        collection.query(
+            query_embeddings=[[1.0, 0.0, 0.0, 0.0]],
+            where={"k": {"$regex": "x"}},
+        )
+
+
+def test_get_with_ids(collection):
+    collection.add(
+        documents=["a", "b"],
+        ids=["a", "b"],
+        embeddings=[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+    )
+    g = collection.get(ids=["a"])
+    assert isinstance(g, GetResult)
+    assert g.ids == ["a"]
+
+
+def test_get_with_limit_and_offset(collection):
+    collection.add(
+        documents=["a", "b", "c"],
+        ids=["a", "b", "c"],
+        embeddings=[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+    )
+    g = collection.get(limit=2, offset=1)
+    assert g.ids == ["b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_by_ids(collection):
+    collection.add(
+        documents=["a", "b"],
+        ids=["a", "b"],
+        embeddings=[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+    )
+    collection.delete(ids=["a"])
+    assert collection.count() == 1
+    assert collection.get(ids=["a"]).ids == []
+
+
+def test_delete_by_where(collection):
+    collection.add(
+        documents=["a", "b", "c"],
+        ids=["a", "b", "c"],
+        metadatas=[{"wing": "x"}, {"wing": "y"}, {"wing": "x"}],
+        embeddings=[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+    )
+    collection.delete(where={"wing": "x"})
+    assert collection.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Health + close
+# ---------------------------------------------------------------------------
+
+
+def test_health_after_close_marked_unhealthy(backend):
+    h = backend.health()
+    assert h.ok
+    backend.close()
+    assert backend.health().ok is False
+
+
+def test_collection_close_blocks_further_ops(collection):
+    collection.close()
+    with pytest.raises(BackendClosedError):
+        collection.count()
+
+
+# ---------------------------------------------------------------------------
+# Multi-collection isolation
+# ---------------------------------------------------------------------------
+
+
+def test_two_collections_isolated_in_same_palace(backend, palace_dir):
+    palace = PalaceRef(id="t", local_path=palace_dir)
+    a = backend.get_collection(
+        palace=palace, collection_name="a", create=True, options={"dimension": 4}
+    )
+    b = backend.get_collection(
+        palace=palace, collection_name="b", create=True, options={"dimension": 4}
+    )
+    a.add(documents=["x"], ids=["x"], embeddings=[[1.0, 0.0, 0.0, 0.0]])
+    b.add(documents=["y"], ids=["y"], embeddings=[[0.0, 1.0, 0.0, 0.0]])
+    assert a.count() == 1
+    assert b.count() == 1
+    assert a.get(ids=["y"]).ids == []
+
+
+# ---------------------------------------------------------------------------
+# Where translator (unit)
+# ---------------------------------------------------------------------------
+
+
+def test_translate_where_eq():
+    sql, params = _translate_where({"wing": "x"})
+    assert "= ?" in sql
+    assert params == ["x"]
+
+
+def test_translate_where_and_or_combination():
+    sql, params = _translate_where(
+        {"$and": [{"wing": "x"}, {"$or": [{"score": 1}, {"score": 2}]}]}
+    )
+    assert "AND" in sql
+    assert "OR" in sql
+    # Order is implementation-defined; only the multiset of params matters.
+    assert len(params) == 3
+    assert "x" in params
+    assert 1 in params
+    assert 2 in params
+
+
+def test_translate_where_in_empty_list_raises():
+    with pytest.raises(UnsupportedFilterError, match="non-empty list"):
+        _translate_where({"wing": {"$in": []}})
+
+
+def test_translate_where_unknown_operator_raises():
+    with pytest.raises(UnsupportedFilterError, match="\\$mod"):
+        _translate_where({"k": {"$mod": 5}})
+
+
+def test_translate_where_document_only_contains():
+    sql, params = _translate_where_document({"$contains": "needle"})
+    assert "LIKE ?" in sql
+    assert params == ["%needle%"]
+
+
+def test_translate_where_document_other_op_raises():
+    with pytest.raises(UnsupportedFilterError):
+        _translate_where_document({"$regex": "x"})
+
+
+def test_sanitize_table_suffix_handles_special_chars():
+    assert _sanitize_table_suffix("hello-world") == "hello_world"
+    assert _sanitize_table_suffix("123abc").startswith("c_")
+    assert _sanitize_table_suffix("") == "_anon"


### PR DESCRIPTION
## Summary

Adds a second in-tree backend, `SQLiteVecBackend`, built on the [sqlite-vec](https://github.com/asg017/sqlite-vec) extension. Sits alongside `ChromaBackend`; users opt in with `MEMPALACE_BACKEND=sqlite-vec`. The default install footprint is unchanged — sqlite-vec is an optional extra (`pip install mempalace[sqlite-vec]`).

## Motivation

On large palaces I've been hitting the recurring HNSW failure modes that this repo already documents in detail:

- `link_lists.bin` sparse-file bloat (#344, partially mitigated by the batch/sync threshold guard)
- `Error finding id` / `Internal error` from where-filtered queries after a rebuild (#1315, #1222, #1218)
- Stale or partially-flushed `index_metadata.pickle` requiring quarantine (#1266 / PR #1285)

The current local recovery flow quarantines segments and falls back to BM25, which works for the unfiltered text path but loses the vector signal for `--wing` / `--room` queries (these go through `_bm25_only_via_sqlite`). sqlite-vec stores vectors in a single `.db` file with no on-disk HNSW segments — drift is impossible by construction — and `vec0` `MATCH` joins cleanly with `WHERE json_extract(metadata_json, '$.wing') = ?`, so where-filtered queries resolve natively.

## What's in this PR

- `mempalace/backends/sqlite_vec.py` (new): `SQLiteVecBackend` + `SQLiteVecCollection` implementing the full RFC 001 surface, plus a where-translator that covers every required operator (`\$eq`, `\$ne`, `\$in`, `\$nin`, `\$and`, `\$or`, `\$contains`) and the optional range operators (`\$gt`, `\$gte`, `\$lt`, `\$lte`). Unknown operators raise `UnsupportedFilterError` per §1.4.
- Atomic `update` override: preserves embeddings when only `documents`/`metadatas` change (the base-class default would need a fresh embedding round-trip).
- Lazy embedder: `embedder=None` (default) resolves `mempalace.embedding.get_embedding_function` on first `get_collection`, so callers can pass `query_texts` and docs-only `add` exactly like Chroma. `embedder=False` disables it for callers that pre-embed; a callable is used as-is.
- Legacy positional `get_collection(palace_path, collection_name, …)` shim mirroring `ChromaBackend`.
- `mempalace/backends/__init__.py` + `registry.py`: registered as built-in (`available_backends() == ['chroma', 'sqlite-vec']`).
- `mempalace/palace.py`: `_select_backend()` calls `resolve_backend_for_palace(env_value=…, palace_path=…)` so the registry priority order is honoured. Chroma stays the singleton default and its per-process client cache is preserved unchanged.
- `pyproject.toml`: optional `[project.optional-dependencies] sqlite-vec` and entry-point under `mempalace.backends`.
- `tests/test_sqlite_vec_backend.py` (34 cases): registry, lifecycle, all CRUD methods, every where-operator translation, multi-collection isolation, unsupported-operator rejection. Whole file is skipped (`importorskip`) when `sqlite-vec` is not installed, so the default test matrix is unaffected.

## Storage layout

One `sqlite_vec.db` per palace, alongside `chroma.sqlite3`:

```
collections (name PK, dimension, embedder_name, created_at)
items       (rowid, collection FK, id, document, metadata_json, …, UNIQUE(collection, id))
items_vec_<sanitised_collection_name>  -- vec0 virtual table, dimension fixed at create
```

`metadata_json` is queried with `json_extract` so where-filters work without a dedicated metadata table. Collections are isolated by the `collection` column on `items` and by per-collection `items_vec_*` virtual tables (dimension is per-collection).

## Validation

End-to-end on a real 268,613-drawer palace (Friol.ai notebooks + Claude Code transcripts):

- Full migration: **27 minutes** (165 drawers/s) via SQL read of `embedding_metadata` + re-embed (ONNX is deterministic, so vectors are bit-equivalent to the originals).
- Paridade post-migration: count match in both collections (267,624 + 989), document sampling 10/10 identical.
- `mempalace search "…" --wing claude-sessions` now returns vector-scored results natively (no BM25 fallback).
- Existing test suite (`tests/test_backends.py`, 45 cases) unchanged and passing.

## Compatibility

- Default behaviour is unchanged: with no env var and no `sqlite_vec.db` on disk, every call still routes to `ChromaBackend`.
- `sqlite-vec >= 0.1.6` (extension is loaded via `db.enable_load_extension`).
- Python 3.9–3.14 (matches the existing classifiers).

## Out of scope

- Embedder-identity check on open (`EmbedderIdentityMismatchError` exists in `base.py` but isn't enforced yet — same as Chroma today).
- Cross-backend live migration tooling. I have a working migrate script (SQL read + re-embed + atomic rename) that I'm happy to PR separately if the maintainers want it in-tree.
- HNSW capacity probe equivalent — sqlite-vec doesn't need one, but the MCP server's existing `vector_disabled` path still routes through `_bm25_only_via_sqlite` and isn't touched here.

Happy to split this if you'd prefer the palace.py rewire as a separate prep PR before the backend lands.