### PR TITLE
Test: Make hooks CLI tests set up palace root

### DIFF
--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -904,9 +904,9 @@ def test_spawn_mine_releases_slot_on_oserror(tmp_path):
             with patch("mempalace.hooks_cli.subprocess.Popen", side_effect=OSError("spawn fail")):
                 with pytest.raises(OSError):
                     _spawn_mine(cmd)
-                assert not pid_file.exists(), (
-                    "slot must be released so the next hook fire isn't permanently blocked"
-                )
+                assert (
+                    not pid_file.exists()
+                ), "slot must be released so the next hook fire isn't permanently blocked"
 
 
 def test_spawn_mine_passes_pid_file_env_var(tmp_path):

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -179,6 +179,7 @@ def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
         palace_root.mkdir(parents=True, exist_ok=True)
         patches.append(patch("mempalace.hooks_cli.PALACE_ROOT", palace_root))
         patches.append(patch("mempalace.hooks_cli.STATE_DIR", state_dir))
+        patches.append(patch("mempalace.hooks_cli._MINE_PID_DIR", state_dir / "mine_pids"))
     # Mock MempalaceConfig so tests don't depend on user's ~/.mempalace/config.json
     mock_config = MagicMock()
     type(mock_config).hook_silent_save = PropertyMock(return_value=True)
@@ -189,6 +190,43 @@ def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
             stack.enter_context(p)
         hook_fn(data, harness)
     return json.loads(buf.getvalue())
+
+
+def test_capture_hook_output_patches_mine_pid_dir_for_auto_ingest(
+    tmp_path, monkeypatch
+):
+    """Regression #1510: helper should isolate background mine PID files too."""
+    state_dir = tmp_path / "hook_state"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(SAVE_INTERVAL)],
+    )
+
+    monkeypatch.setenv("MEMPAL_DIR", str(project_dir))
+
+    with (
+        patch(
+            "mempalace.hooks_cli._save_diary_direct",
+            return_value={"count": SAVE_INTERVAL, "themes": []},
+        ),
+        patch("mempalace.hooks_cli._ingest_transcript"),
+        patch("mempalace.hooks_cli.subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value.pid = 12345
+
+        result = _capture_hook_output(
+            hook_stop,
+            {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
+            state_dir=state_dir,
+        )
+
+    assert "systemMessage" in result
+    assert (state_dir / "mine_pids").is_dir()
+    assert list((state_dir / "mine_pids").glob("mine_*.pid"))
 
 
 def test_capture_hook_output_sets_up_palace_root(tmp_path):

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -192,9 +192,7 @@ def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
     return json.loads(buf.getvalue())
 
 
-def test_capture_hook_output_patches_mine_pid_dir_for_auto_ingest(
-    tmp_path, monkeypatch
-):
+def test_capture_hook_output_patches_mine_pid_dir_for_auto_ingest(tmp_path, monkeypatch):
     """Regression #1510: helper should isolate background mine PID files too."""
     state_dir = tmp_path / "hook_state"
     project_dir = tmp_path / "project"
@@ -906,9 +904,9 @@ def test_spawn_mine_releases_slot_on_oserror(tmp_path):
             with patch("mempalace.hooks_cli.subprocess.Popen", side_effect=OSError("spawn fail")):
                 with pytest.raises(OSError):
                     _spawn_mine(cmd)
-                assert (
-                    not pid_file.exists()
-                ), "slot must be released so the next hook fire isn't permanently blocked"
+                assert not pid_file.exists(), (
+                    "slot must be released so the next hook fire isn't permanently blocked"
+                )
 
 
 def test_spawn_mine_passes_pid_file_env_var(tmp_path):

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -174,6 +174,10 @@ def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
     buf = io.StringIO()
     patches = [patch("mempalace.hooks_cli._output", side_effect=lambda d: buf.write(json.dumps(d)))]
     if state_dir:
+        state_dir = Path(state_dir)
+        palace_root = state_dir / ".mempalace"
+        palace_root.mkdir(parents=True, exist_ok=True)
+        patches.append(patch("mempalace.hooks_cli.PALACE_ROOT", palace_root))
         patches.append(patch("mempalace.hooks_cli.STATE_DIR", state_dir))
     # Mock MempalaceConfig so tests don't depend on user's ~/.mempalace/config.json
     mock_config = MagicMock()
@@ -185,6 +189,20 @@ def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
             stack.enter_context(p)
         hook_fn(data, harness)
     return json.loads(buf.getvalue())
+
+
+def test_capture_hook_output_sets_up_palace_root(tmp_path):
+    """Regression #1510: hook tests should not depend on test_cli.py side effects."""
+    state_dir = tmp_path / "hook_state"
+
+    result = _capture_hook_output(
+        hook_stop,
+        {"session_id": "test", "stop_hook_active": False, "transcript_path": ""},
+        state_dir=state_dir,
+    )
+
+    assert result == {}
+    assert (state_dir / ".mempalace").is_dir()
 
 
 def test_stop_hook_passthrough_when_active(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Fixes #1510.

Some `tests/test_hooks_cli.py` tests depended on `test_cli.py` having already created `~/.mempalace` in the test HOME. When `tests/test_hooks_cli.py` was run by itself, the hook kill-switch saw no palace root and short-circuited before the test behavior could run.

## What changed

- Updated `_capture_hook_output(...)` to create a fake palace root when a test state directory is provided
- Patched `mempalace.hooks_cli.PALACE_ROOT` to that fake root
- Added a regression test for the helper setup itself


## How to test

```bash
ruff format tests/test_hooks_cli.py
python -m pytest tests/test_hooks_cli.py
python -m pytest tests/test_hooks_cli.py -k capture_hook_output
python -m ruff check tests/test_hooks_cli.py
python -m pytest tests/ -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
