### PR TITLE
fix: validate explicit tunnels and honor palace path

### DIFF
--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -335,30 +335,41 @@ def _fuzzy_match(query: str, nodes: dict, n: int = 5):
 # Explicit tunnels are created by agents when they notice a connection
 # between two specific drawers or rooms in different wings/projects.
 #
-# Stored as a JSON file at ~/.mempalace/tunnels.json so they persist
+# Stored as tunnels.json under the configured palace_path so they persist
 # across palace rebuilds (not in ChromaDB which can be recreated).
 
 
-_TUNNEL_FILE = os.path.join(os.path.expanduser("~"), ".mempalace", "tunnels.json")
+# Explicit tunnel file path override for tests / legacy callers. When left
+# unset, resolve tunnels.json under MempalaceConfig().palace_path so all
+# sessions sharing a palace use the same tunnel store even with different HOME.
+_TUNNEL_FILE = None
 
 
-def _load_tunnels():
+def _tunnel_file(config=None):
+    if _TUNNEL_FILE:
+        return _TUNNEL_FILE
+    config = config or MempalaceConfig()
+    return os.path.join(config.palace_path, "tunnels.json")
+
+
+def _load_tunnels(config=None):
     """Load explicit tunnels from disk.
 
     Returns an empty list if the file is missing or corrupt (e.g. truncated
     by a crash mid-write on a system that lacks atomic-rename semantics).
     """
-    if not os.path.exists(_TUNNEL_FILE):
+    tunnel_file = _tunnel_file(config)
+    if not os.path.exists(tunnel_file):
         return []
     try:
-        with open(_TUNNEL_FILE, "r", encoding="utf-8") as f:
+        with open(tunnel_file, "r", encoding="utf-8") as f:
             data = json.load(f)
     except Exception:
         return []
     return data if isinstance(data, list) else []
 
 
-def _save_tunnels(tunnels):
+def _save_tunnels(tunnels, config=None):
     """Persist explicit tunnels atomically.
 
     Writes to ``tunnels.json.tmp`` then ``os.replace``s it into place, so
@@ -371,14 +382,15 @@ def _save_tunnels(tunnels):
     shared Linux/multi-user systems. Matches the file-permission pattern
     established by #814 for the other sensitive palace files.
     """
-    parent = os.path.dirname(_TUNNEL_FILE)
+    tunnel_file = _tunnel_file(config)
+    parent = os.path.dirname(tunnel_file)
     os.makedirs(parent, exist_ok=True)
     try:
         os.chmod(parent, 0o700)
     except (OSError, NotImplementedError):
         # Windows / unsupported filesystems — tolerate.
         pass
-    tmp_path = _TUNNEL_FILE + ".tmp"
+    tmp_path = tunnel_file + ".tmp"
     with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(tunnels, f, indent=2)
         f.flush()
@@ -387,9 +399,9 @@ def _save_tunnels(tunnels):
         except OSError:
             # Not all filesystems (or Windows file handles) support fsync — tolerate.
             pass
-    os.replace(tmp_path, _TUNNEL_FILE)
+    os.replace(tmp_path, tunnel_file)
     try:
-        os.chmod(_TUNNEL_FILE, 0o600)
+        os.chmod(tunnel_file, 0o600)
     except (OSError, NotImplementedError):
         pass
 
@@ -421,6 +433,31 @@ def _require_name(value: str, field: str) -> str:
     return value.strip()
 
 
+def _check_room_exists(wing: str, room: str, col, kind: str = "explicit") -> bool:
+    """Return whether a real palace room exists.
+
+    Explicit tunnels point at real rooms and must fail loud if the palace
+    collection cannot be queried. Topic tunnels intentionally use synthetic
+    ``topic:<name>`` room identifiers, so they tolerate unavailable validation.
+    """
+    if col is None:
+        if kind == "explicit":
+            raise ValueError(f"Cannot validate room existence for {wing}/{room}: ChromaDB unreachable")
+        return True
+
+    try:
+        results = col.get(
+            where={"$and": [{"wing": wing}, {"room": room}]},
+            limit=1,
+            include=[],
+        )
+        return len(results["ids"]) > 0
+    except Exception as exc:
+        if kind == "explicit":
+            raise ValueError(f"Room validation query failed for {wing}/{room}: {exc}") from exc
+        return True
+
+
 def create_tunnel(
     source_wing: str,
     source_room: str,
@@ -430,6 +467,8 @@ def create_tunnel(
     source_drawer_id: str = None,
     target_drawer_id: str = None,
     kind: str = "explicit",
+    col=None,
+    config=None,
 ):
     """Create an explicit (symmetric) tunnel between two locations in the palace.
 
@@ -461,7 +500,8 @@ def create_tunnel(
         The stored tunnel dict.
 
     Raises:
-        ValueError: if any wing or room is empty or non-string.
+        ValueError: if any wing or room is empty or non-string, or if an
+            explicit tunnel endpoint does not exist / cannot be validated.
 
     Note:
         Wing slugs are stored verbatim — passing ``"my-wing"`` and ``"my_wing"``
@@ -474,6 +514,13 @@ def create_tunnel(
     source_room = _require_name(source_room, "source_room")
     target_wing = _require_name(target_wing, "target_wing")
     target_room = _require_name(target_room, "target_room")
+
+    if kind == "explicit" and col is None:
+        col = _get_collection(config)
+    if not _check_room_exists(source_wing, source_room, col, kind=kind):
+        raise ValueError(f"source room not found: {source_wing}/{source_room}")
+    if not _check_room_exists(target_wing, target_room, col, kind=kind):
+        raise ValueError(f"target room not found: {target_wing}/{target_room}")
 
     tunnel_id = _canonical_tunnel_id(source_wing, source_room, target_wing, target_room)
 
@@ -493,8 +540,9 @@ def create_tunnel(
     # Serialize the load → mutate → save cycle. Without this, two concurrent
     # create_tunnel calls can both read the same snapshot and the later
     # writer silently drops the earlier writer's tunnel.
-    with mine_lock(_TUNNEL_FILE):
-        tunnels = _load_tunnels()
+    tunnel_file = _tunnel_file(config)
+    with mine_lock(tunnel_file):
+        tunnels = _load_tunnels(config)
         for existing in tunnels:
             if existing.get("id") == tunnel_id:
                 # Preserve original creation timestamp on label updates.
@@ -502,10 +550,10 @@ def create_tunnel(
                 tunnel["updated_at"] = datetime.now(timezone.utc).isoformat()
                 existing.clear()
                 existing.update(tunnel)
-                _save_tunnels(tunnels)
+                _save_tunnels(tunnels, config)
                 return existing
         tunnels.append(tunnel)
-        _save_tunnels(tunnels)
+        _save_tunnels(tunnels, config)
     return tunnel
 
 
@@ -535,7 +583,8 @@ def list_tunnels(wing: str = None):
 
 def delete_tunnel(tunnel_id: str):
     """Delete an explicit tunnel by ID. Returns ``{"deleted": <id>}``."""
-    with mine_lock(_TUNNEL_FILE):
+    tunnel_file = _tunnel_file()
+    with mine_lock(tunnel_file):
         tunnels = _load_tunnels()
         tunnels = [t for t in tunnels if t.get("id") != tunnel_id]
         _save_tunnels(tunnels)

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -440,6 +440,8 @@ def _check_room_exists(wing: str, room: str, col, kind: str = "explicit") -> boo
     collection cannot be queried. Topic tunnels intentionally use synthetic
     ``topic:<name>`` room identifiers, so they tolerate unavailable validation.
     """
+    if kind == "topic":
+        return True
     if col is None:
         if kind == "explicit":
             raise ValueError(

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -442,7 +442,9 @@ def _check_room_exists(wing: str, room: str, col, kind: str = "explicit") -> boo
     """
     if col is None:
         if kind == "explicit":
-            raise ValueError(f"Cannot validate room existence for {wing}/{room}: ChromaDB unreachable")
+            raise ValueError(
+                f"Cannot validate room existence for {wing}/{room}: ChromaDB unreachable"
+            )
         return True
 
     try:

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -763,13 +763,21 @@ class TestTunnels:
         import mempalace.palace_graph as pg
 
         self._orig = pg._TUNNEL_FILE
+        self._orig_get_collection = pg._get_collection
         self._tmpdir = tempfile.mkdtemp()
         pg._TUNNEL_FILE = os.path.join(self._tmpdir, "tunnels.json")
+
+        class _PermissiveCollection:
+            def get(self, *args, **kwargs):
+                return {"ids": ["exists"]}
+
+        pg._get_collection = lambda config=None: _PermissiveCollection()
 
     def teardown_method(self):
         import mempalace.palace_graph as pg
 
         pg._TUNNEL_FILE = self._orig
+        pg._get_collection = self._orig_get_collection
         import shutil
 
         shutil.rmtree(self._tmpdir, ignore_errors=True)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1372,6 +1372,9 @@ class TestWriteTools:
         from mempalace import mcp_server, palace_graph
 
         monkeypatch.setattr(palace_graph, "_TUNNEL_FILE", str(tmp_path / "tunnels.json"))
+        col = MagicMock()
+        col.get.return_value = {"ids": ["exists"]}
+        monkeypatch.setattr(palace_graph, "_get_collection", lambda config=None: col)
 
         t = mcp_server.tool_create_tunnel(
             source_wing="other-wing",

--- a/tests/test_palace_graph_tunnels.py
+++ b/tests/test_palace_graph_tunnels.py
@@ -14,10 +14,49 @@ with patch.dict("sys.modules", {"chromadb": MagicMock()}):
 def _use_tmp_tunnel_file(monkeypatch, tmp_path):
     tunnel_file = tmp_path / "tunnels.json"
     monkeypatch.setattr(palace_graph, "_TUNNEL_FILE", str(tunnel_file))
+    permissive_col = MagicMock()
+    permissive_col.get.return_value = {"ids": ["exists"]}
+    permissive_col.count.return_value = 0
+    monkeypatch.setattr(palace_graph, "_get_collection", lambda config=None: permissive_col)
     return tunnel_file
 
 
+def _collection_with_rooms(*rooms):
+    room_set = set(rooms)
+    col = MagicMock()
+
+    def get(where=None, **kwargs):
+        clauses = (where or {}).get("$and", [])
+        wing = next((c.get("wing") for c in clauses if "wing" in c), None)
+        room = next((c.get("room") for c in clauses if "room" in c), None)
+        return {"ids": [f"{wing}/{room}"] if (wing, room) in room_set else []}
+
+    col.get.side_effect = get
+    return col
+
+
 class TestTunnelStorage:
+    def test_default_tunnel_file_follows_palace_path_env(self, tmp_path, monkeypatch):
+        """Regression: tunnels.json must live under configured palace_path,
+        not the process HOME, so isolated profiles read/write the same palace."""
+        monkeypatch.setattr(palace_graph, "_TUNNEL_FILE", None)
+        monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path / "palace"))
+
+        palace_graph._save_tunnels(
+            [
+                {
+                    "id": "x",
+                    "source": {"wing": "a", "room": "r1"},
+                    "target": {"wing": "b", "room": "r2"},
+                    "label": "",
+                }
+            ]
+        )
+
+        configured_file = tmp_path / "palace" / "tunnels.json"
+        assert configured_file.exists()
+        assert palace_graph._load_tunnels()[0]["id"] == "x"
+
     def test_load_tunnels_missing_file_returns_empty_list(self, tmp_path, monkeypatch):
         _use_tmp_tunnel_file(monkeypatch, tmp_path)
         assert palace_graph._load_tunnels() == []
@@ -101,6 +140,42 @@ class TestExplicitTunnels:
 
         with pytest.raises(ValueError):
             palace_graph.create_tunnel("", "auth", "wing_people", "users")
+
+    def test_create_tunnel_rejects_missing_explicit_target_room(self, tmp_path, monkeypatch):
+        """Regression for t_57948419: explicit tunnels must not report
+        success when the requested target room is absent from the palace."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        col = _collection_with_rooms(("wing_code", "auth"))
+        monkeypatch.setattr(palace_graph, "_get_collection", lambda config=None: col)
+
+        with pytest.raises(ValueError, match="target room not found"):
+            palace_graph.create_tunnel("wing_code", "auth", "wing_people", "missing")
+
+        assert palace_graph.list_tunnels() == []
+
+    def test_create_tunnel_explicit_fails_when_room_validation_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        monkeypatch.setattr(palace_graph, "_get_collection", lambda config=None: None)
+
+        with pytest.raises(ValueError, match="Cannot validate room existence"):
+            palace_graph.create_tunnel("wing_code", "auth", "wing_people", "users")
+
+        assert palace_graph.list_tunnels() == []
+
+    def test_create_tunnel_topic_allows_synthetic_rooms_when_validation_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        monkeypatch.setattr(palace_graph, "_get_collection", lambda config=None: None)
+
+        tunnel = palace_graph.create_tunnel(
+            "wing_code", "topic:Redis", "wing_ops", "topic:Redis", kind="topic"
+        )
+
+        assert tunnel["kind"] == "topic"
+        assert len(palace_graph.list_tunnels()) == 1
 
     def test_list_tunnels_filters_by_either_side(self, tmp_path, monkeypatch):
         _use_tmp_tunnel_file(monkeypatch, tmp_path)

--- a/tests/test_palace_graph_tunnels.py
+++ b/tests/test_palace_graph_tunnels.py
@@ -177,6 +177,25 @@ class TestExplicitTunnels:
         assert tunnel["kind"] == "topic"
         assert len(palace_graph.list_tunnels()) == 1
 
+    def test_create_tunnel_topic_allows_synthetic_rooms_when_collection_available(
+        self, tmp_path, monkeypatch
+    ):
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        col = _collection_with_rooms(("wing_code", "real-room"))
+        monkeypatch.setattr(palace_graph, "_get_collection", lambda config=None: col)
+
+        tunnel = palace_graph.create_tunnel(
+            "wing_code",
+            "topic:Redis",
+            "wing_ops",
+            "topic:Redis",
+            kind="topic",
+            col=col,
+        )
+
+        assert tunnel["kind"] == "topic"
+        assert len(palace_graph.list_tunnels()) == 1
+
     def test_list_tunnels_filters_by_either_side(self, tmp_path, monkeypatch):
         _use_tmp_tunnel_file(monkeypatch, tmp_path)
 


### PR DESCRIPTION
## Summary
- Store explicit tunnels under the configured `palace_path` instead of hardcoded `~/.mempalace/tunnels.json`
- Validate explicit tunnel endpoints against Chroma before persisting, failing loud when validation is unavailable or the target room is missing
- Preserve synthetic topic tunnel behavior when validation is unavailable

## Test Plan
- `uv run ruff check .`
- `uv run pytest tests/test_palace_graph_tunnels.py tests/test_closets.py tests/test_mcp_server.py::TestWriteTools::test_tool_create_tunnel_preserves_hyphenated_wings tests/test_mcp_server.py::TestWriteTools::test_tool_create_tunnel_surfaces_value_error tests/test_miner.py -q`
- `ulimit -n 4096; uv run pytest tests/ -v --ignore=tests/benchmarks`

Maintainer: @igorls