### PR TITLE
fix(hooks): break mine cascade with failure circuit breaker + Windows commit guard (#1518)

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -332,6 +333,173 @@ def _pid_alive(pid: int) -> bool:
         return False
 
 
+# -- Failure circuit breaker (#1518 cascade prevention) ---------------------
+#
+# Per-target PID slots + O_EXCL claims (above) defeat *concurrent* re-fires
+# of the same target. They do not defeat a *serial* cascade: if a mine
+# subprocess crashes (e.g. the import of chromadb + a heavy embedding
+# backend pushes commit charge past the system limit on Windows, OOM
+# killer fires on Linux, or the 60s ``_mine_sync`` timeout trips), the
+# slot becomes stale and the very next hook fire happily reclaims it and
+# spawns a fresh mine that crashes the same way. Twelve cascaded mines in
+# under an hour have been observed in the wild on Windows, each reserving
+# 320-352 GB of virtual address space before dying.
+#
+# The breaker watches for "PID died before plausibly completing real work"
+# (default: faster than 30 seconds since spawn) and treats that as a
+# failure. After N consecutive failures it imposes an exponential cooldown
+# during which both ``_maybe_auto_ingest`` and ``_mine_sync`` short-circuit
+# without spawning anything. A spawn that survives the threshold resets
+# the counter.
+#
+# Heuristic note: we do not currently capture exit codes (the hook is a
+# new process per fire; no Popen handle survives), so runtime is the only
+# signal available without a wrapper shim. The 30s default is generous
+# enough that a real mine completing quickly on a tiny corpus may be
+# misclassified as a failure once, which only delays the *next* spawn by
+# 60s — a harmless trade for stopping a runaway cascade dead.
+_MINE_FAIL_FILE = STATE_DIR / "mine.failures.json"
+_COOLDOWN_LADDER_SEC = (60, 300, 1800)  # 1 min, 5 min, 30 min
+
+
+def _success_threshold_sec() -> float:
+    try:
+        return float(os.environ.get("MEMPALACE_HOOK_SUCCESS_THRESHOLD_SEC", "30"))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _read_failure_state() -> dict:
+    try:
+        data = json.loads(_MINE_FAIL_FILE.read_text())
+    except (OSError, ValueError):
+        return {"consecutive": 0, "cooldown_until": 0}
+    if not isinstance(data, dict):
+        return {"consecutive": 0, "cooldown_until": 0}
+    return {
+        "consecutive": int(data.get("consecutive", 0)),
+        "cooldown_until": float(data.get("cooldown_until", 0) or 0),
+    }
+
+
+def _write_failure_state(state: dict) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        _MINE_FAIL_FILE.write_text(json.dumps(state))
+    except OSError:
+        pass
+
+
+def _record_failure() -> None:
+    state = _read_failure_state()
+    state["consecutive"] = min(state["consecutive"] + 1, len(_COOLDOWN_LADDER_SEC))
+    delay = _COOLDOWN_LADDER_SEC[state["consecutive"] - 1]
+    state["cooldown_until"] = time.time() + delay
+    _write_failure_state(state)
+    _log(
+        f"mine failure {state['consecutive']}/{len(_COOLDOWN_LADDER_SEC)} recorded; "
+        f"cooldown {delay}s"
+    )
+
+
+def _record_success() -> None:
+    if _MINE_FAIL_FILE.exists():
+        try:
+            _MINE_FAIL_FILE.unlink()
+        except OSError:
+            pass
+
+
+def _in_cooldown() -> bool:
+    state = _read_failure_state()
+    return time.time() < state["cooldown_until"]
+
+
+def _reap_finished_mines() -> None:
+    """Inspect per-target PID slots; classify each finished spawn as
+    success or failure based on how long it ran.
+
+    Runs at the head of ``_maybe_auto_ingest`` / ``_mine_sync`` so the
+    classification reflects the state of the *previous* fire(s) before
+    deciding whether to spawn again. Live PIDs are left alone.
+    """
+    if not _MINE_PID_DIR.exists():
+        return
+    threshold = _success_threshold_sec()
+    now = time.time()
+    for slot in _MINE_PID_DIR.glob("mine_*.pid"):
+        try:
+            recorded = slot.read_text().strip()
+            mtime = slot.stat().st_mtime
+        except OSError:
+            continue
+        if not recorded.isdigit():
+            continue
+        pid = int(recorded)
+        if _pid_alive(pid):
+            continue
+        # Dead PID — classify and release the slot.
+        runtime = now - mtime
+        if runtime < threshold:
+            _record_failure()
+        else:
+            _record_success()
+        try:
+            slot.unlink()
+        except OSError:
+            pass
+
+
+def _commit_pressure_high() -> bool:
+    """Return True when the system is close enough to its commit-charge
+    ceiling that spawning another heavy mine would risk pushing it over.
+
+    Only meaningful on Windows, where commit charge (RAM + pagefile) is a
+    hard ceiling: once exhausted, *any* process VirtualAlloc fails — not
+    just the offender — which can wedge the desktop session. On POSIX,
+    overcommit and an OOM killer give a much softer failure mode, so we
+    skip this check there.
+
+    Tunable via ``MEMPALACE_COMMIT_GUARD_RATIO`` (default 0.85). Set
+    ``MEMPALACE_HOOK_DISABLE_COMMIT_GUARD=1`` to opt out entirely.
+    """
+    if sys.platform != "win32":
+        return False
+    if os.environ.get("MEMPALACE_HOOK_DISABLE_COMMIT_GUARD") in ("1", "true", "True"):
+        return False
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", wintypes.DWORD),
+                ("dwMemoryLoad", wintypes.DWORD),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        stat = MEMORYSTATUSEX()
+        stat.dwLength = ctypes.sizeof(stat)
+        if not ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+            return False
+        if stat.ullTotalPageFile == 0:
+            return False
+        used_ratio = 1.0 - (stat.ullAvailPageFile / stat.ullTotalPageFile)
+    except (OSError, AttributeError, ZeroDivisionError):
+        return False
+    try:
+        threshold = float(os.environ.get("MEMPALACE_COMMIT_GUARD_RATIO", "0.85"))
+    except (TypeError, ValueError):
+        threshold = 0.85
+    return used_ratio > threshold
+
+
 def _mine_already_running(cmd: list[str]) -> bool:
     """Return True if a previous mine for ``cmd``'s target is still alive."""
     pid_file = _pid_file_for_cmd(cmd)
@@ -436,9 +604,20 @@ def _maybe_auto_ingest():
     target gets its own PID slot, so distinct targets never block each
     other but a re-fire of the same target while the previous one is
     still running is silently skipped.
+
+    A failure circuit breaker (#1518) and Windows commit-charge guard
+    short-circuit the spawn when the previous mine(s) died young or
+    when system commit charge is already near its hard ceiling.
     """
     targets = _get_mine_targets()
     if not targets:
+        return
+    _reap_finished_mines()
+    if _in_cooldown():
+        _log("Skipping auto-ingest: previous mines failed; cooldown active")
+        return
+    if _commit_pressure_high():
+        _log("Skipping auto-ingest: system commit pressure too high")
         return
     for mine_dir, mode in targets:
         try:
@@ -453,9 +632,19 @@ def _mine_sync():
     Transcript convos are ingested separately via ``_ingest_transcript``
     in ``hook_precompact`` — keeping them out of this function avoids
     timeout stacking against the harness 30s ceiling (#1231 review).
+
+    Honors the same failure circuit breaker and Windows commit-charge
+    guard as ``_maybe_auto_ingest`` (#1518).
     """
     targets = _get_mine_targets()
     if not targets:
+        return
+    _reap_finished_mines()
+    if _in_cooldown():
+        _log("Skipping mine_sync: previous mines failed; cooldown active")
+        return
+    if _commit_pressure_high():
+        _log("Skipping mine_sync: system commit pressure too high")
         return
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     log_path = STATE_DIR / "hook.log"

--- a/tests/test_hooks_circuit_breaker.py
+++ b/tests/test_hooks_circuit_breaker.py
@@ -1,0 +1,263 @@
+"""Tests for the mine-cascade circuit breaker and Windows commit guard
+introduced in fix for #1518.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import mempalace.hooks_cli as hooks_cli_mod
+from mempalace.hooks_cli import (
+    _COOLDOWN_LADDER_SEC,
+    _commit_pressure_high,
+    _in_cooldown,
+    _read_failure_state,
+    _reap_finished_mines,
+    _record_failure,
+    _record_success,
+    _success_threshold_sec,
+)
+
+
+@pytest.fixture
+def isolated_state(tmp_path, monkeypatch):
+    """Point STATE_DIR and friends at a tmp_path so tests don't poison
+    the developer's real ``~/.mempalace/hook_state``."""
+    state_dir = tmp_path / "hook_state"
+    pid_dir = state_dir / "mine_pids"
+    fail_file = state_dir / "mine.failures.json"
+    monkeypatch.setattr(hooks_cli_mod, "STATE_DIR", state_dir)
+    monkeypatch.setattr(hooks_cli_mod, "_MINE_PID_DIR", pid_dir)
+    monkeypatch.setattr(hooks_cli_mod, "_MINE_FAIL_FILE", fail_file)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    yield state_dir
+
+
+# --- failure state read/write ---
+
+
+def test_read_failure_state_default_when_missing(isolated_state):
+    state = _read_failure_state()
+    assert state == {"consecutive": 0, "cooldown_until": 0}
+
+
+def test_read_failure_state_default_when_corrupt(isolated_state):
+    hooks_cli_mod._MINE_FAIL_FILE.write_text("{not json")
+    state = _read_failure_state()
+    assert state == {"consecutive": 0, "cooldown_until": 0}
+
+
+def test_read_failure_state_default_when_not_dict(isolated_state):
+    hooks_cli_mod._MINE_FAIL_FILE.write_text(json.dumps(["unexpected"]))
+    state = _read_failure_state()
+    assert state == {"consecutive": 0, "cooldown_until": 0}
+
+
+# --- record_failure increments and ladders ---
+
+
+def test_record_failure_increments_and_writes_cooldown(isolated_state):
+    before = time.time()
+    _record_failure()
+    state = _read_failure_state()
+    assert state["consecutive"] == 1
+    assert state["cooldown_until"] >= before + _COOLDOWN_LADDER_SEC[0] - 1
+
+
+def test_record_failure_climbs_ladder(isolated_state):
+    for expected_step in (1, 2, 3):
+        _record_failure()
+        state = _read_failure_state()
+        assert state["consecutive"] == expected_step
+
+
+def test_record_failure_caps_at_ladder_length(isolated_state):
+    for _ in range(len(_COOLDOWN_LADDER_SEC) + 4):
+        _record_failure()
+    state = _read_failure_state()
+    assert state["consecutive"] == len(_COOLDOWN_LADDER_SEC)
+
+
+# --- record_success resets ---
+
+
+def test_record_success_removes_failure_file(isolated_state):
+    _record_failure()
+    assert hooks_cli_mod._MINE_FAIL_FILE.exists()
+    _record_success()
+    assert not hooks_cli_mod._MINE_FAIL_FILE.exists()
+
+
+def test_record_success_noop_when_file_missing(isolated_state):
+    # Must not raise even if no failures were ever recorded.
+    _record_success()
+
+
+# --- cooldown gating ---
+
+
+def test_in_cooldown_false_when_no_failures(isolated_state):
+    assert _in_cooldown() is False
+
+
+def test_in_cooldown_true_immediately_after_failure(isolated_state):
+    _record_failure()
+    assert _in_cooldown() is True
+
+
+def test_in_cooldown_false_after_window_expires(isolated_state, monkeypatch):
+    _record_failure()
+    state = _read_failure_state()
+    fake_now = state["cooldown_until"] + 1
+    monkeypatch.setattr(hooks_cli_mod.time, "time", lambda: fake_now)
+    assert _in_cooldown() is False
+
+
+# --- _reap_finished_mines: PID-classification ---
+
+
+def _write_slot(pid_dir: Path, name: str, pid: int, age_seconds: float):
+    slot = pid_dir / f"mine_{name}.pid"
+    slot.write_text(str(pid))
+    target_mtime = time.time() - age_seconds
+    os.utime(slot, (target_mtime, target_mtime))
+    return slot
+
+
+def test_reap_skips_live_pids(isolated_state):
+    pid_dir = hooks_cli_mod._MINE_PID_DIR
+    slot = _write_slot(pid_dir, "live", pid=12345, age_seconds=5)
+    with patch.object(hooks_cli_mod, "_pid_alive", return_value=True):
+        _reap_finished_mines()
+    assert slot.exists()
+    assert _read_failure_state()["consecutive"] == 0
+
+
+def test_reap_records_failure_when_dead_and_fast(isolated_state):
+    pid_dir = hooks_cli_mod._MINE_PID_DIR
+    slot = _write_slot(pid_dir, "fast", pid=99999, age_seconds=2)
+    with patch.object(hooks_cli_mod, "_pid_alive", return_value=False):
+        _reap_finished_mines()
+    assert not slot.exists()
+    assert _read_failure_state()["consecutive"] == 1
+
+
+def test_reap_records_success_when_dead_and_long_running(isolated_state):
+    pid_dir = hooks_cli_mod._MINE_PID_DIR
+    _record_failure()
+    assert hooks_cli_mod._MINE_FAIL_FILE.exists()
+    slot = _write_slot(pid_dir, "slow", pid=88888, age_seconds=_success_threshold_sec() + 30)
+    with patch.object(hooks_cli_mod, "_pid_alive", return_value=False):
+        _reap_finished_mines()
+    assert not slot.exists()
+    assert not hooks_cli_mod._MINE_FAIL_FILE.exists()
+
+
+def test_reap_ignores_non_numeric_slot(isolated_state):
+    pid_dir = hooks_cli_mod._MINE_PID_DIR
+    slot = pid_dir / "mine_garbage.pid"
+    slot.write_text("not-a-pid")
+    with patch.object(hooks_cli_mod, "_pid_alive", return_value=False):
+        _reap_finished_mines()
+    assert slot.exists()
+    assert _read_failure_state()["consecutive"] == 0
+
+
+def test_reap_handles_missing_pid_dir(isolated_state):
+    # Even if the dir vanished mid-flight, reaping must not raise.
+    pid_dir = hooks_cli_mod._MINE_PID_DIR
+    for child in pid_dir.iterdir():
+        child.unlink()
+    pid_dir.rmdir()
+    _reap_finished_mines()
+
+
+# --- success threshold tunable via env ---
+
+
+def test_success_threshold_uses_env(monkeypatch):
+    monkeypatch.setenv("MEMPALACE_HOOK_SUCCESS_THRESHOLD_SEC", "120")
+    assert _success_threshold_sec() == 120.0
+
+
+def test_success_threshold_default_on_bad_env(monkeypatch):
+    monkeypatch.setenv("MEMPALACE_HOOK_SUCCESS_THRESHOLD_SEC", "not-a-number")
+    assert _success_threshold_sec() == 30.0
+
+
+# --- Windows commit-charge guard ---
+
+
+def test_commit_pressure_false_on_non_windows(monkeypatch):
+    monkeypatch.setattr(hooks_cli_mod.sys, "platform", "linux")
+    assert _commit_pressure_high() is False
+
+
+def test_commit_pressure_respects_disable_env(monkeypatch):
+    monkeypatch.setattr(hooks_cli_mod.sys, "platform", "win32")
+    monkeypatch.setenv("MEMPALACE_HOOK_DISABLE_COMMIT_GUARD", "1")
+    assert _commit_pressure_high() is False
+
+
+# --- _maybe_auto_ingest + _mine_sync honor the gates ---
+
+
+def test_maybe_auto_ingest_short_circuits_in_cooldown(isolated_state, monkeypatch):
+    monkeypatch.setenv("MEMPAL_DIR", str(isolated_state))  # any non-empty target
+    monkeypatch.setattr(
+        hooks_cli_mod, "_get_mine_targets", lambda: [(str(isolated_state), "projects")]
+    )
+    _record_failure()  # forces cooldown
+    spawned = []
+    monkeypatch.setattr(hooks_cli_mod, "_spawn_mine", lambda cmd: spawned.append(cmd))
+    hooks_cli_mod._maybe_auto_ingest()
+    assert spawned == []
+
+
+def test_maybe_auto_ingest_runs_when_no_failures(isolated_state, monkeypatch):
+    monkeypatch.setattr(
+        hooks_cli_mod, "_get_mine_targets", lambda: [(str(isolated_state), "projects")]
+    )
+    monkeypatch.setattr(hooks_cli_mod, "_commit_pressure_high", lambda: False)
+    spawned = []
+    monkeypatch.setattr(hooks_cli_mod, "_spawn_mine", lambda cmd: spawned.append(cmd))
+    hooks_cli_mod._maybe_auto_ingest()
+    assert len(spawned) == 1
+
+
+def test_maybe_auto_ingest_short_circuits_on_commit_pressure(isolated_state, monkeypatch):
+    monkeypatch.setattr(
+        hooks_cli_mod, "_get_mine_targets", lambda: [(str(isolated_state), "projects")]
+    )
+    monkeypatch.setattr(hooks_cli_mod, "_commit_pressure_high", lambda: True)
+    spawned = []
+    monkeypatch.setattr(hooks_cli_mod, "_spawn_mine", lambda cmd: spawned.append(cmd))
+    hooks_cli_mod._maybe_auto_ingest()
+    assert spawned == []
+
+
+def test_mine_sync_short_circuits_in_cooldown(isolated_state, monkeypatch):
+    monkeypatch.setattr(
+        hooks_cli_mod, "_get_mine_targets", lambda: [(str(isolated_state), "projects")]
+    )
+    _record_failure()
+    ran = []
+    monkeypatch.setattr(hooks_cli_mod.subprocess, "run", lambda *a, **kw: ran.append((a, kw)))
+    hooks_cli_mod._mine_sync()
+    assert ran == []
+
+
+def test_mine_sync_short_circuits_on_commit_pressure(isolated_state, monkeypatch):
+    monkeypatch.setattr(
+        hooks_cli_mod, "_get_mine_targets", lambda: [(str(isolated_state), "projects")]
+    )
+    monkeypatch.setattr(hooks_cli_mod, "_commit_pressure_high", lambda: True)
+    ran = []
+    monkeypatch.setattr(hooks_cli_mod.subprocess, "run", lambda *a, **kw: ran.append((a, kw)))
+    hooks_cli_mod._mine_sync()
+    assert ran == []


### PR DESCRIPTION
## What this PR does

Adds two layered defenses against the **serial mine-crash cascade** that the per-target PID slot in develop does not cover. Refs #1518.

1. **Failure circuit breaker.** Every previous mine slot is classified at the head of \`_maybe_auto_ingest\` and \`_mine_sync\`: PID dead + runtime < success threshold (default 30 s) is a failure; longer runtimes reset the counter. Consecutive failures impose an exponential cooldown (60 s → 5 min → 30 min) during which both spawn paths short-circuit without launching anything. A crash-respawn loop dies in at most three rounds.
2. **Windows commit-charge precheck.** Before any spawn, query \`GlobalMemoryStatusEx\` and bail if the pagefile is already > 85 % committed. Skipped on POSIX where the OOM killer provides a softer failure mode. This is the only signal that catches the cascade *before* the next mine has paid the chromadb + torch import tax.

## Why the existing guard isn't enough

The \`_pid_file_for_cmd\` + \`O_CREAT | O_EXCL\` claim added recently defeats *concurrent* re-fires of the same mine target. It does nothing for the *serial* case:

\`\`\`
T0  hook fire → claim slot → Popen mine A
T1  mine A imports chromadb / sentence-transformers / torch
T2  commit charge climbs past the system ceiling (Windows) /
    OOM killer fires (Linux) / 60s _mine_sync timeout trips
T3  mine A dies, slot becomes stale
T4  next hook fire → \`_claim_mine_slot\` reclaims stale slot →
    Popen mine B (will crash the same way)
T5  ... repeat
\`\`\`

## Field observation

Reproduced on Windows 11 (build 26200, 96 GB RAM, 256 GB pagefile, mempalace 3.3.4, Stop hook wired via \`mempalace hook run --hook stop --harness claude-code\`). Twelve cascaded \`python.exe\` processes fired between 00:27 and 01:11 local time, each reserving 320–352 GB of virtual address space (per Windows \`Microsoft-Windows-Resource-Exhaustion-Detector\` event 2004):

\`\`\`
00:27:31 → python.exe (PID redacted) consumed 352 GB virtual
00:34:17 → python.exe                  consumed 351 GB virtual
00:34:57 → python.exe                  consumed 351 GB virtual
00:36:54 → python.exe                  consumed 351 GB virtual
00:43:49 → python.exe                  consumed 343 GB virtual
00:45:45 → python.exe                  consumed 345 GB virtual
00:54:07 → python.exe                  consumed 343 GB virtual
00:57:01 → python.exe                  consumed 339 GB virtual
01:02:30 → python.exe                  consumed 337 GB virtual
01:06:06 → python.exe                  consumed 331 GB virtual
01:06:52 → python.exe                  consumed 330 GB virtual
01:07:40 → python.exe                  consumed 330 GB virtual
\`\`\`

Each spawn is a fresh \`mempalace mine\` cold-starting chromadb + onnxruntime + torch + sentence-transformers. Once total commit charge approached the (RAM + pagefile) ceiling, *any* \`VirtualAlloc\` in the session began failing — including new CLR shells, which produced cascading \`pwsh.exe\` crashes (\`Failed to load System.Private.CoreLib\`, \`Failed to create CoreCLR\`), NetBT initialization failure, Schannel timeouts, and finally the Web Threat Defense service termination. The interactive desktop session wedged for several minutes before recovering.

Windows commit charge is a hard global ceiling; the offender takes the rest of the session down with it. POSIX overcommit + OOM killer is softer but #1518 reports the equivalent symptom (1.6 GB resident per process, two concurrent processes filling 14 GB swap, OOM kill plus a corrupted HNSW file).

## Knobs (all optional)

| Env var | Default | Effect |
|---|---|---|
| \`MEMPALACE_HOOK_SUCCESS_THRESHOLD_SEC\` | 30 | Runtime below which a dead PID counts as a failure |
| \`MEMPALACE_COMMIT_GUARD_RATIO\` | 0.85 | Pagefile-used ratio above which Windows spawns are skipped |
| \`MEMPALACE_HOOK_DISABLE_COMMIT_GUARD\` | unset | \`1\` / \`true\` disables the Windows guard entirely |

The cooldown ladder \`(60, 300, 1800)\` is intentionally a constant; an env-driven ladder is easy to add later if needed.

## Tradeoffs / known limits

- Failure detection is runtime-based, not exit-code-based. The hook process is short-lived and no \`Popen\` handle survives across invocations, so we read \`stat().st_mtime\` of the PID file as a proxy for spawn time. A mine that genuinely completes in < 30 s on a tiny corpus is misclassified as a failure once, only delaying the *next* spawn by 60 s. Easy to revisit if it matters; capturing an exit-code sentinel would require a wrapper shim or a \`cli.py\` change to write a success file before exit (kept out of this PR to bound scope).
- The cooldown is global, not per-target. If two targets share the breaker and only one is crashing, the healthy one waits too. Per-target cooldown is straightforward (key by the same digest \`_pid_file_for_cmd\` already uses) but adds two more state files; happy to add it in a follow-up if maintainers prefer.
- The commit guard is Windows-only by design. Linux \`GlobalMemoryStatusEx\` has no analog; \`cgroups\` memory accounting would be the right answer but feels out of scope for a hook.

## Tests

\`tests/test_hooks_circuit_breaker.py\`, 25 cases:

- failure-state read/write defaults (missing / corrupt JSON / wrong shape)
- ladder increments and caps at length
- success removes file, no-op when missing
- cooldown gate before/after window
- \`_reap_finished_mines\` classification: live skipped, dead+fast = failure, dead+long = success, garbage PID ignored, missing dir no-op
- success threshold env var tunable, defaults on bad input
- commit guard: false on non-Windows, false when disabled by env
- \`_maybe_auto_ingest\` and \`_mine_sync\` short-circuit in cooldown and under commit pressure, run normally otherwise

\`\`\`
tests/test_hooks_circuit_breaker.py  25 passed in 0.16s
\`\`\`

Existing \`_spawn_mine\` / per-target slot tests in \`tests/test_hooks_cli.py\` and \`tests/test_save_hook_*.py\` are untouched. Nine pre-existing failures in \`tests/test_hooks_cli.py\` reproduce on develop without this patch and are unrelated.

## Adheres to project rules

- Hook fast path overhead: file read + (Windows only) one \`GlobalMemoryStatusEx\` call, well under the 500 ms budget.
- No new dependencies.
- snake_case, double quotes, \`ruff check\` + \`ruff format\` clean on the touched files.
- No telemetry, no external API, no summarization, no destructive ops on existing palace state — design principles untouched.

Happy to split into two smaller commits (breaker first, commit guard second) or to thin the doc strings if maintainers prefer.