### PR TITLE
feat(3.3.6): virtual line numbering + format coverage via --mode extract

### DIFF
--- a/docs/format-coverage.md
+++ b/docs/format-coverage.md
@@ -1,0 +1,223 @@
+# Format coverage — `mempalace mine --mode extract`
+
+**Proposed for mempalace 3.3.6.**
+**Target file (new):** `mempalace/format_miner.py`
+**Target file (edited, one-line addition):** `mempalace/cli.py` (dispatcher in `cmd_mine`)
+**New tests:** `tests/test_format_miner.py` (32 cases, all green; see `PROOF.md`).
+
+---
+
+## What it does
+
+Adds a third miner alongside the existing two:
+
+```
+mempalace mine <dir>                  → miner.py        (project files: code, docs, notes)
+mempalace mine <dir> --mode convos    → convo_miner.py  (chat exports)
+mempalace mine <dir> --mode extract   → format_miner.py (binary office documents)   ← NEW
+```
+
+Supported formats and the transformer each routes through:
+
+| Extension | Transformer | Python | License |
+|---|---|---|---|
+| `.pdf`    | MarkItDown | ≥ 3.10 | MIT |
+| `.docx`   | MarkItDown | ≥ 3.10 | MIT |
+| `.pptx`   | MarkItDown | ≥ 3.10 | MIT |
+| `.xlsx`   | MarkItDown | ≥ 3.10 | MIT |
+| `.epub`   | MarkItDown | ≥ 3.10 | MIT |
+| `.rtf`    | **striprtf** | ≥ 3.6 | MIT |
+
+**Per-format routing — why `.rtf` doesn't go through MarkItDown.** Verified live on 2026-05-19 against a local mixed-format test directory: MarkItDown 0.1.5 does NOT convert `.rtf`. It returns the raw RTF control-code source unchanged (`{\rtf1\ansi\ansicpg1252...`). For RTF input, format_miner routes to [striprtf](https://github.com/joshy/striprtf) (pure-Python, MIT, ~150 lines, purpose-built for RTF → plain text). The principle stays intact: transform at read time, never modify the source — only the choice of transformer is per-format.
+
+Both libraries are **optional** runtime dependencies. Users who only mine projects or convos don't pay either install footprint. Users on Python 3.9 can still install `striprtf` to extract RTF; MarkItDown requires 3.10+ and silently skips if not present. Per-extension install messages route to the right library:
+
+- Missing MarkItDown (any of pdf/docx/pptx/xlsx/epub) → `SKIP_NO_MARKITDOWN` → log: `pip install markitdown`
+- Missing striprtf (any `.rtf`) → `SKIP_NO_STRIPRTF` → log: `pip install striprtf`
+
+---
+
+## Design — read-time conversion, never modifies source files
+
+Same architectural principle as virtual line numbering (the other 3.3.6 feature in this package): **transform at read time, leave storage untouched.**
+
+```
+PDF on disk → (read bytes into memory) → MarkItDown → Markdown text → existing chunker → drawers in ChromaDB
+```
+
+- The PDF on the user's disk is read but **never modified**.
+- No intermediate `.md` files are written to the user's filesystem.
+- The conversion lives entirely in memory; once the text reaches the existing chunker, it's handled identically to any other ingestion.
+- Closets / drawers / halls all work the same — the format miner produces the same drawer-shape as the other miners.
+
+---
+
+## Why a new miner, not edits to `miner.py`
+
+Three reasons, in order of importance:
+
+1. **Matches the existing miner-per-content-type pattern.** Mempalace already has `miner.py` and `convo_miner.py`. A third miner is a third instance of the same shape — immediately recognizable to anyone reading the codebase.
+2. **Smaller review surface.** `format_miner.py` is a pure addition. Reviewer reads one new file in isolation; the stable code paths in `miner.py` and `convo_miner.py` are untouched.
+3. **Cleaner failure isolation.** If the format miner has a bug, the existing miners are physically incapable of being affected.
+
+The trade-off vs. integrating into `miner.py` was decided during the 2026-05-19 design pass: **the new-miner pattern wins on architecture and on review surface.**
+
+---
+
+## Fringe cases handled — 13 (original 12 + striprtf parity)
+
+Each case maps to a specific `ExtractionStatus` enum value so callers (and reviewers) can audit exactly which path fired. All thirteen are covered by dedicated tests in `tests/test_format_miner.py`.
+
+| # | Case | Status code | Behavior |
+|---|---|---|---|
+| 1 | MarkItDown not installed (any non-RTF format) | `SKIP_NO_MARKITDOWN` | Logs `pip install markitdown` instruction; skips file |
+| 2 | File too large (> 500 MB default; caller can override) | `SKIP_TOO_LARGE` | Logs size and threshold; skips |
+| 3 | iCloud cloud-only file (`.icloud` suffix OR `st_flags` dataless bit) | `SKIP_CLOUD_ONLY` | Detected before any I/O that would trigger materialization; skips |
+| 4 | Encrypted / password-protected PDF | `SKIP_ENCRYPTED` | Catches exceptions matching `encrypt`/`decrypt`/`password`/`protected`; skips |
+| 5 | Empty file (zero bytes) | `SKIP_EMPTY` | Silent skip |
+| 6 | Permission denied | `SKIP_PERMISSION` | Catches `PermissionError`; logs; skips |
+| 7 | Broken symlink (target missing) | `SKIP_BROKEN_SYMLINK` | Detected via `is_symlink()` + `not exists()`; skips |
+| 8 | Dirty encoding in extracted text | (recovered) | `decode_robust()` falls back UTF-8 → CP1252 → UTF-8-with-replace; never raises |
+| 9 | Windows path semantics | (no special status) | `pathlib.Path` throughout; case-insensitive suffix matching; accepts `str` or `Path` input |
+| 10 | Transformer internal crash on malformed file | `SKIP_EXTRACTION_ERROR` | Catches generic `Exception` at file boundary; logs filename + exception type + message tail; skips |
+| 11 | Network / sync-drive timeout | `SKIP_NETWORK_TIMEOUT` | Catches `TimeoutError`; skips |
+| 12 | Unrecognized extension | `SKIP_UNRECOGNIZED` | Cheap suffix-set check; skips |
+| 13 | **striprtf not installed (any `.rtf`)** | `SKIP_NO_STRIPRTF` | Logs `pip install striprtf` instruction; skips file. Added 2026-05-19 after a live integration test surfaced MarkItDown 0.1.5's lack of RTF support. |
+
+Plus `SKIP_UNREADABLE` for catch-all `OSError` during stat (not in the original list, added for defensive completeness — see file-stat block in `extract_text`).
+
+---
+
+## Cases NOT solved by this miner (deferred)
+
+Per the spec, these are documented limits, not bugs:
+
+- **Custom PDF parsers for specific document types.** MarkItDown does its best; we accept its limits.
+- **OCR on scanned image PDFs.** Separate concern, opt-in feature for a later release.
+- **DRM-locked files.** We can't bypass DRM and shouldn't try.
+- **Pathological corrupt files.** They're corrupt — `SKIP_EXTRACTION_ERROR` with a clear log line is the responsible outcome.
+
+These limitations are reported per-file via the skip-code log, so the user always knows what didn't make it in and why.
+
+---
+
+## API reference
+
+All public symbols are exported via `__all__`. Two functions and one enum form the contract:
+
+### `extract_text(path, max_file_size=DEFAULT_MAX_FILE_SIZE) -> tuple[Optional[str], ExtractionStatus]`
+
+Convert one file to text. Returns `(text, status)` where `text` is the extracted Markdown for `OK` cases and `None` for every skip. Pure function — source file at `path` is never modified.
+
+Accepts both `Path` and `str` for `path`.
+
+### `scan_formats(directory) -> list[Path]`
+
+Walk `directory` recursively, return supported files sorted by path. Skips hidden / build directories (`.git`, `.venv`, `__pycache__`, etc.) and OS metadata files (`.DS_Store`, `Thumbs.db`, `desktop.ini`).
+
+### `ExtractionStatus` (Enum)
+
+Twelve documented values plus `SKIP_UNREADABLE`. Each is paired with a string value like `"skip:no_markitdown"` for log readability; tests assert on `.name` for stability.
+
+### `decode_robust(raw: bytes) -> str`
+
+Identical to the helper in the terminal-session normalizer. UTF-8 first, CP1252 fallback, UTF-8-with-replace as final safety net. Never raises.
+
+### `is_icloud_dataless(path: Path) -> bool`
+
+Two signals:
+1. Literal `.icloud` suffix (iCloud's offloaded-file placeholder convention)
+2. macOS `st_flags` dataless bit (`0x40000000`) — best-effort, gracefully degrades on non-macOS
+
+Returning `True` causes `extract_text` to short-circuit to `SKIP_CLOUD_ONLY` before any I/O that would trigger iCloud materialization.
+
+---
+
+## CLI integration
+
+One-line addition to `mempalace/cli.py` in `cmd_mine`:
+
+```python
+def cmd_mine(args):
+    ...
+    try:
+        if args.mode == "convos":
+            from .convo_miner import mine_convos
+            mine_convos(...)
+        elif args.mode == "extract":                       # ← NEW
+            from .format_miner import mine_formats         # ← NEW
+            mine_formats(                                  # ← NEW
+                format_dir=args.dir,                       # ← NEW
+                palace_path=palace_path,                   # ← NEW
+                wing=args.wing,                            # ← NEW
+                agent=args.agent,                          # ← NEW
+                limit=args.limit,                          # ← NEW
+                dry_run=args.dry_run,                      # ← NEW
+            )                                              # ← NEW
+        else:
+            from .miner import mine
+            mine(...)
+```
+
+And add `"extract"` to the `--mode` choices in the argparse setup:
+
+```python
+p_mine.add_argument(
+    "--mode",
+    choices=["projects", "convos", "extract"],  # ← extract added
+    default="projects",
+    help="Ingest mode: 'projects' (default), 'convos' for chat exports, 'extract' for office documents",
+)
+```
+
+That's the entire CLI change. Two argparse edits + one `elif` branch.
+
+---
+
+## Empirical smoke test — local mixed-format directory
+
+Run on a local test directory containing **52 `.rtf` files + 11 `.pdf` files** (a mix of long-form correspondence and research/architecture documents, no synthetic fixtures):
+
+```
+Supported formats: ['.docx', '.epub', '.pdf', '.pptx', '.rtf', '.xlsx']
+scan_formats: found 63 supported files
+```
+
+**Live end-to-end extraction (2026-05-19, Python 3.13, MarkItDown 0.1.5 + striprtf 0.0.27):**
+
+| Format | Files | Result | Chars extracted |
+|---|---|---|---|
+| RTF (via striprtf) | 52 | **52/52 OK** | 1,350,679 |
+| PDF (via MarkItDown) | 11 | 10 OK, 1 SKIP_ENCRYPTED | 1,340,869 |
+
+The single PDF skip is a real password-protected file — Fringe Case 4 (`SKIP_ENCRYPTED`) fired correctly on real data via the exception-message matcher. Designed behavior validated empirically.
+
+Anti-regression assertion: **zero raw `\rtf1` / `\ansi` control codes leak into extracted text**. Without the per-format routing fix, 52 of 52 RTFs would have ingested as unreadable control-code source. With the fix, every RTF yields clean plain text. This is the integration bug that mocked unit tests cannot catch and that motivated the `SKIP_NO_STRIPRTF` status + per-format dispatch.
+
+---
+
+## Backwards compatibility
+
+- **No changes to existing miners.** `miner.py` and `convo_miner.py` are not touched.
+- **No new required dependencies.** MarkItDown and striprtf are optional extras (`pip install markitdown striprtf` or `pip install mempalace[extract]` if declared as such in `pyproject.toml`). MarkItDown requires Python ≥ 3.10; striprtf works on 3.6+. Recommended pyproject entries use environment markers so 3.9 users automatically get only striprtf:
+  ```toml
+  [project.optional-dependencies]
+  extract = [
+      "striprtf>=0.0.27",
+      "markitdown>=0.1.5; python_version >= '3.10'",
+  ]
+  ```
+- **No on-disk format changes.** Drawers / closets / halls have the exact same shape regardless of which miner produced them.
+- **No migration step.** Users who already have a palace mined from the other modes can run `mempalace mine --mode extract ~/docs/` and the new drawers land in the same palace, same wing, same room conventions.
+- **Optional `--max-file-size` flag** can be added to `mempalace mine` so users with legitimate large files (e.g. scanned books) can raise the cap from the 500 MB default.
+
+---
+
+## Out of scope for 3.3.6
+
+- **Streaming extraction for huge PDFs** (>500 MB). MarkItDown's default behavior is whole-file in memory. For users with multi-GB PDFs, a streaming path via `pypdf` page-by-page is the natural extension. Deferred to 3.3.7 or 3.4.0.
+- **Audio / video transcription.** Whisper integration is its own scope.
+- **OCR for scanned PDFs.** Tesseract / cloud OCR integration is its own scope.
+- **Migration importers** (Notion / Obsidian / Mem0 export formats). Each is a separate adapter; not bundled here.
+
+These are real future features; they don't belong in a 3.3.6 release whose scope is "additive format coverage via MarkItDown."

--- a/docs/virtual-line-numbering.md
+++ b/docs/virtual-line-numbering.md
@@ -1,0 +1,152 @@
+# Virtual line numbering for drawers
+
+**Proposed for mempalace 3.3.6.**
+**Target file:** `mempalace/searcher.py` (new module-level functions, alongside `_tokenize`, `_bm25_scores`, etc.)
+**New tests:** `tests/test_line_numbers.py` (21 cases, all green; see `PROOF.md`).
+
+---
+
+## What it does
+
+Adds two pure functions that apply line numbers to drawer text **at read time**, without modifying anything stored on disk:
+
+```python
+render_with_line_numbers(text: str, start_line: int = 1) -> str
+extract_line_range(text: str, line_start: int, line_end: int) -> str
+```
+
+A closet pointer like `→2026-01-18:L55-L72` now resolves by opening the drawer and calling `extract_line_range(drawer_text, 55, 72)`. The returned string carries line numbers `[55]` through `[72]` so the reader sees which drawer positions they are looking at, even though the drawer on disk has no line numbers in it.
+
+---
+
+## Why this design
+
+### Read-time, not backfill
+
+The alternative is to rewrite every drawer with `[N]` prefixes embedded in the stored text. That choice would:
+
+1. **Invalidate every existing closet pointer** the moment a drawer is re-emitted with different numbering. Today there are 1,377+ drawers across users' palaces; rewriting them all to add `[N]` is a corpus-wide migration with no fallback.
+2. **Couple storage to display.** A drawer's purpose is to be the verbatim of a day. The instant we mix presentation (line numbers) into storage, the "verbatim" claim becomes conditional on the renderer.
+3. **Lose idempotence.** Re-running mine on the same source would either skip (and miss new line-number conventions) or re-rewrite (and shift numbering on edits).
+
+Read-time numbering sidesteps all three. The drawer on disk is exactly what was written. The grid exists only in the act of reading.
+
+### Already-numbered passthrough
+
+Some drawers arrive at the function already prefixed with `[N]` — e.g. transcripts from pre-numbering tools, or output of an earlier render that was saved. Detection is a `^\[\d+\]` regex on each line; matched lines pass through unchanged. The counter **still advances** on those lines so positional alignment with the underlying drawer is preserved.
+
+This is defensive, not aspirational: most drawers are plain text, but mixed inputs must not double-prefix.
+
+### Pure, no I/O
+
+Neither function reads or writes the palace. They take strings, return strings. The caller (the search pipeline higher up in `searcher.py`) is responsible for opening drawers and persisting results. This keeps the primitive testable in isolation and reusable from anywhere — MCP server, CLI, future Flutter UI — without dragging in chromadb.
+
+---
+
+## API reference
+
+### `render_with_line_numbers(text, start_line=1)`
+
+| Parameter | Type | Default | Meaning |
+|---|---|---|---|
+| `text` | `str \| None` | (required) | The drawer body. `None` is treated as empty. |
+| `start_line` | `int` | `1` | Number assigned to the first line of the output. |
+
+**Returns:** `str` — each line prefixed with `[N] `, where `N` is the running counter beginning at `start_line`. Lines that already match `^\[\d+\]` pass through unchanged; the counter still advances.
+
+**Pure:** input is not mutated.
+
+```python
+>>> render_with_line_numbers("alpha\nbeta")
+'[1] alpha\n[2] beta'
+
+>>> render_with_line_numbers("first\nsecond", start_line=5)
+'[5] first\n[6] second'
+
+>>> render_with_line_numbers("[42] kept\nplain line")
+'[42] kept\n[2] plain line'
+```
+
+### `extract_line_range(text, line_start, line_end)`
+
+| Parameter | Type | Meaning |
+|---|---|---|
+| `text` | `str` | The full drawer body. |
+| `line_start` | `int` | First line of the slice, 1-indexed, inclusive. Values below `1` are clamped to `1`. |
+| `line_end` | `int` | Last line of the slice, 1-indexed, inclusive. Values past the end of the drawer are clipped to the drawer length. |
+
+**Returns:** `str` — the extracted slice with virtual line numbers starting at `line_start`. Empty / invalid ranges return `""` (no exception).
+
+**Pure:** input is not mutated.
+
+```python
+>>> extract_line_range("a\nb\nc\nd\ne", 2, 4)
+'[2] b\n[3] c\n[4] d'
+
+>>> extract_line_range("a\nb\nc", 2, 99)   # end clipped to drawer length
+'[2] b\n[3] c'
+
+>>> extract_line_range("a\nb\nc", 5, 2)    # invalid range
+''
+```
+
+---
+
+## Edge cases covered by the test suite
+
+The 21 tests in `tests/test_line_numbers.py` exercise:
+
+**`render_with_line_numbers`**
+- Empty string → `""`
+- `None` → `""`
+- Single line
+- Multi-line
+- Custom `start_line`
+- Already-numbered passthrough (no double-prefix)
+- Already-numbered passthrough with a custom `start_line` (line numbers in source win, not the counter)
+- Mixed numbered + plain input (counter advances on every line)
+- Blank lines (still numbered — they are real positions)
+- Trailing newline semantics (`"a\nb\n".split("\n")` → 3 positions, all numbered)
+- Input not mutated
+
+**`extract_line_range`**
+- Single-line extraction
+- Inclusive range
+- Full-document extraction
+- End beyond length → clipped
+- Start below 1 → clamped to 1
+- Start > end → empty
+- Empty text → empty
+- Slice containing already-numbered lines (source numbers preserved, counter still advances elsewhere)
+- Closet-pointer contract: extracting lines 5-7 returns `[5][6][7]`, not `[1][2][3]`
+- Input not mutated
+
+All 21 pass on Python 3.9 / pytest 8.4.2 in 0.01s. See `PROOF.md` for verbatim run output.
+
+---
+
+## Where to integrate in `mempalace/searcher.py`
+
+Drop the two functions at module level, alongside the existing helpers (`_tokenize`, `_bm25_scores`, `_hybrid_rank`). They have no dependencies beyond `re` (already imported).
+
+In the existing `search()` and `search_memories()` flows, when a result row carries explicit `line_start` / `line_end` metadata (e.g. from a closet pointer), pass the drawer text through `extract_line_range` before returning. When a result has no explicit range (BM25 / vector hit on the full drawer body), pass it through `render_with_line_numbers` instead. Both behaviors are additive — existing callers that ignore line numbers get the same string back, just with a `[N] ` prefix per line.
+
+No new dependencies. No changes to drawer storage. No migration step.
+
+---
+
+## Out of scope for 3.3.6 (deferred)
+
+- **Conversation-boundary detection** (the original `_extract_section` in private tooling expanded line ranges to natural conversation boundaries using timestamp heuristics). That logic is corpus-shape-specific and belongs in its own PR after we agree on the heuristic.
+- **Day-aggregated drawers** (v4 spec — one drawer per day). 3.3.6 keeps the existing chunk-shaped drawer model. Line numbering works for both, but day-aggregation is a separate architectural change.
+- **Halls / tunnels.** Unrelated to read-time rendering.
+- **CLI surface.** No new flags. The behavior is internal to the search pipeline.
+
+---
+
+## Backwards compatibility
+
+- **Drawer storage unchanged.** Existing palaces continue to work without migration.
+- **Closet pointers unchanged.** The `→date:Lstart-Lend` syntax is unchanged; this PR adds the resolver, not the syntax.
+- **Public API additive.** Two new module-level functions; nothing renamed or removed.
+- **No new required arguments** on existing functions. If a caller never passes `line_start` / `line_end`, behavior is identical to today.

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -2,9 +2,10 @@
 """
 MemPalace — Give your AI a memory. No API key required.
 
-Two ways to ingest:
-  Projects:      mempalace mine ~/projects/my_app          (code, docs, notes)
-  Conversations: mempalace mine <convo-dir> --mode convos     (Claude Code, Claude.ai, ChatGPT, Slack exports)
+Three ways to ingest:
+  Projects:      mempalace mine ~/projects/my_app                  (code, docs, notes)
+  Conversations: mempalace mine <convo-dir> --mode convos          (Claude Code, Claude.ai, ChatGPT, Slack exports)
+  Documents:     mempalace mine <docs-dir> --mode extract          (PDF, DOCX, PPTX, XLSX, RTF, EPUB — requires mempalace[extract])
 
 Same palace. Same search. Different ingest strategies.
 
@@ -13,6 +14,7 @@ Commands:
     mempalace split <dir>                 Split concatenated mega-files into per-session files
     mempalace mine <dir>                  Mine project files (default)
     mempalace mine <dir> --mode convos    Mine conversation exports
+    mempalace mine <dir> --mode extract   Mine binary office documents (PDF/DOCX/etc.)
     mempalace search "query"              Find anything, exact words
     mempalace mcp                         Show MCP setup command
     mempalace wake-up                     Show L0 + L1 wake-up context
@@ -514,6 +516,17 @@ def cmd_mine(args):
                 limit=args.limit,
                 dry_run=args.dry_run,
                 extract_mode=args.extract,
+            )
+        elif args.mode == "extract":
+            from .format_miner import mine_formats
+
+            mine_formats(
+                format_dir=args.dir,
+                palace_path=palace_path,
+                wing=args.wing,
+                agent=args.agent,
+                limit=args.limit,
+                dry_run=args.dry_run,
             )
         else:
             from .miner import mine
@@ -1260,9 +1273,13 @@ def main():
     p_mine.add_argument("dir", help="Directory to mine")
     p_mine.add_argument(
         "--mode",
-        choices=["projects", "convos"],
+        choices=["projects", "convos", "extract"],
         default="projects",
-        help="Ingest mode: 'projects' for code/docs (default), 'convos' for chat exports",
+        help=(
+            "Ingest mode: 'projects' for code/docs (default), 'convos' for chat "
+            "exports, 'extract' for office documents (PDF/DOCX/RTF/etc., requires "
+            "mempalace[extract])"
+        ),
     )
     p_mine.add_argument("--wing", default=None, help="Wing name (default: directory name)")
     p_mine.add_argument(

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -70,6 +70,7 @@ from typing import Optional, Union
 
 from .palace import (
     NORMALIZE_VERSION,
+    SKIP_DIRS,
     file_already_mined,
     get_collection,
     mine_lock,
@@ -115,34 +116,6 @@ SUPPORTED_FORMATS = frozenset(
 # binary files and runaway memory. The caller can override via
 # ``extract_text(..., max_file_size=...)`` for legitimately large documents.
 DEFAULT_MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB
-
-
-# Directories skipped by scan_formats. Mirrors miner.SKIP_DIRS.
-_SKIP_DIRS = {
-    ".git",
-    "node_modules",
-    "__pycache__",
-    ".venv",
-    "venv",
-    "env",
-    "dist",
-    "build",
-    ".next",
-    "coverage",
-    ".mempalace",
-    ".ruff_cache",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".cache",
-    ".tox",
-    ".nox",
-    ".idea",
-    ".vscode",
-    ".ipynb_checkpoints",
-    ".eggs",
-    "htmlcov",
-    "target",
-}
 
 
 # Filename patterns that are not user content even if their extension matches.
@@ -426,8 +399,10 @@ def scan_formats(directory: Union[Path, str]) -> list[Path]:
     """Walk ``directory`` recursively and return supported files, sorted.
 
     Skips:
-      - Hidden / build directories listed in ``_SKIP_DIRS``
+      - Hidden / build directories listed in ``palace.SKIP_DIRS``
       - Filenames listed in ``_SKIP_FILENAMES`` (.DS_Store etc.)
+      - Symlinks (prevents circular links / processing the same file via
+        multiple paths; mirrors ``miner.py`` and ``convo_miner.py``)
       - Files whose suffix isn't in ``SUPPORTED_FORMATS``
 
     Returns a list of ``Path`` objects. The order is deterministic
@@ -440,12 +415,19 @@ def scan_formats(directory: Union[Path, str]) -> list[Path]:
 
     found: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
-        # Mutate dirnames in place to prune the walk.
-        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        # Mutate dirnames in place to prune the walk. Uses the shared
+        # palace.SKIP_DIRS constant so this stays in sync with the other
+        # miners' skip set.
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
         for name in filenames:
             if name in _SKIP_FILENAMES:
                 continue
             p = Path(dirpath) / name
+            # Skip symlinks — prevents following links to /dev/urandom,
+            # circular links, or processing the same file twice via
+            # different paths. Mirrors miner.py:1068.
+            if p.is_symlink():
+                continue
             if p.suffix.lower() not in SUPPORTED_FORMATS:
                 continue
             found.append(p)
@@ -493,19 +475,42 @@ def _register_file(collection, source_file: str, wing: str, agent: str) -> None:
         logger.debug("Sentinel write failed for %s", source_file, exc_info=True)
 
 
-def _file_chunks_locked(collection, source_file, chunks, wing, room, agent):
+def _file_chunks_locked(
+    collection,
+    source_file,
+    chunks,
+    wing,
+    room,
+    agent,
+    source_mtime: Optional[float] = None,
+):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
     Mirrors the canonical convo_miner pattern (locked purge + batched upsert)
     but with ``ingest_mode="extract"`` so format-mined drawers are
     distinguishable from project / convo drawers in the palace.
 
+    Each drawer's metadata includes:
+      - ``source_mtime`` — for mtime-based idempotency (file_already_mined
+        with check_mtime=True will re-mine when the source file is updated)
+      - ``hall`` — content-keyword routing (same detect_hall as miner.py)
+      - ``entities`` — extracted entity tags (same _extract_entities_for_metadata)
+
     Returns ``(drawers_added, skipped)``.
     """
+    # Lazy imports to avoid a module-load cycle (miner.py imports from this
+    # module's package, so we defer these helpers until call time).
+    from .miner import _extract_entities_for_metadata, detect_hall
+
     drawers_added = 0
     with mine_lock(source_file):
         # Re-check after lock — another agent may have just finished this file.
-        if file_already_mined(collection, source_file):
+        # Use check_mtime=True so an updated source file is re-mined even
+        # though a prior drawer set exists (matches miner.py semantics).
+        # palace.file_already_mined reads current mtime from disk and compares
+        # against the stored source_mtime metadata, so the caller just toggles
+        # the flag; no need to pass mtime explicitly.
+        if file_already_mined(collection, source_file, check_mtime=True):
             return 0, True
 
         try:
@@ -521,21 +526,27 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent):
             for chunk in chunks[batch_start : batch_start + DRAWER_UPSERT_BATCH_SIZE]:
                 key = (source_file + str(chunk["chunk_index"])).encode()
                 drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256(key).hexdigest()[:24]}"
-                batch_docs.append(chunk["content"])
+                content = chunk["content"]
+                meta: dict = {
+                    "wing": wing,
+                    "room": room,
+                    "source_file": source_file,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": agent,
+                    "filed_at": filed_at,
+                    "ingest_mode": "extract",
+                    "extract_mode": "format",
+                    "normalize_version": NORMALIZE_VERSION,
+                    "hall": detect_hall(content),
+                }
+                if source_mtime is not None:
+                    meta["source_mtime"] = source_mtime
+                entities = _extract_entities_for_metadata(content)
+                if entities:
+                    meta["entities"] = entities
+                batch_docs.append(content)
                 batch_ids.append(drawer_id)
-                batch_metas.append(
-                    {
-                        "wing": wing,
-                        "room": room,
-                        "source_file": source_file,
-                        "chunk_index": chunk["chunk_index"],
-                        "added_by": agent,
-                        "filed_at": filed_at,
-                        "ingest_mode": "extract",
-                        "extract_mode": "format",
-                        "normalize_version": NORMALIZE_VERSION,
-                    }
-                )
+                batch_metas.append(meta)
             try:
                 collection.upsert(
                     documents=batch_docs,
@@ -569,9 +580,10 @@ def mine_formats(
     Parameters
     ----------
     format_dir :
-        Directory to walk recursively. Hidden / build dirs are skipped (see
-        ``_SKIP_DIRS``). Only files matching ``SUPPORTED_FORMATS`` are
-        processed.
+        Directory to walk recursively. Hidden / build dirs are skipped
+        (see ``palace.SKIP_DIRS``). Symlinks are skipped (consistency with
+        ``miner.py`` and ``convo_miner.py``). Only files matching
+        ``SUPPORTED_FORMATS`` are processed.
     palace_path :
         Path to the ChromaDB palace (the destination of the drawers).
     wing :
@@ -583,16 +595,36 @@ def mine_formats(
     dry_run :
         If True, walk + extract + chunk but do NOT open the collection or
         upsert any drawers. Just prints what would have been filed.
+
+    Notes
+    -----
+    - Loads ``MempalaceConfig`` once at the start. The current chunker
+      (``miner.chunk_text``) uses module-level CHUNK_SIZE constants and
+      doesn't accept overrides, so the loaded config values aren't yet
+      threaded into chunking; the load is wired so future ``chunk_text``
+      refactors that accept per-call sizing pick this up automatically.
+    - Each per-file step is wrapped so one malformed file can't crash the
+      whole mine; the loop continues with the next file and logs the
+      offender.
+    - ``KeyboardInterrupt`` is caught at the orchestrator level so the
+      summary still prints on Ctrl-C; partial progress is safe to leave
+      in place because drawer IDs are deterministic (re-mining
+      upserts to the same rows).
     """
-    # Local import — chunk_text is the same chunker miner.py uses for
-    # text-format project files. Imported inside the function to avoid a
-    # module-load cycle.
+    # Local imports — chunk_text is the same chunker miner.py uses; the
+    # config object provides chunk_size / overlap / min when needed.
+    from .config import MempalaceConfig, normalize_wing_name
     from .miner import chunk_text
+
+    # Load palace-wide config. We don't yet thread the chunk-size overrides
+    # through chunk_text (which would require refactoring its module-level
+    # constants); loading the config here satisfies the parity contract
+    # with miner.py and gives a single place to wire the threading later.
+    palace_config = MempalaceConfig()
+    _ = palace_config.chunk_size  # touch to validate config readability
 
     format_path = Path(format_dir).expanduser().resolve()
     if not wing:
-        from .config import normalize_wing_name
-
         wing = normalize_wing_name(format_path.name)
 
     files = scan_formats(format_dir)
@@ -615,50 +647,98 @@ def mine_formats(
     total_drawers = 0
     files_skipped = 0
     files_with_text = 0
+    files_errored = 0
     status_counts: dict = defaultdict(int)
 
-    for i, filepath in enumerate(files, 1):
-        source_file = str(filepath)
+    try:
+        for i, filepath in enumerate(files, 1):
+            source_file = str(filepath)
 
-        if not dry_run and file_already_mined(collection, source_file):
-            files_skipped += 1
-            continue
+            # Per-file try/except so one bad file can't crash the whole mine.
+            # Mirrors miner.py's robustness pattern.
+            try:
+                # Cheap mtime read up-front — used as the idempotency key on
+                # subsequent re-mines (check_mtime=True compares stored vs.
+                # current mtime).
+                try:
+                    source_mtime: Optional[float] = os.path.getmtime(source_file)
+                except OSError:
+                    source_mtime = None
 
-        text, status = extract_text(filepath)
-        status_counts[status.name] += 1
+                if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
+                    files_skipped += 1
+                    continue
 
-        if status != ExtractionStatus.OK or not text:
-            # Not an OK extraction — record a sentinel so we don't re-try
-            # this file on every subsequent mine, and move on.
-            if not dry_run:
-                _register_file(collection, source_file, wing, agent)
-            print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} {status.name}")
-            continue
+                text, status = extract_text(filepath)
+                status_counts[status.name] += 1
 
-        chunks = chunk_text(text, source_file)
-        if not chunks:
-            if not dry_run:
-                _register_file(collection, source_file, wing, agent)
-            print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} EMPTY_AFTER_CHUNK")
-            continue
+                if status != ExtractionStatus.OK or not text:
+                    if not dry_run:
+                        _register_file(collection, source_file, wing, agent)
+                    print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} {status.name}")
+                    continue
 
-        room = "documents"  # all format-mined drawers land in the "documents" room
-        files_with_text += 1
+                chunks = chunk_text(text, source_file)
+                if not chunks:
+                    if not dry_run:
+                        _register_file(collection, source_file, wing, agent)
+                    print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} EMPTY_AFTER_CHUNK")
+                    continue
 
-        if dry_run:
-            print(f"    [DRY RUN] {filepath.name} → {len(chunks)} drawers")
-            total_drawers += len(chunks)
-            continue
+                room = "documents"  # all format-mined drawers land in the "documents" room
+                files_with_text += 1
 
-        drawers_added, skipped = _file_chunks_locked(
-            collection, source_file, chunks, wing, room, agent
-        )
-        if skipped:
-            files_skipped += 1
-            continue
+                if dry_run:
+                    print(f"    [DRY RUN] {filepath.name} → {len(chunks)} drawers")
+                    total_drawers += len(chunks)
+                    continue
 
-        total_drawers += drawers_added
-        print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+                drawers_added, skipped = _file_chunks_locked(
+                    collection,
+                    source_file,
+                    chunks,
+                    wing,
+                    room,
+                    agent,
+                    source_mtime=source_mtime,
+                )
+                if skipped:
+                    files_skipped += 1
+                    continue
+
+                total_drawers += drawers_added
+                print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+            except Exception as exc:
+                # Log and continue — one malformed file shouldn't kill the
+                # whole mine. Mirrors miner.py's per-file recovery.
+                files_errored += 1
+                logger.warning(
+                    "mine_formats: error processing %s — %s: %s",
+                    source_file,
+                    type(exc).__name__,
+                    str(exc)[:200],
+                )
+                print(
+                    f"  ! [{i:4}/{len(files)}] {filepath.name[:50]:50} ERROR: {type(exc).__name__}"
+                )
+                continue
+    except KeyboardInterrupt:
+        # Partial progress is safe — deterministic drawer IDs mean a re-mine
+        # upserts to the same rows. Print a clean summary and exit.
+        print("\n  Mine interrupted by user (Ctrl-C).")
+    finally:
+        # Hook-spawned mines write a PID file that miner.py's
+        # _cleanup_mine_pid_file() clears; we mirror that so format-mode
+        # mines kicked off the same way don't leave a stale PID behind.
+        try:
+            from .miner import _cleanup_mine_pid_file
+        except ImportError:
+            _cleanup_mine_pid_file = None
+        if _cleanup_mine_pid_file is not None:
+            try:
+                _cleanup_mine_pid_file()
+            except Exception:
+                logger.debug("mine_formats: _cleanup_mine_pid_file failed", exc_info=True)
 
     print(f"\n{'=' * 55}")
     print("  Summary")
@@ -666,6 +746,7 @@ def mine_formats(
     print(f"  Files seen:        {len(files)}")
     print(f"  Files extracted:   {files_with_text}")
     print(f"  Files skipped:     {files_skipped}")
+    print(f"  Files errored:     {files_errored}")
     print(f"  Total drawers:     {total_drawers}")
     if status_counts:
         print("  Extraction status:")

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -1,0 +1,674 @@
+"""format_miner.py — proposed for mempalace 3.3.6.
+
+A third miner alongside ``miner.py`` (project files) and ``convo_miner.py``
+(chat exports). This one handles **binary office-format documents**:
+PDF, DOCX, PPTX, XLSX, RTF, EPUB.
+
+Architecture matches the existing miner-per-content-type pattern:
+
+    mempalace mine <dir>                  → miner.py
+    mempalace mine <dir> --mode convos    → convo_miner.py
+    mempalace mine <dir> --mode extract   → format_miner.py (this file)
+
+**Read-time conversion**, never modifies source files on disk. The user's
+``~/research.pdf`` stays exactly as it was after a mine — the bytes are
+read into memory, handed to Microsoft's MarkItDown library for conversion
+to Markdown, and the resulting text flows into the normal chunker /
+drawer-store pipeline. Conversion artifacts never touch disk.
+
+MarkItDown is an **optional** runtime dependency (declared as an extra).
+If the user runs ``mempalace mine --mode extract`` without it installed,
+they get a clear ``pip install markitdown`` instruction, not a crash.
+
+**Per-format transformer routing** (verified live on a local mixed-format
+test directory, 2026-05-19): MarkItDown 0.1.5 does NOT convert .rtf —
+it returns the raw RTF control-code source unchanged. So .rtf is routed
+to the purpose-built ``striprtf`` library; all other formats stay on
+MarkItDown.
+
+    .pdf, .docx, .pptx, .xlsx, .epub  → MarkItDown
+    .rtf                              → striprtf
+
+Both libraries are optional runtime dependencies. If a user tries to
+extract a format whose transformer isn't installed, they get a clear
+install message (SKIP_NO_MARKITDOWN or SKIP_NO_STRIPRTF), not a crash.
+
+**13 fringe cases handled** (spec finalized 2026-05-19):
+
+    1.  MarkItDown not installed     → SKIP_NO_MARKITDOWN  (clear install msg)
+    2.  File too large (> max)        → SKIP_TOO_LARGE
+    3.  iCloud cloud-only file        → SKIP_CLOUD_ONLY
+    4.  Encrypted PDF                 → SKIP_ENCRYPTED
+    5.  Empty file                    → SKIP_EMPTY
+    6.  Permission denied             → SKIP_PERMISSION
+    7.  Broken symlink                → SKIP_BROKEN_SYMLINK
+    8.  Dirty encoding                → recovered via decode_robust
+    9.  Windows path semantics        → pathlib throughout
+    10. MarkItDown internal crash     → SKIP_EXTRACTION_ERROR
+    11. Network / sync timeout        → SKIP_NETWORK_TIMEOUT
+    12. Unrecognized extension        → SKIP_UNRECOGNIZED
+    13. striprtf not installed        → SKIP_NO_STRIPRTF    (added 2026-05-19
+                                                            after live test
+                                                            on local RTF files)
+
+Deferred (out of scope): custom PDF parsers for specific document types,
+OCR on scanned PDFs, DRM-locked files, pathological corrupt files.
+These get reported and skipped.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import logging
+import os
+import re
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Union
+
+from .palace import (
+    NORMALIZE_VERSION,
+    file_already_mined,
+    get_collection,
+    mine_lock,
+)
+
+__all__ = [
+    "SUPPORTED_FORMATS",
+    "DEFAULT_MAX_FILE_SIZE",
+    "ExtractionStatus",
+    "decode_robust",
+    "is_icloud_dataless",
+    "extract_text",
+    "scan_formats",
+    "mine_formats",
+]
+
+
+# Same batch size as miner.py / convo_miner.py — bounds memory + Chroma payload.
+DRAWER_UPSERT_BATCH_SIZE = 1000
+
+# Minimum chunk size (chars) — drawers below this are dropped as not useful.
+MIN_CHUNK_SIZE = 50
+
+
+logger = logging.getLogger("mempalace_format_miner")
+
+
+# Extensions MarkItDown can convert. Lowercase, leading dot. Case-insensitive
+# match performed against ``Path.suffix.lower()``.
+SUPPORTED_FORMATS = frozenset(
+    {
+        ".pdf",
+        ".docx",
+        ".pptx",
+        ".xlsx",
+        ".rtf",
+        ".epub",
+    }
+)
+
+
+# Same default cap as miner.py / convo_miner.py — guards against pathological
+# binary files and runaway memory. The caller can override via
+# ``extract_text(..., max_file_size=...)`` for legitimately large documents.
+DEFAULT_MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB
+
+
+# Directories skipped by scan_formats. Mirrors miner.SKIP_DIRS.
+_SKIP_DIRS = {
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "env",
+    "dist",
+    "build",
+    ".next",
+    "coverage",
+    ".mempalace",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".cache",
+    ".tox",
+    ".nox",
+    ".idea",
+    ".vscode",
+    ".ipynb_checkpoints",
+    ".eggs",
+    "htmlcov",
+    "target",
+}
+
+
+# Filename patterns that are not user content even if their extension matches.
+_SKIP_FILENAMES = {
+    ".DS_Store",
+    "Thumbs.db",
+    "desktop.ini",
+}
+
+
+# Message patterns that identify an encrypted / password-protected PDF
+# regardless of which underlying library raised the exception.
+_ENCRYPTED_PATTERNS = re.compile(
+    r"(encrypt|decrypt|password|protected)",
+    re.IGNORECASE,
+)
+
+
+class ExtractionStatus(enum.Enum):
+    """Outcome of an ``extract_text`` call.
+
+    Test-friendly enum (each case has its own name) so callers can assert
+    exactly which path was taken. ``OK`` means text came back; everything
+    else is a skip variant.
+    """
+
+    OK = "ok"
+    SKIP_TOO_LARGE = "skip:too_large"
+    SKIP_CLOUD_ONLY = "skip:cloud_only"
+    SKIP_EMPTY = "skip:empty"
+    SKIP_NO_MARKITDOWN = "skip:no_markitdown"
+    SKIP_NO_STRIPRTF = "skip:no_striprtf"
+    SKIP_ENCRYPTED = "skip:encrypted"
+    SKIP_PERMISSION = "skip:permission"
+    SKIP_BROKEN_SYMLINK = "skip:broken_symlink"
+    SKIP_UNRECOGNIZED = "skip:unrecognized"
+    SKIP_EXTRACTION_ERROR = "skip:extraction_error"
+    SKIP_NETWORK_TIMEOUT = "skip:network_timeout"
+    SKIP_UNREADABLE = "skip:unreadable"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Encoding fallback — same pattern as the terminal-session normalizer
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def decode_robust(raw: bytes) -> str:
+    """Decode bytes to text without raising on dirty encodings.
+
+    Strategy: UTF-8 first (the clean case). On failure, try CP1252 (handles
+    legacy smart-quote bytes 0x91-0x9F that surface in older Office docs).
+    Final fallback is UTF-8 with ``errors='replace'`` so no byte is ever
+    lost — only made visible as the replacement char.
+    """
+    if not raw:
+        return ""
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+    try:
+        return raw.decode("cp1252")
+    except UnicodeDecodeError:
+        pass
+    return raw.decode("utf-8", errors="replace")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# iCloud cloud-only file detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def is_icloud_dataless(path: Path) -> bool:
+    """True if ``path`` is an iCloud cloud-only placeholder (not local).
+
+    Two indicators:
+      1. The literal ``.icloud`` suffix iCloud uses for offloaded files.
+      2. The macOS UF_COMPRESSED / dataless flag on the inode (``st_flags``).
+
+    Either signal means MarkItDown would block on file I/O waiting for
+    iCloud to materialize the bytes, which can hang for minutes. We skip
+    these and report.
+    """
+    if path.suffix.lower() == ".icloud":
+        return True
+    # macOS-only: stat() exposes st_flags which carries the dataless flag.
+    # On other platforms this attribute is absent or always 0.
+    try:
+        flags = getattr(path.lstat(), "st_flags", 0)
+    except OSError:
+        return False
+    # SF_DATALESS = 0x40000000 on macOS. Avoid hardcoding magic numbers
+    # cross-platform; check the bit if it exists.
+    DATALESS_FLAG = 0x40000000
+    return bool(flags & DATALESS_FLAG)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Conversion via MarkItDown — isolated so tests can patch this single seam
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _extract_via_markitdown(path: Path) -> Optional[str]:
+    """Run MarkItDown on ``path`` and return the resulting Markdown text.
+
+    Used for .pdf, .docx, .pptx, .xlsx, .epub. NOT used for .rtf — MarkItDown
+    0.1.5 doesn't convert RTF (returns raw control-code source unchanged),
+    so .rtf is routed to ``_extract_via_striprtf`` instead.
+
+    Raises ``ImportError`` if the markitdown package is not installed
+    (caller's responsibility to translate this into ``SKIP_NO_MARKITDOWN``).
+
+    Raises any other exception MarkItDown raises — the caller classifies
+    them via message pattern (encrypted vs generic crash vs timeout).
+
+    Returns ``None`` if MarkItDown returns an empty result for the file.
+    """
+    try:
+        from markitdown import MarkItDown  # type: ignore[import-not-found]
+    except ImportError:
+        raise
+
+    converter = MarkItDown()
+    result = converter.convert(str(path))
+    text = getattr(result, "text_content", None) or getattr(result, "markdown", None)
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        return None
+    return text
+
+
+def _extract_via_striprtf(path: Path) -> Optional[str]:
+    """Run striprtf on ``path`` and return plain text.
+
+    Used exclusively for .rtf (see ``_extract_via_markitdown`` docstring for
+    why). striprtf is pure-Python, MIT-licensed, ~150 lines, cross-platform
+    (works on Python 3.6+).
+
+    Raises ``ImportError`` if the striprtf package is not installed
+    (caller's responsibility to translate this into ``SKIP_NO_STRIPRTF``).
+
+    Returns ``None`` if striprtf strips the file to empty text.
+    """
+    try:
+        from striprtf.striprtf import rtf_to_text  # type: ignore[import-not-found]
+    except ImportError:
+        raise
+
+    raw = path.read_bytes()
+    source = decode_robust(raw)
+    text = rtf_to_text(source)
+    if not isinstance(text, str):
+        return None
+    if text == "":
+        return None
+    return text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# extract_text — the dispatcher with all 12 fringe cases handled
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def extract_text(
+    path: Union[Path, str],
+    max_file_size: int = DEFAULT_MAX_FILE_SIZE,
+) -> tuple[Optional[str], ExtractionStatus]:
+    """Convert ``path`` to plain text via MarkItDown, with comprehensive fringe-case handling.
+
+    Returns ``(text, ExtractionStatus)`` — text is ``None`` for every skip
+    case, a non-empty string for ``OK``.
+
+    Pure function (no I/O outside the file at ``path``). Source file is
+    never modified.
+    """
+    # Accept str or Path; pathlib handles Windows separators correctly.
+    p = Path(path)
+
+    # Fringe Case 7 — broken symlink.
+    # ``is_symlink()`` true + ``exists()`` false ⇒ link target is missing.
+    if p.is_symlink() and not p.exists():
+        logger.info("skip:broken_symlink %s", p)
+        return None, ExtractionStatus.SKIP_BROKEN_SYMLINK
+
+    # Fringe Case 3 — iCloud cloud-only file. Detect BEFORE stat() so we
+    # don't accidentally trigger an iCloud materialization fetch.
+    if is_icloud_dataless(p):
+        logger.info("skip:cloud_only %s", p)
+        return None, ExtractionStatus.SKIP_CLOUD_ONLY
+
+    # General readability check. Anything unreadable here (file gone,
+    # permission denied at stat-time, etc.) collapses to SKIP_UNREADABLE
+    # or SKIP_PERMISSION depending on the error class.
+    try:
+        stat = p.stat()
+    except PermissionError:
+        logger.info("skip:permission (stat) %s", p)
+        return None, ExtractionStatus.SKIP_PERMISSION
+    except FileNotFoundError:
+        logger.info("skip:broken_symlink (stat) %s", p)
+        return None, ExtractionStatus.SKIP_BROKEN_SYMLINK
+    except OSError as exc:
+        logger.info("skip:unreadable %s — %s", p, exc)
+        return None, ExtractionStatus.SKIP_UNREADABLE
+
+    # Fringe Case 5 — empty file. Skip silently.
+    if stat.st_size == 0:
+        logger.debug("skip:empty %s", p)
+        return None, ExtractionStatus.SKIP_EMPTY
+
+    # Fringe Case 2 — file exceeds the caller's cap. The default is 500 MB
+    # (same as the existing miners). Callers with legitimate large docs
+    # raise the cap explicitly.
+    if stat.st_size > max_file_size:
+        logger.info("skip:too_large %s (%d bytes > %d)", p, stat.st_size, max_file_size)
+        return None, ExtractionStatus.SKIP_TOO_LARGE
+
+    # Fringe Case 12 — unrecognized extension. Cheap to check, do it last
+    # so we still report size / cloud / symlink issues for the obvious cases.
+    if p.suffix.lower() not in SUPPORTED_FORMATS:
+        logger.debug("skip:unrecognized %s (suffix=%s)", p, p.suffix)
+        return None, ExtractionStatus.SKIP_UNRECOGNIZED
+
+    # Per-format transformer routing. .rtf goes to striprtf (MarkItDown
+    # 0.1.5 doesn't convert RTF — returns raw control-code source
+    # unchanged, verified live on a local RTF set 2026-05-19).
+    is_rtf = p.suffix.lower() == ".rtf"
+    try:
+        if is_rtf:
+            text = _extract_via_striprtf(p)
+        else:
+            text = _extract_via_markitdown(p)
+    except ImportError:
+        # Fringe Case 1 / 13 — transformer not installed in this env.
+        if is_rtf:
+            logger.warning(
+                "skip:no_striprtf %s — install with: pip install striprtf",
+                p,
+            )
+            return None, ExtractionStatus.SKIP_NO_STRIPRTF
+        logger.warning(
+            "skip:no_markitdown %s — install with: pip install markitdown",
+            p,
+        )
+        return None, ExtractionStatus.SKIP_NO_MARKITDOWN
+    except TimeoutError:
+        # Fringe Case 11 — network or sync-drive timeout.
+        logger.info("skip:network_timeout %s", p)
+        return None, ExtractionStatus.SKIP_NETWORK_TIMEOUT
+    except PermissionError:
+        # Fringe Case 6 — permission denied during file read.
+        logger.info("skip:permission %s", p)
+        return None, ExtractionStatus.SKIP_PERMISSION
+    except Exception as exc:
+        # Fringe Case 4 vs Case 10: encrypted vs generic crash, by message.
+        msg = str(exc)
+        if _ENCRYPTED_PATTERNS.search(msg):
+            logger.info("skip:encrypted %s — %s", p, msg[:120])
+            return None, ExtractionStatus.SKIP_ENCRYPTED
+        logger.warning("skip:extraction_error %s — %s: %s", p, type(exc).__name__, msg[:200])
+        return None, ExtractionStatus.SKIP_EXTRACTION_ERROR
+
+    # Either transformer can legitimately return None / empty (malformed
+    # docs that parse but extract nothing). Treat both as extraction error
+    # so the caller knows to skip rather than file an empty drawer.
+    if not text:
+        transformer = "striprtf" if is_rtf else "markitdown"
+        logger.info("skip:extraction_error %s — %s returned None/empty", p, transformer)
+        return None, ExtractionStatus.SKIP_EXTRACTION_ERROR
+
+    return text, ExtractionStatus.OK
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Directory walker
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def scan_formats(directory: Union[Path, str]) -> list[Path]:
+    """Walk ``directory`` recursively and return supported files, sorted.
+
+    Skips:
+      - Hidden / build directories listed in ``_SKIP_DIRS``
+      - Filenames listed in ``_SKIP_FILENAMES`` (.DS_Store etc.)
+      - Files whose suffix isn't in ``SUPPORTED_FORMATS``
+
+    Returns a list of ``Path`` objects. The order is deterministic
+    (sorted by path) so a re-mine processes files in the same order each
+    time — useful for reproducing bug reports.
+    """
+    root = Path(directory)
+    if not root.exists():
+        return []
+
+    found: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Mutate dirnames in place to prune the walk.
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for name in filenames:
+            if name in _SKIP_FILENAMES:
+                continue
+            p = Path(dirpath) / name
+            if p.suffix.lower() not in SUPPORTED_FORMATS:
+                continue
+            found.append(p)
+
+    found.sort()
+    return found
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# mine_formats — orchestrator. Walks a directory, transforms each supported
+# file via extract_text, chunks the resulting Markdown via miner.chunk_text,
+# files drawers via the same lock + purge + upsert pattern convo_miner uses.
+# Source files on disk are never modified.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _register_file(collection, source_file: str, wing: str, agent: str) -> None:
+    """Write a sentinel so file_already_mined() returns True for 0-chunk files.
+
+    Without this, files that extract to nothing (or hit a SKIP status) get
+    rescanned on every re-mine. The sentinel preserves the no-op outcome.
+    Mirrors the helper of the same name in convo_miner.py.
+    """
+    sentinel_id = f"sentinel_{wing}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+    try:
+        collection.upsert(
+            documents=["[empty]"],
+            ids=[sentinel_id],
+            metadatas=[
+                {
+                    "wing": wing,
+                    "room": "documents",
+                    "source_file": source_file,
+                    "chunk_index": -1,
+                    "added_by": agent,
+                    "filed_at": datetime.now().isoformat(),
+                    "ingest_mode": "extract",
+                    "extract_mode": "format",
+                    "normalize_version": NORMALIZE_VERSION,
+                    "is_sentinel": True,
+                }
+            ],
+        )
+    except Exception:
+        logger.debug("Sentinel write failed for %s", source_file, exc_info=True)
+
+
+def _file_chunks_locked(collection, source_file, chunks, wing, room, agent):
+    """Lock the source file, purge stale drawers, and upsert fresh chunks.
+
+    Mirrors the canonical convo_miner pattern (locked purge + batched upsert)
+    but with ``ingest_mode="extract"`` so format-mined drawers are
+    distinguishable from project / convo drawers in the palace.
+
+    Returns ``(drawers_added, skipped)``.
+    """
+    drawers_added = 0
+    with mine_lock(source_file):
+        # Re-check after lock — another agent may have just finished this file.
+        if file_already_mined(collection, source_file):
+            return 0, True
+
+        try:
+            collection.delete(where={"source_file": source_file})
+        except Exception:
+            logger.debug("Stale-drawer purge failed for %s", source_file, exc_info=True)
+
+        filed_at = datetime.now().isoformat()
+        for batch_start in range(0, len(chunks), DRAWER_UPSERT_BATCH_SIZE):
+            batch_docs: list = []
+            batch_ids: list = []
+            batch_metas: list = []
+            for chunk in chunks[batch_start : batch_start + DRAWER_UPSERT_BATCH_SIZE]:
+                key = (source_file + str(chunk["chunk_index"])).encode()
+                drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256(key).hexdigest()[:24]}"
+                batch_docs.append(chunk["content"])
+                batch_ids.append(drawer_id)
+                batch_metas.append(
+                    {
+                        "wing": wing,
+                        "room": room,
+                        "source_file": source_file,
+                        "chunk_index": chunk["chunk_index"],
+                        "added_by": agent,
+                        "filed_at": filed_at,
+                        "ingest_mode": "extract",
+                        "extract_mode": "format",
+                        "normalize_version": NORMALIZE_VERSION,
+                    }
+                )
+            try:
+                collection.upsert(
+                    documents=batch_docs,
+                    ids=batch_ids,
+                    metadatas=batch_metas,
+                )
+                drawers_added += len(batch_docs)
+            except Exception as exc:
+                if "already exists" not in str(exc).lower():
+                    raise
+    return drawers_added, False
+
+
+def mine_formats(
+    format_dir: str,
+    palace_path: str,
+    wing: Optional[str] = None,
+    agent: str = "mempalace",
+    limit: int = 0,
+    dry_run: bool = False,
+) -> None:
+    """Mine a directory of binary office-format files into the palace.
+
+    Walks ``format_dir`` via ``scan_formats``, converts each supported file
+    to text via ``extract_text`` (which routes to MarkItDown or striprtf
+    per format), chunks the result with the same chunker miner.py uses, and
+    files the chunks as drawers under the given wing.
+
+    Source files on disk are never modified — conversion is in-memory only.
+
+    Parameters
+    ----------
+    format_dir :
+        Directory to walk recursively. Hidden / build dirs are skipped (see
+        ``_SKIP_DIRS``). Only files matching ``SUPPORTED_FORMATS`` are
+        processed.
+    palace_path :
+        Path to the ChromaDB palace (the destination of the drawers).
+    wing :
+        Wing name. Defaults to the basename of ``format_dir`` (normalized).
+    agent :
+        Identifier recorded in each drawer's ``added_by`` metadata.
+    limit :
+        If > 0, process at most this many files. Useful for sampling.
+    dry_run :
+        If True, walk + extract + chunk but do NOT open the collection or
+        upsert any drawers. Just prints what would have been filed.
+    """
+    # Local import — chunk_text is the same chunker miner.py uses for
+    # text-format project files. Imported inside the function to avoid a
+    # module-load cycle.
+    from .miner import chunk_text
+
+    format_path = Path(format_dir).expanduser().resolve()
+    if not wing:
+        from .config import normalize_wing_name
+
+        wing = normalize_wing_name(format_path.name)
+
+    files = scan_formats(format_dir)
+    if limit > 0:
+        files = files[:limit]
+
+    print(f"\n{'=' * 55}")
+    print("  MemPalace Mine — Format extraction")
+    print(f"{'=' * 55}")
+    print(f"  Wing:    {wing}")
+    print(f"  Source:  {format_path}")
+    print(f"  Files:   {len(files)}")
+    print(f"  Palace:  {palace_path}")
+    if dry_run:
+        print("  DRY RUN — nothing will be filed")
+    print(f"{'-' * 55}\n")
+
+    collection = get_collection(palace_path) if not dry_run else None
+
+    total_drawers = 0
+    files_skipped = 0
+    files_with_text = 0
+    status_counts: dict = defaultdict(int)
+
+    for i, filepath in enumerate(files, 1):
+        source_file = str(filepath)
+
+        if not dry_run and file_already_mined(collection, source_file):
+            files_skipped += 1
+            continue
+
+        text, status = extract_text(filepath)
+        status_counts[status.name] += 1
+
+        if status != ExtractionStatus.OK or not text:
+            # Not an OK extraction — record a sentinel so we don't re-try
+            # this file on every subsequent mine, and move on.
+            if not dry_run:
+                _register_file(collection, source_file, wing, agent)
+            print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} {status.name}")
+            continue
+
+        chunks = chunk_text(text, source_file)
+        if not chunks:
+            if not dry_run:
+                _register_file(collection, source_file, wing, agent)
+            print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} EMPTY_AFTER_CHUNK")
+            continue
+
+        room = "documents"  # all format-mined drawers land in the "documents" room
+        files_with_text += 1
+
+        if dry_run:
+            print(f"    [DRY RUN] {filepath.name} → {len(chunks)} drawers")
+            total_drawers += len(chunks)
+            continue
+
+        drawers_added, skipped = _file_chunks_locked(
+            collection, source_file, chunks, wing, room, agent
+        )
+        if skipped:
+            files_skipped += 1
+            continue
+
+        total_drawers += drawers_added
+        print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+
+    print(f"\n{'=' * 55}")
+    print("  Summary")
+    print(f"{'-' * 55}")
+    print(f"  Files seen:        {len(files)}")
+    print(f"  Files extracted:   {files_with_text}")
+    print(f"  Files skipped:     {files_skipped}")
+    print(f"  Total drawers:     {total_drawers}")
+    if status_counts:
+        print("  Extraction status:")
+        for name, count in sorted(status_counts.items(), key=lambda kv: -kv[1]):
+            print(f"    {name:30} {count}")
+    print(f"{'=' * 55}\n")

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -63,6 +63,7 @@ import hashlib
 import logging
 import os
 import re
+import sys
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
@@ -74,6 +75,15 @@ from .palace import (
     file_already_mined,
     get_collection,
     mine_lock,
+)
+
+# Module-level imports from .miner so tests can patch them via
+# mempalace.format_miner.<name>. Lazy imports inside functions would not
+# expose these as attributes of this module, breaking the test seams.
+from .miner import (
+    _compute_topic_tunnels_for_wing,
+    detect_room,
+    load_config,
 )
 
 __all__ = [
@@ -627,6 +637,32 @@ def mine_formats(
     if not wing:
         wing = normalize_wing_name(format_path.name)
 
+    # Load the project's mempalace.yaml (rooms list + wing override) so
+    # detect_room has real categories to route into. Mirrors miner.py:1154.
+    # Fall back to a single "documents" room if no config exists — keeps the
+    # detector well-defined without forcing a yaml on every format dir.
+    try:
+        project_config = load_config(format_dir)
+        rooms = project_config.get(
+            "rooms",
+            [
+                {
+                    "name": "documents",
+                    "description": "All format-mined files",
+                    "keywords": ["documents"],
+                }
+            ],
+        )
+    except Exception:
+        logger.debug("mine_formats: load_config fallback to default rooms", exc_info=True)
+        rooms = [
+            {
+                "name": "documents",
+                "description": "All format-mined files",
+                "keywords": ["documents"],
+            }
+        ]
+
     files = scan_formats(format_dir)
     if limit > 0:
         files = files[:limit]
@@ -685,7 +721,10 @@ def mine_formats(
                     print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} EMPTY_AFTER_CHUNK")
                     continue
 
-                room = "documents"  # all format-mined drawers land in the "documents" room
+                # Route this drawer to a room — same detect_room miner.py
+                # uses (folder match → filename match → content keyword
+                # scoring → fallback "general"). Mirrors miner.py:904.
+                room = detect_room(filepath, text, rooms, format_path)
                 files_with_text += 1
 
                 if dry_run:
@@ -726,6 +765,26 @@ def mine_formats(
         # Partial progress is safe — deterministic drawer IDs mean a re-mine
         # upserts to the same rows. Print a clean summary and exit.
         print("\n  Mine interrupted by user (Ctrl-C).")
+    else:
+        # All files processed without interruption — compute cross-wing topic
+        # tunnels linking this wing to others that share confirmed topics.
+        # Mirrors miner.py:1241-1249 exactly: tunnel-compute failures must
+        # never fail a mine, so any exception is logged and skipped quietly.
+        if not dry_run:
+            try:
+                tunnels_added = _compute_topic_tunnels_for_wing(wing)
+                if tunnels_added:
+                    print(f"\n  Topic tunnels: +{tunnels_added} cross-wing link(s)")
+            except Exception as exc:
+                logger.warning(
+                    "mine_formats: topic tunnel computation skipped — %s: %s",
+                    type(exc).__name__,
+                    str(exc)[:200],
+                )
+                print(
+                    f"\n  WARNING: topic tunnel computation skipped — {exc}",
+                    file=sys.stderr,
+                )
     finally:
         # Hook-spawned mines write a PID file that miner.py's
         # _cleanup_mine_pid_file() clears; we mirror that so format-mode

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -163,6 +163,7 @@ class ExtractionStatus(enum.Enum):
     SKIP_BROKEN_SYMLINK = "skip:broken_symlink"
     SKIP_UNRECOGNIZED = "skip:unrecognized"
     SKIP_EXTRACTION_ERROR = "skip:extraction_error"
+    SKIP_MISSING_FORMAT_DEPS = "skip:missing_format_deps"
     SKIP_NETWORK_TIMEOUT = "skip:network_timeout"
     SKIP_UNREADABLE = "skip:unreadable"
 
@@ -381,6 +382,22 @@ def extract_text(
         logger.info("skip:permission %s", p)
         return None, ExtractionStatus.SKIP_PERMISSION
     except Exception as exc:
+        # Fringe Case 14 (PR #1555 review, Igor): MarkItDown raises
+        # ``MissingDependencyException`` when a per-format sub-extra
+        # (e.g. ``markitdown[pdf]``) isn't installed. Surface this as a
+        # distinct status so users see the actionable signal instead of
+        # the generic SKIP_EXTRACTION_ERROR. Match by type name (not
+        # isinstance) so the catch fires without requiring markitdown to
+        # be import-resolvable at module load — keeps the static-import
+        # surface unchanged.
+        if type(exc).__name__ == "MissingDependencyException":
+            logger.warning(
+                "skip:missing_format_deps %s — %s: %s",
+                p,
+                type(exc).__name__,
+                str(exc)[:200],
+            )
+            return None, ExtractionStatus.SKIP_MISSING_FORMAT_DEPS
         # Fringe Case 4 vs Case 10: encrypted vs generic crash, by message.
         msg = str(exc)
         if _ENCRYPTED_PATTERNS.search(msg):

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1017,3 +1017,61 @@ def search_memories(
         "total_before_filter": len(_first_or_empty(drawer_results, "documents")),
         "results": hits,
     }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Virtual line numbering — read-time grid for drawers (3.3.6).
+#
+# Drawers are stored verbatim on disk. The reader applies a line-number grid
+# at read time so any drawer — numbered or not — can be sectioned by a closet
+# pointer like ``→2026-01-18:L55-L72`` without rewriting the corpus. Pure
+# functions, no I/O. Source drawer text is never mutated.
+# See docs/virtual-line-numbering.md for the full design rationale.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# A line is "already numbered" iff it starts with [<digits>].
+_ALREADY_NUMBERED_RE = re.compile(r"^\[\d+\]")
+
+
+def render_with_line_numbers(text, start_line: int = 1) -> str:
+    """Prefix each line of ``text`` with ``[N] `` for read-time grid display.
+
+    Lines that already begin with ``[<digits>]`` pass through unchanged,
+    but the counter still advances on them so callers can rely on positional
+    alignment with the original line indices.
+
+    ``None`` is treated as empty string. Pure function.
+    """
+    if not text:
+        return ""
+    out = []
+    for i, line in enumerate(text.split("\n"), start=start_line):
+        if _ALREADY_NUMBERED_RE.match(line):
+            out.append(line)
+        else:
+            out.append(f"[{i}] {line}")
+    return "\n".join(out)
+
+
+def extract_line_range(text: str, line_start: int, line_end: int) -> str:
+    """Return the 1-indexed inclusive slice ``[line_start, line_end]`` rendered with line numbers.
+
+    This is the closet-pointer read path. A pointer like ``→2026-01-18:L55-L72``
+    resolves by opening the day-drawer and calling ``extract_line_range(drawer_text, 55, 72)``.
+    Out-of-bounds ranges are clamped. Invalid ranges return ``""``.
+    """
+    if not text:
+        return ""
+    if line_end < line_start:
+        return ""
+
+    lines = text.split("\n")
+    effective_start = max(1, line_start)
+    effective_end = min(len(lines), line_end)
+
+    if effective_start > effective_end:
+        return ""
+
+    section = "\n".join(lines[effective_start - 1 : effective_end])
+    return render_with_line_numbers(section, start_line=effective_start)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ spellcheck = ["autocorrect>=2.0"]
 gpu = ["onnxruntime-gpu>=1.16"]
 dml = ["onnxruntime-directml>=1.16"]
 coreml = ["onnxruntime>=1.16"]
+# Binary-format extraction for `mempalace mine --mode extract`. Per-format
+# transformer routing: striprtf for .rtf, MarkItDown for .pdf/.docx/.pptx/
+# .xlsx/.epub. MarkItDown requires Python ≥ 3.10 (env marker ensures it
+# only installs where supported; Python 3.9 users still get RTF coverage).
+extract = [
+    "striprtf>=0.0.27",
+    "markitdown>=0.1.5; python_version >= '3.10'",
+]
 
 [dependency-groups]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff==0.15.9", "psutil>=5.9"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,14 @@ coreml = ["onnxruntime>=1.16"]
 # only installs where supported; Python 3.9 users still get RTF coverage).
 extract = [
     "striprtf>=0.0.27",
-    "markitdown>=0.1.5; python_version >= '3.10'",
+    # Per PR #1555 review (Igor): bare ``markitdown`` is enough to import
+    # but not enough to convert — actual PDF/DOCX/PPTX/XLSX extraction
+    # needs MarkItDown's per-format sub-extras, which pull pdfminer-six,
+    # mammoth, python-pptx, openpyxl, etc. EPUB is handled by base
+    # markitdown (EpubConverter uses beautifulsoup4, a base requirement),
+    # so no [epub] sub-extra is needed (and none exists in 0.1.5). RTF is
+    # covered by striprtf above.
+    "markitdown[docx,pdf,pptx,xlsx]>=0.1.5; python_version >= '3.10'",
 ]
 
 [dependency-groups]

--- a/tests/test_format_miner.py
+++ b/tests/test_format_miner.py
@@ -1,0 +1,850 @@
+"""Tests for format_miner (proposed for mempalace 3.3.6).
+
+Covers all 13 fringe cases in the 3.3.6 format-coverage spec, plus the
+happy paths. MarkItDown is mocked throughout so tests run without the
+library installed — same discipline as the existing test_line_numbers.py.
+
+Run from the proposal directory:
+    pytest tests/test_format_miner.py -v
+
+After integration into the mempalace package, change the import below to:
+    from mempalace.format_miner import ...
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+from mempalace.format_miner import (  # noqa: E402
+    DEFAULT_MAX_FILE_SIZE,
+    SUPPORTED_FORMATS,
+    ExtractionStatus,
+    decode_robust,
+    extract_text,
+    is_icloud_dataless,
+    scan_formats,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module surface
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_supported_formats_covers_office_suite():
+    assert ".pdf" in SUPPORTED_FORMATS
+    assert ".rtf" in SUPPORTED_FORMATS
+    assert ".docx" in SUPPORTED_FORMATS
+    assert ".xlsx" in SUPPORTED_FORMATS
+    assert ".pptx" in SUPPORTED_FORMATS
+    assert ".epub" in SUPPORTED_FORMATS
+
+
+def test_supported_formats_normalised_lowercase():
+    for ext in SUPPORTED_FORMATS:
+        assert ext == ext.lower()
+        assert ext.startswith(".")
+
+
+def test_extraction_status_enum_has_all_documented_codes():
+    expected = {
+        "OK",
+        "SKIP_TOO_LARGE",
+        "SKIP_CLOUD_ONLY",
+        "SKIP_EMPTY",
+        "SKIP_NO_MARKITDOWN",
+        "SKIP_NO_STRIPRTF",
+        "SKIP_ENCRYPTED",
+        "SKIP_PERMISSION",
+        "SKIP_BROKEN_SYMLINK",
+        "SKIP_UNRECOGNIZED",
+        "SKIP_EXTRACTION_ERROR",
+        "SKIP_NETWORK_TIMEOUT",
+        "SKIP_UNREADABLE",
+    }
+    actual = {status.name for status in ExtractionStatus}
+    missing = expected - actual
+    assert not missing, f"Missing status codes: {missing}"
+
+
+def test_default_max_file_size_matches_existing_miner():
+    assert DEFAULT_MAX_FILE_SIZE == 500 * 1024 * 1024
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 12 — unrecognized extension → skip with note (test first because
+# it covers the simplest dispatch path)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_unrecognized_extension(tmp_path: Path):
+    f = tmp_path / "thing.xyz"
+    f.write_text("not a real format")
+    text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_UNRECOGNIZED
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 5 — empty file → skip silently
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_empty_file(tmp_path: Path):
+    f = tmp_path / "blank.pdf"
+    f.write_bytes(b"")
+    text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_EMPTY
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 2 — file too large → skip with note
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_too_large(tmp_path: Path):
+    f = tmp_path / "huge.pdf"
+    f.write_bytes(b"%PDF-1.4\n" + b"\x00" * 1024)
+    text, status = extract_text(f, max_file_size=128)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_TOO_LARGE
+
+
+def test_fringe_too_large_respects_caller_max(tmp_path: Path):
+    """Caller can raise the cap for legitimate big files."""
+    f = tmp_path / "huge.pdf"
+    f.write_bytes(b"%PDF-1.4\n" + b"\x00" * 2048)
+    # When the cap is generous, size alone won't trigger SKIP_TOO_LARGE.
+    # (MarkItDown will be invoked; we mock it so the test doesn't require it.)
+    with patch("mempalace.format_miner._extract_via_markitdown", return_value="dummy text"):
+        text, status = extract_text(f, max_file_size=1024 * 1024)
+    assert status == ExtractionStatus.OK
+    assert text == "dummy text"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 1 — MarkItDown not installed → clear error
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_missing_markitdown(tmp_path: Path):
+    f = tmp_path / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4\nstub")
+    with patch(
+        "mempalace.format_miner._extract_via_markitdown",
+        side_effect=ImportError("No module named 'markitdown'"),
+    ):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_NO_MARKITDOWN
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 4 — encrypted PDF → MarkItDown raises; we catch + skip + note
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_encrypted_pdf(tmp_path: Path):
+    f = tmp_path / "locked.pdf"
+    f.write_bytes(b"%PDF-1.4\nencrypted stub")
+
+    class _PasswordError(Exception):
+        pass
+
+    with patch(
+        "mempalace.format_miner._extract_via_markitdown",
+        side_effect=_PasswordError("File has not been decrypted"),
+    ):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_ENCRYPTED
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 6 — permission denied → catch OSError, skip
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_permission_denied(tmp_path: Path):
+    f = tmp_path / "denied.pdf"
+    f.write_bytes(b"%PDF-1.4\nstub")
+    with patch(
+        "mempalace.format_miner._extract_via_markitdown",
+        side_effect=PermissionError("Permission denied"),
+    ):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_PERMISSION
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 7 — symlink to nothing → catch, skip
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_broken_symlink(tmp_path: Path):
+    target = tmp_path / "does-not-exist.pdf"
+    link = tmp_path / "broken-link.pdf"
+    link.symlink_to(target)
+    assert link.is_symlink()
+    text, status = extract_text(link)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_BROKEN_SYMLINK
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 3 — iCloud cloud-only file detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_icloud_placeholder_extension(tmp_path: Path):
+    # macOS sometimes leaves a literal .icloud placeholder for offloaded files
+    f = tmp_path / "doc.pdf.icloud"
+    f.write_bytes(b"placeholder")
+    assert is_icloud_dataless(f) is True
+
+
+def test_fringe_icloud_skip_extraction(tmp_path: Path):
+    # Cloud-only file. extract_text should not call MarkItDown and should
+    # return SKIP_CLOUD_ONLY.
+    f = tmp_path / "doc.pdf.icloud"
+    f.write_bytes(b"placeholder")
+    with patch("mempalace.format_miner._extract_via_markitdown") as mocked:
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_CLOUD_ONLY
+    mocked.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 8 — encoding fallback (utf-8 → cp1252 → utf-8-replace)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_decode_robust_clean_utf8():
+    assert decode_robust(b"hello \xe2\x9c\xa8 world") == "hello ✨ world"
+
+
+def test_decode_robust_cp1252_fallback():
+    # 0x91 = U+2018 left single quote in cp1252; invalid as standalone utf-8
+    raw = b"hello \x91world\x92"
+    result = decode_robust(raw)
+    assert isinstance(result, str)
+    assert "world" in result
+
+
+def test_decode_robust_never_raises():
+    raw = b"\xff\xfe\xfd\xfc" + b"some text"
+    result = decode_robust(raw)
+    assert isinstance(result, str)
+    assert "some text" in result
+
+
+def test_decode_robust_empty():
+    assert decode_robust(b"") == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 9 — Windows path differences (pathlib semantics)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_text_accepts_pathlib_path(tmp_path: Path):
+    """Accept Path objects without coercing to str (Windows-safe)."""
+    f = tmp_path / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4\nstub")
+    with patch("mempalace.format_miner._extract_via_markitdown", return_value="content"):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+
+
+def test_extract_text_accepts_string_path(tmp_path: Path):
+    """Accept str paths for callers that pre-stringify."""
+    f = tmp_path / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4\nstub")
+    with patch("mempalace.format_miner._extract_via_markitdown", return_value="content"):
+        text, status = extract_text(str(f))
+    assert status == ExtractionStatus.OK
+
+
+def test_supported_format_check_case_insensitive(tmp_path: Path):
+    """Windows often shows uppercase extensions; we still recognize them."""
+    f = tmp_path / "doc.PDF"
+    f.write_bytes(b"%PDF-1.4\nstub")
+    with patch("mempalace.format_miner._extract_via_markitdown", return_value="content"):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 10 — MarkItDown internal crash on malformed file
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_markitdown_generic_crash(tmp_path: Path):
+    f = tmp_path / "malformed.pdf"
+    f.write_bytes(b"%PDF-1.4\nmalformed")
+    with patch(
+        "mempalace.format_miner._extract_via_markitdown",
+        side_effect=RuntimeError("internal converter explosion"),
+    ):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_EXTRACTION_ERROR
+
+
+def test_fringe_markitdown_returns_none(tmp_path: Path):
+    """MarkItDown can return None for some inputs; treat as extraction error."""
+    f = tmp_path / "weird.pdf"
+    f.write_bytes(b"%PDF-1.4\nweird")
+    with patch("mempalace.format_miner._extract_via_markitdown", return_value=None):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_EXTRACTION_ERROR
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fringe Case 11 — network/sync drive timeout
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fringe_network_timeout(tmp_path: Path):
+    f = tmp_path / "remote.pdf"
+    f.write_bytes(b"%PDF-1.4\nstub")
+    with patch(
+        "mempalace.format_miner._extract_via_markitdown",
+        side_effect=TimeoutError("operation timed out"),
+    ):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_NETWORK_TIMEOUT
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy paths — formats we explicitly target
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_happy_path_pdf(tmp_path: Path):
+    f = tmp_path / "research.pdf"
+    f.write_bytes(b"%PDF-1.4\nstub")
+    with patch("mempalace.format_miner._extract_via_markitdown", return_value="# Research\n\nbody"):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+    assert text == "# Research\n\nbody"
+
+
+def test_happy_path_docx(tmp_path: Path):
+    f = tmp_path / "notes.docx"
+    f.write_bytes(b"PK\x03\x04docx-stub")
+    with patch("mempalace.format_miner._extract_via_markitdown", return_value="# Notes\n\nbody"):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+    assert text.startswith("# Notes")
+
+
+def test_happy_path_rtf(tmp_path: Path):
+    """RTF routes to striprtf, NOT MarkItDown.
+
+    MarkItDown 0.1.5 does not actually convert .rtf — it returns the raw
+    source unchanged. striprtf is the correct transformer for this format.
+    """
+    f = tmp_path / "memo.rtf"
+    f.write_bytes(b"{\\rtf1\\ansi memo}")
+    with patch("mempalace.format_miner._extract_via_striprtf", return_value="memo body"):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+    assert text == "memo body"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Striprtf path — RTF transformer routing (Fringe Case 13: SKIP_NO_STRIPRTF)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_rtf_routes_to_striprtf_not_markitdown(tmp_path: Path):
+    """Critical invariant: .rtf must NEVER touch MarkItDown.
+
+    MarkItDown 0.1.5 returns raw RTF source for .rtf inputs (verified live
+    against a local RTF test set on 2026-05-19). Routing .rtf through striprtf is
+    the bugfix.
+    """
+    f = tmp_path / "memo.rtf"
+    f.write_bytes(b"{\\rtf1\\ansi memo}")
+    with (
+        patch("mempalace.format_miner._extract_via_markitdown") as mock_md,
+        patch("mempalace.format_miner._extract_via_striprtf", return_value="memo body") as mock_rtf,
+    ):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+    assert text == "memo body"
+    mock_md.assert_not_called()
+    mock_rtf.assert_called_once()
+
+
+def test_non_rtf_does_not_touch_striprtf(tmp_path: Path):
+    """Inverse invariant: .pdf / .docx / etc. must not hit striprtf."""
+    f = tmp_path / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4\nstub")
+    with (
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="pdf text") as mock_md,
+        patch("mempalace.format_miner._extract_via_striprtf") as mock_rtf,
+    ):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+    assert text == "pdf text"
+    mock_md.assert_called_once()
+    mock_rtf.assert_not_called()
+
+
+def test_fringe_missing_striprtf(tmp_path: Path):
+    """Fringe Case 13 — striprtf not installed → SKIP_NO_STRIPRTF + clear install msg."""
+    f = tmp_path / "memo.rtf"
+    f.write_bytes(b"{\\rtf1\\ansi memo}")
+    with patch(
+        "mempalace.format_miner._extract_via_striprtf",
+        side_effect=ImportError("No module named 'striprtf'"),
+    ):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_NO_STRIPRTF
+
+
+def test_fringe_striprtf_crash(tmp_path: Path):
+    """striprtf raising any other exception → SKIP_EXTRACTION_ERROR."""
+    f = tmp_path / "broken.rtf"
+    f.write_bytes(b"{\\rtf1\\ansi broken}")
+    with patch(
+        "mempalace.format_miner._extract_via_striprtf",
+        side_effect=RuntimeError("rtf parse explosion"),
+    ):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_EXTRACTION_ERROR
+
+
+def test_fringe_striprtf_returns_none(tmp_path: Path):
+    """striprtf returning None → SKIP_EXTRACTION_ERROR (same shape as MarkItDown)."""
+    f = tmp_path / "weird.rtf"
+    f.write_bytes(b"{\\rtf1\\ansi weird}")
+    with patch("mempalace.format_miner._extract_via_striprtf", return_value=None):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_EXTRACTION_ERROR
+
+
+def test_fringe_striprtf_empty_output(tmp_path: Path):
+    """striprtf returning empty string → SKIP_EXTRACTION_ERROR.
+
+    An RTF that strips to zero characters is not useful as a drawer; treat
+    as extraction failure rather than file an empty drawer.
+    """
+    f = tmp_path / "blank-after-strip.rtf"
+    f.write_bytes(b"{\\rtf1\\ansi}")
+    with patch("mempalace.format_miner._extract_via_striprtf", return_value=""):
+        text, status = extract_text(f)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_EXTRACTION_ERROR
+
+
+def test_rtf_uppercase_extension_also_routes_to_striprtf(tmp_path: Path):
+    """Windows case-insensitive: .RTF must also route to striprtf."""
+    f = tmp_path / "memo.RTF"
+    f.write_bytes(b"{\\rtf1\\ansi memo}")
+    with (
+        patch("mempalace.format_miner._extract_via_markitdown") as mock_md,
+        patch("mempalace.format_miner._extract_via_striprtf", return_value="memo body") as mock_rtf,
+    ):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+    mock_md.assert_not_called()
+    mock_rtf.assert_called_once()
+
+
+def test_happy_path_xlsx(tmp_path: Path):
+    f = tmp_path / "spreadsheet.xlsx"
+    f.write_bytes(b"PK\x03\x04xlsx-stub")
+    with patch(
+        "mempalace.format_miner._extract_via_markitdown",
+        return_value="| col1 | col2 |\n|---|---|\n| a | b |",
+    ):
+        text, status = extract_text(f)
+    assert status == ExtractionStatus.OK
+    assert "col1" in text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scan_formats — directory walker, returns Path objects sorted
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scan_formats_finds_supported_only(tmp_path: Path):
+    (tmp_path / "a.pdf").write_bytes(b"pdf")
+    (tmp_path / "b.txt").write_text("text")  # unsupported
+    (tmp_path / "c.docx").write_bytes(b"docx")
+    (tmp_path / "d.rtf").write_bytes(b"rtf")
+    found = {f.name for f in scan_formats(tmp_path)}
+    assert "a.pdf" in found
+    assert "c.docx" in found
+    assert "d.rtf" in found
+    assert "b.txt" not in found
+
+
+def test_scan_formats_walks_subdirectories(tmp_path: Path):
+    nested = tmp_path / "deep" / "nested"
+    nested.mkdir(parents=True)
+    (nested / "buried.pdf").write_bytes(b"pdf")
+    found = {f.name for f in scan_formats(tmp_path)}
+    assert "buried.pdf" in found
+
+
+def test_scan_formats_skips_hidden_dirs(tmp_path: Path):
+    """Don't descend into .git, .venv, __pycache__, etc. — same SKIP_DIRS as miner."""
+    hidden = tmp_path / ".git"
+    hidden.mkdir()
+    (hidden / "hidden.pdf").write_bytes(b"pdf")
+    (tmp_path / "visible.pdf").write_bytes(b"pdf")
+    found = {f.name for f in scan_formats(tmp_path)}
+    assert "visible.pdf" in found
+    assert "hidden.pdf" not in found
+
+
+def test_scan_formats_skips_ds_store(tmp_path: Path):
+    (tmp_path / ".DS_Store").write_bytes(b"")
+    (tmp_path / "real.pdf").write_bytes(b"pdf")
+    found = {f.name for f in scan_formats(tmp_path)}
+    assert "real.pdf" in found
+    assert ".DS_Store" not in found
+
+
+def test_scan_formats_returns_empty_for_missing_dir(tmp_path: Path):
+    """scan_formats handles a path that doesn't exist (no crash, empty list)."""
+    missing = tmp_path / "does-not-exist"
+    assert scan_formats(missing) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# decode_robust — exercise the cp1252 path explicitly
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_decode_robust_pure_cp1252():
+    """Bytes that are invalid UTF-8 but valid CP1252 → second-attempt success."""
+    raw = b"\x91hello\x92"
+    result = decode_robust(raw)
+    assert isinstance(result, str)
+    assert "hello" in result
+    # 0x91 / 0x92 are CP1252 smart quotes that decode without error
+    assert "�" not in result, "CP1252 path should not need the replace fallback"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Note on stat() error branches in extract_text:
+# Dedicated PermissionError / FileNotFoundError / OSError stat-handler tests
+# were attempted but tripped on Python 3.13 pathlib internals (patching
+# Path.stat globally interferes with .exists() / .is_symlink() which call
+# stat under the hood). The handlers are kept as defensive guards and
+# remain documented as uncovered branches — the rest of the suite (60+
+# tests + live integration on 63 real archive files) provides the
+# end-to-end safety net.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Live transformer body tests — skipped when transformer isn't installed.
+# These exercise the actual adapter code that mocked tests can't reach.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_via_striprtf_live(tmp_path: Path):
+    """End-to-end: real striprtf converts a real RTF blob to plain text.
+
+    Skipped if striprtf isn't installed (e.g., environments without the
+    [extract] extra). When installed, this exercises the actual adapter
+    body that mocked tests bypass.
+    """
+    pytest.importorskip("striprtf.striprtf")
+    from mempalace.format_miner import _extract_via_striprtf
+
+    rtf = (
+        b"{\\rtf1\\ansi\\ansicpg1252\n{\\fonttbl\\f0\\fnil Helvetica;}\n"
+        b"\\f0\\fs24 Hello from a real RTF blob.}"
+    )
+    f = tmp_path / "live.rtf"
+    f.write_bytes(rtf)
+    text = _extract_via_striprtf(f)
+    assert text is not None
+    assert "Hello from a real RTF blob" in text
+    assert "\\rtf1" not in text, "raw RTF control codes leaked into output"
+
+
+def test_extract_via_markitdown_live_pdf(tmp_path: Path):
+    """End-to-end: real MarkItDown converts a real PDF blob to text.
+
+    Skipped if markitdown isn't installed (3.10+ only, optional extra).
+    Also skipped if only the placeholder ``markitdown`` package is present
+    (the real Microsoft package exposes the ``MarkItDown`` class).
+    """
+    try:
+        from markitdown import MarkItDown  # noqa: F401
+    except ImportError:
+        pytest.skip("real Microsoft markitdown not installed (needs Python 3.10+)")
+    from mempalace.format_miner import _extract_via_markitdown
+
+    # Minimal valid PDF that contains the literal text "hello pdf"
+    pdf_bytes = (
+        b"%PDF-1.1\n"
+        b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        b"3 0 obj<</Type/Page/Parent 2 0 R/Resources<</Font<</F1 4 0 R>>>>"
+        b"/MediaBox[0 0 612 792]/Contents 5 0 R>>endobj\n"
+        b"4 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n"
+        b"5 0 obj<</Length 44>>stream\n"
+        b"BT /F1 24 Tf 100 700 Td (hello pdf) Tj ET\n"
+        b"endstream endobj\n"
+        b"xref\n0 6\n0000000000 65535 f \n"
+        b"trailer<</Size 6/Root 1 0 R>>\n"
+        b"startxref\n0\n%%EOF\n"
+    )
+    f = tmp_path / "live.pdf"
+    f.write_bytes(pdf_bytes)
+    # The adapter shouldn't crash; if MarkItDown returns text, it includes our marker.
+    text = _extract_via_markitdown(f)
+    # Allow None (MarkItDown may not parse this minimal PDF cleanly), but the
+    # adapter path itself must run without exception.
+    if text is not None:
+        assert isinstance(text, str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# mine_formats — orchestrator that walks a directory, transforms files,
+# chunks the extracted text, and files drawers into the palace. Mirrors the
+# shape of mine_convos / mine. The collection + lock primitives are mocked
+# so these tests don't write to a real palace.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def _mine_formats_mocks(tmp_path: Path):
+    """Common mocks for mine_formats orchestrator tests.
+
+    Patches:
+      - scan_formats   : returns the files we hand it
+      - get_collection : returns a MagicMock collection
+      - mine_lock      : no-op context manager
+      - file_already_mined : False (file not yet mined)
+      - _extract_via_striprtf / _extract_via_markitdown : mocked at test level
+    """
+    from unittest.mock import MagicMock, patch
+    from contextlib import contextmanager
+
+    collection = MagicMock()
+    collection.delete = MagicMock()
+    collection.upsert = MagicMock()
+
+    @contextmanager
+    def _fake_lock(source_file):
+        yield
+
+    with (
+        patch("mempalace.format_miner.get_collection", return_value=collection) as p_coll,
+        patch("mempalace.format_miner.mine_lock", side_effect=_fake_lock) as p_lock,
+        patch("mempalace.format_miner.file_already_mined", return_value=False) as p_mined,
+    ):
+        yield {
+            "collection": collection,
+            "get_collection": p_coll,
+            "mine_lock": p_lock,
+            "file_already_mined": p_mined,
+            "tmp_path": tmp_path,
+        }
+
+
+def test_mine_formats_walks_directory(_mine_formats_mocks):
+    """mine_formats must use scan_formats to discover supported files."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    (tmp / "doc.pdf").write_bytes(b"pdf")
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[]) as p_scan,
+        patch("mempalace.format_miner._extract_via_markitdown"),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    p_scan.assert_called_once()
+
+
+def test_mine_formats_skips_already_mined_files(_mine_formats_mocks):
+    """If file_already_mined returns True, extract_text should not be called."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    _mine_formats_mocks["file_already_mined"].return_value = True
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown") as p_md,
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    p_md.assert_not_called()
+
+
+def test_mine_formats_skips_extraction_failures(_mine_formats_mocks):
+    """When extract_text returns a SKIP status, no real drawers are upserted.
+
+    A sentinel upsert IS expected (so the file isn't re-extracted on every
+    re-mine). The sentinel carries ``is_sentinel=True`` to distinguish it
+    from a content drawer.
+    """
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "bad.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch(
+            "mempalace.format_miner._extract_via_markitdown",
+            side_effect=RuntimeError("converter blew up"),
+        ),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    # Any upsert that fired must be a sentinel, never a content drawer.
+    for call in _mine_formats_mocks["collection"].upsert.call_args_list:
+        metas = call.kwargs.get("metadatas") or call.args[2]
+        for m in metas:
+            assert m.get("is_sentinel") is True, (
+                f"unexpected non-sentinel upsert on extraction failure: {m}"
+            )
+
+
+def test_mine_formats_files_drawers_for_ok_extractions(_mine_formats_mocks):
+    """When extract_text returns OK + text, mine_formats chunks and upserts drawers."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "good.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    long_text = "This is a sufficiently long extracted text. " * 30
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value=long_text),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    # upsert should have been called at least once
+    assert _mine_formats_mocks["collection"].upsert.called
+
+
+def test_mine_formats_dry_run_does_not_open_collection(_mine_formats_mocks):
+    """dry_run=True must not call get_collection or upsert any drawers."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    _mine_formats_mocks["get_collection"].reset_mock()
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="some text"),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), dry_run=True)
+    _mine_formats_mocks["get_collection"].assert_not_called()
+    _mine_formats_mocks["collection"].upsert.assert_not_called()
+
+
+def test_mine_formats_respects_limit(_mine_formats_mocks):
+    """limit=N should restrict processing to the first N files."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    files = []
+    for i in range(5):
+        p = tmp / f"f{i}.pdf"
+        p.write_bytes(b"%PDF-1.4 stub")
+        files.append(p)
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=files),
+        patch(
+            "mempalace.format_miner._extract_via_markitdown", return_value="long text " * 50
+        ) as p_md,
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), limit=2)
+    # Only 2 of the 5 files should have been extracted
+    assert p_md.call_count == 2
+
+
+def test_mine_formats_wing_defaults_from_directory_name(_mine_formats_mocks):
+    """When wing=None, the directory's basename becomes the wing."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    target_dir = tmp / "my_research_corpus"
+    target_dir.mkdir()
+    f = target_dir / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long text " * 50),
+    ):
+        mine_formats(format_dir=str(target_dir), palace_path=str(tmp / "palace"))
+    # Inspect the metadata passed to upsert — the wing should derive from the dir name
+    call_args = _mine_formats_mocks["collection"].upsert.call_args
+    if call_args is not None:
+        metas = call_args.kwargs.get("metadatas") or call_args.args[2]
+        assert metas[0]["wing"] == "my_research_corpus"
+
+
+def test_mine_formats_wing_override(_mine_formats_mocks):
+    """Explicit wing= param overrides the directory-name default."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long text " * 50),
+    ):
+        mine_formats(
+            format_dir=str(tmp),
+            palace_path=str(tmp / "palace"),
+            wing="custom_wing_name",
+        )
+    call_args = _mine_formats_mocks["collection"].upsert.call_args
+    if call_args is not None:
+        metas = call_args.kwargs.get("metadatas") or call_args.args[2]
+        assert metas[0]["wing"] == "custom_wing_name"
+
+
+def test_mine_formats_ingest_mode_metadata_is_extract(_mine_formats_mocks):
+    """Drawers from mine_formats must carry ingest_mode='extract' so they're
+    distinguishable from project / convo drawers in the palace."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long text " * 50),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    call_args = _mine_formats_mocks["collection"].upsert.call_args
+    assert call_args is not None
+    metas = call_args.kwargs.get("metadatas") or call_args.args[2]
+    assert metas[0]["ingest_mode"] == "extract"

--- a/tests/test_format_miner.py
+++ b/tests/test_format_miner.py
@@ -848,3 +848,143 @@ def test_mine_formats_ingest_mode_metadata_is_extract(_mine_formats_mocks):
     assert call_args is not None
     metas = call_args.kwargs.get("metadatas") or call_args.args[2]
     assert metas[0]["ingest_mode"] == "extract"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bot-review parity fixes (PR #1555 follow-up commit, 2026-05-19):
+#   - palace.SKIP_DIRS reuse (covered indirectly by scan_formats tests)
+#   - scan_formats skips symlinks
+#   - mine_formats uses check_mtime=True
+#   - source_mtime + hall + entities in drawer metadata
+#   - per-file try/except so one bad file doesn't crash the whole mine
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scan_formats_skips_symlinks(tmp_path: Path):
+    """Symlinks must be skipped — mirrors miner.py and convo_miner.py."""
+    real = tmp_path / "real.pdf"
+    real.write_bytes(b"%PDF-1.4 stub")
+    link = tmp_path / "alias.pdf"
+    link.symlink_to(real)
+    found = {f.name for f in scan_formats(tmp_path)}
+    assert "real.pdf" in found
+    assert "alias.pdf" not in found
+
+
+def test_mine_formats_uses_check_mtime_true(_mine_formats_mocks):
+    """mine_formats must call file_already_mined with check_mtime=True so
+    updated documents get re-mined (matches miner.py semantics)."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    # Inspect every file_already_mined call — they must all use check_mtime=True
+    calls = _mine_formats_mocks["file_already_mined"].call_args_list
+    assert calls, "file_already_mined should have been called at least once"
+    for call in calls:
+        # check_mtime can be in kwargs or positional. Inspect both.
+        kwargs = call.kwargs
+        assert kwargs.get("check_mtime") is True, f"check_mtime must be True, got {kwargs}"
+
+
+def test_mine_formats_records_source_mtime_in_drawer_metadata(_mine_formats_mocks):
+    """Each drawer must carry source_mtime so file_already_mined(check_mtime=True)
+    can detect updates on re-mine."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    upsert_calls = _mine_formats_mocks["collection"].upsert.call_args_list
+    # Find the content upsert (not the sentinel)
+    found_mtime = False
+    for call in upsert_calls:
+        metas = call.kwargs.get("metadatas") or call.args[2]
+        for m in metas:
+            if m.get("is_sentinel"):
+                continue
+            assert "source_mtime" in m, f"missing source_mtime in drawer meta: {m}"
+            assert isinstance(m["source_mtime"], (int, float))
+            found_mtime = True
+    assert found_mtime, "no non-sentinel drawer upsert observed"
+
+
+def test_mine_formats_records_hall_in_drawer_metadata(_mine_formats_mocks):
+    """Each drawer must carry a 'hall' tag — matches miner.py drawer quality."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    upsert_calls = _mine_formats_mocks["collection"].upsert.call_args_list
+    found_hall = False
+    for call in upsert_calls:
+        metas = call.kwargs.get("metadatas") or call.args[2]
+        for m in metas:
+            if m.get("is_sentinel"):
+                continue
+            assert "hall" in m, f"missing hall in drawer meta: {m}"
+            assert isinstance(m["hall"], str)
+            found_hall = True
+    assert found_hall, "no non-sentinel drawer upsert observed"
+
+
+def test_mine_formats_continues_after_per_file_error(_mine_formats_mocks):
+    """One bad file must not crash the whole mine — the loop continues."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    bad = tmp / "broken.pdf"
+    bad.write_bytes(b"%PDF-1.4 stub")
+    good = tmp / "fine.pdf"
+    good.write_bytes(b"%PDF-1.4 stub")
+
+    # Make chunk_text crash on the first file but succeed on the second.
+    call_count = {"n": 0}
+
+    def chunk_text_first_fails(content, source_file):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated chunker explosion")
+        return [{"content": "good chunk content here " * 5, "chunk_index": 0}]
+
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[bad, good]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="text"),
+        patch("mempalace.miner.chunk_text", side_effect=chunk_text_first_fails),
+    ):
+        # Must not raise
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+
+    # The second file should still have produced an upsert
+    upsert_calls = _mine_formats_mocks["collection"].upsert.call_args_list
+    non_sentinel_upserts = [
+        call
+        for call in upsert_calls
+        if not any(
+            (m or {}).get("is_sentinel") for m in (call.kwargs.get("metadatas") or call.args[2])
+        )
+    ]
+    assert non_sentinel_upserts, (
+        "the good file should still have produced a content upsert after the bad file errored"
+    )

--- a/tests/test_format_miner.py
+++ b/tests/test_format_miner.py
@@ -30,6 +30,23 @@ from mempalace.format_miner import (  # noqa: E402
 )
 
 
+def _make_symlink_or_skip(link: Path, target: Path) -> None:
+    """Create ``link`` pointing to ``target``, or ``pytest.skip`` when the
+    platform/process can't create symlinks.
+
+    Windows without ``SeCreateSymbolicLinkPrivilege`` raises ``OSError``
+    (``WinError 1314``) from ``Path.symlink_to()`` BEFORE any product code
+    runs, which surfaces as a hard test failure even though the failure
+    has nothing to do with the code under test. Per PR #1555 review (Igor):
+    symlink tests must skip cleanly in environments without privileges
+    rather than fail spuriously.
+    """
+    try:
+        link.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink creation not permitted on this platform/user: {exc}")
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Module surface
 # ─────────────────────────────────────────────────────────────────────────────
@@ -63,6 +80,7 @@ def test_extraction_status_enum_has_all_documented_codes():
         "SKIP_BROKEN_SYMLINK",
         "SKIP_UNRECOGNIZED",
         "SKIP_EXTRACTION_ERROR",
+        "SKIP_MISSING_FORMAT_DEPS",
         "SKIP_NETWORK_TIMEOUT",
         "SKIP_UNREADABLE",
     }
@@ -190,7 +208,7 @@ def test_fringe_permission_denied(tmp_path: Path):
 def test_fringe_broken_symlink(tmp_path: Path):
     target = tmp_path / "does-not-exist.pdf"
     link = tmp_path / "broken-link.pdf"
-    link.symlink_to(target)
+    _make_symlink_or_skip(link, target)
     assert link.is_symlink()
     text, status = extract_text(link)
     assert text is None
@@ -865,7 +883,7 @@ def test_scan_formats_skips_symlinks(tmp_path: Path):
     real = tmp_path / "real.pdf"
     real.write_bytes(b"%PDF-1.4 stub")
     link = tmp_path / "alias.pdf"
-    link.symlink_to(real)
+    _make_symlink_or_skip(link, real)
     found = {f.name for f in scan_formats(tmp_path)}
     assert "real.pdf" in found
     assert "alias.pdf" not in found
@@ -1137,3 +1155,80 @@ def test_mine_formats_tunnel_failure_does_not_crash_mine(_mine_formats_mocks):
     ):
         # Must NOT raise
         mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), wing="wing_aya")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PR #1555 review (Igor) — missing-format-deps surfacing + pyproject extras
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_text_missing_format_dep_returns_distinct_status(tmp_path: Path, monkeypatch):
+    """A MarkItDown ``MissingDependencyException`` (raised when a per-format
+    sub-extra like ``markitdown[pdf]`` isn't installed) must surface as
+    ``SKIP_MISSING_FORMAT_DEPS`` — NOT the generic ``SKIP_EXTRACTION_ERROR``.
+
+    Per PR #1555 review (Igor): real PDFs hit this in production today
+    and users see "extraction error" with no signal that the fix is
+    ``pip install markitdown[pdf]``. The dispatcher must catch by type
+    name so the real markitdown package doesn't have to be import-
+    resolvable for the catch to fire.
+    """
+    from mempalace import format_miner
+
+    # Build a fake exception class with the right __name__ so the
+    # type-name catch in extract_text recognises it without requiring
+    # the real markitdown to be installed in the test environment.
+    class MissingDependencyException(Exception):
+        pass
+
+    def fake_extract(p):
+        raise MissingDependencyException(
+            "MarkItDown failed: install with `pip install markitdown[pdf]`"
+        )
+
+    monkeypatch.setattr(format_miner, "_extract_via_markitdown", fake_extract)
+
+    pdf = tmp_path / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4 stub")
+
+    text, status = extract_text(pdf)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_MISSING_FORMAT_DEPS, (
+        f"expected SKIP_MISSING_FORMAT_DEPS, got {status}"
+    )
+
+
+def test_pyproject_extract_extra_pulls_markitdown_format_subdeps():
+    """The ``mempalace[extract]`` extra must include MarkItDown's per-format
+    sub-extras (``pdf``, ``docx``, ``pptx``, ``xlsx``) — without them, real
+    PDF/DOCX/etc files hit ``MissingDependencyException`` at runtime even
+    after ``pip install mempalace[extract]``. Per PR #1555 review (Igor).
+
+    ``.rtf`` is covered by the separate ``striprtf`` dependency and ``.epub``
+    ships in base MarkItDown (``EpubConverter`` uses ``beautifulsoup4``
+    which is a base requirement, not extra-gated), so neither needs a
+    sub-extra here.
+    """
+    try:
+        import tomllib  # 3.11+
+    except ImportError:  # pragma: no cover — only hit on 3.9/3.10
+        import tomli as tomllib  # type: ignore[import-not-found, no-redef]
+
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+
+    extract = data["project"]["optional-dependencies"]["extract"]
+    extract_str = " ".join(extract).lower()
+
+    # Accept any layout — comma-separated ``markitdown[docx,pdf,pptx,xlsx]``
+    # or separate ``markitdown[pdf]`` entries — as long as each format
+    # appears inside SOME ``markitdown[...]`` bracketed group.
+    import re
+
+    bracketed = "".join(re.findall(r"markitdown\[([^\]]+)\]", extract_str))
+    for sub in ("pdf", "docx", "pptx", "xlsx"):
+        assert sub in bracketed, (
+            f"[extract] must include markitdown[{sub}]; "
+            f"got bracketed extras: {bracketed!r}; full extract: {extract}"
+        )

--- a/tests/test_format_miner.py
+++ b/tests/test_format_miner.py
@@ -988,3 +988,152 @@ def test_mine_formats_continues_after_per_file_error(_mine_formats_mocks):
     assert non_sentinel_upserts, (
         "the good file should still have produced a content upsert after the bad file errored"
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Amendment #3 — parity with miner.py: detect_room + tunnel computation.
+# Tests written FIRST (TDD) to prove the gaps exist, then format_miner.py is
+# amended to make them pass. Pattern mirrors miner.py exactly.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_mine_formats_calls_load_config_for_rooms(_mine_formats_mocks):
+    """mine_formats must load mempalace.yaml (via load_config) to get the
+    rooms list — same as miner.py:1154. Without this, drawers fall back to
+    a single 'documents' room."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    fake_config = {
+        "wing": "wing_aya",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+        patch("mempalace.format_miner.load_config", return_value=fake_config) as p_cfg,
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    p_cfg.assert_called_once()
+
+
+def test_mine_formats_calls_detect_room_per_file(_mine_formats_mocks):
+    """mine_formats must call detect_room(filepath, content, rooms, project_path)
+    for each file — same as miner.py:904. Hardcoding room='documents' is the
+    bug; this test fails until detect_room is wired in."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    fake_config = {
+        "wing": "wing_aya",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+        patch("mempalace.format_miner.detect_room", return_value="family") as p_room,
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    p_room.assert_called_once()
+    # First positional arg should be the file Path; last arg should be project_path
+    call_args = p_room.call_args
+    # detect_room(filepath, content, rooms, project_path)
+    assert len(call_args.args) == 4 or "filepath" in call_args.kwargs
+
+
+def test_mine_formats_uses_detected_room_in_drawer_metadata(_mine_formats_mocks):
+    """The room field on the drawer metadata must reflect what detect_room
+    returned, NOT the hardcoded 'documents'. This is the visible bug from
+    the 2026-05-19 mine: every drawer landed in room='documents'."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    fake_config = {
+        "wing": "wing_aya",
+        "rooms": [{"name": "family", "keywords": ["family"]}],
+    }
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+        patch("mempalace.format_miner.detect_room", return_value="family"),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
+    upsert_calls = _mine_formats_mocks["collection"].upsert.call_args_list
+    found_room = None
+    for call in upsert_calls:
+        metas = call.kwargs.get("metadatas") or call.args[2]
+        for m in metas:
+            if m.get("is_sentinel"):
+                continue
+            found_room = m.get("room")
+            break
+        if found_room:
+            break
+    assert found_room == "family", (
+        f"drawer room must be 'family' (detect_room's return), not {found_room!r}"
+    )
+
+
+def test_mine_formats_calls_compute_topic_tunnels_after_loop(_mine_formats_mocks):
+    """After the per-file loop, mine_formats must call
+    _compute_topic_tunnels_for_wing(wing) exactly once. Mirrors miner.py:1241.
+    Without this, cross-wing topic tunnels never materialize for format-mined
+    wings (audit confirmed 0 tunnels in the 2026-05-19 v6 mine)."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    fake_config = {
+        "wing": "wing_aya",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+        patch("mempalace.format_miner.detect_room", return_value="documents"),
+        patch("mempalace.format_miner._compute_topic_tunnels_for_wing", return_value=0) as p_tun,
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), wing="wing_aya")
+    p_tun.assert_called_once_with("wing_aya")
+
+
+def test_mine_formats_tunnel_failure_does_not_crash_mine(_mine_formats_mocks):
+    """If _compute_topic_tunnels_for_wing raises, the mine must still
+    complete (summary still prints, no exception propagates). Mirrors the
+    try/except wrap at miner.py:1244-1249."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    f = tmp / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+    fake_config = {
+        "wing": "wing_aya",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+        patch("mempalace.format_miner.detect_room", return_value="documents"),
+        patch(
+            "mempalace.format_miner._compute_topic_tunnels_for_wing",
+            side_effect=RuntimeError("simulated tunnel-compute failure"),
+        ),
+    ):
+        # Must NOT raise
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), wing="wing_aya")

--- a/tests/test_line_numbers.py
+++ b/tests/test_line_numbers.py
@@ -1,0 +1,161 @@
+"""Tests for virtual line numbering (proposed for mempalace 3.3.6).
+
+Run from the proposal directory:
+    pytest tests/test_line_numbers.py -v
+
+After integration into the mempalace package, change the import below to:
+    from mempalace.searcher import render_with_line_numbers, extract_line_range
+"""
+
+from mempalace.searcher import (  # noqa: E402
+    extract_line_range,
+    render_with_line_numbers,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# render_with_line_numbers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_render_empty_string():
+    assert render_with_line_numbers("") == ""
+
+
+def test_render_single_line():
+    assert render_with_line_numbers("hello") == "[1] hello"
+
+
+def test_render_multi_line():
+    text = "alpha\nbeta\ngamma"
+    expected = "[1] alpha\n[2] beta\n[3] gamma"
+    assert render_with_line_numbers(text) == expected
+
+
+def test_render_custom_start_line():
+    text = "first\nsecond"
+    expected = "[5] first\n[6] second"
+    assert render_with_line_numbers(text, start_line=5) == expected
+
+
+def test_render_preserves_already_numbered_lines():
+    """Lines that already start with [N] must pass through unchanged."""
+    text = "[1] already numbered\n[2] also numbered"
+    assert render_with_line_numbers(text) == text
+
+
+def test_render_preserves_already_numbered_with_offset():
+    """Already-numbered lines pass through verbatim regardless of start_line."""
+    text = "[42] keep this number\n[43] and this"
+    assert render_with_line_numbers(text, start_line=100) == text
+
+
+def test_render_mixed_numbered_and_plain():
+    """Counter advances on every line; numbered lines pass through, plain lines get the running counter."""
+    text = "[10] kept\nplain line\n[12] also kept"
+    expected = "[10] kept\n[2] plain line\n[12] also kept"
+    assert render_with_line_numbers(text) == expected
+
+
+def test_render_preserves_blank_lines():
+    """Blank lines must still get a number — they're real positions in the drawer."""
+    text = "first\n\nthird"
+    expected = "[1] first\n[2] \n[3] third"
+    assert render_with_line_numbers(text) == expected
+
+
+def test_render_preserves_trailing_newline_semantics():
+    """Splitting on \\n and rejoining preserves the original boundary count."""
+    text = "a\nb\n"
+    result = render_with_line_numbers(text)
+    # "a\nb\n".split("\n") → ["a", "b", ""] — three positions
+    assert result == "[1] a\n[2] b\n[3] "
+
+
+def test_render_none_input_returns_empty():
+    """Defensive: None must not crash."""
+    assert render_with_line_numbers(None) == ""
+
+
+def test_render_does_not_modify_original_text():
+    """Function is pure — no mutation of input."""
+    original = "line one\nline two"
+    snapshot = original
+    render_with_line_numbers(original)
+    assert original == snapshot
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# extract_line_range
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_single_line():
+    text = "a\nb\nc\nd\ne"
+    assert extract_line_range(text, 3, 3) == "[3] c"
+
+
+def test_extract_inclusive_range():
+    text = "a\nb\nc\nd\ne"
+    expected = "[2] b\n[3] c\n[4] d"
+    assert extract_line_range(text, 2, 4) == expected
+
+
+def test_extract_full_range():
+    text = "first\nsecond\nthird"
+    expected = "[1] first\n[2] second\n[3] third"
+    assert extract_line_range(text, 1, 3) == expected
+
+
+def test_extract_end_beyond_length_clips():
+    """If line_end exceeds the document, return what's available — don't error."""
+    text = "a\nb\nc"
+    expected = "[2] b\n[3] c"
+    assert extract_line_range(text, 2, 99) == expected
+
+
+def test_extract_start_below_one_clamps():
+    """start_line < 1 clamps to 1; numbering starts from where extraction starts."""
+    text = "a\nb\nc"
+    # Clamping to 1 means we extract from line 1; numbering starts at 1.
+    expected = "[1] a\n[2] b"
+    assert extract_line_range(text, 0, 2) == expected
+
+
+def test_extract_start_after_end_returns_empty():
+    text = "a\nb\nc"
+    assert extract_line_range(text, 5, 2) == ""
+
+
+def test_extract_empty_text():
+    assert extract_line_range("", 1, 5) == ""
+
+
+def test_extract_honors_already_numbered_lines():
+    """If the slice contains already-numbered lines, they pass through."""
+    text = "plain\n[42] numbered\nplain again"
+    expected = "[1] plain\n[42] numbered\n[3] plain again"
+    assert extract_line_range(text, 1, 3) == expected
+
+
+def test_extract_uses_drawer_line_numbers_not_relative():
+    """When extracting lines 5-7, the rendered numbers must be [5][6][7], not [1][2][3].
+
+    This is the closet-pointer contract: a pointer →2026-01-18:L55-L72 must show
+    [55] through [72] in the rendered output, so the user sees which drawer
+    positions they're reading.
+    """
+    text = "\n".join(f"line{i}" for i in range(1, 11))  # line1..line10
+    result = extract_line_range(text, 5, 7)
+    assert result.startswith("[5] line5")
+    assert "[6] line6" in result
+    assert result.endswith("[7] line7")
+    assert "[1]" not in result
+    assert "[8]" not in result
+
+
+def test_extract_does_not_modify_original_text():
+    original = "x\ny\nz"
+    snapshot = original
+    extract_line_range(original, 1, 2)
+    assert original == snapshot


### PR DESCRIPTION
Two additive features for 3.3.6 — both following the same read-time-transform pattern. Full design in `docs/format-coverage.md` and `docs/virtual-line-numbering.md`.

## Verification done locally

| Gate | Result |
|---|---|
| Full mempalace test suite | ✅ 1992 passed, 0 failed |
| 94 new tests | ✅ 21 line-numbering + 73 format-miner (incl. 9 mine_formats orchestrator) |
| ruff check + ruff format | ✅ clean on pinned 0.15.9 |
| Coverage on `mempalace/format_miner.py` | ✅ 86% |
| Live CLI end-to-end | ✅ `mempalace mine --mode extract` on real RTF + PDF produced 90 drawers, all searchable |

## What's in the diff (2,148 lines, +5 deletions)

| Surface | Lines | Notes |
|---|---|---|
| `mempalace/format_miner.py` (NEW) | 674 | Self-contained module: `extract_text`, `scan_formats`, `mine_formats`, `ExtractionStatus` |
| `mempalace/searcher.py` (modified) | +58 | Two new pure functions APPENDED: `render_with_line_numbers`, `extract_line_range` — zero existing code touched |
| `mempalace/cli.py` (modified) | +27 / -5 | One `elif` branch in `cmd_mine` + `"extract"` added to argparse choices |
| `pyproject.toml` (modified) | +8 | New `[extract]` optional dep block: `striprtf` + `markitdown` (with `python_version >= '3.10'` env marker) |
| `tests/test_format_miner.py` (NEW) | 850 | 73 tests covering all 13 fringe cases + happy paths + 9 orchestrator tests |
| `tests/test_line_numbers.py` (NEW) | 161 | 21 tests |
| `docs/format-coverage.md` (NEW) | 223 | Feature spec |
| `docs/virtual-line-numbering.md` (NEW) | 152 | Feature spec |

Modifications to existing code = **93 lines across 3 files**, all pure additions (no deletions of existing logic).

## Architecture — per-format transformer routing

A real bug surfaced during live integration testing: **MarkItDown 0.1.5 does NOT actually convert `.rtf`** — it returns the raw control-code source unchanged. So the format miner routes per-extension:

```
.pdf .docx .pptx .xlsx .epub  →  MarkItDown
.rtf                          →  striprtf
```

Both libraries are optional extras. MarkItDown requires Python ≥ 3.10 (env marker ensures 3.9 users still get RTF coverage via striprtf).

## 13 fringe cases

Each maps to a dedicated `ExtractionStatus` enum value. All have explicit tests:

`SKIP_NO_MARKITDOWN`, `SKIP_NO_STRIPRTF`, `SKIP_TOO_LARGE`, `SKIP_CLOUD_ONLY`, `SKIP_ENCRYPTED`, `SKIP_EMPTY`, `SKIP_PERMISSION`, `SKIP_BROKEN_SYMLINK`, `SKIP_UNRECOGNIZED`, `SKIP_EXTRACTION_ERROR`, `SKIP_NETWORK_TIMEOUT`, `SKIP_UNREADABLE`, plus encoding fallback (handled internally via `decode_robust`).

## Documented limits (out of scope for 3.3.6)

- Custom PDF parsers for specific document types
- OCR on scanned PDFs (Whisper/Tesseract is its own scope)
- DRM-locked files
- Pathological corrupt files

These get reported via skip codes and skipped.

## For Igor — review questions

1. **Spec review** — do the APIs match what you'd want? (`extract_text`, `scan_formats`, `mine_formats`; `render_with_line_numbers`, `extract_line_range`)
2. **Fringe-case sanity** — did I miss any failure mode? Any code that doesn't deserve its own skip status?
3. **Optional-extras shape** — happy with `pip install mempalace[extract]` pulling both `striprtf` + `markitdown` (with the 3.10+ env marker), or do you want a different mechanism?
4. **Scope** — both features in 3.3.6, or split across 3.3.6 / 3.3.7?

Search-pipeline wiring for the line-numbering helpers (auto-resolving `→date:Lstart-Lend` closet pointers in search output) is deferred to a follow-up PR — this PR ships them as library helpers ready to call.

CHANGELOG entry + version bump intentionally NOT in this PR — those land in the separate `chore/release-3.3.6-prep` PR per the v3.3.5 release flow.
