### PR TITLE
feat(tunnels): cross-wing entity tunnels derived from hallways

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1269,6 +1269,22 @@ def _mine_impl(
                     file=sys.stderr,
                 )
 
+            # Cross-wing entity tunnels: derived from the hallway records
+            # materialized just above. When an entity appears in hallways of
+            # this wing AND another wing, a tunnel bridges them. Runs in
+            # parallel with topic tunnels — both kinds coexist via
+            # ``kind="entity"`` / ``kind="topic"``. Same fault-tolerance
+            # pattern: never fail a mine over a derived analytic.
+            try:
+                entity_tunnels_added = _compute_entity_tunnels_for_wing(wing)
+                if entity_tunnels_added:
+                    print(f"\n  Entity tunnels: +{entity_tunnels_added} cross-wing entity link(s)")
+            except Exception as e:
+                print(
+                    f"\n  WARNING: entity tunnel computation skipped — {e}",
+                    file=sys.stderr,
+                )
+
         print(f"\n{'=' * 55}")
         print("  Done.")
         print(f"  Files processed: {len(files) - files_skipped}")
@@ -1367,6 +1383,31 @@ def _compute_topic_tunnels_for_wing(wing: str) -> int:
     cfg = MempalaceConfig()
     min_count = cfg.topic_tunnel_min_count
     created = topic_tunnels_for_wing(wing, topics_map, min_count=min_count)
+    return len(created)
+
+
+def _compute_entity_tunnels_for_wing(wing: str) -> int:
+    """Drop tunnels between ``wing`` and every other wing that shares an
+    entity via the within-wing hallway primitive.
+
+    Reads hallway records (``mempalace.hallways.list_hallways``) and
+    materializes cross-wing tunnels for any entity that has hallways in
+    this wing AND at least one other wing. Tunnels use ``kind="entity"``
+    and the synthetic endpoint room ``entity:<name>`` so they're
+    distinguishable from explicit and topic tunnels at read time but
+    interchangeable with them via the standard ``list_tunnels`` /
+    ``follow_tunnels`` API.
+
+    Returns the number of tunnels created or refreshed. Zero means no
+    eligible entity exists in this wing yet (or no hallway records do).
+    """
+    from .hallways import list_hallways
+    from .palace_graph import entity_tunnels_for_wing
+
+    hallways = list_hallways()
+    if not hallways:
+        return 0
+    created = entity_tunnels_for_wing(wing, hallways)
     return len(created)
 
 

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -779,3 +779,78 @@ def topic_tunnels_for_wing(
             )
         )
     return created
+
+
+def entity_tunnels_for_wing(
+    wing: str,
+    hallways: list,
+    label_prefix: str = "shared entity",
+) -> list:
+    """Compute entity tunnels involving a single wing.
+
+    An entity tunnel bridges two wings when the same entity (person,
+    project, concept, interest) appears in within-wing hallways of both.
+    This is the architectural counterpart to ``topic_tunnels_for_wing`` —
+    same storage path (``create_tunnel`` → ``~/.mempalace/tunnels.json``),
+    same dedup, same listing API — but the substrate is hallway records
+    rather than raw topic words. See v4 architecture doc, Wing →
+    Drawer-entities → Hallway → Tunnel.
+
+    Endpoints use the synthetic room id ``entity:<name>`` (mirrors
+    ``topic:<slug>``) so they can't collide with literal folder-derived
+    rooms of the same name. Casing of the entity is preserved.
+
+    Topic tunnels are NOT replaced — both systems coexist for one release
+    cycle while entity tunnels prove out. Deprecation is a separate PR.
+    """
+    if not hallways or not isinstance(wing, str) or not wing.strip():
+        return []
+
+    wing_norm = normalize_wing_name(wing.strip())
+
+    # Build: entity -> {normalized_wing -> original_wing_display_name}
+    # Both entity_a and entity_b positions count toward "this entity is
+    # in this wing"; the hallway primitive treats the pair as unordered.
+    entity_wings: dict = {}
+    for h in hallways:
+        if not isinstance(h, dict):
+            continue
+        h_wing = h.get("wing")
+        if not isinstance(h_wing, str) or not h_wing.strip():
+            continue
+        h_wing_norm = normalize_wing_name(h_wing.strip())
+        for ent_key in ("entity_a", "entity_b"):
+            ent = h.get(ent_key)
+            if not isinstance(ent, str) or not ent.strip():
+                continue
+            # setdefault preserves the first-seen display form so the
+            # tunnel endpoint matches the wing name the caller used.
+            entity_wings.setdefault(ent, {}).setdefault(h_wing_norm, h_wing)
+
+    if not entity_wings:
+        return []
+
+    created: list = []
+    # Stable entity order so tunnels materialize deterministically across
+    # runs — matters for tests and for diff-able tunnels.json files.
+    for entity in sorted(entity_wings.keys()):
+        wings_for_entity = entity_wings[entity]
+        if wing_norm not in wings_for_entity:
+            continue
+        own_wing_display = wings_for_entity[wing_norm]
+        # Stable other-wing order; ``wing_norm`` itself is excluded so an
+        # entity that lives only in this wing produces zero tunnels.
+        other_wings_norm = sorted(w for w in wings_for_entity if w != wing_norm)
+        for other_norm in other_wings_norm:
+            other_display = wings_for_entity[other_norm]
+            room = f"entity:{entity}"
+            tunnel = create_tunnel(
+                source_wing=own_wing_display,
+                source_room=room,
+                target_wing=other_display,
+                target_room=room,
+                label=f"{label_prefix}: {entity}",
+                kind="entity",
+            )
+            created.append(tunnel)
+    return created

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -154,6 +154,100 @@ def test_mine_hallway_failure_does_not_crash_mine(monkeypatch):
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_mine_computes_entity_tunnels_for_wing_post_mine(monkeypatch):
+    """After mine() completes (non-dry-run), ``_compute_entity_tunnels_for_wing``
+    must be called once with the wing name from mempalace.yaml.
+
+    Without this call the entity-tunnel feature is dead code — no miner
+    triggers it, no entity tunnels ever land in ~/.mempalace/tunnels.json.
+    Mirrors the existing hallway- and topic-tunnel integration tests in
+    this file.
+    """
+    from mempalace import miner as miner_mod
+
+    entity_tunnel_calls = []
+
+    def fake_compute(wing):
+        entity_tunnel_calls.append({"wing": wing})
+        return 0  # no tunnels — that's not what we're testing here
+
+    # Patch at the call site (mempalace.miner._compute_entity_tunnels_for_wing)
+    # so the integration in mine() routes through our stub.
+    monkeypatch.setattr(miner_mod, "_compute_entity_tunnels_for_wing", fake_compute)
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "backend")
+        write_file(
+            project_root / "backend" / "app.py",
+            "def main():\n    print('hello world')\n" * 20,
+        )
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "backend", "description": "Backend code"}],
+                },
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        mine(str(project_root), str(palace_path))
+
+        assert len(entity_tunnel_calls) == 1, (
+            f"expected _compute_entity_tunnels_for_wing to be called once, "
+            f"got {len(entity_tunnel_calls)}"
+        )
+        assert entity_tunnel_calls[0]["wing"] == "test_project"
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_entity_tunnel_failure_does_not_crash_mine(monkeypatch):
+    """If ``_compute_entity_tunnels_for_wing`` raises, the mine must still
+    complete and the drawer write must remain committed.
+
+    Mirrors the try/except wrap around the existing tunnel- and hallway-
+    computation blocks. Entity tunnel computation is a derived analytic,
+    not load-bearing for the drawer write itself.
+    """
+    from mempalace import miner as miner_mod
+
+    def angry_compute(wing):
+        raise RuntimeError("simulated entity-tunnel-compute explosion")
+
+    monkeypatch.setattr(miner_mod, "_compute_entity_tunnels_for_wing", angry_compute)
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+        os.makedirs(project_root / "backend")
+        write_file(
+            project_root / "backend" / "app.py",
+            "def main():\n    print('hello world')\n" * 20,
+        )
+        with open(project_root / "mempalace.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "wing": "test_project",
+                    "rooms": [{"name": "backend", "description": "Backend code"}],
+                },
+                f,
+            )
+
+        palace_path = project_root / "palace"
+        # Must NOT raise — the failure has to be caught + logged but not propagated.
+        mine(str(project_root), str(palace_path))
+
+        # Drawer-write side of the mine still committed.
+        client = chromadb.PersistentClient(path=str(palace_path))
+        col = client.get_collection("mempalace_drawers")
+        assert col.count() > 0
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def test_load_config_uses_defaults_when_yaml_missing():
     tmpdir = tempfile.mkdtemp()
     try:

--- a/tests/test_palace_graph_tunnels.py
+++ b/tests/test_palace_graph_tunnels.py
@@ -481,3 +481,159 @@ class TestHyphenatedWingNormalization:
 
         assert len(palace_graph.follow_tunnels("mempalace_public", "auth")) == 1
         assert len(palace_graph.follow_tunnels("mempalace-public", "auth")) == 1
+
+
+class TestEntityTunnels:
+    """Cross-wing entity tunnels (the Wing → Drawer-entities → Hallway →
+    Tunnel sequence from the v4 architecture vision).
+
+    When an entity has within-wing hallways in two or more wings, an entity
+    tunnel bridges those wings, anchored on the entity. This is the
+    architectural counterpart to ``compute_topic_tunnels`` — same storage,
+    same dedup, but the substrate is hallway records (entity-grounded)
+    rather than raw topic words.
+
+    Endpoints use the synthetic room id ``entity:<name>`` so they can't
+    collide with literal folder-derived rooms of the same name (mirrors
+    the ``topic:<name>`` convention).
+
+    Topic tunnels are NOT removed by this work — both systems run in
+    parallel for one release cycle so existing palaces don't lose
+    tunnels between mines. Deprecation is a separate follow-up PR.
+    """
+
+    def test_entity_tunnels_creates_cross_wing_tunnel_for_shared_entity(
+        self, tmp_path, monkeypatch
+    ):
+        """Ben appears in a hallway in wing_aya AND in wing_mempalace →
+        exactly one entity tunnel between those two wings, anchored on Ben."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        hallways = [
+            {"wing": "wing_aya", "entity_a": "Ben", "entity_b": "Aya"},
+            {"wing": "wing_mempalace", "entity_a": "Ben", "entity_b": "Igor"},
+        ]
+        created = palace_graph.entity_tunnels_for_wing("wing_aya", hallways)
+        assert len(created) == 1
+        tunnel = created[0]
+        assert {tunnel["source"]["wing"], tunnel["target"]["wing"]} == {
+            "wing_aya",
+            "wing_mempalace",
+        }
+        # Endpoint is the synthetic entity room — same casing as the
+        # stored entity, prefixed with ``entity:`` to prevent collision
+        # with a literal folder room of the same name.
+        assert tunnel["source"]["room"] == "entity:Ben"
+        assert tunnel["target"]["room"] == "entity:Ben"
+        assert tunnel["kind"] == "entity"
+        # Label carries the entity name without the prefix.
+        assert "Ben" in tunnel["label"]
+        assert "entity:Ben" not in tunnel["label"]
+
+    def test_entity_tunnels_skips_entities_in_only_one_wing(self, tmp_path, monkeypatch):
+        """Aya has hallways only in wing_aya → no tunnel for her."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        hallways = [
+            {"wing": "wing_aya", "entity_a": "Aya", "entity_b": "Lumi"},
+            {"wing": "wing_aya", "entity_a": "Aya", "entity_b": "Ever"},
+        ]
+        created = palace_graph.entity_tunnels_for_wing("wing_aya", hallways)
+        assert created == []
+
+    def test_entity_tunnels_counts_entity_in_either_pair_position(self, tmp_path, monkeypatch):
+        """Entity may appear as entity_a in one hallway and entity_b in
+        another. Both positions count toward 'this entity is in this wing'."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        hallways = [
+            # Ben is entity_b in wing_aya
+            {"wing": "wing_aya", "entity_a": "Aya", "entity_b": "Ben"},
+            # Ben is entity_a in wing_mempalace
+            {"wing": "wing_mempalace", "entity_a": "Ben", "entity_b": "Igor"},
+        ]
+        created = palace_graph.entity_tunnels_for_wing("wing_aya", hallways)
+        assert len(created) == 1
+        assert "Ben" in created[0]["label"]
+
+    def test_entity_tunnels_three_wings_pairwise_from_focus_wing(self, tmp_path, monkeypatch):
+        """When Ben has hallways in {wing_aya, wing_mp, wing_lt} and we
+        compute for wing_aya, we create wing_aya↔wing_mp AND wing_aya↔wing_lt
+        only — NOT wing_mp↔wing_lt. The cross-wing tunnel between the two
+        other wings is the job of whichever of those two mines next.
+        """
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        hallways = [
+            {"wing": "wing_aya", "entity_a": "Ben", "entity_b": "Aya"},
+            {"wing": "wing_mempalace", "entity_a": "Ben", "entity_b": "Igor"},
+            {"wing": "wing_lantern", "entity_a": "Ben", "entity_b": "Lumi"},
+        ]
+        created = palace_graph.entity_tunnels_for_wing("wing_aya", hallways)
+        assert len(created) == 2
+        target_wings = set()
+        for t in created:
+            other = (
+                t["target"]["wing"] if t["source"]["wing"] == "wing_aya" else t["source"]["wing"]
+            )
+            target_wings.add(other)
+        assert target_wings == {"wing_mempalace", "wing_lantern"}
+
+    def test_entity_tunnels_idempotent_on_rerun(self, tmp_path, monkeypatch):
+        """Re-running on the same hallway data must not duplicate tunnels.
+        ``create_tunnel`` dedup-on-canonical-id is the guarantee — this test
+        pins the contract."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        hallways = [
+            {"wing": "wing_aya", "entity_a": "Ben", "entity_b": "Aya"},
+            {"wing": "wing_mempalace", "entity_a": "Ben", "entity_b": "Igor"},
+        ]
+        palace_graph.entity_tunnels_for_wing("wing_aya", hallways)
+        palace_graph.entity_tunnels_for_wing("wing_aya", hallways)
+        listed = palace_graph.list_tunnels()
+        # Only one stored tunnel even after two passes.
+        entity_tunnels = [t for t in listed if t.get("kind") == "entity"]
+        assert len(entity_tunnels) == 1
+
+    def test_entity_tunnels_retrievable_via_list_tunnels(self, tmp_path, monkeypatch):
+        """Once written, entity tunnels appear in the standard
+        ``list_tunnels`` query — readers don't need a separate API."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        hallways = [
+            {"wing": "wing_aya", "entity_a": "Ben", "entity_b": "Aya"},
+            {"wing": "wing_mempalace", "entity_a": "Ben", "entity_b": "Igor"},
+        ]
+        created = palace_graph.entity_tunnels_for_wing("wing_aya", hallways)
+        listed = palace_graph.list_tunnels()
+        assert {t["id"] for t in listed} == {t["id"] for t in created}
+
+    def test_entity_tunnels_empty_hallways_is_noop(self, tmp_path, monkeypatch):
+        """No hallways → no tunnels. No crash."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        assert palace_graph.entity_tunnels_for_wing("wing_aya", []) == []
+
+    def test_entity_tunnels_unknown_wing_is_noop(self, tmp_path, monkeypatch):
+        """Wing that doesn't appear in any hallway → no tunnels (the wing
+        has no entities to bridge from)."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        hallways = [
+            {"wing": "wing_other", "entity_a": "Ben", "entity_b": "Aya"},
+        ]
+        assert palace_graph.entity_tunnels_for_wing("wing_nonexistent", hallways) == []
+
+    def test_entity_tunnel_room_does_not_collide_with_literal_room(self, tmp_path, monkeypatch):
+        """A literal folder room ``Ben`` (created via explicit tunnel) and the
+        synthetic entity room ``entity:Ben`` must produce distinct tunnels —
+        not get deduped together by id collision."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        # Pre-create an explicit tunnel with a literal "Ben" room.
+        palace_graph.create_tunnel(
+            "wing_aya", "Ben", "wing_mempalace", "Ben", label="literal", kind="explicit"
+        )
+        hallways = [
+            {"wing": "wing_aya", "entity_a": "Ben", "entity_b": "Aya"},
+            {"wing": "wing_mempalace", "entity_a": "Ben", "entity_b": "Igor"},
+        ]
+        palace_graph.entity_tunnels_for_wing("wing_aya", hallways)
+        listed = palace_graph.list_tunnels()
+        # Two distinct tunnels: one literal "Ben" → "Ben", one
+        # "entity:Ben" → "entity:Ben". Different canonical IDs.
+        assert len(listed) == 2
+        kinds = {t.get("kind") for t in listed}
+        assert kinds == {"explicit", "entity"}


### PR DESCRIPTION
Adds the architectural counterpart to ``compute_topic_tunnels`` that materializes cross-wing tunnels from the within-wing hallway records introduced in PR #1558. When an entity (person, project, concept, interest) has hallways in two wings, an entity tunnel bridges them — anchored on the entity. This completes the v4 sequence: Wing → Drawer-entities → Hallway → Tunnel.

Topic tunnels are NOT replaced. Both systems coexist for one release cycle so existing palaces don't lose tunnels between mines. Deprecation of topic tunnels is a separate follow-up PR after entity tunnels prove out in real use.

## What this commit does

1. Adds ``entity_tunnels_for_wing(wing, hallways, label_prefix)`` to ``mempalace/palace_graph.py``. Pure function: groups hallway records by entity-and-wing, finds entities present in ``wing`` AND ≥1 other wing, and emits one ``create_tunnel`` call per (entity, other_wing) pair. Uses ``kind="entity"`` and synthetic endpoint room ``entity:<name>`` so the new tunnels are distinguishable from explicit/topic tunnels at read time but interchangeable with them via the standard ``list_tunnels`` / ``follow_tunnels`` API.

2. Adds ``_compute_entity_tunnels_for_wing(wing)`` wrapper to ``mempalace/miner.py``. Loads hallway records via ``hallways.list_hallways()`` and calls the algorithm. Module-level so tests can patch it as ``mempalace.miner._compute_entity_tunnels_for_wing``.

3. Wires the wrapper into ``_mine_impl`` immediately after the existing hallway-compute block. Same try/except fault-tolerance pattern as the topic-tunnel and hallway blocks — entity-tunnel computation is a derived analytic and must never fail a mine.

## Tests (RED-first)

Nine algorithm tests in ``tests/test_palace_graph_tunnels.py`` (new ``TestEntityTunnels`` class):

  test_entity_tunnels_creates_cross_wing_tunnel_for_shared_entity
  test_entity_tunnels_skips_entities_in_only_one_wing
  test_entity_tunnels_counts_entity_in_either_pair_position
  test_entity_tunnels_three_wings_pairwise_from_focus_wing
  test_entity_tunnels_idempotent_on_rerun
  test_entity_tunnels_retrievable_via_list_tunnels
  test_entity_tunnels_empty_hallways_is_noop
  test_entity_tunnels_unknown_wing_is_noop
  test_entity_tunnel_room_does_not_collide_with_literal_room

Two integration tests in ``tests/test_miner.py``:

  test_mine_computes_entity_tunnels_for_wing_post_mine
  test_mine_entity_tunnel_failure_does_not_crash_mine

All 11 RED before this commit (AttributeError on the missing names). All 11 GREEN after.

## Out of scope (deferred to follow-up PRs)

- ``format_miner.py`` and ``convo_miner.py`` integration: separate PRs per the scope discipline used for #1560.
- Deprecating ``_compute_topic_tunnels_for_wing``: separate PR after entity tunnels prove out in real use.
- Surfacing ``kind="entity"`` in MCP / search-result UI: not yet required by any reader; behaviorally interchangeable with the other tunnel kinds today.

## Stacking

This PR stacks on PR #1558 (which introduces the hallway primitive and its miner integration). Base branch is
``feat/hallways-within-wing-connectors``. When #1558 merges to develop, GitHub auto-updates this PR's base to ``develop`` and the diff reduces to just the entity-tunnel additions.

## Verification

  pytest tests/test_palace_graph_tunnels.py::TestEntityTunnels
    → 9 passed (RED before, GREEN after)
  pytest tests/test_miner.py::test_mine_computes_entity_tunnels_for_wing_post_mine
        tests/test_miner.py::test_mine_entity_tunnel_failure_does_not_crash_mine
    → 2 passed (RED before, GREEN after)
  pytest tests/test_palace_graph_tunnels.py
    → 39 passed (no regressions)
  pytest tests/test_miner.py
    → 49 passed (no regressions)
  pytest -q (full mempalace suite)
    → 1949 passed, 1 skipped, 0 regressions
  ruff check mempalace/palace_graph.py mempalace/miner.py tests/
    → All checks passed!
  ruff format --check ...
    → 4 files already formatted (pinned 0.15.9)

