### PR TITLE
fix(extract): polish PR — address bot review feedback on PR #1555

### DIFF
--- a/docs/format-coverage.md
+++ b/docs/format-coverage.md
@@ -1,9 +1,9 @@
 # Format coverage — `mempalace mine --mode extract`
 
-**Proposed for mempalace 3.3.6.**
-**Target file (new):** `mempalace/format_miner.py`
-**Target file (edited, one-line addition):** `mempalace/cli.py` (dispatcher in `cmd_mine`)
-**New tests:** `tests/test_format_miner.py` (32 cases, all green; see `PROOF.md`).
+**Shipped in mempalace 3.3.6 (PR #1555).**
+**Module:** `mempalace/format_miner.py`
+**CLI entry:** `mempalace/cli.py` — `cmd_mine` dispatcher routes `--mode extract` here.
+**Tests:** `tests/test_format_miner.py` — covers all 14 fringe cases plus orchestrator behavior. See the file for the current test inventory (the count drifts as polish PRs land).
 
 ---
 

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -80,8 +80,10 @@ from .palace import (
 # Module-level imports from .miner so tests can patch them via
 # mempalace.format_miner.<name>. Lazy imports inside functions would not
 # expose these as attributes of this module, breaking the test seams.
+from .config import MempalaceConfig, normalize_wing_name
 from .miner import (
     _compute_topic_tunnels_for_wing,
+    chunk_text,
     detect_room,
     load_config,
 )
@@ -166,6 +168,22 @@ class ExtractionStatus(enum.Enum):
     SKIP_MISSING_FORMAT_DEPS = "skip:missing_format_deps"
     SKIP_NETWORK_TIMEOUT = "skip:network_timeout"
     SKIP_UNREADABLE = "skip:unreadable"
+
+
+# Skip variants that represent TRANSIENT environmental issues — the optional
+# transformer dep isn't installed yet, or the network blipped. Sentinel
+# writes for these would permanently mark the file as "already mined" and
+# defeat re-mining after the missing piece is installed / the network is
+# back. The orchestrator (``mine_formats``) checks this set before calling
+# ``_register_file``. Per PR #1555 review (Copilot #14).
+_TRANSIENT_MISSING_DEP_STATUSES = frozenset(
+    {
+        ExtractionStatus.SKIP_NO_MARKITDOWN,
+        ExtractionStatus.SKIP_NO_STRIPRTF,
+        ExtractionStatus.SKIP_MISSING_FORMAT_DEPS,
+        ExtractionStatus.SKIP_NETWORK_TIMEOUT,
+    }
+)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -304,7 +322,9 @@ def extract_text(
     never modified.
     """
     # Accept str or Path; pathlib handles Windows separators correctly.
-    p = Path(path)
+    # ``expanduser()`` resolves ``~/foo.pdf`` style paths so CLI inputs work
+    # without forcing the caller to pre-resolve. Per PR #1555 review (Copilot).
+    p = Path(path).expanduser()
 
     # Fringe Case 7 — broken symlink.
     # ``is_symlink()`` true + ``exists()`` false ⇒ link target is missing.
@@ -327,8 +347,17 @@ def extract_text(
         logger.info("skip:permission (stat) %s", p)
         return None, ExtractionStatus.SKIP_PERMISSION
     except FileNotFoundError:
-        logger.info("skip:broken_symlink (stat) %s", p)
-        return None, ExtractionStatus.SKIP_BROKEN_SYMLINK
+        # Distinguish "broken symlink" (target gone) from "file disappeared
+        # between scan and extract" (regular file, no longer exists). The
+        # is_symlink() check at the top of this function catches the symlink
+        # case BEFORE stat(), so by the time we land here the symlink path
+        # is rare — but a race between scan_formats and extract_text on a
+        # plain file is the common cause. Per PR #1555 review (Copilot #8).
+        if p.is_symlink():
+            logger.info("skip:broken_symlink (stat) %s", p)
+            return None, ExtractionStatus.SKIP_BROKEN_SYMLINK
+        logger.info("skip:unreadable (file gone after scan) %s", p)
+        return None, ExtractionStatus.SKIP_UNREADABLE
     except OSError as exc:
         logger.info("skip:unreadable %s — %s", p, exc)
         return None, ExtractionStatus.SKIP_UNREADABLE
@@ -436,7 +465,10 @@ def scan_formats(directory: Union[Path, str]) -> list[Path]:
     (sorted by path) so a re-mine processes files in the same order each
     time — useful for reproducing bug reports.
     """
-    root = Path(directory)
+    # ``expanduser().resolve()`` normalizes ``~/docs`` and relative paths so
+    # CLI inputs like ``mempalace mine --mode extract ~/docs`` work without
+    # the caller pre-resolving. Per PR #1555 review (Copilot #9).
+    root = Path(directory).expanduser().resolve()
     if not root.exists():
         return []
 
@@ -469,6 +501,51 @@ def scan_formats(directory: Union[Path, str]) -> list[Path]:
 # files drawers via the same lock + purge + upsert pattern convo_miner uses.
 # Source files on disk are never modified.
 # ─────────────────────────────────────────────────────────────────────────────
+
+
+def _print_mine_summary(
+    files: list,
+    files_with_text: int,
+    files_skipped: int,
+    files_errored: int,
+    total_drawers: int,
+    status_counts: dict,
+) -> None:
+    """Print the post-mine summary block.
+
+    Factored out of ``mine_formats`` to keep the orchestrator under the
+    project's mccabe complexity ceiling (max-complexity=25 in pyproject.toml).
+    No behavior change.
+    """
+    print(f"\n{'=' * 55}")
+    print("  Summary")
+    print(f"{'-' * 55}")
+    print(f"  Files seen:        {len(files)}")
+    print(f"  Files extracted:   {files_with_text}")
+    print(f"  Files skipped:     {files_skipped}")
+    print(f"  Files errored:     {files_errored}")
+    print(f"  Total drawers:     {total_drawers}")
+    if status_counts:
+        print("  Extraction status:")
+        for name, count in sorted(status_counts.items(), key=lambda kv: -kv[1]):
+            print(f"    {name:30} {count}")
+    print(f"{'=' * 55}\n")
+
+
+def _register_skip_sentinel_if_appropriate(
+    collection, source_file: str, wing: str, agent: str, status: ExtractionStatus
+) -> None:
+    """Write the ``file_already_mined`` sentinel ONLY when the skip is durable.
+
+    Transient missing-dep statuses (``SKIP_NO_MARKITDOWN``, ``SKIP_NO_STRIPRTF``,
+    ``SKIP_MISSING_FORMAT_DEPS``, ``SKIP_NETWORK_TIMEOUT``) intentionally do
+    NOT mark the file as mined — installing the missing extra later (or
+    reconnecting the network) should let the next mine pass pick it up.
+    Per PR #1555 review (Copilot #14).
+    """
+    if status in _TRANSIENT_MISSING_DEP_STATUSES:
+        return
+    _register_file(collection, source_file, wing, agent)
 
 
 def _register_file(collection, source_file: str, wing: str, agent: str) -> None:
@@ -537,7 +614,11 @@ def _file_chunks_locked(
         # palace.file_already_mined reads current mtime from disk and compares
         # against the stored source_mtime metadata, so the caller just toggles
         # the flag; no need to pass mtime explicitly.
-        if file_already_mined(collection, source_file, check_mtime=True):
+        # ``extract_mode="format"`` scopes the idempotency check to format-mode
+        # drawers only — drawers from convo_miner / project miner on the same
+        # source_file don't falsely indicate "already mined" to the format
+        # miner. Per PR #1555 review (Copilot #12).
+        if file_already_mined(collection, source_file, check_mtime=True, extract_mode="format"):
             return 0, True
 
         try:
@@ -638,17 +719,16 @@ def mine_formats(
       in place because drawer IDs are deterministic (re-mining
       upserts to the same rows).
     """
-    # Local imports — chunk_text is the same chunker miner.py uses; the
-    # config object provides chunk_size / overlap / min when needed.
-    from .config import MempalaceConfig, normalize_wing_name
-    from .miner import chunk_text
+    # MempalaceConfig + chunk_text are imported at module level (above) so
+    # tests can patch ``mempalace.format_miner.MempalaceConfig`` and
+    # ``mempalace.format_miner.chunk_text`` directly. Hoisted as part of the
+    # PR #1555 polish PR (Gemini #3).
 
-    # Load palace-wide config. We don't yet thread the chunk-size overrides
-    # through chunk_text (which would require refactoring its module-level
-    # constants); loading the config here satisfies the parity contract
-    # with miner.py and gives a single place to wire the threading later.
+    # Load palace-wide config. Chunk parameters (chunk_size, chunk_overlap,
+    # min_chunk_size) are now threaded through chunk_text below, so users
+    # who customized their config see the effect in format-mode mining.
+    # Per PR #1555 review (Gemini #3).
     palace_config = MempalaceConfig()
-    _ = palace_config.chunk_size  # touch to validate config readability
 
     format_path = Path(format_dir).expanduser().resolve()
     if not wing:
@@ -680,23 +760,12 @@ def mine_formats(
             }
         ]
 
-    files = scan_formats(format_dir)
-    if limit > 0:
-        files = files[:limit]
-
-    print(f"\n{'=' * 55}")
-    print("  MemPalace Mine — Format extraction")
-    print(f"{'=' * 55}")
-    print(f"  Wing:    {wing}")
-    print(f"  Source:  {format_path}")
-    print(f"  Files:   {len(files)}")
-    print(f"  Palace:  {palace_path}")
-    if dry_run:
-        print("  DRY RUN — nothing will be filed")
-    print(f"{'-' * 55}\n")
-
-    collection = get_collection(palace_path) if not dry_run else None
-
+    # Initialize loop-state up-front so the outer try/except handlers and the
+    # post-try summary print can run safely even if scan_formats or
+    # get_collection raises before the for loop starts. Per PR #1555 review
+    # (Gemini #5).
+    files: list = []
+    collection = None
     total_drawers = 0
     files_skipped = 0
     files_with_text = 0
@@ -704,6 +773,26 @@ def mine_formats(
     status_counts: dict = defaultdict(int)
 
     try:
+        # Use the resolved ``format_path``, not the raw ``format_dir``, so that
+        # ``~/docs`` and relative inputs work consistently. Per PR #1555 review
+        # (Copilot #10).
+        files = scan_formats(format_path)
+        if limit > 0:
+            files = files[:limit]
+
+        print(f"\n{'=' * 55}")
+        print("  MemPalace Mine — Format extraction")
+        print(f"{'=' * 55}")
+        print(f"  Wing:    {wing}")
+        print(f"  Source:  {format_path}")
+        print(f"  Files:   {len(files)}")
+        print(f"  Palace:  {palace_path}")
+        if dry_run:
+            print("  DRY RUN — nothing will be filed")
+        print(f"{'-' * 55}\n")
+
+        collection = get_collection(palace_path) if not dry_run else None
+
         for i, filepath in enumerate(files, 1):
             source_file = str(filepath)
 
@@ -718,7 +807,14 @@ def mine_formats(
                 except OSError:
                     source_mtime = None
 
-                if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
+                # Pass extract_mode="format" so format-mode idempotency is
+                # scoped to its own drawer set — drawers from convo_miner /
+                # project miner on the same source_file don't falsely
+                # indicate "already mined" to the format miner. Per PR #1555
+                # review (Copilot #11).
+                if not dry_run and file_already_mined(
+                    collection, source_file, check_mtime=True, extract_mode="format"
+                ):
                     files_skipped += 1
                     continue
 
@@ -727,11 +823,22 @@ def mine_formats(
 
                 if status != ExtractionStatus.OK or not text:
                     if not dry_run:
-                        _register_file(collection, source_file, wing, agent)
+                        _register_skip_sentinel_if_appropriate(
+                            collection, source_file, wing, agent, status
+                        )
                     print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} {status.name}")
                     continue
 
-                chunks = chunk_text(text, source_file)
+                # Thread the user's MempalaceConfig chunk parameters through
+                # so format-mode mining honors their tuning. Per PR #1555
+                # review (Gemini #3).
+                chunks = chunk_text(
+                    text,
+                    source_file,
+                    chunk_size=palace_config.chunk_size,
+                    chunk_overlap=palace_config.chunk_overlap,
+                    min_chunk_size=palace_config.min_chunk_size,
+                )
                 if not chunks:
                     if not dry_run:
                         _register_file(collection, source_file, wing, agent)
@@ -782,6 +889,23 @@ def mine_formats(
         # Partial progress is safe — deterministic drawer IDs mean a re-mine
         # upserts to the same rows. Print a clean summary and exit.
         print("\n  Mine interrupted by user (Ctrl-C).")
+    except Exception as exc:
+        # Defense in depth — the per-file try/except above catches most
+        # realistic crashes, but a programming error in the outer-loop
+        # plumbing (file enumeration, scan_formats itself, etc.) would
+        # otherwise propagate as a bare traceback. Catch it here so the
+        # summary still prints and the PID-file finally-block still runs.
+        # Per PR #1555 review (Gemini #5). Mirrors miner.py's belt-and-
+        # suspenders pattern.
+        logger.warning(
+            "mine_formats: unexpected outer-loop exception — %s: %s",
+            type(exc).__name__,
+            str(exc)[:200],
+        )
+        print(
+            f"\n  Mine aborted by exception ({type(exc).__name__}: {str(exc)[:120]})",
+            file=sys.stderr,
+        )
     else:
         # All files processed without interruption — compute cross-wing topic
         # tunnels linking this wing to others that share confirmed topics.
@@ -816,16 +940,11 @@ def mine_formats(
             except Exception:
                 logger.debug("mine_formats: _cleanup_mine_pid_file failed", exc_info=True)
 
-    print(f"\n{'=' * 55}")
-    print("  Summary")
-    print(f"{'-' * 55}")
-    print(f"  Files seen:        {len(files)}")
-    print(f"  Files extracted:   {files_with_text}")
-    print(f"  Files skipped:     {files_skipped}")
-    print(f"  Files errored:     {files_errored}")
-    print(f"  Total drawers:     {total_drawers}")
-    if status_counts:
-        print("  Extraction status:")
-        for name, count in sorted(status_counts.items(), key=lambda kv: -kv[1]):
-            print(f"    {name:30} {count}")
-    print(f"{'=' * 55}\n")
+    _print_mine_summary(
+        files=files,
+        files_with_text=files_with_text,
+        files_skipped=files_skipped,
+        files_errored=files_errored,
+        total_drawers=total_drawers,
+        status_counts=status_counts,
+    )

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1034,7 +1034,7 @@ def search_memories(
 _ALREADY_NUMBERED_RE = re.compile(r"^\[\d+\]")
 
 
-def render_with_line_numbers(text, start_line: int = 1) -> str:
+def render_with_line_numbers(text: "str | None", start_line: int = 1) -> str:
     """Prefix each line of ``text`` with ``[N] `` for read-time grid display.
 
     Lines that already begin with ``[<digits>]`` pass through unchanged,

--- a/tests/test_format_miner.py
+++ b/tests/test_format_miner.py
@@ -1,14 +1,12 @@
-"""Tests for format_miner (proposed for mempalace 3.3.6).
+"""Tests for format_miner (mempalace 3.3.6, integrated in PR #1555).
 
-Covers all 13 fringe cases in the 3.3.6 format-coverage spec, plus the
-happy paths. MarkItDown is mocked throughout so tests run without the
-library installed — same discipline as the existing test_line_numbers.py.
+Covers all 14 fringe cases in the format-coverage spec plus orchestrator
+behavior. MarkItDown is mocked at the seam for most tests; a few guarded
+integration tests exercise live transformers when the optional extras are
+installed.
 
-Run from the proposal directory:
+Run with:
     pytest tests/test_format_miner.py -v
-
-After integration into the mempalace package, change the import below to:
-    from mempalace.format_miner import ...
 """
 
 from __future__ import annotations
@@ -980,7 +978,7 @@ def test_mine_formats_continues_after_per_file_error(_mine_formats_mocks):
     # Make chunk_text crash on the first file but succeed on the second.
     call_count = {"n": 0}
 
-    def chunk_text_first_fails(content, source_file):
+    def chunk_text_first_fails(content, source_file, **kwargs):
         call_count["n"] += 1
         if call_count["n"] == 1:
             raise RuntimeError("simulated chunker explosion")
@@ -989,7 +987,11 @@ def test_mine_formats_continues_after_per_file_error(_mine_formats_mocks):
     with (
         patch("mempalace.format_miner.scan_formats", return_value=[bad, good]),
         patch("mempalace.format_miner._extract_via_markitdown", return_value="text"),
-        patch("mempalace.miner.chunk_text", side_effect=chunk_text_first_fails),
+        # Patch the module-level binding in format_miner (hoisted in the
+        # PR #1555 polish work — Gemini #3). The old patch target
+        # ``mempalace.miner.chunk_text`` no longer works because
+        # format_miner now binds chunk_text at its own module scope.
+        patch("mempalace.format_miner.chunk_text", side_effect=chunk_text_first_fails),
     ):
         # Must not raise
         mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"))
@@ -1232,3 +1234,290 @@ def test_pyproject_extract_extra_pulls_markitdown_format_subdeps():
             f"[extract] must include markitdown[{sub}]; "
             f"got bracketed extras: {bracketed!r}; full extract: {extract}"
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PR #1555 review polish — bot feedback items addressed post-merge.
+# Five behavioral changes; the trivial items (path expanduser, signature
+# annotations, docstring/doc updates) don't need their own RED tests.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_text_nonexistent_regular_file_returns_unreadable_not_broken_symlink(
+    tmp_path: Path,
+):
+    """A non-existent REGULAR file (not a symlink) must return
+    ``SKIP_UNREADABLE``, not ``SKIP_BROKEN_SYMLINK``.
+
+    Per PR #1555 review (Copilot #8): the ``FileNotFoundError`` arm in
+    ``extract_text`` was unconditionally mapping to ``SKIP_BROKEN_SYMLINK``,
+    which is misleading when the path was a regular file that got deleted
+    between scan and extract. ``SKIP_BROKEN_SYMLINK`` should only fire
+    when ``p.is_symlink()`` is true.
+    """
+    p = tmp_path / "deleted.pdf"
+    assert not p.exists()
+    assert not p.is_symlink()
+    text, status = extract_text(p)
+    assert text is None
+    assert status == ExtractionStatus.SKIP_UNREADABLE, (
+        f"Expected SKIP_UNREADABLE for non-existent regular file (file was "
+        f"deleted between scan and extract); got {status}. "
+        f"SKIP_BROKEN_SYMLINK should only fire when the path is_symlink()."
+    )
+
+
+def test_mine_formats_passes_extract_mode_format_to_file_already_mined(monkeypatch, tmp_path: Path):
+    """``mine_formats`` must call ``file_already_mined`` with
+    ``extract_mode='format'`` so format-mode idempotency is scoped to its
+    own drawer set. Otherwise drawers from convo_miner / project miner
+    on the same source file falsely indicate "already mined" to the
+    format miner (and vice versa).
+
+    Per PR #1555 review (Copilot #11 + #12). Both call sites — the
+    pre-lock check in ``mine_formats`` and the post-lock recheck in
+    ``_file_chunks_locked`` — must pass the kwarg.
+    """
+    from mempalace import format_miner
+    from mempalace.format_miner import mine_formats
+
+    calls: list = []
+
+    def fake_check(collection, source_file, check_mtime=False, extract_mode=None):
+        calls.append(
+            {
+                "source_file": source_file,
+                "check_mtime": check_mtime,
+                "extract_mode": extract_mode,
+            }
+        )
+        return False  # never already mined — let the mine proceed
+
+    monkeypatch.setattr(format_miner, "file_already_mined", fake_check)
+
+    tmp = tmp_path / "src"
+    tmp.mkdir()
+    f = tmp / "x.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+
+    fake_config = {
+        "wing": "wing_test",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 50),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+        patch("mempalace.format_miner.detect_room", return_value="documents"),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), wing="wing_test")
+
+    assert calls, "expected file_already_mined to be called at least once"
+    for call in calls:
+        assert call["extract_mode"] == "format", (
+            f"file_already_mined call missing extract_mode='format': {call}"
+        )
+
+
+def test_mine_formats_does_not_write_sentinel_for_skip_no_markitdown(monkeypatch, tmp_path: Path):
+    """Sentinel writing must be skipped when the status is a transient
+    "missing optional dependency" (``SKIP_NO_MARKITDOWN``,
+    ``SKIP_NO_STRIPRTF``, ``SKIP_MISSING_FORMAT_DEPS``). Otherwise the
+    file is permanently marked as "already mined" — installing the missing
+    extra later does NOT trigger a re-mine, which is a real user surprise.
+
+    Per PR #1555 review (Copilot #14).
+    """
+    from mempalace import format_miner
+    from mempalace.format_miner import mine_formats
+
+    register_calls: list = []
+
+    def fake_register(collection, source_file, wing, agent):
+        register_calls.append(source_file)
+
+    monkeypatch.setattr(format_miner, "_register_file", fake_register)
+
+    tmp = tmp_path / "src"
+    tmp.mkdir()
+    f = tmp / "y.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+
+    fake_config = {
+        "wing": "wing_test",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+
+    # Force the extract path to raise ImportError so we hit SKIP_NO_MARKITDOWN.
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch(
+            "mempalace.format_miner._extract_via_markitdown",
+            side_effect=ImportError("no markitdown"),
+        ),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+        patch("mempalace.format_miner.detect_room", return_value="documents"),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), wing="wing_test")
+
+    assert str(f) not in register_calls, (
+        f"sentinel was written for SKIP_NO_MARKITDOWN file; should be skipped "
+        f"so installing markitdown later triggers a re-mine. "
+        f"register_calls={register_calls}"
+    )
+
+
+def test_mine_formats_does_not_write_sentinel_for_skip_missing_format_deps(
+    monkeypatch, tmp_path: Path
+):
+    """Same as the SKIP_NO_MARKITDOWN test but for SKIP_MISSING_FORMAT_DEPS
+    (raised when markitdown is installed but a per-format sub-extra like
+    ``markitdown[pdf]`` is missing).
+    """
+    from mempalace import format_miner
+    from mempalace.format_miner import mine_formats
+
+    register_calls: list = []
+
+    def fake_register(collection, source_file, wing, agent):
+        register_calls.append(source_file)
+
+    monkeypatch.setattr(format_miner, "_register_file", fake_register)
+
+    tmp = tmp_path / "src"
+    tmp.mkdir()
+    f = tmp / "z.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+
+    fake_config = {
+        "wing": "wing_test",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+
+    class _FakeMissingDep(Exception):
+        pass
+
+    _FakeMissingDep.__name__ = "MissingDependencyException"
+
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch(
+            "mempalace.format_miner._extract_via_markitdown",
+            side_effect=_FakeMissingDep("install markitdown[pdf]"),
+        ),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+        patch("mempalace.format_miner.detect_room", return_value="documents"),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), wing="wing_test")
+
+    assert str(f) not in register_calls, (
+        f"sentinel was written for SKIP_MISSING_FORMAT_DEPS file; should be "
+        f"skipped so installing markitdown[<fmt>] later triggers a re-mine. "
+        f"register_calls={register_calls}"
+    )
+
+
+def test_mine_formats_catches_unexpected_exception_and_prints_summary(
+    monkeypatch, tmp_path: Path, capsys
+):
+    """If an unexpected error happens during mining (something the
+    per-file try/except doesn't catch — e.g., the topic-tunnel block
+    blowing up in a way the inner handler misses), mine_formats must
+    catch it at the outer level, print a partial-progress summary, and
+    clean up the PID file. Not crash with a traceback to the user.
+
+    Per PR #1555 review (Gemini #5).
+    """
+    from mempalace.format_miner import mine_formats
+
+    tmp = tmp_path / "src"
+    tmp.mkdir()
+    f = tmp / "exc.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+
+    fake_config = {
+        "wing": "wing_test",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+
+    # Patch the file enumeration step to raise something unexpected —
+    # this fires OUTSIDE the per-file try/except. Without an outer
+    # ``except Exception`` clause, the traceback propagates and the
+    # summary block never prints.
+    def angry_enumerate(*args, **kwargs):
+        raise RuntimeError("simulated outer-loop explosion")
+
+    with (
+        patch("mempalace.format_miner.scan_formats", side_effect=angry_enumerate),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+    ):
+        # Must NOT raise — outer except Exception should catch.
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), wing="wing_test")
+
+
+def test_mine_formats_threads_chunk_size_from_user_config(monkeypatch, tmp_path: Path):
+    """``mine_formats`` must pass ``chunk_size`` (and ``chunk_overlap``,
+    ``min_chunk_size``) from MempalaceConfig through to ``chunk_text``.
+    Currently the config is loaded only to validate readability; the
+    custom chunk parameters are never used during format-mode mining,
+    so users who tuned their config see no effect.
+
+    Per PR #1555 review (Gemini #3).
+    """
+    from mempalace import format_miner
+    from mempalace.format_miner import mine_formats
+
+    chunk_calls: list = []
+
+    def fake_chunk_text(content, source_file, **kwargs):
+        chunk_calls.append(kwargs)
+        return [{"content": content, "chunk_index": 0}]
+
+    monkeypatch.setattr(format_miner, "chunk_text", fake_chunk_text)
+
+    tmp = tmp_path / "src"
+    tmp.mkdir()
+    f = tmp / "config.pdf"
+    f.write_bytes(b"%PDF-1.4 stub")
+
+    fake_config = {
+        "wing": "wing_test",
+        "rooms": [{"name": "documents", "keywords": ["documents"]}],
+    }
+
+    # Inject custom config values via a fake MempalaceConfig.
+    class _FakeMempalaceConfig:
+        chunk_size = 1234
+        chunk_overlap = 56
+        min_chunk_size = 78
+
+        @property
+        def palace_path(self):
+            return str(tmp_path / "palace")
+
+    monkeypatch.setattr(format_miner, "MempalaceConfig", _FakeMempalaceConfig)
+
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=[f]),
+        patch("mempalace.format_miner._extract_via_markitdown", return_value="long " * 200),
+        patch("mempalace.format_miner.load_config", return_value=fake_config),
+        patch("mempalace.format_miner.detect_room", return_value="documents"),
+        patch("mempalace.format_miner.file_already_mined", return_value=False),
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), wing="wing_test")
+
+    assert chunk_calls, "expected chunk_text to be called at least once"
+    call = chunk_calls[0]
+    assert call.get("chunk_size") == 1234, (
+        f"chunk_text called without user's chunk_size from MempalaceConfig "
+        f"(got {call.get('chunk_size')}, expected 1234). kwargs={call}"
+    )
+    assert call.get("chunk_overlap") == 56, (
+        f"chunk_text called without user's chunk_overlap "
+        f"(got {call.get('chunk_overlap')}, expected 56). kwargs={call}"
+    )
+    assert call.get("min_chunk_size") == 78, (
+        f"chunk_text called without user's min_chunk_size "
+        f"(got {call.get('min_chunk_size')}, expected 78). kwargs={call}"
+    )

--- a/tests/test_line_numbers.py
+++ b/tests/test_line_numbers.py
@@ -1,10 +1,7 @@
-"""Tests for virtual line numbering (proposed for mempalace 3.3.6).
+"""Tests for virtual line numbering (mempalace 3.3.6, integrated in PR #1555).
 
-Run from the proposal directory:
+Run with:
     pytest tests/test_line_numbers.py -v
-
-After integration into the mempalace package, change the import below to:
-    from mempalace.searcher import render_with_line_numbers, extract_line_range
 """
 
 from mempalace.searcher import (  # noqa: E402


### PR DESCRIPTION
Polish PR addressing the inline bot review feedback (Copilot + gemini-code-assist) on PR #1555 that wasn't load-bearing enough to block the original ship.

## Scope: 12 of 13 bot polish items

One item — **Copilot #13 (drawer ID delimiter collision)** — is intentionally **deferred** to its own dedicated PR because it's a breaking schema change to drawer IDs that requires migration design beyond the scope of a polish PR.

Four other bot comments were verified during audit to be **already addressed** by amendment #3 before PR #1555's merge — no action needed: `_SKIP_DIRS` dedup, `scan_formats` symlink skip, `source_mtime` tracking with `check_mtime=True`, hall + entities metadata tagging on format-mined drawers.

## What changes

### Behavioral fixes (5 items, RED-tested first)

| # | Item | Reviewer |
|---|---|---|
| 1 | `FileNotFoundError` from `extract_text` stat() now returns `SKIP_BROKEN_SYMLINK` only when the path is actually a symlink; regular files deleted between scan and extract return `SKIP_UNREADABLE` | Copilot #8 |
| 2 | Both `file_already_mined` call sites in `format_miner` now pass `extract_mode="format"` to scope idempotency to format-mode drawers | Copilot #11, #12 |
| 3 | Sentinel writes skipped for transient missing-dep statuses (`SKIP_NO_MARKITDOWN`, `SKIP_NO_STRIPRTF`, `SKIP_MISSING_FORMAT_DEPS`, `SKIP_NETWORK_TIMEOUT`) so installing the missing extra later triggers a re-mine | Copilot #14 |
| 4 | `mine_formats` outer try now also catches `Exception` (in addition to existing `KeyboardInterrupt`), logs it, prints partial-progress summary, lets `finally` PID-cleanup run | Gemini #5 |
| 5 | `chunk_size` / `chunk_overlap` / `min_chunk_size` from user's `MempalaceConfig` now threaded through to `chunk_text` in format-mode mining (previously the config was loaded only to validate readability) | Gemini #3 |

### Trivial fixes (5 items)

| # | Item | Reviewer |
|---|---|---|
| 6 | `Path(path).expanduser()` in `extract_text` so `~/docs/file.pdf` resolves | Copilot #7 |
| 7 | `Path(directory).expanduser().resolve()` in `scan_formats` | Copilot #9 |
| 8 | `scan_formats(format_path)` instead of `scan_formats(format_dir)` so the already-resolved path is used | Copilot #10 |
| 9 | `render_with_line_numbers` signature now `text: "str | None"` to match the documented + tested None handling | Copilot #15 |
| 10 | Stale doc/test framings removed (proposal-directory references, frozen test count, "MarkItDown mocked throughout" claim) | Copilot #16, #17, #18 |

### Module-level hoists (enables clean test patching)

- `MempalaceConfig` and `chunk_text` hoisted from lazy local imports to module-level so tests can patch `mempalace.format_miner.MempalaceConfig` and `mempalace.format_miner.chunk_text` directly. Follows the pattern PR #1565 used for `compute_hallways_for_wing`.

### Complexity refactor

- Extracted `_print_mine_summary` helper from `mine_formats` so the orchestrator stays under the project's `max-complexity = 25` mccabe ceiling. Behavior unchanged; pure extraction.

## Tests (RED-first)

Six new RED-first tests in `tests/test_format_miner.py`:

| Test | Asserts |
|---|---|
| `test_extract_text_nonexistent_regular_file_returns_unreadable_not_broken_symlink` | Non-existent regular file (not symlink) → `SKIP_UNREADABLE` |
| `test_mine_formats_passes_extract_mode_format_to_file_already_mined` | Both `file_already_mined` call sites pass `extract_mode="format"` |
| `test_mine_formats_does_not_write_sentinel_for_skip_no_markitdown` | Sentinel skipped for `SKIP_NO_MARKITDOWN` |
| `test_mine_formats_does_not_write_sentinel_for_skip_missing_format_deps` | Sentinel skipped for `SKIP_MISSING_FORMAT_DEPS` |
| `test_mine_formats_catches_unexpected_exception_and_prints_summary` | Outer `except Exception` prevents bare-traceback crash from setup-time errors |
| `test_mine_formats_threads_chunk_size_from_user_config` | User's `MempalaceConfig.chunk_size` is passed to `chunk_text` |

All six RED before the implementation commit (failures correctly identified the bugs they were targeting); all six GREEN after.

One existing test (`test_mine_formats_continues_after_per_file_error`) updated to patch the new module-level binding `mempalace.format_miner.chunk_text` (instead of the old source-location `mempalace.miner.chunk_text`) and to accept the `**kwargs` the call now passes through. Behavior unchanged.

## Verification

| Gate | Result |
|---|---|
| Full `pytest -q` | ✅ 2065 passed, 3 skipped, 0 regressions |
| `ruff check` | ✅ All checks passed |
| `ruff format --check` | ✅ All 4 touched files formatted (pinned 0.15.9) |
| `mine_formats` mccabe complexity | ✅ ≤ 25 (under project ceiling) |

## Deferred to follow-up

- **Drawer ID delimiter collision** (Copilot #13) — `f"{source_file}{chunk_index}"` can theoretically collide. Fixing it is a breaking schema change requiring migration design; will land as its own PR after design.