### PR TITLE
feat(hallways): within-wing entity-to-entity connector primitive

### DIFF
--- a/mempalace/hallways.py
+++ b/mempalace/hallways.py
@@ -1,0 +1,301 @@
+"""Hallways — within-wing entity-to-entity connectors.
+
+A **hallway** is a connection between two entities (people, projects,
+concepts, interests) inside one wing, materialized from their
+co-occurrence across that wing's drawers. Conceptually:
+
+    WING → has DRAWERS (each tagged with entities)
+            entities → connected to other entities by HALLWAYS
+                       (within-wing, built from drawer co-occurrence)
+                       hallways → are the primitive
+                                   tunnels → use hallways to spawn
+                                             cross-wing connections
+
+If Aya and Lumi are both mentioned in 47 drawers across the diary,
+letters, and ideas rooms, there's a hallway between them. If Aya
+and "consciousness" co-occur in 19 drawers, there's a hallway between
+them too. The hallway *is* the structural fact of "these two entities
+travel together inside this wing."
+
+Mempalace's tunnel primitive in ``palace_graph.py`` connects rooms
+across wings. This module fills the within-wing gap with an
+entity-centric (not room-centric) model: hallways are about *who/what
+relates to whom/what*, not *which rooms relate to which*. A planned
+follow-up PR will refactor ``_compute_topic_tunnels_for_wing`` to
+build cross-wing tunnels from hallway data (Wing → Drawer-entities →
+Hallway → Tunnel).
+
+Persistence mirrors ``palace_graph._TUNNEL_FILE``: a JSON file under
+``~/.mempalace/`` so the records survive across mines and are
+inspectable / editable by hand if needed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from collections import defaultdict
+from datetime import datetime, timezone
+from itertools import combinations
+from typing import Optional
+
+logger = logging.getLogger("mempalace_hallways")
+
+# Persistence target. Mirrors ``palace_graph._TUNNEL_FILE`` so the storage
+# pattern is uniform across the two related primitives. Tests override
+# this via ``monkeypatch.setattr(hallways, "_HALLWAY_FILE", tmp_path/...)``.
+_HALLWAY_FILE = os.path.join(os.path.expanduser("~"), ".mempalace", "hallways.json")
+
+_SCHEMA_VERSION = 1
+
+
+__all__ = [
+    "compute_hallways_for_wing",
+    "list_hallways",
+    "delete_hallway",
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Persistence — JSON file at _HALLWAY_FILE, restricted perms (0600) on POSIX
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _load_hallways() -> list[dict]:
+    """Read all hallway records. Returns ``[]`` if the file is missing or corrupt."""
+    if not os.path.exists(_HALLWAY_FILE):
+        return []
+    try:
+        with open(_HALLWAY_FILE, encoding="utf-8") as f:
+            raw = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        logger.debug("hallways: load failed, treating as empty", exc_info=True)
+        return []
+    if isinstance(raw, dict) and "hallways" in raw:
+        return raw.get("hallways") or []
+    if isinstance(raw, list):
+        return raw
+    return []
+
+
+def _save_hallways(hallways: list[dict]) -> None:
+    """Atomically persist hallway records to _HALLWAY_FILE.
+
+    Uses an os.replace temp-file dance so a crash mid-write doesn't
+    corrupt the file. POSIX permission is restricted to 0600 because
+    hallways reveal within-wing entity connections that the user may
+    not want world-readable.
+    """
+    directory = os.path.dirname(_HALLWAY_FILE)
+    os.makedirs(directory, exist_ok=True)
+    payload = {
+        "schema_version": _SCHEMA_VERSION,
+        "hallways": list(hallways),
+    }
+    fd, tmp_path = tempfile.mkstemp(prefix=".hallways-", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            # Non-POSIX systems may not support chmod; not fatal.
+            pass
+        os.replace(tmp_path, _HALLWAY_FILE)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core algorithm — compute entity-pair hallways for one wing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_entities(value) -> list[str]:
+    """Drawer ``entities`` metadata is a semicolon-separated string. Parse it.
+
+    Returns a deterministic *list* (not a set) because order matters for
+    the deduplication semantics below: a drawer that mentions ``Aya;Aya``
+    should only contribute one Aya to the entity set for that drawer.
+    """
+    if not value:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        items = [str(v).strip() for v in value if str(v).strip()]
+    elif isinstance(value, str):
+        items = [v.strip() for v in value.split(";") if v.strip()]
+    else:
+        return []
+    # Dedupe while preserving first-seen order so id derivation is stable.
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _hallway_id(wing: str, entity_a: str, entity_b: str) -> str:
+    """Deterministic id derived from wing + sorted entity pair.
+
+    Sorting before hashing makes the id symmetric — (Aya, Lumi) and
+    (Lumi, Aya) produce the same record. So an idempotent re-mine
+    upserts the same hallway instead of creating two parallel records.
+    """
+    a, b = sorted([entity_a, entity_b])
+    key = f"{wing}::{a}::{b}".encode("utf-8")
+    suffix = hashlib.sha256(key).hexdigest()[:8]
+    return f"hallway_{wing}_{a}_{b}_{suffix}"
+
+
+def compute_hallways_for_wing(
+    wing: str,
+    col=None,
+    min_count: int = 2,
+) -> list[dict]:
+    """Compute entity-pair hallways for one wing.
+
+    Algorithm:
+      1. Query drawers for ``wing`` from ``col``.
+      2. For each drawer with entities, every pair of distinct entities in
+         that drawer is one co-occurrence. Increment a counter for each
+         pair; also record the room the drawer lives in.
+      3. For each (entity_a, entity_b) pair whose co-occurrence count is
+         ``>= min_count``, materialize a hallway record. The record
+         carries the pair, the count, and the set of rooms where they
+         co-occurred (useful context for navigation).
+      4. Persist the full hallway list (records for other wings preserved,
+         this wing's records replaced) and return the just-computed list.
+
+    Args:
+        wing: wing name to scan.
+        col: ChromaDB collection — must support ``.get(where=..., include=...)``.
+            If ``None``, returns ``[]`` (caller didn't supply a backing
+            store, so nothing to compute against). Tests pass a controlled
+            MagicMock.
+        min_count: minimum co-occurrence count required to materialize a
+            hallway between two entities. Default 2 — single co-occurrences
+            are noise (entities mentioned together once in one drawer);
+            two or more is a real signal. Clamped to ``>=1``.
+
+    Returns:
+        List of hallway dicts created for this wing. Records for other
+        wings already on disk are preserved.
+    """
+    if col is None:
+        logger.debug("compute_hallways_for_wing: no collection provided for %s", wing)
+        return []
+
+    min_count = max(1, int(min_count))
+
+    # 1. Query drawers for this wing.
+    try:
+        results = col.get(where={"wing": wing}, include=["metadatas"])
+    except Exception:
+        logger.warning(
+            "compute_hallways_for_wing: collection.get failed for %s", wing, exc_info=True
+        )
+        return []
+
+    metadatas = (results or {}).get("metadatas") or []
+    if not metadatas:
+        return []
+
+    # 2. Walk drawers, counting entity-pair co-occurrence + tracking rooms.
+    # pair_counts: {(entity_a, entity_b): count} — keys always sorted to
+    # canonicalize the (a, b) vs (b, a) symmetry.
+    pair_counts: dict[tuple[str, str], int] = defaultdict(int)
+    pair_rooms: dict[tuple[str, str], set[str]] = defaultdict(set)
+
+    for meta in metadatas:
+        if not isinstance(meta, dict):
+            continue
+        # Sentinel drawers carry no real content — skip them.
+        if meta.get("is_sentinel"):
+            continue
+        entities = _parse_entities(meta.get("entities"))
+        if len(entities) < 2:
+            # Need at least 2 entities for a pair to exist.
+            continue
+        room = meta.get("room")
+        room_str = room if isinstance(room, str) and room.strip() else None
+
+        # Each unordered pair of distinct entities in this drawer is one
+        # co-occurrence. itertools.combinations already gives unordered
+        # pairs without repetition.
+        for a, b in combinations(entities, 2):
+            # Canonicalize order so (Aya, Lumi) and (Lumi, Aya) are the
+            # same key. Skip self-pairs defensively.
+            if a == b:
+                continue
+            key = tuple(sorted([a, b]))
+            pair_counts[key] += 1
+            if room_str:
+                pair_rooms[key].add(room_str)
+
+    if not pair_counts:
+        return []
+
+    # 3. Materialize hallway records for pairs above the threshold.
+    created: list[dict] = []
+    created_at = datetime.now(timezone.utc).isoformat()
+    for key in sorted(pair_counts.keys()):
+        count = pair_counts[key]
+        if count < min_count:
+            continue
+        entity_a, entity_b = key
+        rooms = sorted(pair_rooms.get(key, set()))
+        room_summary = ", ".join(rooms[:3]) if rooms else "(no room tags)"
+        if len(rooms) > 3:
+            room_summary += f", +{len(rooms) - 3} more"
+        created.append(
+            {
+                "id": _hallway_id(wing, entity_a, entity_b),
+                "wing": wing,
+                "entity_a": entity_a,
+                "entity_b": entity_b,
+                "co_occurrence_count": count,
+                "rooms": rooms,
+                "label": f"{entity_a} ↔ {entity_b} (co-occur in {count} drawers across {len(rooms) or 'no'} room{'s' if len(rooms) != 1 else ''}: {room_summary})",
+                "created_at": created_at,
+                "created_by": "auto",
+            }
+        )
+
+    # 4. Persist — preserve other-wing records, replace this wing's records.
+    existing = _load_hallways()
+    preserved = [h for h in existing if h.get("wing") != wing]
+    _save_hallways(preserved + created)
+
+    return created
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Query API — list_hallways, delete_hallway
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def list_hallways(wing: Optional[str] = None) -> list[dict]:
+    """List hallway records. Filter by ``wing`` if specified."""
+    all_hallways = _load_hallways()
+    if wing is None:
+        return list(all_hallways)
+    return [h for h in all_hallways if h.get("wing") == wing]
+
+
+def delete_hallway(hallway_id: str) -> bool:
+    """Remove one hallway record by id. Returns True if a record was removed."""
+    hallways = _load_hallways()
+    filtered = [h for h in hallways if h.get("id") != hallway_id]
+    if len(filtered) == len(hallways):
+        return False
+    _save_hallways(filtered)
+    return True

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -33,6 +33,12 @@ from .palace import (
     upsert_closet_lines,
 )
 
+# Module-level import so tests can patch it as
+# ``mempalace.miner.compute_hallways_for_wing``. The integration call
+# lives at the end of _mine_impl, alongside the existing
+# ``_compute_topic_tunnels_for_wing`` post-mine block.
+from .hallways import compute_hallways_for_wing
+
 logger = logging.getLogger("mempalace_mcp")
 
 READABLE_EXTENSIONS = {
@@ -1245,6 +1251,21 @@ def _mine_impl(
                 # Tunnel computation must never fail a mine — degrade quietly.
                 print(
                     f"\n  WARNING: topic tunnel computation skipped — {e}",
+                    file=sys.stderr,
+                )
+
+            # Within-wing hallways: link entities (people, projects, concepts)
+            # that co-occur in drawers across this wing's rooms. Mirrors the
+            # tunnel-compute fault-tolerance pattern — hallway computation
+            # must never fail a mine; it's a derived analytic, not load-bearing
+            # for the drawer write that already committed above.
+            try:
+                hallways_created = compute_hallways_for_wing(wing, col=collection)
+                if hallways_created:
+                    print(f"\n  Hallways: +{len(hallways_created)} within-wing entity link(s)")
+            except Exception as e:
+                print(
+                    f"\n  WARNING: hallway computation skipped — {e}",
                     file=sys.stderr,
                 )
 

--- a/tests/test_hallways.py
+++ b/tests/test_hallways.py
@@ -1,0 +1,282 @@
+"""Tests for the within-wing hallway primitive.
+
+Hallways are bridges INSIDE a wing that connect entities (people,
+projects, concepts, interests) to each other, materialized from
+drawer-level co-occurrence. Two entities are linked by a hallway when
+they appear together in enough drawers across the wing.
+
+This file is RED-first. The corresponding implementation lives in
+``mempalace/hallways.py`` and is written to make these tests pass.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+# Mock chromadb at import time so the hallways module can be loaded even
+# in environments where chromadb isn't installed. Mirrors the pattern in
+# ``tests/test_palace_graph_tunnels.py``.
+with patch.dict("sys.modules", {"chromadb": MagicMock()}):
+    from mempalace import hallways as hallways_mod
+
+
+def _use_tmp_hallway_file(monkeypatch, tmp_path):
+    """Redirect hallway persistence to a per-test JSON file."""
+    hallway_file = tmp_path / "hallways.json"
+    monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", str(hallway_file))
+    return hallway_file
+
+
+def _fake_collection(drawers):
+    """Build a MagicMock collection whose .get() returns the given drawer set."""
+    col = MagicMock()
+    metadatas = [d for d in drawers]
+    ids = [f"drawer_{i}" for i in range(len(drawers))]
+    col.get.return_value = {"ids": ids, "metadatas": metadatas}
+    return col
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Storage primitives — _load_hallways / _save_hallways
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHallwayStorage:
+    def test_load_hallways_missing_file_returns_empty_list(self, tmp_path, monkeypatch):
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        assert hallways_mod._load_hallways() == []
+
+    def test_load_hallways_corrupt_file_returns_empty_list(self, tmp_path, monkeypatch):
+        hallway_file = _use_tmp_hallway_file(monkeypatch, tmp_path)
+        hallway_file.write_text("{not valid json", encoding="utf-8")
+        assert hallways_mod._load_hallways() == []
+
+    def test_save_and_load_round_trip(self, tmp_path, monkeypatch):
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        sample = [
+            {
+                "id": "hallway_wing_aya_aya_lumi_abc12345",
+                "wing": "wing_aya",
+                "entity_a": "Aya",
+                "entity_b": "Lumi",
+                "co_occurrence_count": 47,
+                "rooms": ["diary", "letters"],
+                "label": "Aya ↔ Lumi (co-occur in 47 drawers across 2 rooms)",
+            }
+        ]
+        hallways_mod._save_hallways(sample)
+        assert hallways_mod._load_hallways() == sample
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# compute_hallways_for_wing — entity-pair co-occurrence algorithm
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestComputeHallways:
+    def test_returns_empty_for_unknown_wing(self, tmp_path, monkeypatch):
+        """Wing with no drawers → no hallways, no crash."""
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection([])
+        result = hallways_mod.compute_hallways_for_wing("wing_nonexistent", col=col)
+        assert result == []
+
+    def test_returns_empty_when_no_drawer_has_two_entities(self, tmp_path, monkeypatch):
+        """A drawer must mention >= 2 entities to contribute a pair."""
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya"},  # only one
+                {"wing": "wing_aya", "room": "diary", "entities": ""},  # none
+            ]
+        )
+        result = hallways_mod.compute_hallways_for_wing("wing_aya", col=col)
+        assert result == []
+
+    def test_creates_hallway_for_entity_pair_when_threshold_met(self, tmp_path, monkeypatch):
+        """Two entities co-occurring in >= min_count drawers → one hallway record.
+
+        With min_count=2, Aya↔Lumi appear together in 3 drawers; that's a hallway.
+        """
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi;Ever"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+            ]
+        )
+        result = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        # Find the Aya↔Lumi hallway (other pairs like Aya↔Ever might also be present)
+        aya_lumi = [h for h in result if {h["entity_a"], h["entity_b"]} == {"Aya", "Lumi"}]
+        assert len(aya_lumi) == 1
+        hallway = aya_lumi[0]
+        assert hallway["wing"] == "wing_aya"
+        assert hallway["co_occurrence_count"] == 3
+        assert set(hallway["rooms"]) == {"diary", "letters"}
+
+    def test_connects_person_to_concept(self, tmp_path, monkeypatch):
+        """Entities aren't only people — projects/concepts/interests count too.
+
+        The entity tag treats 'consciousness' the same as 'Aya'; both are
+        just tokens in the drawer's entities field. So Aya↔consciousness is
+        a valid hallway when they co-occur enough.
+        """
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;consciousness"},
+                {"wing": "wing_aya", "room": "research", "entities": "Aya;consciousness"},
+                {"wing": "wing_aya", "room": "ideas", "entities": "Aya;consciousness;Lumi"},
+            ]
+        )
+        result = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        aya_consciousness = [
+            h for h in result if {h["entity_a"], h["entity_b"]} == {"Aya", "consciousness"}
+        ]
+        assert len(aya_consciousness) == 1
+        assert aya_consciousness[0]["co_occurrence_count"] == 3
+        assert set(aya_consciousness[0]["rooms"]) == {"diary", "research", "ideas"}
+
+    def test_respects_min_count_threshold(self, tmp_path, monkeypatch):
+        """min_count=3 filters out pairs that only co-occur twice."""
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+            ]
+        )
+        result = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=3)
+        assert result == []
+
+    def test_creates_deterministic_id_per_entity_pair(self, tmp_path, monkeypatch):
+        """Same wing + same entity pair → same hallway id (idempotent re-runs)."""
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+            ]
+        )
+        first = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        second = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        # Find the Aya↔Lumi record in both runs; ids must match.
+        f_id = next(h["id"] for h in first if {h["entity_a"], h["entity_b"]} == {"Aya", "Lumi"})
+        s_id = next(h["id"] for h in second if {h["entity_a"], h["entity_b"]} == {"Aya", "Lumi"})
+        assert f_id == s_id
+        assert f_id.startswith("hallway_")
+
+    def test_entity_pair_is_symmetric(self, tmp_path, monkeypatch):
+        """Drawer says 'Aya;Lumi'; another says 'Lumi;Aya' — same hallway."""
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Lumi;Aya"},
+            ]
+        )
+        result = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        aya_lumi = [h for h in result if {h["entity_a"], h["entity_b"]} == {"Aya", "Lumi"}]
+        # Symmetry: the two drawers count as 2 co-occurrences, not 0 (no
+        # double-bookkeeping despite the swapped order).
+        assert len(aya_lumi) == 1
+        assert aya_lumi[0]["co_occurrence_count"] == 2
+
+    def test_persists_to_json(self, tmp_path, monkeypatch):
+        """After compute, _load_hallways() returns the new records."""
+        hallway_file = _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+            ]
+        )
+        hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        assert hallway_file.exists()
+        loaded = hallways_mod._load_hallways()
+        assert any({h["entity_a"], h["entity_b"]} == {"Aya", "Lumi"} for h in loaded)
+
+    def test_tracks_rooms_across_co_occurrences(self, tmp_path, monkeypatch):
+        """A hallway records the set of rooms where its entities co-occurred."""
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+            ]
+        )
+        result = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        h = next(h for h in result if {h["entity_a"], h["entity_b"]} == {"Aya", "Lumi"})
+        assert set(h["rooms"]) == {"diary", "letters"}
+        assert h["co_occurrence_count"] == 3  # 3 drawers, not 3 rooms
+
+    def test_skips_sentinel_drawers(self, tmp_path, monkeypatch):
+        """Sentinels exist for file_already_mined() bookkeeping. Skip them."""
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {
+                    "wing": "wing_aya",
+                    "room": "documents",
+                    "entities": "Aya;Lumi",
+                    "is_sentinel": True,
+                },
+                {
+                    "wing": "wing_aya",
+                    "room": "documents",
+                    "entities": "Aya;Lumi",
+                    "is_sentinel": True,
+                },
+            ]
+        )
+        result = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        assert result == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Query API — list_hallways, delete_hallway
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHallwayQuery:
+    def test_list_hallways_returns_all_when_no_filter(self, tmp_path, monkeypatch):
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        hallways_mod._save_hallways(
+            [
+                {"id": "h1", "wing": "wing_aya", "entity_a": "Aya", "entity_b": "Lumi"},
+                {"id": "h2", "wing": "wing_lumi", "entity_a": "Lumi", "entity_b": "Ever"},
+            ]
+        )
+        assert len(hallways_mod.list_hallways()) == 2
+
+    def test_list_hallways_filters_by_wing(self, tmp_path, monkeypatch):
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        hallways_mod._save_hallways(
+            [
+                {"id": "h1", "wing": "wing_aya", "entity_a": "Aya", "entity_b": "Lumi"},
+                {"id": "h2", "wing": "wing_lumi", "entity_a": "Lumi", "entity_b": "Ever"},
+            ]
+        )
+        result = hallways_mod.list_hallways(wing="wing_aya")
+        assert len(result) == 1
+        assert result[0]["id"] == "h1"
+
+    def test_delete_hallway_removes_record(self, tmp_path, monkeypatch):
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        hallways_mod._save_hallways(
+            [
+                {"id": "h1", "wing": "wing_aya", "entity_a": "Aya", "entity_b": "Lumi"},
+                {"id": "h2", "wing": "wing_aya", "entity_a": "Aya", "entity_b": "Ever"},
+            ]
+        )
+        assert hallways_mod.delete_hallway("h1") is True
+        remaining = hallways_mod._load_hallways()
+        assert len(remaining) == 1
+        assert remaining[0]["id"] == "h2"
+
+    def test_delete_hallway_unknown_id_returns_false(self, tmp_path, monkeypatch):
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        hallways_mod._save_hallways([{"id": "h1", "wing": "wing_aya"}])
+        assert hallways_mod.delete_hallway("nonexistent") is False

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -55,6 +55,105 @@ def test_project_mining():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_mine_computes_hallways_for_wing_post_mine(monkeypatch):
+    """After mine() completes (non-dry-run), compute_hallways_for_wing must be
+    called once with the wing name and the live collection.
+
+    This is the integration test for the hallway primitive — without this
+    call, the hallway module is dead code (no miner triggers it). Mirrors
+    the existing tunnel-computation integration pattern at miner.py:1241.
+    """
+
+    from mempalace import miner as miner_mod
+
+    hallway_calls = []
+
+    def fake_compute(wing, col=None, min_count=2):
+        hallway_calls.append({"wing": wing, "col": col, "min_count": min_count})
+        return []  # no hallways materialized — that's not what we're testing
+
+    # Patch at the call site (mempalace.miner.compute_hallways_for_wing) so
+    # the integration in mine() routes through our stub.
+    monkeypatch.setattr(miner_mod, "compute_hallways_for_wing", fake_compute)
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "backend")
+        write_file(
+            project_root / "backend" / "app.py",
+            "def main():\n    print('hello world')\n" * 20,
+        )
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "backend", "description": "Backend code"}],
+                },
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        mine(str(project_root), str(palace_path))
+
+        # Must have been called exactly once, with our wing name + a live
+        # collection. We don't pin min_count — the integration may pick a
+        # default that differs from the function's own default.
+        assert len(hallway_calls) == 1, (
+            f"expected compute_hallways_for_wing to be called once, got {len(hallway_calls)}"
+        )
+        call = hallway_calls[0]
+        assert call["wing"] == "test_project"
+        assert call["col"] is not None, (
+            "must pass the live collection so hallways can query drawers"
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_hallway_failure_does_not_crash_mine(monkeypatch):
+    """If compute_hallways_for_wing raises, the mine must still complete.
+
+    Mirrors the try/except wrap around the existing tunnel-computation block
+    at miner.py:1244-1249. Hallway computation is a derived analytic, not
+    load-bearing for the drawer write itself.
+    """
+    from mempalace import miner as miner_mod
+
+    def angry_compute(wing, col=None, min_count=2):
+        raise RuntimeError("simulated hallway-compute explosion")
+
+    monkeypatch.setattr(miner_mod, "compute_hallways_for_wing", angry_compute)
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "backend")
+        write_file(
+            project_root / "backend" / "app.py",
+            "def main():\n    print('hello world')\n" * 20,
+        )
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "backend", "description": "Backend code"}],
+                },
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        # Must NOT raise — the failure has to be caught + logged but not propagated.
+        mine(str(project_root), str(palace_path))
+
+        # Drawer-write side of the mine still committed.
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() > 0
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def test_load_config_uses_defaults_when_yaml_missing():
     tmpdir = tempfile.mkdtemp()
     try:


### PR DESCRIPTION
Introduces the missing palace primitive: **hallways** — within-wing entity-to-entity connectors.

## The gap this fills

Mempalace today implements **Wing → Rooms → Tunnels**. Tunnels connect rooms ACROSS wings. What's missing is the connector between **entities** (people, projects, concepts, interests) inside one wing.

The intended architecture (per the design conversation that motivated this PR):

```
WING → has DRAWERS (each tagged with entities)
        entities → connected to other entities by HALLWAYS
                   (within-wing, built from drawer co-occurrence)
                   hallways → are the primitive
                               tunnels → use hallways to spawn
                                         cross-wing connections
```

A hallway is the structural fact of "these two entities travel together inside this wing." If Aya and Lumi co-occur in 47 drawers across `diary`, `letters`, and `ideas` rooms, that's a hallway between Aya and Lumi. If Aya and `consciousness` co-occur in 19 drawers, that's another hallway — entities aren't only people; projects/concepts/interests share the same entity-tag substrate.

> Side note for reviewers: `palace_graph.py:253` currently calls cross-wing tunnels "hallways" in its docstring. That naming conflation is fixed in a separate cleanup PR — this PR doesn't touch existing tunnel code.

## Public API

New module `mempalace/hallways.py`:

```python
compute_hallways_for_wing(wing, col=None, min_count=2) -> list[dict]
list_hallways(wing=None) -> list[dict]
delete_hallway(hallway_id) -> bool
```

Plus `_load_hallways()` / `_save_hallways()` JSON persistence at `~/.mempalace/hallways.json` (atomic writes, 0600 perms on POSIX, mirrors `palace_graph._TUNNEL_FILE`).

## Data model

```jsonc
{
  "schema_version": 1,
  "hallways": [
    {
      "id": "hallway_<wing>_<entity_a>_<entity_b>_<sha8>",
      "wing": "wing_aya",
      "entity_a": "Aya",
      "entity_b": "Lumi",
      "co_occurrence_count": 47,
      "rooms": ["diary", "letters", "ideas"],
      "label": "Aya ↔ Lumi (co-occur in 47 drawers across 3 rooms: diary, letters, ideas)",
      "created_at": "2026-05-20T03:30:00Z",
      "created_by": "auto"
    }
  ]
}
```

Hallway IDs are deterministic — `sha256(wing + sorted(entity_a, entity_b))` truncated. Sorted-pair canonicalization means (Aya, Lumi) and (Lumi, Aya) produce the same id, so re-runs upsert idempotently and a drawer with `Aya;Lumi` or `Lumi;Aya` counts as one co-occurrence (not two).

## Algorithm

For each drawer in the wing:
1. Parse `entities` metadata (semicolon-separated string).
2. For each unordered pair of distinct entities in that drawer, increment a co-occurrence counter and record the room.

Then for each entity pair with `count >= min_count`, materialize a hallway record.

## Verification

| Gate | Result |
|---|---|
| 17 RED-first tests in `tests/test_hallways.py` | ✅ all pass |
| `ruff check` on new module + test | ✅ clean (pinned 0.15.9) |
| `ruff format --check` | ✅ already formatted |
| Full mempalace test suite | ✅ 1936 passed, 1 skipped, 0 regressions caused by this PR |
| Linux CI parity (OrbStack, Python 3.9 / 3.11 / 3.13) | ✅ 17/17 hallway tests pass, ruff clean on all three |

## Out of scope (deferred to follow-up PRs)

This PR introduces the primitive ONLY. Each follow-up is small enough to review independently:

1. **Integration into miner.py / convo_miner.py / format_miner.py** — one-line `compute_hallways_for_wing(wing)` call post-mine alongside the existing `_compute_topic_tunnels_for_wing(wing)`. Small, focused PR.
2. **Refactor `_compute_topic_tunnels_for_wing` to build FROM hallways** — the architecturally meaningful follow-up that completes the Wing → Drawer-entities → Hallway → Tunnel sequence.
3. **Rename misleading docstrings** in `palace_graph.py:253` and `mcp_server.py:994` that currently call cross-wing tunnels "hallways."
4. **MCP exposure** — `mempalace_hallways(wing)` tool. Deferred until a clear UX need surfaces.

Shipping the primitive first lets you think about the API surface separately from the integration choices.

## Why this matters

Hallways make the relationships *between people and ideas* first-class. Right now, the fact that "Aya talks about consciousness across 19 drawers" or "Lumi and Vinny co-occur 12 times" lives only as derived statistics — search has to rediscover it on every query. Hallways persist the structure so it's queryable / visualizable / addressable.

The empty `entities` metadata on lowercase-corpora drawers (fixed in the just-pushed [case-insensitive entity matching PR](#)) was the prerequisite — hallways consume entity tags, so they only work when those tags actually capture the corpus's people. With both PRs landed, personal/journal/chat-style corpora finally have the structural connectivity their content warrants.
