### PR TITLE
fix(mine): validate FTS5 at end of mine (#1537)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -502,7 +502,7 @@ def cmd_mine(args):
             llm_provider=None,
         )
 
-    from .palace import MineAlreadyRunning
+    from .palace import MineAlreadyRunning, MineValidationError
 
     try:
         if args.mode == "convos":
@@ -548,6 +548,24 @@ def cmd_mine(args):
         # to wait for (or stop), and exit non-zero so wrappers like
         # nohup / scripts can detect the contention.
         print(f"mempalace: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except MineValidationError as exc:
+        # PRAGMA quick_check on chroma.sqlite3 returned errors at end of mine.
+        # The corruption may pre-date the mine; we surface it here so automation
+        # cannot proceed against a half-broken palace. Reuse cmd_repair's
+        # recovery banner so the operator sees one consistent message regardless
+        # of which command surfaces it.
+        from .repair import print_sqlite_integrity_abort
+
+        print_sqlite_integrity_abort(exc.palace_path, exc.errors)
+        print(
+            "\n  PRAGMA quick_check after this mine reported errors (the corruption\n"
+            "  may pre-date the mine itself). Drawers may still be intact for direct\n"
+            "  lookup; wing-filtered or full-text search will fail until the FTS5\n"
+            "  index is rebuilt. `mempalace repair --yes` rebuilds the FTS5 virtual\n"
+            "  table automatically (step 6 of the recovery above).",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -22,6 +22,7 @@ from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
     _metadata_matches_extract_mode,
+    _validate_palace_fts5_after_mine,
     file_already_mined,
     get_collection,
     mine_lock,
@@ -696,6 +697,9 @@ def _mine_convos_impl(
 
         total_drawers += drawers_added
         print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+
+    if not dry_run:
+        _validate_palace_fts5_after_mine(palace_path)
 
     print(f"\n{'=' * 55}")
     print("  Done.")

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -72,6 +72,7 @@ from typing import Optional, Union
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
+    _validate_palace_fts5_after_mine,
     file_already_mined,
     get_collection,
     mine_lock,
@@ -928,8 +929,9 @@ def mine_formats(
     else:
         # All files processed without interruption — compute cross-wing topic
         # tunnels linking this wing to others that share confirmed topics.
-        # Mirrors miner.py:1241-1249 exactly: tunnel-compute failures must
-        # never fail a mine, so any exception is logged and skipped quietly.
+        # Mirrors the post-loop tunnel block in miner._mine_impl: tunnel-compute
+        # failures must never fail a mine, so any exception is logged and
+        # skipped quietly.
         if not dry_run:
             try:
                 tunnels_added = _compute_topic_tunnels_for_wing(wing)
@@ -945,6 +947,14 @@ def mine_formats(
                     f"\n  WARNING: topic tunnel computation skipped — {exc}",
                     file=sys.stderr,
                 )
+
+            # End-of-mine FTS5 integrity check (#1537). Mirrors _mine_impl;
+            # raises MineValidationError to cmd_mine if PRAGMA quick_check
+            # finds malformed FTS5 rows so a corrupted palace cannot silently
+            # exit Done on the --mode extract path that bypasses _mine_impl.
+            # Sits outside the per-file try/except in the for-loop body, so
+            # caught per-file errors do not mask the integrity result.
+            _validate_palace_fts5_after_mine(palace_path)
     finally:
         # Hook-spawned mines write a PID file that miner.py's
         # _cleanup_mine_pid_file() clears; we mirror that so format-mode

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -22,7 +22,9 @@ from typing import Optional
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
+    MineValidationError,
     _open_collection_or_explain,
+    _validate_palace_fts5_after_mine,
     build_closet_lines,
     file_already_mined,
     get_closets_collection,
@@ -1739,6 +1741,8 @@ def _mine_impl(
                     file=sys.stderr,
                 )
 
+            _validate_palace_fts5_after_mine(palace_path)
+
         print(f"\n{'=' * 55}")
         print("  Done.")
         print(f"  Files processed: {len(files) - files_skipped}")
@@ -1783,6 +1787,13 @@ def _mine_impl(
             "already-filed drawers are\n  upserted idempotently and will not duplicate.\n"
         )
         sys.exit(130)
+    except MineValidationError:
+        # End-of-mine FTS5 validation failed (#1537). The loop completed
+        # successfully; cmd_mine prints the recovery banner. Don't print a
+        # "Mine aborted" partial-progress summary here: the mine didn't
+        # abort mid-loop, the post-write integrity check did, and the
+        # double-banner would mislead the operator.
+        raise
     except Exception as exc:
         # Without this, an arbitrary exception (ONNX bad_alloc, chromadb HNSW
         # error, OS fault) propagates and the process exits with no completion

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -458,6 +458,42 @@ class MineAlreadyRunning(RuntimeError):
     """Raised when another `mempalace mine` already holds the per-palace lock."""
 
 
+class MineValidationError(RuntimeError):
+    """Raised at end of mine when PRAGMA quick_check on the palace reports errors."""
+
+    def __init__(self, palace_path: str, errors: list[str]) -> None:
+        if not errors:
+            raise ValueError("MineValidationError requires at least one error string")
+        if not palace_path:
+            raise ValueError("MineValidationError requires a non-empty palace_path")
+        super().__init__(f"FTS5/SQLite quick_check failed: {len(errors)} issue(s)")
+        self.palace_path = palace_path
+        # Freeze the forensic snapshot so handlers cannot mutate it.
+        self.errors: tuple[str, ...] = tuple(errors)
+
+
+def _validate_palace_fts5_after_mine(palace_path: str) -> None:
+    """Raise MineValidationError if PRAGMA quick_check reports any error after a mine.
+
+    Reuses the same primitive that `cmd_repair` already runs as preflight so the
+    operator sees the same recovery banner regardless of which command surfaces
+    the bug.
+    """
+    # Defer-import: keeps the repair module graph out of mine's hot import path.
+    from .repair import _close_chroma_handles, sqlite_integrity_errors
+
+    # Pass the live singleton so the writer's cached PersistentClient actually
+    # gets closed and WAL flushes before the read-only sqlite3 re-open.
+    # A transient ChromaBackend (the default) would only clear its own empty
+    # `_clients` dict and leave _DEFAULT_BACKEND's live handle in place,
+    # which on Windows keeps the sqlite file mmap'd.
+    _close_chroma_handles(palace_path, backend=_DEFAULT_BACKEND)
+
+    errors = sqlite_integrity_errors(palace_path)
+    if errors:
+        raise MineValidationError(palace_path, errors)
+
+
 # Per-thread record of palaces this thread already holds the lock for. Used by
 # `mine_palace_lock` to short-circuit re-entrant acquisition from the same
 # thread (e.g. miner.mine() acquires the outer lock then calls

--- a/tests/test_miner_fts5_validation.py
+++ b/tests/test_miner_fts5_validation.py
@@ -1,0 +1,557 @@
+"""Tests for end-of-mine FTS5 validation (#1537).
+
+mempalace mine must not print "Done." and exit 0 on a palace whose
+chroma.sqlite3 left FTS5 in a malformed state. The validation hook in
+``palace._validate_palace_fts5_after_mine`` runs PRAGMA quick_check at
+the end of every non-dry-run mine and raises ``MineValidationError`` so
+``cmd_mine`` can surface the same recovery banner ``cmd_repair`` prints.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mempalace import cli, convo_miner, miner
+from mempalace.palace import (
+    MineValidationError,
+    _validate_palace_fts5_after_mine,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _build_palace_with_drawer(palace_path: Path) -> None:
+    """Create a real chromadb palace with one drawer so chroma.sqlite3 exists."""
+    palace_path.mkdir(parents=True, exist_ok=True)
+    from mempalace.backends.chroma import ChromaBackend
+
+    backend = ChromaBackend()
+    try:
+        col = backend.create_collection(str(palace_path), "mempalace_drawers")
+        col.upsert(
+            ids=["d1"],
+            documents=["hello world memorable phrase"],
+            metadatas=[{"wing": "w", "room": "r"}],
+        )
+    finally:
+        backend.close()
+
+
+def _page_mangle(sqlite_path: Path) -> int:
+    """Corrupt 4 mid-file pages so PRAGMA quick_check fails. Returns offset used."""
+    PAGE = 4096
+    CORRUPT_BYTES = 16384  # 4 pages
+    HEADER_GUARD = PAGE * 2
+    pre_size = sqlite_path.stat().st_size
+    assert pre_size >= HEADER_GUARD + CORRUPT_BYTES, (
+        f"sqlite db too small to mangle: {pre_size} bytes"
+    )
+    max_offset = (pre_size - CORRUPT_BYTES) & ~(PAGE - 1)
+    corrupt_offset = min(40960, max_offset)
+    assert corrupt_offset >= HEADER_GUARD
+    with open(sqlite_path, "r+b") as f:
+        f.seek(corrupt_offset)
+        f.write(b"\xde\xad\xbe\xef" * (CORRUPT_BYTES // 4))
+    return corrupt_offset
+
+
+def _corrupt_fts5_segment(sqlite_path: Path) -> None:
+    """Soft FTS5-only corruption: replace one segment blob with garbage.
+
+    Mirrors the reporter's natural failure mode where chromadb opens cleanly
+    but ``PRAGMA quick_check`` returns ``malformed inverted index for FTS5
+    table main.embedding_fulltext_search``.
+    """
+    import sqlite3
+
+    with sqlite3.connect(str(sqlite_path)) as conn:
+        # Schema-drift guard: chromadb's FTS5 shadow table name is private
+        # API and may rename across versions. Skip cleanly rather than error.
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE name LIKE 'embedding_fulltext_search%'"
+            ).fetchall()
+        }
+        if "embedding_fulltext_search_data" not in tables:
+            pytest.skip(
+                f"chromadb FTS5 shadow table 'embedding_fulltext_search_data' not present; "
+                f"found: {sorted(tables)}"
+            )
+        rows = conn.execute("SELECT id, block FROM embedding_fulltext_search_data").fetchall()
+        if not rows:
+            pytest.skip("FTS5 segments empty: cannot fabricate FTS5-only corruption")
+        target = next((r for r in rows if r[0] > 10), rows[0])
+        garbage = b"\xde\xad\xbe\xef" * (len(target[1]) // 4)
+        conn.execute(
+            "UPDATE embedding_fulltext_search_data SET block=? WHERE id=?",
+            (garbage, target[0]),
+        )
+        conn.commit()
+
+
+def _mine_args(
+    palace: str, src: str, *, mode: str = "project", dry_run: bool = False
+) -> SimpleNamespace:
+    """Build the args namespace cmd_mine reads."""
+    return SimpleNamespace(
+        palace=palace,
+        dir=src,
+        mode=mode,
+        wing=None,
+        agent="mempalace",
+        limit=0,
+        dry_run=dry_run,
+        no_gitignore=False,
+        include_ignored=None,
+        extract="exchange",
+        redetect_origin=False,
+    )
+
+
+# ── 1. Helper returns silently on a clean palace ────────────────────
+
+
+def test_helper_returns_silently_on_clean_palace(tmp_path):
+    palace = tmp_path / "palace"
+    _build_palace_with_drawer(palace)
+
+    # Should not raise: quick_check returns ('ok',) so no errors collected.
+    assert _validate_palace_fts5_after_mine(str(palace)) is None
+
+
+# ── 2. Helper raises MineValidationError on corrupt sqlite ──────────
+
+
+def test_helper_raises_on_page_mangled_sqlite(tmp_path):
+    palace = tmp_path / "palace"
+    _build_palace_with_drawer(palace)
+    _page_mangle(palace / "chroma.sqlite3")
+
+    with pytest.raises(MineValidationError) as exc_info:
+        _validate_palace_fts5_after_mine(str(palace))
+
+    err = exc_info.value
+    assert err.palace_path == str(palace)
+    assert err.errors, "errors list must be populated"
+    combined = " ".join(err.errors).lower()
+    assert "malformed" in combined or "quick_check failed" in combined
+
+
+def test_helper_raises_on_fts5_segment_corruption(tmp_path):
+    """The reporter-shaped failure: FTS5 inverted index malformed, main pages OK."""
+    palace = tmp_path / "palace"
+    _build_palace_with_drawer(palace)
+    _corrupt_fts5_segment(palace / "chroma.sqlite3")
+
+    with pytest.raises(MineValidationError) as exc_info:
+        _validate_palace_fts5_after_mine(str(palace))
+
+    err = exc_info.value
+    assert "fts5" in " ".join(err.errors).lower()
+
+
+# ── 3. cmd_mine surfaces MineValidationError as exit-1 + banner ─────
+
+
+def test_cmd_mine_project_mode_exits_nonzero_with_banner(tmp_path, monkeypatch, capsys):
+    palace = str(tmp_path / "palace")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.md").write_text("placeholder")
+
+    def _raise(*_, **__):
+        raise MineValidationError(
+            palace, ["malformed inverted index for FTS5 table main.embedding_fulltext_search"]
+        )
+
+    monkeypatch.setattr(miner, "mine", _raise)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.cmd_mine(_mine_args(palace, str(src), mode="project"))
+
+    assert exit_info.value.code == 1
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "SQLite-layer corruption detected" in combined
+    assert "PRAGMA quick_check" in combined
+    assert "malformed inverted index" in combined
+    assert "mempalace repair --yes" in combined
+
+
+def test_cmd_mine_convos_mode_exits_nonzero_with_banner(tmp_path, monkeypatch, capsys):
+    palace = str(tmp_path / "palace")
+    src = tmp_path / "convos"
+    src.mkdir()
+
+    def _raise(*_, **__):
+        raise MineValidationError(palace, ["malformed inverted index for FTS5 table"])
+
+    monkeypatch.setattr(convo_miner, "mine_convos", _raise)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.cmd_mine(_mine_args(palace, str(src), mode="convos"))
+
+    assert exit_info.value.code == 1
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "SQLite-layer corruption detected" in combined
+    assert "mempalace repair --yes" in combined
+
+
+# ── 4. Dry-run skips validation ─────────────────────────────────────
+
+
+def test_validate_skipped_on_dry_run(tmp_path, monkeypatch):
+    """`mine(..., dry_run=True)` must not invoke the validator (no writes happened)."""
+    palace = tmp_path / "palace"
+    src = tmp_path / "src"
+    _build_palace_with_drawer(palace)
+    src.mkdir()
+    big = "lorem ipsum " * 500
+    (src / "big.md").write_text(big)
+
+    calls = []
+
+    def _spy(palace_path):
+        calls.append(palace_path)
+
+    monkeypatch.setattr(miner, "_validate_palace_fts5_after_mine", _spy)
+
+    miner.mine(
+        project_dir=str(src),
+        palace_path=str(palace),
+        wing_override=None,
+        agent="mempalace",
+        limit=0,
+        dry_run=True,
+    )
+
+    assert calls == [], f"validator must not run in dry-run mode, got: {calls}"
+
+
+# ── 5. Real exception chain through _mine_impl (no monkeypatch) ────
+
+
+def test_full_chain_raises_through_mine_impl(tmp_path, monkeypatch):
+    """Run a real mine, corrupt FTS5 mid-process, re-mine. The validator
+    inside _mine_impl must raise MineValidationError as the explicit source
+    (spy verifies). The new `except MineValidationError: raise` clause in
+    miner._mine_impl bypasses the partial-progress "Mine aborted" banner so
+    cmd_mine prints the single, authoritative recovery message.
+    """
+    from mempalace import miner as miner_mod
+    from mempalace import palace as palace_mod
+
+    palace = tmp_path / "palace"
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "big.md").write_text("lorem ipsum " * 200)
+
+    miner_mod.mine(
+        project_dir=str(src),
+        palace_path=str(palace),
+        wing_override=None,
+        agent="mempalace",
+        limit=0,
+        dry_run=False,
+    )
+
+    _corrupt_fts5_segment(palace / "chroma.sqlite3")
+
+    # Spy on the validator so we can prove IT was the raise-source, not
+    # some other exception masquerading as MineValidationError.
+    called = []
+    real_validator = palace_mod._validate_palace_fts5_after_mine
+
+    def _validator_spy(path):
+        called.append(path)
+        return real_validator(path)
+
+    monkeypatch.setattr(miner_mod, "_validate_palace_fts5_after_mine", _validator_spy)
+
+    with pytest.raises(MineValidationError) as exc_info:
+        miner_mod.mine(
+            project_dir=str(src),
+            palace_path=str(palace),
+            wing_override=None,
+            agent="mempalace",
+            limit=0,
+            dry_run=False,
+        )
+
+    assert called == [str(palace)], f"validator must be the raise-source; spy recorded: {called}"
+    assert "fts5" in " ".join(exc_info.value.errors).lower()
+    assert exc_info.value.palace_path == str(palace)
+
+
+def test_mine_impl_does_not_print_partial_summary_on_validation_error(tmp_path, capsys):
+    """When _validate_palace_fts5_after_mine raises, miner._mine_impl must
+    NOT print the "Mine aborted by exception" partial-progress banner that
+    `except Exception` adds. That banner is reserved for true mid-loop
+    failures and would double-up with cmd_mine's recovery banner.
+    """
+    from mempalace import miner as miner_mod
+
+    palace = tmp_path / "palace"
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "big.md").write_text("lorem ipsum " * 200)
+
+    miner_mod.mine(
+        project_dir=str(src),
+        palace_path=str(palace),
+        wing_override=None,
+        agent="mempalace",
+        limit=0,
+        dry_run=False,
+    )
+    _corrupt_fts5_segment(palace / "chroma.sqlite3")
+
+    with pytest.raises(MineValidationError):
+        miner_mod.mine(
+            project_dir=str(src),
+            palace_path=str(palace),
+            wing_override=None,
+            agent="mempalace",
+            limit=0,
+            dry_run=False,
+        )
+
+    captured = capsys.readouterr()
+    assert "Mine aborted by exception" not in captured.out + captured.err
+
+
+def test_mine_validation_error_rejects_empty_errors():
+    """Defense-in-depth: the type should not allow construction with an
+    empty errors list (the message would say "0 issue(s)") or a blank path.
+    """
+    with pytest.raises(ValueError, match="at least one error"):
+        MineValidationError("/tmp/x", [])
+    with pytest.raises(ValueError, match="non-empty palace_path"):
+        MineValidationError("", ["err"])
+
+
+def test_mine_validation_error_errors_attribute_is_immutable():
+    err = MineValidationError("/tmp/x", ["a", "b"])
+    assert isinstance(err.errors, tuple)
+    with pytest.raises(AttributeError):
+        err.errors.append("c")  # type: ignore[attr-defined]
+
+
+def test_helper_silent_on_missing_palace(tmp_path):
+    """Helper returns silently when chroma.sqlite3 doesn't exist (palace
+    dir missing or mine never wrote). The repair primitive `sqlite_integrity_errors`
+    already short-circuits on missing path; verify the contract holds end-to-end.
+    """
+    missing = tmp_path / "no_palace_here"
+    assert _validate_palace_fts5_after_mine(str(missing)) is None
+
+
+def test_convo_miner_dry_run_skips_validator(tmp_path, monkeypatch):
+    """`mine_convos(..., dry_run=True)` must not invoke the validator;
+    mirrors the project-miner guarantee.
+    """
+    from mempalace import convo_miner as convo_mod
+
+    palace = tmp_path / "palace"
+    _build_palace_with_drawer(palace)
+    src = tmp_path / "convos"
+    src.mkdir()
+
+    calls = []
+
+    def _spy(palace_path):
+        calls.append(palace_path)
+
+    monkeypatch.setattr(convo_mod, "_validate_palace_fts5_after_mine", _spy)
+
+    convo_mod.mine_convos(
+        convo_dir=str(src),
+        palace_path=str(palace),
+        wing="testwing",
+        agent="mempalace",
+        limit=0,
+        dry_run=True,
+    )
+
+    assert calls == [], f"convo_miner must not validate in dry-run, got: {calls}"
+
+
+# ── 6. Helper closes ChromaDB handles before re-opening read-only ───
+
+
+def test_close_handles_called_before_quick_check(tmp_path, monkeypatch):
+    """Windows guard: ChromaDB mmap handles must be released before the read-only re-open."""
+    palace = tmp_path / "palace"
+    _build_palace_with_drawer(palace)
+
+    order = []
+
+    from mempalace import repair as repair_mod
+
+    real_close = repair_mod._close_chroma_handles
+    real_errors = repair_mod.sqlite_integrity_errors
+
+    def _close_spy(palace_path, *args, **kwargs):
+        order.append("close")
+        return real_close(palace_path, *args, **kwargs)
+
+    def _errors_spy(palace_path, *args, **kwargs):
+        order.append("quick_check")
+        return real_errors(palace_path, *args, **kwargs)
+
+    monkeypatch.setattr(repair_mod, "_close_chroma_handles", _close_spy)
+    monkeypatch.setattr(repair_mod, "sqlite_integrity_errors", _errors_spy)
+
+    _validate_palace_fts5_after_mine(str(palace))
+
+    assert order == ["close", "quick_check"], (
+        f"_close_chroma_handles must run before sqlite_integrity_errors, got: {order}"
+    )
+
+
+# ── 7. --mode extract / mine_formats coverage (post-#1555 gap close) ──
+
+
+def test_cmd_mine_extract_mode_exits_nonzero_with_banner(tmp_path, monkeypatch, capsys):
+    """cmd_mine on --mode extract must surface the same recovery banner as
+    --mode convos / project when mine_formats raises MineValidationError.
+    The third mine entry point landed in develop via #1555 (3.3.6 release)
+    after #1548 was written, so without this wire-up the extract path
+    would exit 0 on a corrupted FTS5 palace.
+    """
+    from mempalace import format_miner as format_mod
+
+    palace = str(tmp_path / "palace")
+    src = tmp_path / "docs"
+    src.mkdir()
+
+    def _raise(*_, **__):
+        raise MineValidationError(palace, ["malformed inverted index for FTS5 table"])
+
+    monkeypatch.setattr(format_mod, "mine_formats", _raise)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.cmd_mine(_mine_args(palace, str(src), mode="extract"))
+
+    assert exit_info.value.code == 1
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "SQLite-layer corruption detected" in combined
+    assert "mempalace repair --yes" in combined
+
+
+def test_mine_formats_dry_run_skips_validator(tmp_path, monkeypatch):
+    """`mine_formats(..., dry_run=True)` must not invoke the validator;
+    mirrors the project-miner and convo-miner guarantees.
+    """
+    from mempalace import format_miner as format_mod
+
+    palace = tmp_path / "palace"
+    _build_palace_with_drawer(palace)
+    src = tmp_path / "docs"
+    src.mkdir()
+
+    calls = []
+
+    def _spy(palace_path):
+        calls.append(palace_path)
+
+    monkeypatch.setattr(format_mod, "_validate_palace_fts5_after_mine", _spy)
+
+    format_mod.mine_formats(
+        format_dir=str(src),
+        palace_path=str(palace),
+        wing="testwing",
+        agent="mempalace",
+        limit=0,
+        dry_run=True,
+    )
+
+    assert calls == [], f"mine_formats must not validate in dry-run, got: {calls}"
+
+
+def test_mine_formats_keyboard_interrupt_skips_validator(tmp_path, monkeypatch):
+    """KeyboardInterrupt mid-mine routes through the outer `except
+    KeyboardInterrupt` branch, NOT the `else` branch where validation
+    sits, so a Ctrl-C abort must not trigger end-of-mine FTS5 validation.
+    The per-file `except Exception` does not catch BaseException, so the
+    interrupt propagates up to the outer handler as required.
+    """
+    from mempalace import format_miner as format_mod
+
+    palace = tmp_path / "palace"
+    _build_palace_with_drawer(palace)
+    src = tmp_path / "docs"
+    src.mkdir()
+    fake_doc = src / "stub.docx"
+    fake_doc.write_bytes(b"PK\x03\x04stub")
+
+    calls = []
+
+    def _spy(palace_path):
+        calls.append(palace_path)
+
+    def _interrupt(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(format_mod, "_validate_palace_fts5_after_mine", _spy)
+    monkeypatch.setattr(format_mod, "scan_formats", lambda *_a, **_k: [fake_doc])
+    monkeypatch.setattr(format_mod, "extract_text", _interrupt)
+
+    format_mod.mine_formats(
+        format_dir=str(src),
+        palace_path=str(palace),
+        wing="testwing",
+        agent="mempalace",
+        limit=0,
+        dry_run=False,
+    )
+
+    assert calls == [], f"mine_formats must not validate on KeyboardInterrupt, got: {calls}"
+
+
+def test_mine_formats_full_chain_raises_when_fts5_corrupt(tmp_path, monkeypatch):
+    """End-to-end: a palace with corrupted FTS5 + real mine_formats call
+    must propagate MineValidationError from `_validate_palace_fts5_after_mine`.
+    Mirrors `test_full_chain_raises_through_mine_impl` for the extract path.
+    Empty source dir is sufficient: the for-loop iterates zero times, the
+    `else` branch runs, validation fires on the pre-corrupted sqlite.
+    """
+    from mempalace import format_miner as format_mod
+    from mempalace import palace as palace_mod
+
+    palace = tmp_path / "palace"
+    _build_palace_with_drawer(palace)
+    _corrupt_fts5_segment(palace / "chroma.sqlite3")
+
+    src = tmp_path / "docs"
+    src.mkdir()
+
+    called = []
+    real_validator = palace_mod._validate_palace_fts5_after_mine
+
+    def _validator_spy(path):
+        called.append(path)
+        return real_validator(path)
+
+    monkeypatch.setattr(format_mod, "_validate_palace_fts5_after_mine", _validator_spy)
+
+    with pytest.raises(MineValidationError) as exc_info:
+        format_mod.mine_formats(
+            format_dir=str(src),
+            palace_path=str(palace),
+            wing="testwing",
+            agent="mempalace",
+            limit=0,
+            dry_run=False,
+        )
+
+    assert called == [str(palace)], f"validator must be the raise-source; spy recorded: {called}"
+    assert "fts5" in " ".join(exc_info.value.errors).lower()
+    assert exc_info.value.palace_path == str(palace)


### PR DESCRIPTION
## What does this PR do?

Fixes #1537. `mempalace mine` currently prints `Done.` and exits 0 even when the resulting `chroma.sqlite3` left FTS5 in a malformed state. Automation, hooks, and CI then proceed against a palace whose wing-filtered searches will fail with `Error finding id`. The sibling `repair --yes` path already runs `PRAGMA quick_check` and refuses on the same failure (closed via #1216 / #1523); this PR closes the same gap on the `mine` path.

### Change shape

* `mempalace/palace.py`: new `MineValidationError(RuntimeError)` plus `_validate_palace_fts5_after_mine(palace_path)` helper. Helper composes two existing repair-side primitives: `_close_chroma_handles(palace_path, backend=_DEFAULT_BACKEND)` to release the live writer's handles (Windows mmap guard) and `sqlite_integrity_errors(palace_path)` to run `PRAGMA quick_check` on a fresh read-only connection. Raises `MineValidationError(palace_path, errors)` on any non-`ok` row.
* `mempalace/miner.py`: validator call after the topic-tunnels block, before the `Done.` banner, inside `if not dry_run:`. A new explicit `except MineValidationError: raise` clause sits before the existing `except Exception as exc:` partial-progress handler. Without it the operator would see the misleading "Mine aborted by exception. files_processed: N. last_file: <none>." banner *before* the recovery banner, since the loop completed cleanly and validation ran post-loop.
* `mempalace/convo_miner.py`: symmetric call site. `mine_convos` has no outer `try/except` (pre-existing), so the exception bubbles directly to the CLI handler.
* `mempalace/format_miner.py`: symmetric call site in `mine_formats` (the `--mode extract` entry point), placed in the post-loop `else:` branch after `_compute_topic_tunnels_for_wing`. Closes a gap that opened on develop after this PR was rebased (see next section).
* `mempalace/cli.py`: `cmd_mine` adds an `except MineValidationError` arm that prints `print_sqlite_integrity_abort` (the exact recovery banner `cmd_repair` already prints), appends a mine-specific note to stderr, and exits 1. The arm wraps all three mode branches (`project` / `convos` / `extract`).

### Post-#1555 extract-mode coverage

When this PR was opened on 2026-05-18, `_mine_impl` was the single mine entry point and the validator there covered every mine path. Merge #1555 (3.3.6 release, 2026-05-21) introduced `mempalace/format_miner.py::mine_formats` as a third mine entry point, wired into `cli.py` as `elif args.mode == "extract":`. Without an additional validator call, `mempalace mine <dir> --mode extract` would have exited 0 on a corrupted palace exactly as the original reporter scenario describes, just from a different operator-facing command. The rebase in this branch resolves the develop conflict in `_mine_impl` (preserving the upstream hallways + entity-tunnels additions while keeping the validator call at the end) and extends the same `_validate_palace_fts5_after_mine` helper into `mine_formats`'s `else:` branch so all three modes share the same end-of-mine integrity contract.

### Why reuse repair-side primitives

The same `PRAGMA quick_check` failure can be reached from two paths: a corrupted-by-repair sqlite (#1517, fixed in #1216 / #1523) and a corrupted-by-mine sqlite (this issue). Operators should see the same authoritative recovery banner regardless of which command surfaced it. Reusing `print_sqlite_integrity_abort` keeps the wording singular and the recovery steps coherent.

### Threaded `backend=_DEFAULT_BACKEND`

`_close_chroma_handles` without a `backend` argument falls back to a transient `ChromaBackend()` instance whose `_clients` dict is empty, so it never closes the live writer's `PersistentClient`. The helper passes `palace._DEFAULT_BACKEND` so the cached client for the just-mined palace actually gets closed and WAL flushes before the read-only sqlite3 re-open. Matches the `backend=backend` pattern `cmd_repair` already uses (`mempalace/repair.py:838`, `:851`; `mempalace/cli.py:972`).

### Wording note

The mine-specific stderr note explicitly hedges attribution: "the corruption may pre-date the mine itself." `quick_check` runs once at end-of-mine, so it cannot distinguish corruption produced by this mine from pre-existing corruption surfaced by it. `mempalace repair --yes` rebuilds the FTS5 virtual table either way.

## How to test

```bash
uv sync --extra dev
uv run pytest tests/test_miner_fts5_validation.py -v
uv run pytest tests/ --ignore=tests/benchmarks -q
uvx --from 'ruff==0.15.9' ruff check .
uvx --from 'ruff==0.15.9' ruff format --check .
```

End-to-end against the actual `mempalace` binary:

```bash
# Happy path: clean mine still exits 0 with Done banner.
rm -rf /tmp/mp1537 && mkdir -p /tmp/mp1537/src
echo "lorem ipsum " > /tmp/mp1537/src/a.md
PALACE=/tmp/mp1537/palace
cd /tmp/mp1537
mempalace --palace "$PALACE" init . --yes
# (mine ran via init or directly)
mempalace --palace "$PALACE" mine .

# Reporter-shape failure: soft FTS5-only corruption.
python3 -c "
import sqlite3
conn = sqlite3.connect('$PALACE/chroma.sqlite3')
rows = conn.execute('SELECT id, block FROM embedding_fulltext_search_data').fetchall()
target = next((r for r in rows if r[0] > 10), rows[0])
conn.execute('UPDATE embedding_fulltext_search_data SET block=? WHERE id=?',
             (b'\\xde\\xad\\xbe\\xef' * (len(target[1]) // 4), target[0]))
conn.commit()
"
mempalace --palace "$PALACE" mine .   # should exit 1 with recovery banner
echo "exit=$?"                          # → 1
```

The corrupted second run prints `ABORT: SQLite-layer corruption detected before repair rebuild` plus `quick_check output: - malformed inverted index for FTS5 table main.embedding_fulltext_search`, verbatim the operator-facing message reporter cited. The `--mode extract` and `--mode convos` paths surface the same banner via the shared `cmd_mine` handler.

## Test coverage

17 new cases in `tests/test_miner_fts5_validation.py`:

1. Helper returns silently on a clean palace.
2. Helper raises `MineValidationError` on a page-mangled sqlite (corruption recipe mirrors `tests/test_repair.py`).
3. Helper raises on FTS5-segment-only corruption: the reporter's exact failure mode (chromadb opens cleanly, only the inverted index is malformed). Skips cleanly with `pytest.skip` if chromadb renames the shadow table in a future version.
4. `cmd_mine` project mode surfaces `MineValidationError` as exit 1 + recovery banner.
5. `cmd_mine` convos mode symmetric.
6. Dry-run skips the validator in project miner (no writes, nothing to check).
7. `_close_chroma_handles` runs before `sqlite_integrity_errors` (Windows guard order).
8. **Full chain through real `_mine_impl`** (no monkeypatch): mine, corrupt FTS5, re-mine, assert validator was the explicit raise-source via spy.
9. `_mine_impl` does NOT print the "Mine aborted by exception" partial-progress banner on `MineValidationError` (the new explicit `except MineValidationError: raise` clause bypasses the generic handler).
10. `MineValidationError` constructor rejects empty errors list and blank palace_path (defense-in-depth against future mis-construction).
11. `MineValidationError.errors` is a tuple (immutable forensic snapshot; handlers cannot mutate).
12. Helper is silent on missing `chroma.sqlite3` (palace dir without sqlite file).
13. `mine_convos(dry_run=True)` skips the validator (mirrors project-miner guarantee).
14. `cmd_mine --mode extract` surfaces `MineValidationError` as exit 1 + recovery banner (post-#1555 third entry point).
15. `mine_formats(dry_run=True)` skips the validator (matches the other two miners).
16. `mine_formats` on `KeyboardInterrupt` skips the validator: the per-file `except Exception` does not catch `BaseException`, so the interrupt propagates past the `else:` branch where validation sits.
17. **Full chain through real `mine_formats`** (no monkeypatch on the validator itself): build palace, corrupt FTS5, invoke `mine_formats`, assert the helper raised `MineValidationError` with the corrupt path in `errors`.

## Out of scope

A codebase-wide audit found additional write paths that print success and exit 0 without validating FTS5. They are deliberately not touched here: each is a separate user-visible surface, and the reporter scope is `mempalace mine` specifically. A follow-up issue will track adopting the same `_validate_palace_fts5_after_mine` helper across these sites.

CLI surface:
* `cmd_sweep` (`sweeper.sweep` / `sweep_directory`)
* `cmd_sync --apply` (`sync_palace`; deletes can leave FTS5 shadow tables stale)
* `cmd_compress` (`comp_col.upsert` of compressed closets)
* `dedup_palace` (deletes drawers)
* `closet_llm.regenerate_closets`
* `diary_ingest` (`drawers_col.upsert` + `upsert_closet_lines`)
* `migrate.migrate` (`col.add` batch into temp palace, then swap; no post-swap quick_check)
* `repair.rebuild_from_sqlite` (multi-collection upsert; preflight covers the legacy `rebuild_index` path but not this sub-mode)

Library surface:
* `sources/context.py:PalaceContext.upsert_drawer` (shared helper used by source adapters)

MCP surface:
* `tool_add_drawer`, `tool_diary_write`, `tool_delete_drawer` (`mcp_server.py:1171`). Different surface: JSON-RPC responses rather than CLI exit codes.

The recovery path this PR's stderr note directs operators to (`mempalace repair --yes` → `rebuild_index`) is itself safe: it preflights via `sqlite_integrity_errors` and post-#1523 rebuilds the FTS5 virtual table.

Three pre-existing structural asymmetries that this PR observes but does not address:

* `mine_convos` does not wrap its body in `mine_palace_lock` the way `mine()` does. The validator therefore runs outside the palace lock in convos mode, which means a concurrent writer (e.g. MCP server) could in principle slip in between the last upsert and the validator. The new stderr note hedges attribution rather than falsely blaming the mine.
* `mine_formats` (introduced by #1555) also lacks `mine_palace_lock`, with the same concurrent-writer caveat as `mine_convos`. The validator wired in by this PR runs in the same lock-free zone. Locking parity across the three miners is a separate refactor.
* `mine_convos` and `mine_formats` have no outer `try/except` wrapping their `Done.` banners, so project mode prints a partial-progress summary on `MineValidationError` while convos and extract modes print only the recovery banner. Recovering symmetry is a separate refactor.

## Checklist
- [x] Tests pass (`uv run pytest tests/ --ignore=tests/benchmarks`): 2076 passed, 3 skipped
- [x] No hardcoded paths
- [x] Linter passes (`uvx --from 'ruff==0.15.9' ruff check .` + `ruff format --check`)

Closes #1537.

Co-authored-by: Caleb Wells <15988028+calebcwells@users.noreply.github.com>
