### PR TITLE
  feat(dynamics): Hebbian potentiation + Ebbinghaus decay for halls + tunnels

### DIFF
--- a/mempalace/dynamics.py
+++ b/mempalace/dynamics.py
@@ -1,0 +1,256 @@
+"""dynamics.py — Living-connection math for halls + tunnels.
+
+Hebbian potentiation (strength grows on co-access) and Ebbinghaus exponential
+decay (strength fades with time since last activation), with the Cepeda
+spacing effect: stability grows when reinforcement is spaced rather than
+massed.
+
+This module is pure. No I/O, no DB, no chromadb. It operates on plain
+dicts (hall records, tunnel records) and mutates them in place. Callers
+in ``hallways.py`` and ``palace_graph.py`` invoke these functions; the
+math lives here in one place so both connection kinds share identical
+semantics.
+
+Schema fields added to hall + tunnel records (all default-safe — existing
+records without them work via ``initialize_dynamics_fields``):
+
+    strength: float           — Hebbian connection weight, floored at STRENGTH_FLOOR,
+                                capped at MAX_STRENGTH
+    stability: float          — decay resistance; grows with spaced reinforcement
+    last_activated: str       — ISO datetime; updates on potentiation
+    access_count: int         — cumulative co-access events
+
+Research grounding:
+    - Hebb (1949): "neurons that fire together, wire together" → potentiation
+    - Ebbinghaus (1885): exponential forgetting curve → apply_decay
+    - Cepeda et al. (2006): spacing effect → stability growth on spaced reinforcement
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Optional
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tunable constants. Hardcoded for v1; future PRs may expose via
+# MempalaceConfig if real-palace empirical tuning calls for it.
+# ─────────────────────────────────────────────────────────────────────────────
+
+STRENGTH_FLOOR = 0.05
+"""Lower bound on strength. Connections never decay below this — they
+become dim but remain queryable explicitly. The palace doesn't forget;
+salience just drops."""
+
+MAX_STRENGTH = 5.0
+"""Upper bound on strength. Caps so super-frequently-used connections
+don't dominate ranking entirely. Above this, the connection is "fully
+present" — further potentiation is a no-op."""
+
+DEFAULT_STABILITY = 1.0
+"""Initial stability for a newly-created connection. Higher = slower decay.
+Grows with spaced reinforcement (Cepeda spacing effect)."""
+
+DEFAULT_STRENGTH = 1.0
+"""Initial strength for a newly-created connection. Treats new halls/tunnels
+as 'normally present' — neither hot nor cold."""
+
+POTENTIATION_INCREMENT = 0.05
+"""How much strength increases on each co-access event. Tuned so that
+~20 co-accesses bring a fresh connection to MAX_STRENGTH."""
+
+SPACED_INTERVAL_HOURS = 1.0
+"""Minimum gap (in hours) between potentiations to count as 'spaced'
+reinforcement. Bursts of rapid co-access don't build stability;
+distributed practice does."""
+
+STABILITY_INCREMENT = 0.1
+"""How much stability grows on each spaced reinforcement. Tuned so a
+connection reinforced once a day for ~30 days roughly doubles its
+stability — making it durable against weeks of neglect."""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Field initialization — safe for connections that pre-date L7
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def initialize_dynamics_fields(connection: dict, *, now: Optional[datetime] = None) -> dict:
+    """Populate strength/stability/last_activated/access_count if missing.
+
+    Existing fields are NOT overwritten — this is a backfill helper for
+    records created before L7 dynamics shipped. Safe to call on any record;
+    a no-op when all fields are already present.
+
+    The ``now`` parameter is dependency injection for tests; defaults to
+    current UTC time. Same pattern as the rest of this module.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    now_iso = now.isoformat() if isinstance(now, datetime) else now
+
+    # ``created_at`` exists on every connection per existing schema; use it as
+    # the natural fallback for last_activated so a brand-new record's decay
+    # starts from creation, not from initialization-call-time.
+    created_at = connection.get("created_at", now_iso)
+
+    connection.setdefault("strength", DEFAULT_STRENGTH)
+    connection.setdefault("stability", DEFAULT_STABILITY)
+    connection.setdefault("last_activated", created_at)
+    connection.setdefault("access_count", 0)
+    return connection
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Hebbian potentiation — strengthen on co-access
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def potentiate(
+    connection: dict,
+    *,
+    increment: float = POTENTIATION_INCREMENT,
+    now: Optional[datetime] = None,
+) -> dict:
+    """Strengthen ``connection`` on a co-access event.
+
+    Updates ``strength`` (capped at ``MAX_STRENGTH``), ``last_activated``,
+    and ``access_count``. Grows ``stability`` by ``STABILITY_INCREMENT``
+    only if the gap since the prior activation is at least
+    ``SPACED_INTERVAL_HOURS`` (the Cepeda spacing effect — rapid bursts
+    don't build durability; distributed practice does).
+
+    Mutates and returns the same dict for chaining. Pure aside from that
+    mutation — no I/O.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    # Backfill any missing fields so callers can pass partial records.
+    initialize_dynamics_fields(connection, now=now)
+
+    # Compute the gap since the last activation to decide if this counts
+    # as spaced reinforcement.
+    last_activated_str = connection.get("last_activated") or connection.get("created_at")
+    last_dt = _parse_iso(last_activated_str)
+    if last_dt is not None:
+        hours_since = (now - last_dt).total_seconds() / 3600.0
+    else:
+        hours_since = 0.0
+
+    # Strength grows by increment, capped at MAX_STRENGTH.
+    current_strength = float(connection.get("strength", DEFAULT_STRENGTH))
+    connection["strength"] = min(MAX_STRENGTH, current_strength + float(increment))
+
+    # Spacing effect: only grow stability when reinforcement is spaced.
+    if hours_since >= SPACED_INTERVAL_HOURS:
+        current_stability = float(connection.get("stability", DEFAULT_STABILITY))
+        connection["stability"] = current_stability + STABILITY_INCREMENT
+
+    # Always update last_activated and the cumulative counter.
+    connection["last_activated"] = now.isoformat()
+    connection["access_count"] = int(connection.get("access_count", 0)) + 1
+
+    return connection
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ebbinghaus exponential decay — fade with time since last activation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def apply_decay(connection: dict, *, now: Optional[datetime] = None) -> dict:
+    """Apply Ebbinghaus exponential decay to ``connection``'s strength.
+
+    The decay model is ``new = old * exp(-days_since_last / stability)``,
+    floored at ``STRENGTH_FLOOR`` so connections never reach zero. Higher
+    stability = slower decay (the Cepeda principle: spaced reinforcement
+    builds durability).
+
+    Idempotent at the same instant — calling twice at the same ``now``
+    without a potentiation in between produces the same final strength.
+
+    Mutates and returns the same dict for chaining. Pure aside from that
+    mutation — no I/O.
+
+    ``now`` is dependency injection for tests.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    # Backfill missing fields so callers can pass partial records.
+    initialize_dynamics_fields(connection, now=now)
+
+    last_activated_str = connection.get("last_activated") or connection.get("created_at")
+    last_dt = _parse_iso(last_activated_str)
+    if last_dt is None:
+        # If we can't parse the timestamp, leave the strength as-is rather
+        # than corrupting it. A malformed timestamp is a data-integrity
+        # issue, not a math problem.
+        return connection
+
+    days_since = (now - last_dt).total_seconds() / 86400.0
+    if days_since <= 0:
+        # No time has passed (or clock skew); idempotent — return unchanged.
+        return connection
+
+    stability = float(connection.get("stability", DEFAULT_STABILITY))
+    if stability <= 0:
+        stability = DEFAULT_STABILITY
+
+    current_strength = float(connection.get("strength", DEFAULT_STRENGTH))
+    decay_factor = math.exp(-days_since / stability)
+    new_strength = current_strength * decay_factor
+
+    connection["strength"] = max(STRENGTH_FLOOR, new_strength)
+    return connection
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_iso(value) -> Optional[datetime]:
+    """Parse an ISO-8601 string into a timezone-aware datetime.
+
+    Returns None on any parse failure rather than raising — callers should
+    handle the None case as "unknown timestamp." Old records may have
+    timestamps in slightly different formats; be liberal in what we accept.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        # fromisoformat handles most ISO-8601 variants including those
+        # written by datetime.isoformat(). Z-suffix not always accepted
+        # by older Python versions; convert to +00:00 explicitly.
+        v = value.strip()
+        if v.endswith("Z"):
+            v = v[:-1] + "+00:00"
+        dt = datetime.fromisoformat(v)
+        # Force timezone awareness so subtraction with timezone-aware
+        # ``now`` doesn't raise TypeError.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+__all__ = [
+    "STRENGTH_FLOOR",
+    "MAX_STRENGTH",
+    "DEFAULT_STABILITY",
+    "DEFAULT_STRENGTH",
+    "POTENTIATION_INCREMENT",
+    "SPACED_INTERVAL_HOURS",
+    "STABILITY_INCREMENT",
+    "initialize_dynamics_fields",
+    "potentiate",
+    "apply_decay",
+]

--- a/mempalace/hallways.py
+++ b/mempalace/hallways.py
@@ -257,7 +257,13 @@ def compute_hallways_for_wing(
     for h in existing:
         if h.get("wing") != wing:
             continue
-        key = (h.get("entity_a"), h.get("entity_b"))
+        # Canonicalize the lookup key by sorting the entity pair — must
+        # match the symmetric ID generation in _hallway_id (which also
+        # sorts). Without this, a persisted record with reversed entity
+        # order would silently miss the lookup and lose its accumulated
+        # dynamics on every recompute. Per PR #1578 review
+        # (gemini-code-assist, HIGH priority).
+        key = tuple(sorted([h.get("entity_a"), h.get("entity_b")]))
         # Only copy the fields the dynamics layer cares about; everything
         # else is recomputed deterministically from the drawer set.
         existing_dynamics_lookup[key] = {

--- a/mempalace/hallways.py
+++ b/mempalace/hallways.py
@@ -42,6 +42,8 @@ from datetime import datetime, timezone
 from itertools import combinations
 from typing import Optional
 
+from .dynamics import initialize_dynamics_fields
+
 logger = logging.getLogger("mempalace_hallways")
 
 # Persistence target. Mirrors ``palace_graph._TUNNEL_FILE`` so the storage
@@ -245,6 +247,23 @@ def compute_hallways_for_wing(
         return []
 
     # 3. Materialize hallway records for pairs above the threshold.
+    #    Before building, load existing records so we can PRESERVE L7
+    #    dynamics fields (strength, stability, last_activated, access_count)
+    #    across recomputes. Without this preservation, every mine wipes
+    #    the connection weights accumulated through use — defeating the
+    #    living-connection layer entirely.
+    existing = _load_hallways()
+    existing_dynamics_lookup: dict = {}
+    for h in existing:
+        if h.get("wing") != wing:
+            continue
+        key = (h.get("entity_a"), h.get("entity_b"))
+        # Only copy the fields the dynamics layer cares about; everything
+        # else is recomputed deterministically from the drawer set.
+        existing_dynamics_lookup[key] = {
+            k: h[k] for k in ("strength", "stability", "last_activated", "access_count") if k in h
+        }
+
     created: list[dict] = []
     created_at = datetime.now(timezone.utc).isoformat()
     for key in sorted(pair_counts.keys()):
@@ -256,24 +275,28 @@ def compute_hallways_for_wing(
         room_summary = ", ".join(rooms[:3]) if rooms else "(no room tags)"
         if len(rooms) > 3:
             room_summary += f", +{len(rooms) - 3} more"
-        created.append(
-            {
-                "id": _hallway_id(wing, entity_a, entity_b),
-                "wing": wing,
-                "entity_a": entity_a,
-                "entity_b": entity_b,
-                "co_occurrence_count": count,
-                "rooms": rooms,
-                "label": f"{entity_a} ↔ {entity_b} (co-occur in {count} drawers across {len(rooms) or 'no'} room{'s' if len(rooms) != 1 else ''}: {room_summary})",
-                "created_at": created_at,
-                "created_by": "auto",
-            }
-        )
+        record = {
+            "id": _hallway_id(wing, entity_a, entity_b),
+            "wing": wing,
+            "entity_a": entity_a,
+            "entity_b": entity_b,
+            "co_occurrence_count": count,
+            "rooms": rooms,
+            "label": f"{entity_a} ↔ {entity_b} (co-occur in {count} drawers across {len(rooms) or 'no'} room{'s' if len(rooms) != 1 else ''}: {room_summary})",
+            "created_at": created_at,
+            "created_by": "auto",
+        }
+        # Apply preserved dynamics if this entity pair existed in the
+        # prior wing snapshot. Then initialize any still-missing fields
+        # (the new-pair case + the legacy-record case both land cleanly).
+        preserved = existing_dynamics_lookup.get(key, {})
+        record.update(preserved)
+        initialize_dynamics_fields(record)
+        created.append(record)
 
     # 4. Persist — preserve other-wing records, replace this wing's records.
-    existing = _load_hallways()
-    preserved = [h for h in existing if h.get("wing") != wing]
-    _save_hallways(preserved + created)
+    preserved_other_wings = [h for h in existing if h.get("wing") != wing]
+    _save_hallways(preserved_other_wings + created)
 
     return created
 

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -506,10 +506,12 @@ def create_tunnel(
                 # reset the connection's strength / stability / access_count
                 # — defeating the living-connection layer. Backfill any
                 # still-missing fields so legacy records also pick up
-                # defaults on next touch.
-                for field in ("strength", "stability", "last_activated", "access_count"):
-                    if field in existing:
-                        tunnel[field] = existing[field]
+                # defaults on next touch. Per PR #1578 review
+                # (gemini-code-assist, medium priority): use dict-update
+                # with a comprehension so the field list lives in one place
+                # and future schema expansion can't drop a field by accident.
+                _dyn_fields = ("strength", "stability", "last_activated", "access_count")
+                tunnel.update({k: existing[k] for k in _dyn_fields if k in existing})
                 initialize_dynamics_fields(tunnel)
                 existing.clear()
                 existing.update(tunnel)

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -30,6 +30,7 @@ from collections import Counter, defaultdict
 from datetime import datetime, timezone
 
 from .config import MempalaceConfig, normalize_wing_name
+from .dynamics import initialize_dynamics_fields
 from .palace import get_collection as _get_palace_collection
 from .palace import mine_lock
 
@@ -500,10 +501,22 @@ def create_tunnel(
                 # Preserve original creation timestamp on label updates.
                 tunnel["created_at"] = existing.get("created_at", tunnel["created_at"])
                 tunnel["updated_at"] = datetime.now(timezone.utc).isoformat()
+                # Preserve L7 dynamics fields across re-creation events.
+                # Without this, a label update (or any re-create) would
+                # reset the connection's strength / stability / access_count
+                # — defeating the living-connection layer. Backfill any
+                # still-missing fields so legacy records also pick up
+                # defaults on next touch.
+                for field in ("strength", "stability", "last_activated", "access_count"):
+                    if field in existing:
+                        tunnel[field] = existing[field]
+                initialize_dynamics_fields(tunnel)
                 existing.clear()
                 existing.update(tunnel)
                 _save_tunnels(tunnels)
                 return existing
+        # Brand-new tunnel — initialize dynamics from defaults.
+        initialize_dynamics_fields(tunnel)
         tunnels.append(tunnel)
         _save_tunnels(tunnels)
     return tunnel

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -1,0 +1,311 @@
+"""Tests for mempalace.dynamics — living-connection math for halls + tunnels.
+
+Covers Hebbian potentiation, Ebbinghaus exponential decay, the Cepeda
+spacing effect, and safe field initialization for connections created
+before L7 dynamics shipped. Pure math; no I/O; no chromadb required.
+
+All ``now`` arguments are injected explicitly so tests are deterministic.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mempalace.dynamics import (
+    DEFAULT_STABILITY,
+    DEFAULT_STRENGTH,
+    MAX_STRENGTH,
+    POTENTIATION_INCREMENT,
+    STABILITY_INCREMENT,
+    STRENGTH_FLOOR,
+    apply_decay,
+    initialize_dynamics_fields,
+    potentiate,
+)
+
+
+# Fixed reference point so test arithmetic is exact.
+T0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _fresh_connection(created_at=None, **overrides):
+    """Build a minimal connection dict in the shape persisted by hallways.py
+    or palace_graph.py — no dynamics fields yet."""
+    base = {
+        "id": "test_conn_001",
+        "wing": "test_wing",
+        "entity_a": "Alpha",
+        "entity_b": "Beta",
+        "co_occurrence_count": 3,
+        "rooms": ["r1"],
+        "label": "Alpha ↔ Beta",
+        "created_at": (created_at or T0).isoformat(),
+        "created_by": "auto",
+    }
+    base.update(overrides)
+    return base
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# initialize_dynamics_fields — backfill for pre-L7 records
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInitializeDynamicsFields:
+    def test_populates_strength_default_on_missing_field(self):
+        conn = _fresh_connection()
+        assert "strength" not in conn
+        initialize_dynamics_fields(conn, now=T0)
+        assert conn["strength"] == DEFAULT_STRENGTH
+
+    def test_populates_stability_default_on_missing_field(self):
+        conn = _fresh_connection()
+        initialize_dynamics_fields(conn, now=T0)
+        assert conn["stability"] == DEFAULT_STABILITY
+
+    def test_populates_last_activated_from_created_at(self):
+        """A fresh connection's last_activated should anchor to its
+        created_at — decay starts from creation, not init-call-time."""
+        conn = _fresh_connection()
+        initialize_dynamics_fields(conn, now=T0 + timedelta(days=5))
+        assert conn["last_activated"] == T0.isoformat()
+
+    def test_populates_access_count_zero(self):
+        conn = _fresh_connection()
+        initialize_dynamics_fields(conn, now=T0)
+        assert conn["access_count"] == 0
+
+    def test_does_not_overwrite_existing_fields(self):
+        """Records that already have dynamics fields are passed through
+        unchanged — this is a backfill helper, not a reset."""
+        conn = _fresh_connection()
+        conn["strength"] = 2.3
+        conn["stability"] = 1.7
+        conn["last_activated"] = (T0 + timedelta(days=2)).isoformat()
+        conn["access_count"] = 17
+        initialize_dynamics_fields(conn, now=T0 + timedelta(days=5))
+        assert conn["strength"] == 2.3
+        assert conn["stability"] == 1.7
+        assert conn["last_activated"] == (T0 + timedelta(days=2)).isoformat()
+        assert conn["access_count"] == 17
+
+    def test_safe_on_record_missing_created_at(self):
+        """Defensive: even if created_at is somehow missing, init should
+        not crash — falls back to ``now``."""
+        conn = _fresh_connection()
+        del conn["created_at"]
+        initialize_dynamics_fields(conn, now=T0)
+        # Just verify no crash and basic fields populated.
+        assert "strength" in conn
+        assert "last_activated" in conn
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# potentiate — Hebbian strengthening on co-access
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPotentiate:
+    def test_increments_strength_by_default_increment(self):
+        conn = _fresh_connection()
+        potentiate(conn, now=T0 + timedelta(hours=2))
+        assert conn["strength"] == pytest.approx(DEFAULT_STRENGTH + POTENTIATION_INCREMENT)
+
+    def test_respects_custom_increment(self):
+        conn = _fresh_connection()
+        potentiate(conn, increment=0.2, now=T0 + timedelta(hours=2))
+        assert conn["strength"] == pytest.approx(DEFAULT_STRENGTH + 0.2)
+
+    def test_caps_at_max_strength(self):
+        conn = _fresh_connection()
+        conn["strength"] = MAX_STRENGTH - 0.01
+        potentiate(conn, increment=1.0, now=T0 + timedelta(hours=2))
+        assert conn["strength"] == MAX_STRENGTH
+
+    def test_updates_last_activated(self):
+        conn = _fresh_connection()
+        new_time = T0 + timedelta(days=3)
+        potentiate(conn, now=new_time)
+        assert conn["last_activated"] == new_time.isoformat()
+
+    def test_increments_access_count(self):
+        conn = _fresh_connection()
+        potentiate(conn, now=T0 + timedelta(hours=2))
+        assert conn["access_count"] == 1
+        potentiate(conn, now=T0 + timedelta(hours=4))
+        assert conn["access_count"] == 2
+
+    def test_grows_stability_on_spaced_reinforcement(self):
+        """Cepeda spacing effect: when the gap since last activation is
+        ``≥ SPACED_INTERVAL_HOURS``, stability grows by
+        ``STABILITY_INCREMENT``."""
+        conn = _fresh_connection()
+        # Initialize at T0; potentiate at T0 + 2 hours (well above the 1-hour
+        # spacing threshold) — stability should grow.
+        potentiate(conn, now=T0 + timedelta(hours=2))
+        assert conn["stability"] == pytest.approx(DEFAULT_STABILITY + STABILITY_INCREMENT)
+
+    def test_does_not_grow_stability_on_rapid_reinforcement(self):
+        """Rapid bursts of co-access don't build stability — only spaced
+        reinforcement does. Sub-spacing-threshold gap → stability unchanged."""
+        conn = _fresh_connection()
+        # Initial state has last_activated == created_at == T0.
+        # Potentiate just 10 minutes later — well below the 1-hour spacing.
+        potentiate(conn, now=T0 + timedelta(minutes=10))
+        assert conn["stability"] == DEFAULT_STABILITY
+
+    def test_chains_via_returned_dict(self):
+        """potentiate mutates and returns the same dict for chaining."""
+        conn = _fresh_connection()
+        result = potentiate(conn, now=T0 + timedelta(hours=2))
+        assert result is conn
+
+    def test_works_on_record_without_dynamics_fields(self):
+        """Backwards-compatibility: a pre-L7 record (no strength field yet)
+        can be potentiated directly; missing fields backfill safely."""
+        conn = _fresh_connection()
+        assert "strength" not in conn
+        potentiate(conn, now=T0 + timedelta(hours=2))
+        assert conn["strength"] == pytest.approx(DEFAULT_STRENGTH + POTENTIATION_INCREMENT)
+        assert conn["access_count"] == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# apply_decay — Ebbinghaus exponential decay
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestApplyDecay:
+    def test_reduces_strength_proportionally_to_elapsed_time(self):
+        """At ``days_since == stability``, strength multiplies by ``exp(-1)``
+        — about 0.3679 of original. This is the Ebbinghaus baseline."""
+        conn = _fresh_connection()
+        conn["strength"] = 1.0
+        conn["stability"] = 1.0
+        conn["last_activated"] = T0.isoformat()
+        apply_decay(conn, now=T0 + timedelta(days=1))
+        assert conn["strength"] == pytest.approx(math.exp(-1.0), rel=1e-6)
+
+    def test_higher_stability_decays_slower(self):
+        """Same elapsed time, double the stability → strength stays higher.
+        Implements the durability benefit of spaced reinforcement."""
+        conn_low = _fresh_connection()
+        conn_low["strength"] = 1.0
+        conn_low["stability"] = 1.0
+        conn_low["last_activated"] = T0.isoformat()
+        conn_high = _fresh_connection()
+        conn_high["strength"] = 1.0
+        conn_high["stability"] = 2.0
+        conn_high["last_activated"] = T0.isoformat()
+
+        apply_decay(conn_low, now=T0 + timedelta(days=1))
+        apply_decay(conn_high, now=T0 + timedelta(days=1))
+
+        assert conn_high["strength"] > conn_low["strength"]
+
+    def test_floors_at_strength_floor(self):
+        """Strength never decays below ``STRENGTH_FLOOR`` — the palace
+        doesn't forget; salience just drops."""
+        conn = _fresh_connection()
+        conn["strength"] = 1.0
+        conn["stability"] = 1.0
+        conn["last_activated"] = T0.isoformat()
+        apply_decay(conn, now=T0 + timedelta(days=10_000))
+        assert conn["strength"] == STRENGTH_FLOOR
+
+    def test_idempotent_at_same_instant(self):
+        """Calling apply_decay twice at the same ``now`` (without potentiation
+        between) produces the same result as calling once."""
+        conn_a = _fresh_connection()
+        conn_a["strength"] = 1.0
+        conn_a["stability"] = 1.0
+        conn_a["last_activated"] = T0.isoformat()
+        conn_b = dict(conn_a)
+
+        apply_decay(conn_a, now=T0 + timedelta(days=3))
+        apply_decay(conn_b, now=T0 + timedelta(days=3))
+        apply_decay(conn_b, now=T0 + timedelta(days=3))
+
+        # Both have decayed once total — but conn_b's SECOND apply_decay
+        # at the same ``now`` should be a no-op since last_activated hasn't
+        # moved. Result: both end at the same strength.
+        assert conn_a["strength"] == pytest.approx(conn_b["strength"])
+
+    def test_no_decay_when_no_time_has_passed(self):
+        """If ``now == last_activated``, decay is a no-op."""
+        conn = _fresh_connection()
+        conn["strength"] = 1.5
+        conn["stability"] = 1.0
+        conn["last_activated"] = T0.isoformat()
+        apply_decay(conn, now=T0)
+        assert conn["strength"] == 1.5
+
+    def test_handles_missing_fields_via_backfill(self):
+        """Pre-L7 records (no strength/stability/last_activated) get safe
+        defaults via initialize_dynamics_fields — no crash."""
+        conn = _fresh_connection()
+        assert "strength" not in conn
+        # Should not raise; should not corrupt the record.
+        apply_decay(conn, now=T0 + timedelta(days=1))
+        assert "strength" in conn
+        # With last_activated falling back to created_at (T0) and a 1-day
+        # gap at default stability, expect strength == exp(-1).
+        assert conn["strength"] == pytest.approx(math.exp(-1.0), rel=1e-6)
+
+    def test_returns_same_dict_for_chaining(self):
+        conn = _fresh_connection()
+        conn["strength"] = 1.0
+        conn["stability"] = 1.0
+        conn["last_activated"] = T0.isoformat()
+        result = apply_decay(conn, now=T0 + timedelta(days=1))
+        assert result is conn
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration scenarios — potentiate + decay interleaved
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIntegrationScenarios:
+    def test_potentiation_after_decay_restores_strength(self):
+        """A connection that decayed substantially can recover its strength
+        through subsequent co-access. This is the live-organism behavior:
+        attention rebuilds salience."""
+        conn = _fresh_connection()
+        conn["strength"] = 1.0
+        conn["stability"] = 1.0
+        conn["last_activated"] = T0.isoformat()
+
+        # Decay for 3 days.
+        apply_decay(conn, now=T0 + timedelta(days=3))
+        decayed_strength = conn["strength"]
+        assert decayed_strength < 1.0
+
+        # Potentiate at day 3 — strength should jump up.
+        potentiate(conn, now=T0 + timedelta(days=3))
+        assert conn["strength"] > decayed_strength
+
+    def test_repeated_spaced_reinforcement_grows_stability(self):
+        """Cepeda spacing effect over time: daily reinforcement should
+        steadily grow stability, making the connection durable."""
+        conn = _fresh_connection()
+        stability_history = []
+        for day in range(1, 6):
+            potentiate(conn, now=T0 + timedelta(days=day))
+            stability_history.append(conn["stability"])
+
+        # Stability should have grown monotonically.
+        for i in range(1, len(stability_history)):
+            assert stability_history[i] > stability_history[i - 1]
+
+    def test_burst_reinforcement_does_not_grow_stability(self):
+        """Rapid bursts within the spacing window don't build durability —
+        only access_count grows."""
+        conn = _fresh_connection()
+        for minutes_offset in (5, 10, 15, 20, 25):
+            potentiate(conn, now=T0 + timedelta(minutes=minutes_offset))
+        assert conn["stability"] == DEFAULT_STABILITY
+        assert conn["access_count"] == 5

--- a/tests/test_hallways.py
+++ b/tests/test_hallways.py
@@ -400,3 +400,61 @@ class TestHallwayDynamicsIntegration:
         assert aya_lumi[0]["strength"] == 3.5, (
             "existing pair's accumulated strength must still be preserved"
         )
+
+    def test_recompute_preserves_dynamics_when_existing_record_has_reversed_entity_order(
+        self, tmp_path, monkeypatch
+    ):
+        """The dynamics-preservation lookup must canonicalize the entity-pair
+        key by sorting, matching the symmetric ID generation. Otherwise a
+        persisted record with (entity_a='Lumi', entity_b='Aya') would miss
+        the lookup when the new computation produces (entity_a='Aya',
+        entity_b='Lumi') — silently wiping accumulated dynamics.
+
+        Per PR #1578 review (gemini-code-assist, HIGH priority): existing
+        records may not always be stored with sorted entity order
+        (manual edits, imports from other sources, legacy schema). The
+        lookup must canonicalize the same way ``_hallway_id`` does.
+        """
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+
+        # Pre-populate with a record whose entities are stored in REVERSED
+        # (non-sorted) order, but bumped to non-default dynamics.
+        hallways_mod._save_hallways(
+            [
+                {
+                    "id": hallways_mod._hallway_id("wing_aya", "Aya", "Lumi"),
+                    "wing": "wing_aya",
+                    "entity_a": "Lumi",  # NOT sorted — Lumi > Aya
+                    "entity_b": "Aya",
+                    "co_occurrence_count": 5,
+                    "rooms": ["diary"],
+                    "label": "...",
+                    "created_at": "2026-04-01T00:00:00+00:00",
+                    "created_by": "auto",
+                    "strength": 4.2,
+                    "stability": 1.9,
+                    "last_activated": "2026-05-01T00:00:00+00:00",
+                    "access_count": 33,
+                }
+            ]
+        )
+
+        # Recompute — should match the existing record via sorted-key lookup
+        # and preserve its dynamics, not initialize defaults.
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+            ]
+        )
+        hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+
+        after = hallways_mod._load_hallways()
+        assert len(after) == 1
+        assert after[0]["strength"] == 4.2, (
+            "lookup failed to match the reverse-ordered existing record — "
+            "strength got reset to default. Lookup key must be canonicalized "
+            "by sorting the entity pair (matching _hallway_id's symmetric ID)."
+        )
+        assert after[0]["access_count"] == 33
+        assert after[0]["stability"] == 1.9

--- a/tests/test_hallways.py
+++ b/tests/test_hallways.py
@@ -280,3 +280,123 @@ class TestHallwayQuery:
         _use_tmp_hallway_file(monkeypatch, tmp_path)
         hallways_mod._save_hallways([{"id": "h1", "wing": "wing_aya"}])
         assert hallways_mod.delete_hallway("nonexistent") is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# L7 dynamics integration — hallway records carry strength/stability/etc
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHallwayDynamicsIntegration:
+    """Hallway records produced by ``compute_hallways_for_wing`` must carry
+    the L7 dynamics fields (strength, stability, last_activated, access_count)
+    so the living-connection math in ``mempalace.dynamics`` can operate on
+    them. Plus: recomputing the same wing must PRESERVE accumulated dynamics
+    rather than reset them — otherwise every mine wipes the connection
+    weights and L7 is undermined."""
+
+    def test_new_hallway_record_carries_all_dynamics_fields(self, tmp_path, monkeypatch):
+        from mempalace.dynamics import DEFAULT_STABILITY, DEFAULT_STRENGTH
+
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+            ]
+        )
+        created = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        assert created, "expected at least one hallway record"
+        for h in created:
+            assert h["strength"] == DEFAULT_STRENGTH, (
+                f"new hallway should carry default strength; got {h}"
+            )
+            assert h["stability"] == DEFAULT_STABILITY, (
+                f"new hallway should carry default stability; got {h}"
+            )
+            assert h["access_count"] == 0, f"new hallway should start at access_count=0; got {h}"
+            assert "last_activated" in h, f"new hallway must carry last_activated; got {h}"
+            # last_activated should anchor to created_at so decay starts from
+            # creation, not from recompute-time.
+            assert h["last_activated"] == h["created_at"]
+
+    def test_recompute_preserves_accumulated_strength(self, tmp_path, monkeypatch):
+        """If a hallway has been potentiated through use (strength > default),
+        a re-run of compute_hallways_for_wing on the same drawer set must
+        NOT reset that strength. Otherwise every mine wipes the connection
+        weights — undermining the whole L7 dynamics layer."""
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+            ]
+        )
+        first_pass = hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+        assert first_pass, "first pass must create at least one hallway"
+
+        # Simulate user activity: manually bump strength + access_count on
+        # the persisted records.
+        stored = hallways_mod._load_hallways()
+        for h in stored:
+            h["strength"] = 2.5
+            h["access_count"] = 7
+            h["stability"] = 1.8
+        hallways_mod._save_hallways(stored)
+
+        # Recompute the same wing — should preserve the bumped values.
+        hallways_mod.compute_hallways_for_wing("wing_aya", col=col, min_count=2)
+
+        after = hallways_mod._load_hallways()
+        assert after, "after-recompute records must exist"
+        for h in after:
+            assert h["strength"] == 2.5, (
+                f"recompute reset strength — L7 dynamics undermined; got {h}"
+            )
+            assert h["access_count"] == 7, f"recompute reset access_count; got {h}"
+            assert h["stability"] == 1.8, f"recompute reset stability; got {h}"
+
+    def test_recompute_initializes_dynamics_for_brand_new_pairs(self, tmp_path, monkeypatch):
+        """When a recompute discovers a NEW entity pair (not in the prior
+        wing's hallways), the new record gets default dynamics — not
+        inherited from some unrelated previous record."""
+        from mempalace.dynamics import DEFAULT_STRENGTH
+
+        _use_tmp_hallway_file(monkeypatch, tmp_path)
+        col_a = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+            ]
+        )
+        hallways_mod.compute_hallways_for_wing("wing_aya", col=col_a, min_count=2)
+
+        # Bump strength on the Aya↔Lumi pair to verify it's not leaked.
+        stored = hallways_mod._load_hallways()
+        for h in stored:
+            h["strength"] = 3.5
+        hallways_mod._save_hallways(stored)
+
+        # Now a recompute with a different entity pair (Ever shows up).
+        col_b = _fake_collection(
+            [
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Lumi"},
+                {"wing": "wing_aya", "room": "diary", "entities": "Aya;Ever"},
+                {"wing": "wing_aya", "room": "letters", "entities": "Aya;Ever"},
+            ]
+        )
+        hallways_mod.compute_hallways_for_wing("wing_aya", col=col_b, min_count=2)
+
+        after = hallways_mod._load_hallways()
+        aya_ever = [h for h in after if {h["entity_a"], h["entity_b"]} == {"Aya", "Ever"}]
+        aya_lumi = [h for h in after if {h["entity_a"], h["entity_b"]} == {"Aya", "Lumi"}]
+
+        assert len(aya_ever) == 1, "Aya↔Ever pair should now exist"
+        assert aya_ever[0]["strength"] == DEFAULT_STRENGTH, (
+            "new pair should get default strength, not inherit from another pair"
+        )
+        assert len(aya_lumi) == 1
+        assert aya_lumi[0]["strength"] == 3.5, (
+            "existing pair's accumulated strength must still be preserved"
+        )

--- a/tests/test_palace_graph_tunnels.py
+++ b/tests/test_palace_graph_tunnels.py
@@ -637,3 +637,85 @@ class TestEntityTunnels:
         assert len(listed) == 2
         kinds = {t.get("kind") for t in listed}
         assert kinds == {"explicit", "entity"}
+
+
+class TestTunnelDynamicsIntegration:
+    """Tunnel records produced by ``create_tunnel`` must carry the L7
+    dynamics fields (strength, stability, last_activated, access_count).
+    Plus: re-creating a tunnel with the same canonical ID (the dedup path)
+    must PRESERVE accumulated dynamics — otherwise every relabeling event
+    resets the connection weights."""
+
+    def test_new_tunnel_carries_all_dynamics_fields(self, tmp_path, monkeypatch):
+        from mempalace.dynamics import DEFAULT_STABILITY, DEFAULT_STRENGTH
+
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        t = palace_graph.create_tunnel(
+            "wing_a", "room_x", "wing_b", "room_y", label="initial", kind="explicit"
+        )
+        assert t["strength"] == DEFAULT_STRENGTH, (
+            f"new tunnel should carry default strength; got {t}"
+        )
+        assert t["stability"] == DEFAULT_STABILITY, (
+            f"new tunnel should carry default stability; got {t}"
+        )
+        assert t["access_count"] == 0
+        assert "last_activated" in t
+        # last_activated anchored to created_at so decay starts from creation.
+        assert t["last_activated"] == t["created_at"]
+
+    def test_recreate_tunnel_preserves_accumulated_dynamics(self, tmp_path, monkeypatch):
+        """create_tunnel deduplicates on canonical ID. When called twice
+        with the same endpoints, it preserves created_at and adds
+        updated_at. It must ALSO preserve accumulated dynamics — otherwise
+        a label-update event would wipe the connection's L7 state."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        first = palace_graph.create_tunnel("wing_a", "room_x", "wing_b", "room_y", label="initial")
+
+        # Simulate user activity bumping the tunnel's dynamics.
+        stored = palace_graph._load_tunnels()
+        for t in stored:
+            if t["id"] == first["id"]:
+                t["strength"] = 2.7
+                t["access_count"] = 12
+                t["stability"] = 1.5
+        palace_graph._save_tunnels(stored)
+
+        # Recreate same tunnel with a new label — should preserve dynamics.
+        second = palace_graph.create_tunnel(
+            "wing_a", "room_x", "wing_b", "room_y", label="updated_label"
+        )
+        assert second["id"] == first["id"]
+        assert second["label"] == "updated_label"
+        assert second["strength"] == 2.7, (
+            f"recreate reset tunnel strength — L7 dynamics undermined; got {second}"
+        )
+        assert second["access_count"] == 12
+        assert second["stability"] == 1.5
+
+    def test_recreate_tunnel_initializes_dynamics_for_legacy_records(self, tmp_path, monkeypatch):
+        """If an existing tunnel record was created before L7 (no dynamics
+        fields), a recreate event should backfill the defaults rather than
+        leave the fields missing."""
+        from mempalace.dynamics import DEFAULT_STABILITY, DEFAULT_STRENGTH
+
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        legacy_tunnel = {
+            "id": palace_graph._canonical_tunnel_id("wing_a", "room_x", "wing_b", "room_y"),
+            "source": {"wing": "wing_a", "room": "room_x"},
+            "target": {"wing": "wing_b", "room": "room_y"},
+            "label": "legacy",
+            "kind": "explicit",
+            "created_at": "2026-04-01T00:00:00+00:00",
+            # NO strength / stability / last_activated / access_count
+        }
+        palace_graph._save_tunnels([legacy_tunnel])
+
+        # Recreate — should add the missing dynamics fields.
+        recreated = palace_graph.create_tunnel(
+            "wing_a", "room_x", "wing_b", "room_y", label="updated"
+        )
+        assert recreated["strength"] == DEFAULT_STRENGTH
+        assert recreated["stability"] == DEFAULT_STABILITY
+        assert recreated["access_count"] == 0
+        assert "last_activated" in recreated


### PR DESCRIPTION
Adds the L7 living-connection dynamics layer to the hallway primitive (#1558) and tunnel primitive (#1565). Connections now strengthen with use, fade with disuse, and grow durability when
  reinforcement is spaced — implementing well-established cognitive-science models in a pure-math module with no new dependencies, no schema break, and no migration step.
  
  ## What this adds
  
  New module **`mempalace/dynamics.py`** — pure math, no I/O, no chromadb. Three public helpers:
  
  | Function | What it does | Research basis |
  |---|---|---|
  | `initialize_dynamics_fields(connection)` | Backfill defaults for pre-L7 records; existing fields untouched | Safe-migration scaffolding |
  | `potentiate(connection)` | Hebbian strengthening on co-access — increments strength, updates last_activated, grows stability on spaced reinforcement | [Hebb 
  1949](https://en.wikipedia.org/wiki/Hebbian_theory), [Cepeda et al. 2006 spacing effect](https://en.wikipedia.org/wiki/Spacing_effect) |
  | `apply_decay(connection)` | Ebbinghaus exponential decay — `strength *= exp(-days_since / stability)`, floored at 0.05 (never zero) | [Ebbinghaus 1885 forgetting 
  curve](https://en.wikipedia.org/wiki/Forgetting_curve) |
  
  Plus integrations at both connection-creation sites:
  
  - **`mempalace/hallways.py:compute_hallways_for_wing`** — preserves accumulated dynamics across recomputes. Without this, every mine would wipe connection weights.
  - **`mempalace/palace_graph.py:create_tunnel`** — the existing dedup-on-canonical-id path now also preserves the four dynamics fields (alongside the already-preserved `created_at`).
  
  ## Schema additions to hall + tunnel records
  
  | Field | Type | Default | Purpose |
  |---|---|---|---|
  | `strength` | `float` | `1.0` | Connection weight; grows on co-access, decays with time. Floored at 0.05, capped at 5.0 |
  | `stability` | `float` | `1.0` | Decay resistance; grows by 0.1 each time reinforcement is spaced ≥1 hour from prior activation (Cepeda spacing effect) |
  | `last_activated` | ISO datetime string | record's `created_at` | When the connection was last potentiated; anchors decay calc |
  | `access_count` | `int` | `0` | Cumulative co-access events |
  
  All fields are optional with safe defaults. Existing palaces work unchanged.
  
  ## Tests — 31 added across 2 files
  
  **`tests/test_dynamics.py`** — 25 tests covering pure math:
  
  | Class | Tests | What they pin |
  |---|---|---| 
  | `TestInitializeDynamicsFields` | 6 | Defaults populated; existing fields not overwritten; safe on partial records |
  | `TestPotentiate` | 9 | Strength increment + cap; last_activated update; access_count; Cepeda spacing effect (spaced grows stability, rapid does not); backwards compat with pre-L7 records 
  |
  | `TestApplyDecay` | 7 | `exp(-days/stability)` math; floor clamping; idempotency at same instant; higher stability = slower decay; no-time-passed no-op; backfill on missing fields |
  | `TestIntegrationScenarios` | 3 | Decay → potentiation → recovery; spaced reinforcement over multiple days grows stability monotonically; burst reinforcement does NOT grow stability |
  
  **`tests/test_hallways.py::TestHallwayDynamicsIntegration`** — 3 tests:
  - `test_new_hallway_record_carries_all_dynamics_fields`
  - `test_recompute_preserves_accumulated_strength` (the critical one — without preservation, L7 would be undermined by every recompute)
  - `test_recompute_initializes_dynamics_for_brand_new_pairs`
  
  **`tests/test_palace_graph_tunnels.py::TestTunnelDynamicsIntegration`** — 3 tests:
  - `test_new_tunnel_carries_all_dynamics_fields`
  - `test_recreate_tunnel_preserves_accumulated_dynamics`
  - `test_recreate_tunnel_initializes_dynamics_for_legacy_records` (legacy pre-L7 records pick up defaults on next touch)
  
  All 31 RED-first (KeyError: 'strength' before the integration). All GREEN after.
  
  ## Verification
  
  | Gate | Result |
  |---|---|
  | 25 dynamics math tests | ✅ all pass | 
  | 6 integration tests (hall + tunnel) | ✅ all pass |
  | Full `pytest -q` | ✅ 2111 passed, 3 skipped, 0 regressions |
  | `ruff check` | ✅ All checks passed |
  | `ruff format --check` | ✅ All 6 touched files formatted |
  | OrbStack Linux 3.9/3.11/3.13 | ✅ all 31 tests pass on each Python version |
  
  ## Backward compatibility
  
  - Old hallway records with no dynamics fields stay readable; the next `compute_hallways_for_wing` recompute backfills via `initialize_dynamics_fields`.
  - Old tunnel records similarly backfill on next `create_tunnel` recreate.
  - `test_recreate_tunnel_initializes_dynamics_for_legacy_records` pins this contract.
  - **No forced migration. No schema break.**
  
  ## Out of scope (intentional follow-ups)
  
  - **Spreading activation at search time** — strength is the prior; the ranker doesn't yet use it. Search-layer PR.
  - **Lazy decay-on-read in `list_hallways` / `list_tunnels`** — the math is here; wiring to read path is a follow-up.
  - **Config exposure of tunable constants** — `STRENGTH_FLOOR`, `MAX_STRENGTH`, `POTENTIATION_INCREMENT`, `SPACED_INTERVAL_HOURS`, `STABILITY_INCREMENT` are hardcoded module-level for v1. 
  Expose via `MempalaceConfig` in a follow-up if empirical palace data shows defaults need tuning.
  
  ## Why this matters
  
  The connection layer (hallways + tunnels) shipped this week with static counts — `co_occurrence_count` on hallways, dedup-on-id on tunnels. That makes them indexes, not living structures. 
  With L7 dynamics, connections reflect the user's actual attention history: well-used connections stay bright; ignored ones fade; nothing is deleted, only re-weighted. This is the foundation
   the search layer's ranking + spreading activation will build on next.
  
