### PR TITLE
feat(miner): integrate compute_hallways_for_wing into post-mine flow

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -33,6 +33,12 @@ from .palace import (
     upsert_closet_lines,
 )
 
+# Module-level import so tests can patch it as
+# ``mempalace.miner.compute_hallways_for_wing``. The integration call
+# lives at the end of _mine_impl, alongside the existing
+# ``_compute_topic_tunnels_for_wing`` post-mine block.
+from .hallways import compute_hallways_for_wing
+
 logger = logging.getLogger("mempalace_mcp")
 
 READABLE_EXTENSIONS = {
@@ -1245,6 +1251,21 @@ def _mine_impl(
                 # Tunnel computation must never fail a mine — degrade quietly.
                 print(
                     f"\n  WARNING: topic tunnel computation skipped — {e}",
+                    file=sys.stderr,
+                )
+
+            # Within-wing hallways: link entities (people, projects, concepts)
+            # that co-occur in drawers across this wing's rooms. Mirrors the
+            # tunnel-compute fault-tolerance pattern — hallway computation
+            # must never fail a mine; it's a derived analytic, not load-bearing
+            # for the drawer write that already committed above.
+            try:
+                hallways_created = compute_hallways_for_wing(wing, col=collection)
+                if hallways_created:
+                    print(f"\n  Hallways: +{len(hallways_created)} within-wing entity link(s)")
+            except Exception as e:
+                print(
+                    f"\n  WARNING: hallway computation skipped — {e}",
                     file=sys.stderr,
                 )
 

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -55,6 +55,105 @@ def test_project_mining():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_mine_computes_hallways_for_wing_post_mine(monkeypatch):
+    """After mine() completes (non-dry-run), compute_hallways_for_wing must be
+    called once with the wing name and the live collection.
+
+    This is the integration test for the hallway primitive — without this
+    call, the hallway module is dead code (no miner triggers it). Mirrors
+    the existing tunnel-computation integration pattern at miner.py:1241.
+    """
+
+    from mempalace import miner as miner_mod
+
+    hallway_calls = []
+
+    def fake_compute(wing, col=None, min_count=2):
+        hallway_calls.append({"wing": wing, "col": col, "min_count": min_count})
+        return []  # no hallways materialized — that's not what we're testing
+
+    # Patch at the call site (mempalace.miner.compute_hallways_for_wing) so
+    # the integration in mine() routes through our stub.
+    monkeypatch.setattr(miner_mod, "compute_hallways_for_wing", fake_compute)
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "backend")
+        write_file(
+            project_root / "backend" / "app.py",
+            "def main():\n    print('hello world')\n" * 20,
+        )
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "backend", "description": "Backend code"}],
+                },
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        mine(str(project_root), str(palace_path))
+
+        # Must have been called exactly once, with our wing name + a live
+        # collection. We don't pin min_count — the integration may pick a
+        # default that differs from the function's own default.
+        assert len(hallway_calls) == 1, (
+            f"expected compute_hallways_for_wing to be called once, got {len(hallway_calls)}"
+        )
+        call = hallway_calls[0]
+        assert call["wing"] == "test_project"
+        assert call["col"] is not None, (
+            "must pass the live collection so hallways can query drawers"
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_hallway_failure_does_not_crash_mine(monkeypatch):
+    """If compute_hallways_for_wing raises, the mine must still complete.
+
+    Mirrors the try/except wrap around the existing tunnel-computation block
+    at miner.py:1244-1249. Hallway computation is a derived analytic, not
+    load-bearing for the drawer write itself.
+    """
+    from mempalace import miner as miner_mod
+
+    def angry_compute(wing, col=None, min_count=2):
+        raise RuntimeError("simulated hallway-compute explosion")
+
+    monkeypatch.setattr(miner_mod, "compute_hallways_for_wing", angry_compute)
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "backend")
+        write_file(
+            project_root / "backend" / "app.py",
+            "def main():\n    print('hello world')\n" * 20,
+        )
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "backend", "description": "Backend code"}],
+                },
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        # Must NOT raise — the failure has to be caught + logged but not propagated.
+        mine(str(project_root), str(palace_path))
+
+        # Drawer-write side of the mine still committed.
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() > 0
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def test_load_config_uses_defaults_when_yaml_missing():
     tmpdir = tempfile.mkdtemp()
     try:


### PR DESCRIPTION
Wires the hallway primitive from PR #1558 into the project miner's post-mine flow.

> **This PR stacks on #1558.** Base branch is `feat/hallways-within-wing-connectors`. When #1558 merges, GitHub auto-updates this PR's base to `develop` and the diff shrinks to just the `miner.py` + test changes.

## Why this is necessary

PR #1558 introduces the `compute_hallways_for_wing` function — but no miner calls it yet. Without this integration, that module is dead code: no hallways ever materialize in `~/.mempalace/hallways.json`.

This PR wires the call into `_mine_impl` so every project mine triggers hallway computation for the wing it just touched.

## What changes

1. **Module-level import** in `miner.py`:
   ```python
   from .hallways import compute_hallways_for_wing
   ```
   Module-level (not lazy inside a function) so tests can patch the seam as `mempalace.miner.compute_hallways_for_wing`.

2. **Post-mine call block** in `_mine_impl`, immediately after the existing topic-tunnel computation. Mirrors that block's fault-tolerance pattern exactly:
   ```python
   try:
       hallways_created = compute_hallways_for_wing(wing, col=collection)
       if hallways_created:
           print(f"\n  Hallways: +{len(hallways_created)} within-wing entity link(s)")
   except Exception as e:
       print(f"\n  WARNING: hallway computation skipped — {e}", file=sys.stderr)
   ```
   Hallway computation is a derived analytic. If it fails, the drawer write (which happens earlier in `_mine_impl`) has already committed. The failure must never propagate.

## Tests

Two new RED-first tests in `tests/test_miner.py`:

| Test | What it verifies |
|---|---|
| `test_mine_computes_hallways_for_wing_post_mine` | Stubs the hallway function, runs a real mine, asserts it was called once with the wing name + the live ChromaDB collection. |
| `test_mine_hallway_failure_does_not_crash_mine` | Stubs the hallway function to raise. Mine still completes, drawer write commits, exception doesn't propagate. |

Both RED before this commit (`AttributeError`: module had no `compute_hallways_for_wing` attribute). Both GREEN after.

## Verification

| Gate | Result |
|---|---|
| 2 RED-first tests | ✅ both pass |
| `ruff check` + `ruff format --check` | ✅ clean (pinned 0.15.9) |
| Full `tests/test_miner.py` | ✅ 47 passed (2 new + 45 pre-existing) |
| Full mempalace suite | ✅ 1938 passed, 1 skipped, 0 regressions |
| Linux CI parity (OrbStack, Python 3.9 / 3.11 / 3.13) | ✅ 2/2 pass, ruff clean on all three |

## Out of scope (deferred to follow-up PRs)

- **`format_miner.py` integration** — lives on a different branch (PR #1555). Goes in as an amendment commit there once #1558 lands.
- **`convo_miner.py` integration** — convo_miner currently doesn't call `_compute_topic_tunnels_for_wing` either. Adding both calls (tunnels + hallways) is a separate concerned PR about convo_miner parity.
- **Refactor `_compute_topic_tunnels_for_wing` to BUILD ON hallways** — the architecturally meaningful follow-up that completes the Wing → Drawer-entities → Hallway → Tunnel sequence per the design. Real refactor, separate PR.

This PR is intentionally narrow: just turn on hallway computation for the most-used miner. Convo / format miners follow in stacked PRs.
