### PR TITLE
feat(closets): Tier 6a — date+line locators with content-date hierarchy

### DIFF
--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -587,6 +587,7 @@ def _file_chunks_locked(
     room,
     agent,
     source_mtime: Optional[float] = None,
+    content: Optional[str] = None,
 ):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
@@ -604,7 +605,13 @@ def _file_chunks_locked(
     """
     # Lazy imports to avoid a module-load cycle (miner.py imports from this
     # module's package, so we defer these helpers until call time).
-    from .miner import _extract_entities_for_metadata, detect_hall
+    from .miner import _extract_content_date, _extract_entities_for_metadata, detect_hall
+
+    # Tier 6a content-date: extract once per file (not per chunk). Format-mined
+    # files often have date-rich content (RTF/PDF dates in body text, mtimes on
+    # the binary source). Caller may pass ``content`` (full extracted text) for
+    # the body-scan branch; if absent, the helper still uses filename + mtime.
+    file_content_date = _extract_content_date(source_file, content or "")
 
     drawers_added = 0
     with mine_lock(source_file):
@@ -649,6 +656,17 @@ def _file_chunks_locked(
                 }
                 if source_mtime is not None:
                     meta["source_mtime"] = source_mtime
+                # Tier 6a — propagate line range from chunk dict into drawer
+                # metadata so closet pointers can carry "where in source"
+                # info. Chunks emitted by older code paths without these
+                # keys produce drawers without the keys (graceful fallback).
+                if chunk.get("line_start") is not None:
+                    meta["line_start"] = chunk["line_start"]
+                if chunk.get("line_end") is not None:
+                    meta["line_end"] = chunk["line_end"]
+                # Tier 6a content-date: shared across all chunks of the file.
+                if file_content_date:
+                    meta["content_date"] = file_content_date
                 entities = _extract_entities_for_metadata(content)
                 if entities:
                     meta["entities"] = entities
@@ -864,6 +882,7 @@ def mine_formats(
                     room,
                     agent,
                     source_mtime=source_mtime,
+                    content=text,
                 )
                 if skipped:
                     files_skipped += 1

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -475,7 +475,13 @@ def chunk_text(
     """
     Split content into drawer-sized chunks.
     Tries to split on paragraph/line boundaries.
-    Returns list of {"content": str, "chunk_index": int}
+    Returns list of {"content": str, "chunk_index": int, "line_start": int, "line_end": int}
+
+    ``line_start`` / ``line_end`` are 1-indexed line numbers in the stripped
+    source, giving an approximate locator for where the chunk came from.
+    Closet pointers (Tier 6a) use this to emit ``YYYY-MM-DD:L42-L78`` segments
+    so retrieval can jump straight to the right span without opening the
+    whole drawer.
 
     Optional params override module-level defaults when provided.
     """
@@ -531,10 +537,17 @@ def chunk_text(
 
         chunk = content[start:end].strip()
         if len(chunk) >= min_chunk_size:
+            # Tier 6a — 1-indexed line range in the stripped source.
+            # Approximate locator (±1 at boundaries is fine for "jump to
+            # roughly here"); exact-quote positioning is a future tier.
+            line_start = content[:start].count("\n") + 1
+            line_end = content[:end].count("\n") + 1
             chunks.append(
                 {
                     "content": chunk,
                     "chunk_index": chunk_index,
+                    "line_start": line_start,
+                    "line_end": line_end,
                 }
             )
             chunk_index += 1
@@ -867,6 +880,231 @@ def _extract_entities_for_metadata(content: str) -> str:
     return ";".join(capped)
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 6a content-date extraction
+#
+# Hierarchy (first match wins):
+#   1. Filename — ISO regex on stem, then dateutil fuzzy parse for natural-
+#      language formats (handles "April-6th-2011-notes", "Nov-8-2024", etc.)
+#   2. YAML frontmatter — date / created / published field
+#   3. Content body, first ~10 lines:
+#        a. ISO regex (YYYY-MM-DD / YYYY/MM/DD / YYYY.MM.DD)
+#        b. Slash dates with locale auto-disambiguation
+#           (if any day > 12 appears in the file, lock locale to DD/MM)
+#        c. dateutil fuzzy parse for natural-language ("November 8, 2024",
+#           "April 6th 2011", "8 Nov 2024", etc.)
+#   4. Filesystem mtime (os.path.getmtime)
+#   5. None — caller falls back to filed_at
+#
+# The "approximate locator" philosophy applies: this is a metadata enrichment
+# that makes closet pointers honest for content with embedded dates, NOT a
+# bulletproof timeline-reconstruction tool. Files with no date markers
+# anywhere and no filesystem mtime return None (caller uses filed_at).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_ORDINAL_SUFFIX_RE = re.compile(r"\b(\d+)(st|nd|rd|th)\b", re.IGNORECASE)
+_ISO_DATE_RE = re.compile(r"\b(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})\b")
+_SLASH_DATE_RE = re.compile(r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})\b")
+
+
+def _try_iso_match(text: str) -> Optional[str]:
+    """Try to extract YYYY-MM-DD from text via the ISO regex. Returns ISO string or None."""
+    m = _ISO_DATE_RE.search(text)
+    if not m:
+        return None
+    try:
+        from datetime import date
+
+        return date(int(m.group(1)), int(m.group(2)), int(m.group(3))).isoformat()
+    except (ValueError, TypeError):
+        return None
+
+
+def _try_filename_date(source_file: str) -> Optional[str]:
+    """Extract date from filename stem. ISO regex first, then dateutil fuzzy."""
+    try:
+        stem = Path(source_file).stem
+    except (TypeError, ValueError):
+        return None
+    if not stem:
+        return None
+
+    # ISO direct: "2024-11-08", "2024-11-08-notes", etc.
+    iso = _try_iso_match(stem)
+    if iso:
+        return iso
+
+    # Natural language: "April-6th-2011-notes", "Nov-8-2024", etc.
+    # Preprocess: strip ordinals, dashes/underscores → spaces.
+    normalized = _ORDINAL_SUFFIX_RE.sub(r"\1", stem).replace("-", " ").replace("_", " ")
+    try:
+        from dateutil import parser as dateutil_parser
+
+        dt = dateutil_parser.parse(normalized, fuzzy=True)
+        return dt.strftime("%Y-%m-%d")
+    except (ValueError, OverflowError, ImportError):
+        return None
+    except Exception:
+        # dateutil can raise unexpected exceptions on weird input; treat as no match.
+        return None
+
+
+def _try_frontmatter_date(content: str) -> Optional[str]:
+    """Extract date from YAML frontmatter date / created / published field."""
+    if not content:
+        return None
+    stripped = content.lstrip()
+    if not stripped.startswith("---"):
+        return None
+
+    lines = stripped.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    # Find closing ---
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        return None
+
+    frontmatter_text = "\n".join(lines[1:end_idx])
+    try:
+        import yaml
+
+        data = yaml.safe_load(frontmatter_text)
+    except (ImportError, Exception):
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    for field in ("date", "created", "published"):
+        value = data.get(field)
+        if value is None:
+            continue
+        # yaml.safe_load may parse ISO dates as datetime.date/datetime objects directly.
+        if hasattr(value, "strftime"):
+            return value.strftime("%Y-%m-%d")
+        # Otherwise parse via dateutil.
+        try:
+            from dateutil import parser as dateutil_parser
+
+            dt = dateutil_parser.parse(str(value))
+            return dt.strftime("%Y-%m-%d")
+        except (ValueError, OverflowError, ImportError):
+            continue
+        except Exception:
+            continue
+    return None
+
+
+def _try_content_body_date(content: str) -> Optional[str]:
+    """Scan first ~10 lines of content body for a date.
+
+    Order within the scan:
+      1. ISO regex (highest signal)
+      2. Slash dates with locale auto-disambiguation (DD/MM vs MM/DD)
+      3. dateutil fuzzy for natural-language ("November 8, 2024" etc.)
+    """
+    if not content:
+        return None
+
+    # Skip frontmatter if present.
+    stripped = content.lstrip()
+    if stripped.startswith("---"):
+        lines = stripped.split("\n")
+        for i, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                stripped = "\n".join(lines[i + 1 :])
+                break
+
+    head = "\n".join(stripped.split("\n")[:10])
+    if not head:
+        return None
+
+    # 1. ISO regex — explicit, highest confidence.
+    iso = _try_iso_match(head)
+    if iso:
+        return iso
+
+    # 2. Slash dates with locale auto-disambiguation.
+    slash_matches = _SLASH_DATE_RE.findall(head)
+    if slash_matches:
+        # If any first-number > 12, the locale MUST be DD/MM (otherwise that
+        # number couldn't be a month). Lock it for ALL dates in this file.
+        is_dd_mm = any(int(m[0]) > 12 for m in slash_matches)
+        first = slash_matches[0]
+        a, b, y = int(first[0]), int(first[1]), int(first[2])
+        if y < 100:
+            # Two-digit year — stdlib convention: 70-99 → 19xx, 00-69 → 20xx.
+            y = 1900 + y if y >= 70 else 2000 + y
+        try:
+            from datetime import date
+
+            if is_dd_mm:
+                return date(y, b, a).isoformat()
+            return date(y, a, b).isoformat()
+        except (ValueError, TypeError):
+            pass  # Fall through to dateutil fuzzy.
+
+    # 3. dateutil fuzzy — natural-language fallback ("November 8, 2024" etc.).
+    try:
+        from dateutil import parser as dateutil_parser
+
+        dt = dateutil_parser.parse(head, fuzzy=True)
+        return dt.strftime("%Y-%m-%d")
+    except (ValueError, OverflowError, ImportError):
+        return None
+    except Exception:
+        return None
+
+
+def _try_mtime_date(source_file: str) -> Optional[str]:
+    """Filesystem mtime → ISO date."""
+    try:
+        mtime = os.path.getmtime(source_file)
+    except (OSError, TypeError):
+        return None
+    try:
+        return datetime.fromtimestamp(mtime).strftime("%Y-%m-%d")
+    except (OSError, ValueError, OverflowError):
+        return None
+
+
+def _extract_content_date(source_file: str, content: str) -> Optional[str]:
+    """Extract a content date from source_file or content.
+
+    Returns ISO 'YYYY-MM-DD' string, or None if no date can be determined.
+    See module-level comment block for the full hierarchy + design rationale.
+    """
+    # 1. Filename
+    result = _try_filename_date(source_file)
+    if result:
+        return result
+
+    # 2. YAML frontmatter
+    result = _try_frontmatter_date(content)
+    if result:
+        return result
+
+    # 3. Content body
+    result = _try_content_body_date(content)
+    if result:
+        return result
+
+    # 4. Filesystem mtime
+    result = _try_mtime_date(source_file)
+    if result:
+        return result
+
+    # 5. Nothing found — caller falls back to filed_at.
+    return None
+
+
 def _build_drawer_metadata(
     wing: str,
     room: str,
@@ -875,12 +1113,24 @@ def _build_drawer_metadata(
     agent: str,
     content: str,
     source_mtime: Optional[float],
+    line_start: Optional[int] = None,
+    line_end: Optional[int] = None,
+    content_date: Optional[str] = None,
 ) -> dict:
     """Build the metadata dict for one drawer without upserting.
 
     Split out from ``add_drawer`` so ``process_file`` can batch all chunks
     of a file into a single ``collection.upsert`` — one embedding forward
     pass per batch instead of per chunk.
+
+    Tier 6a — ``line_start`` / ``line_end`` are optional 1-indexed line
+    numbers in the source file. ``content_date`` is the optional ISO date
+    extracted from filename / frontmatter / content body / mtime. When
+    passed, they're stored in metadata so closet pointers can carry
+    "where in the source" + "when the content is from" info. When omitted
+    (legacy callers, pre-Tier-6a drawers), the keys are absent from the
+    returned dict and downstream code falls back to ``filed_at`` for the
+    date and the 3-segment closet pointer format.
     """
     metadata = {
         "wing": wing,
@@ -893,6 +1143,12 @@ def _build_drawer_metadata(
     }
     if source_mtime is not None:
         metadata["source_mtime"] = source_mtime
+    if line_start is not None:
+        metadata["line_start"] = line_start
+    if line_end is not None:
+        metadata["line_end"] = line_end
+    if content_date:
+        metadata["content_date"] = content_date
     metadata["hall"] = detect_hall(content)
     entities = _extract_entities_for_metadata(content)
     if entities:
@@ -1024,6 +1280,12 @@ def process_file(
         except OSError:
             source_mtime = None
 
+        # Tier 6a content-date: extract once per file (not per chunk) and
+        # share across all chunks. Reads filename / frontmatter / content /
+        # mtime hierarchy. Returns None when nothing usable found → caller
+        # falls back to filed_at downstream.
+        file_content_date = _extract_content_date(source_file, content)
+
         drawers_added = 0
         for batch_start in range(0, len(chunks), DRAWER_UPSERT_BATCH_SIZE):
             batch_docs: list = []
@@ -1042,6 +1304,9 @@ def process_file(
                         agent,
                         chunk["content"],
                         source_mtime,
+                        line_start=chunk.get("line_start"),
+                        line_end=chunk.get("line_end"),
+                        content_date=file_content_date,
                     )
                 )
             collection.upsert(

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -912,6 +912,42 @@ _ORDINAL_SUFFIX_RE = re.compile(r"\b(\d+)(st|nd|rd|th)\b", re.IGNORECASE)
 _ISO_DATE_RE = re.compile(r"\b(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})\b")
 _SLASH_DATE_RE = re.compile(r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})\b")
 
+# Gate for dateutil fallback. A candidate string must match ONE of these
+# patterns to be considered a real date — otherwise dateutil's fuzzy mode
+# would hallucinate dates from any digit-bearing text (Igor's reproductions
+# on PR #1584: "tmp_random_file_5" → 2026-05-05, "Version 3.3.6" → 2006-03-03,
+# "Tested with 1000 drawers" → 1000-05-22, etc.). The fuzzy=True flag is
+# never set — dateutil only runs in strict mode on a substring we've
+# already validated.
+#
+# Three accepted shapes (all require a 4-digit year explicitly):
+#   1. Numeric: 4-digit year + separator + 1-2 digit month + separator + 1-2 digit day
+#      ("2024-11-08", "2024 11 08", "2024/06/15", "2024.11.08")
+#   2. Month-name + day + year: "November 8 2024", "Nov 8 2024", "Apr 6 2011"
+#   3. Day + month-name + year: "8 November 2024", "8 Nov 2024", "6 April 2011"
+#
+# Partial dates ("2024-06", "notes.2024", "Nov 8", "April 6") are
+# DELIBERATELY rejected — without all three components we'd fall back to
+# padding from today's date, which is hallucination, not extraction.
+_MONTH_NAME = (
+    r"(?:january|february|march|april|may|june|july|august|"
+    r"september|october|november|december|"
+    r"jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)"
+)
+_VALID_DATE_RE = re.compile(
+    r"(?:"
+    # Shape 1: YYYY sep MM sep DD (sep = - / . or whitespace)
+    r"\b\d{4}[-/.\s]+\d{1,2}[-/.\s]+\d{1,2}\b"
+    r"|"
+    # Shape 2: month-name + day + year
+    r"\b" + _MONTH_NAME + r"\.?[-\s]+\d{1,2}(?:st|nd|rd|th)?[,\s-]+\d{4}\b"
+    r"|"
+    # Shape 3: day + month-name + year
+    r"\b\d{1,2}(?:st|nd|rd|th)?[-\s]+" + _MONTH_NAME + r"\.?[,\s-]+\d{4}\b"
+    r")",
+    re.IGNORECASE,
+)
+
 
 def _try_iso_match(text: str) -> Optional[str]:
     """Try to extract YYYY-MM-DD from text via the ISO regex. Returns ISO string or None."""
@@ -927,7 +963,15 @@ def _try_iso_match(text: str) -> Optional[str]:
 
 
 def _try_filename_date(source_file: str) -> Optional[str]:
-    """Extract date from filename stem. ISO regex first, then dateutil fuzzy."""
+    """Extract date from filename stem.
+
+    ISO regex first (catches the canonical ``2024-11-08*`` diary pattern).
+    Then a strict regex gate (``_VALID_DATE_RE``) screens for complete
+    natural-language dates before invoking dateutil. ``fuzzy=True`` is
+    NOT used — it hallucinates dates on any digit-bearing input. Junk
+    filenames like ``tmp_random_file_5`` or ``notes.2024`` return None
+    so the caller falls through to frontmatter / content / mtime.
+    """
     try:
         stem = Path(source_file).stem
     except (TypeError, ValueError):
@@ -943,10 +987,18 @@ def _try_filename_date(source_file: str) -> Optional[str]:
     # Natural language: "April-6th-2011-notes", "Nov-8-2024", etc.
     # Preprocess: strip ordinals, dashes/underscores → spaces.
     normalized = _ORDINAL_SUFFIX_RE.sub(r"\1", stem).replace("-", " ").replace("_", " ")
+
+    # Gate: require a complete date pattern. Without this, dateutil would
+    # accept any digit-bearing junk and fabricate a date.
+    m = _VALID_DATE_RE.search(normalized)
+    if not m:
+        return None
+
     try:
         from dateutil import parser as dateutil_parser
 
-        dt = dateutil_parser.parse(normalized, fuzzy=True)
+        # Parse the matched substring only, no fuzzy mode.
+        dt = dateutil_parser.parse(m.group(0))
         return dt.strftime("%Y-%m-%d")
     except (ValueError, OverflowError, ImportError):
         return None
@@ -1064,11 +1116,17 @@ def _try_content_body_date(content: str) -> Optional[str]:
         except (ValueError, TypeError):
             pass  # Fall through to dateutil fuzzy.
 
-    # 3. dateutil fuzzy — natural-language fallback ("November 8, 2024" etc.).
+    # 3. dateutil natural-language fallback. Strict regex gate first
+    # (no fuzzy=True) — without it, dateutil hallucinates dates from any
+    # digit-bearing text. The gate requires a complete year+month+day
+    # pattern OR a month-name + day + year combination.
+    m = _VALID_DATE_RE.search(head)
+    if not m:
+        return None
     try:
         from dateutil import parser as dateutil_parser
 
-        dt = dateutil_parser.parse(head, fuzzy=True)
+        dt = dateutil_parser.parse(m.group(0))
         return dt.strftime("%Y-%m-%d")
     except (ValueError, OverflowError, ImportError):
         return None
@@ -1300,6 +1358,12 @@ def process_file(
         file_content_date = _extract_content_date(source_file, content)
 
         drawers_added = 0
+        # Accumulate drawer metadata across batches so the closet emitter
+        # below can consume it (Tier 6a date+line locators). Without this,
+        # the new ``drawer_metas`` kwarg never reaches ``build_closet_lines``
+        # in production and the 4-segment pointer form lives only in tests.
+        # Per PR #1584 review (Igor, 2026-05-22).
+        all_metas: list = []
         for batch_start in range(0, len(chunks), DRAWER_UPSERT_BATCH_SIZE):
             batch_docs: list = []
             batch_ids: list = []
@@ -1328,6 +1392,7 @@ def process_file(
                 metadatas=batch_metas,
             )
             drawers_added += len(batch_docs)
+            all_metas.extend(batch_metas)
 
         # Build closet — the searchable index pointing to these drawers.
         # Purge first: a re-mine (mtime change or normalize_version bump) must
@@ -1337,7 +1402,18 @@ def process_file(
                 f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(c['chunk_index'])).encode()).hexdigest()[:24]}"
                 for c in chunks
             ]
-            closet_lines = build_closet_lines(source_file, drawer_ids, content, wing, room)
+            # Pass drawer_metas so build_closet_lines can emit the Tier 6a
+            # 4-segment pointer (``topic|entities|YYYY-MM-DD:Lstart-Lend|→ids``)
+            # when line_start / line_end / content_date are present. Falls
+            # back to the legacy 3-segment form automatically when not.
+            closet_lines = build_closet_lines(
+                source_file,
+                drawer_ids,
+                content,
+                wing,
+                room,
+                drawer_metas=all_metas,
+            )
             closet_id_base = (
                 f"closet_{wing}_{room}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
             )

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -540,8 +540,13 @@ def chunk_text(
             # Tier 6a — 1-indexed line range in the stripped source.
             # Approximate locator (±1 at boundaries is fine for "jump to
             # roughly here"); exact-quote positioning is a future tier.
-            line_start = content[:start].count("\n") + 1
-            line_end = content[:end].count("\n") + 1
+            # Use the bounds form of ``str.count`` (counts on the original
+            # string with start/end limits) instead of slicing — slicing
+            # would allocate a new substring per chunk and produce O(N^2)
+            # work on a 500MB file with 50K chunks. Per PR #1579 review
+            # (gemini-code-assist, medium priority).
+            line_start = content.count("\n", 0, start) + 1
+            line_end = content.count("\n", 0, end) + 1
             chunks.append(
                 {
                     "content": chunk,
@@ -951,32 +956,33 @@ def _try_filename_date(source_file: str) -> Optional[str]:
 
 
 def _try_frontmatter_date(content: str) -> Optional[str]:
-    """Extract date from YAML frontmatter date / created / published field."""
+    """Extract date from YAML frontmatter date / created / published field.
+
+    Uses ``str.find`` to locate the closing ``\\n---`` delimiter and slices
+    the frontmatter directly. The earlier implementation split the entire
+    file into lines just to scan the first handful — wasteful on large
+    files. Per PR #1579 review (gemini-code-assist, medium priority).
+    """
     if not content:
         return None
     stripped = content.lstrip()
     if not stripped.startswith("---"):
         return None
 
-    lines = stripped.split("\n")
-    if not lines or lines[0].strip() != "---":
+    # Locate the closing "\n---" without materializing a line-list.
+    end_pos = stripped.find("\n---", 3)
+    if end_pos == -1:
         return None
 
-    # Find closing ---
-    end_idx = None
-    for i, line in enumerate(lines[1:], start=1):
-        if line.strip() == "---":
-            end_idx = i
-            break
-    if end_idx is None:
+    frontmatter_text = stripped[3:end_pos].strip()
+    if not frontmatter_text:
         return None
 
-    frontmatter_text = "\n".join(lines[1:end_idx])
     try:
         import yaml
 
         data = yaml.safe_load(frontmatter_text)
-    except (ImportError, Exception):
+    except Exception:
         return None
 
     if not isinstance(data, dict):
@@ -1009,20 +1015,27 @@ def _try_content_body_date(content: str) -> Optional[str]:
       1. ISO regex (highest signal)
       2. Slash dates with locale auto-disambiguation (DD/MM vs MM/DD)
       3. dateutil fuzzy for natural-language ("November 8, 2024" etc.)
+
+    Uses ``str.find`` to skip frontmatter and bounded ``str.split(..., 10)``
+    to bound the head extraction — never materializes a full line-list on a
+    large file. Per PR #1579 review (gemini-code-assist, medium priority).
     """
     if not content:
         return None
 
-    # Skip frontmatter if present.
     stripped = content.lstrip()
-    if stripped.startswith("---"):
-        lines = stripped.split("\n")
-        for i, line in enumerate(lines[1:], start=1):
-            if line.strip() == "---":
-                stripped = "\n".join(lines[i + 1 :])
-                break
 
-    head = "\n".join(stripped.split("\n")[:10])
+    # Skip frontmatter if present, using ``find`` instead of full split.
+    if stripped.startswith("---"):
+        end_fm = stripped.find("\n---", 3)
+        if end_fm != -1:
+            eol = stripped.find("\n", end_fm + 1)
+            if eol != -1:
+                stripped = stripped[eol + 1 :]
+
+    # Bounded split — maxsplit=10 caps the work to 10 newline scans rather
+    # than splitting the entire file just to look at the first 10 lines.
+    head = "\n".join(stripped.split("\n", 10)[:10])
     if not head:
         return None
 

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -237,19 +237,30 @@ def _candidate_entity_words(text: str) -> list:
     return words
 
 
-def build_closet_lines(source_file, drawer_ids, content, wing, room):
+def build_closet_lines(source_file, drawer_ids, content, wing, room, drawer_metas=None):
     """Build compact closet pointer lines from drawer content.
 
     Returns a LIST of lines (not joined). Each line is one complete topic
     pointer — never split across closets.
 
-    Format: topic|entities|→drawer_ids
+    Legacy format (3 segments): ``topic|entities|→drawer_ids``
+    Tier 6a format (4 segments): ``topic|entities|YYYY-MM-DD:Lstart-Lend|→drawer_ids``
+
+    When ``drawer_metas`` is provided and the first meta carries both
+    ``line_start``/``line_end`` plus a parseable ``filed_at``, the 4-segment
+    form is emitted so retrieval can jump to the right span. Otherwise the
+    legacy 3-segment form is used — backward compat for drawers filed before
+    Tier 6a and for direct callers that don't have metadata handy.
     """
     import re
     from pathlib import Path
 
     drawer_ref = ",".join(drawer_ids[:3])
     window = content[:CLOSET_EXTRACT_WINDOW]
+
+    # Tier 6a — date+line locator segment. Built once per call; ``None``
+    # signals "fall back to legacy 3-segment format" for every emitted line.
+    date_line_seg = _build_date_line_segment(drawer_metas)
 
     # Extract proper nouns (2+ occurrences). Uses i18n-aware patterns so
     # non-Latin names (Cyrillic, accented Latin, etc.) are also detected.
@@ -280,19 +291,67 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room):
     # Extract quotes
     quotes = re.findall(r'"([^"]{15,150})"', window)
 
-    # Build pointer lines — each one is atomic, never split
+    # Build pointer lines — each one is atomic, never split. When the
+    # Tier 6a date+line segment is available, splice it in as the 3rd
+    # pipe-separated field; otherwise emit the legacy 3-segment form.
+    def _pointer(prefix: str) -> str:
+        if date_line_seg is not None:
+            return f"{prefix}|{entity_str}|{date_line_seg}|→{drawer_ref}"
+        return f"{prefix}|{entity_str}|→{drawer_ref}"
+
     lines = []
     for topic in topics:
-        lines.append(f"{topic}|{entity_str}|→{drawer_ref}")
+        lines.append(_pointer(topic))
     for quote in quotes[:3]:
-        lines.append(f'"{quote}"|{entity_str}|→{drawer_ref}')
+        lines.append(_pointer(f'"{quote}"'))
 
     # Always have at least one line
     if not lines:
         name = Path(source_file).stem[:40]
-        lines.append(f"{wing}/{room}/{name}|{entity_str}|→{drawer_ref}")
+        lines.append(_pointer(f"{wing}/{room}/{name}"))
 
     return lines
+
+
+def _build_date_line_segment(drawer_metas):
+    """Tier 6a — produce ``YYYY-MM-DD:Lstart-Lend`` from a drawer-meta list.
+
+    Reads the first meta's ``filed_at`` (date prefix only — never the raw
+    ISO timestamp; closet pointers stay compact and grep-friendly) plus its
+    ``line_start`` / ``line_end``. Returns ``None`` when any of the three
+    fields is missing or unparseable — caller then falls back to the legacy
+    3-segment closet pointer format. The choice to read only the first meta
+    matches ``drawer_ids[:3]`` truncation in ``build_closet_lines``: pointers
+    are approximate locators, not exhaustive indexes.
+    """
+    if not drawer_metas:
+        return None
+    meta = drawer_metas[0]
+    if not isinstance(meta, dict):
+        return None
+    line_start = meta.get("line_start")
+    line_end = meta.get("line_end")
+    if line_start is None or line_end is None:
+        return None
+
+    # Tier 6a date hierarchy: prefer ``content_date`` (extracted from file
+    # content, frontmatter, filename, or mtime — see
+    # mempalace.miner._extract_content_date) when present. Fall back to
+    # ``filed_at`` (ingestion timestamp) only when no content-aware date
+    # was extractable. ``content_date`` is already an ISO ``YYYY-MM-DD``;
+    # ``filed_at`` may be a full ISO timestamp like
+    # ``2026-05-21T22:30:00.123456+00:00`` and gets truncated at ``T``.
+    content_date = meta.get("content_date")
+    if content_date:
+        date_part = str(content_date)
+    else:
+        filed_at = meta.get("filed_at")
+        if not filed_at:
+            return None
+        date_part = str(filed_at).split("T", 1)[0]
+    if not date_part:
+        return None
+    return f"{date_part}:L{line_start}-L{line_end}"
 
 
 def purge_file_closets(closets_col, source_file: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,13 @@ dependencies = [
     "chromadb>=1.5.4,<2",
     "pyyaml>=6.0,<7",
     "tomli>=2.0.0; python_version < '3.11'",
+    # Tier 6a content-date extraction uses dateutil for natural-language
+    # date parsing (filename + content body branches). It happens to install
+    # transitively today via chromadb→kubernetes→python-dateutil, but that
+    # chain is not a contract — declared explicitly here to ensure
+    # _extract_content_date keeps working if upstream kubernetes drops the
+    # dependency. Per PR #1584 review (Igor, 2026-05-22).
+    "python-dateutil>=2.8",
 ]
 
 [project.urls]

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -141,9 +141,9 @@ class TestMineLock:
         # Sort by entry time and verify the second entry is after the first exit.
         intervals.sort(key=lambda iv: iv[1])
         (_, enter_a, exit_a), (_, enter_b, exit_b) = intervals
-        assert enter_a < exit_a <= enter_b < exit_b, (
-            f"critical sections overlapped — lock failed to serialize: {intervals}"
-        )
+        assert (
+            enter_a < exit_a <= enter_b < exit_b
+        ), f"critical sections overlapped — lock failed to serialize: {intervals}"
 
 
 # ── build_closet_lines ─────────────────────────────────────────────────
@@ -218,6 +218,133 @@ class TestBuildClosetLines:
         ids = [f"drawer_{i}" for i in range(10)]
         lines = build_closet_lines("/x.md", ids, "# A\n# B", "w", "r")
         assert all("→drawer_0,drawer_1,drawer_2" in line for line in lines)
+
+    # ── Tier 6a — date + line-range pointer segment ────────────────────────
+
+    def test_includes_date_line_segment_when_metas_provided(self):
+        """When drawer_metas carry filed_at + line_start/line_end, each pointer
+        line gains a 4th pipe-separated segment of shape ``YYYY-MM-DD:Lstart-Lend``
+        between the entities and the ``→drawer_ids`` segment.
+        """
+        content = (
+            "# Auth rewrite\n\nDecided we need to migrate to passkeys. "
+            "Built the prototype with WebAuthn. Reviewed the API surface."
+        )
+        metas = [
+            {
+                "wing": "proj",
+                "room": "backend",
+                "source_file": "/proj/auth.md",
+                "filed_at": "2026-05-21T22:30:00.123456",
+                "line_start": 42,
+                "line_end": 78,
+            },
+            {
+                "wing": "proj",
+                "room": "backend",
+                "source_file": "/proj/auth.md",
+                "filed_at": "2026-05-21T22:30:00.123456",
+                "line_start": 79,
+                "line_end": 110,
+            },
+        ]
+        lines = build_closet_lines(
+            "/proj/auth.md",
+            ["drawer_a", "drawer_b"],
+            content,
+            wing="proj",
+            room="backend",
+            drawer_metas=metas,
+        )
+        assert lines
+        for line in lines:
+            parts = line.split("|")
+            assert len(parts) == 4, f"expected 4 segments, got {line!r}"
+            date_line_seg = parts[2]
+            assert (
+                date_line_seg == "2026-05-21:L42-L78"
+            ), f"date+line segment wrong: {date_line_seg!r}"
+            assert parts[3].startswith("→")
+
+    def test_falls_back_to_3_segment_format_when_metas_missing(self):
+        """Backward compat — no drawer_metas → old 3-segment pointer shape."""
+        content = "# Header\n\nBuilt the feature. Tested it."
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r")
+        for line in lines:
+            assert len(line.split("|")) == 3, f"expected 3-segment legacy format, got {line!r}"
+
+    def test_falls_back_to_3_segment_format_when_metas_lack_line_keys(self):
+        """Backward compat — metas present but no line_start/line_end → 3 segments.
+
+        Drawers filed before Tier 6a landed lack line range keys. Closets
+        built from those drawers must emit the legacy 3-segment form, not a
+        broken pointer with ``None`` or empty values.
+        """
+        content = "# Header\n\nBuilt the feature. Tested it."
+        metas = [
+            {
+                "wing": "w",
+                "room": "r",
+                "source_file": "/x.md",
+                "filed_at": "2026-05-21T10:00:00",
+                # line_start / line_end intentionally absent
+            }
+        ]
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r", drawer_metas=metas)
+        for line in lines:
+            assert (
+                len(line.split("|")) == 3
+            ), f"meta without line keys should fall back to 3-seg; got {line!r}"
+
+    def test_date_segment_uses_filed_at_date_portion_only(self):
+        """The date portion is the YYYY-MM-DD prefix of filed_at, not the
+        full ISO timestamp. Closet pointers stay compact and grep-friendly.
+        """
+        content = "# Topic\n\nDid the work. Reviewed it. Shipped it."
+        metas = [
+            {
+                "wing": "w",
+                "room": "r",
+                "source_file": "/x.md",
+                "filed_at": "2026-05-21T22:30:00.123456+00:00",
+                "line_start": 1,
+                "line_end": 12,
+            }
+        ]
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r", drawer_metas=metas)
+        for line in lines:
+            seg = line.split("|")[2]
+            assert seg.startswith("2026-05-21:L"), f"date prefix wrong in {seg!r}"
+            assert "T" not in seg, f"raw timestamp leaked into closet pointer: {seg!r}"
+
+    def test_content_date_preferred_over_filed_at(self):
+        """When meta carries content_date, the closet pointer's date segment
+        reflects content-time (the date the content is FROM), not
+        ingestion-time (the date the chunk was mined). Critical for legacy
+        content where ingestion-time would be misleading.
+        """
+        content = "# Topic\n\nDid the work. Reviewed it. Shipped it."
+        metas = [
+            {
+                "wing": "w",
+                "room": "r",
+                "source_file": "/x.md",
+                # filed_at says "we mined this last week"
+                "filed_at": "2026-05-21T22:30:00.123456+00:00",
+                # content_date says "the content itself is from Nov 8 2024"
+                "content_date": "2024-11-08",
+                "line_start": 42,
+                "line_end": 78,
+            }
+        ]
+        lines = build_closet_lines("/x.md", ["d1"], content, "w", "r", drawer_metas=metas)
+        assert lines
+        for line in lines:
+            parts = line.split("|")
+            assert len(parts) == 4, f"expected 4 segments: {line!r}"
+            assert (
+                parts[2] == "2024-11-08:L42-L78"
+            ), f"closet date segment did not prefer content_date: {parts[2]!r}"
 
 
 # ── upsert_closet_lines ───────────────────────────────────────────────
@@ -316,15 +443,15 @@ class TestMinerClosetRebuild:
         second_docs = "\n".join(second_pass["documents"]).lower()
         assert "only topic now" in second_docs
         for i in range(15):
-            assert f"topic {i}\n" not in second_docs, (
-                f"stale 'Topic {i}' from first mine survived the rebuild"
-            )
+            assert (
+                f"topic {i}\n" not in second_docs
+            ), f"stale 'Topic {i}' from first mine survived the rebuild"
         # Numbered closets that existed only in the larger first run must be gone.
         leftover = first_ids - set(second_pass["ids"])
         for stale_id in leftover:
-            assert not col.get(ids=[stale_id])["ids"], (
-                f"orphan closet {stale_id} from larger first run survived purge"
-            )
+            assert not col.get(ids=[stale_id])[
+                "ids"
+            ], f"orphan closet {stale_id} from larger first run survived purge"
 
 
 # ── _extract_drawer_ids_from_closet ───────────────────────────────────
@@ -703,9 +830,9 @@ class TestDiaryIngest:
 
         # No state file inside the user's diary dir.
         for entry in diary_dir.iterdir():
-            assert "diary_ingest" not in entry.name, (
-                f"state file leaked into user diary dir: {entry}"
-            )
+            assert (
+                "diary_ingest" not in entry.name
+            ), f"state file leaked into user diary dir: {entry}"
 
         # State file does exist under ~/.mempalace/state/.
         state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
@@ -803,13 +930,13 @@ class TestDiaryIngest:
         docs = drawers["documents"]
 
         max_len = max(len(d) for d in docs)
-        assert max_len <= 800, (
-            f"no drawer document may exceed CHUNK_SIZE=800; got max_len={max_len}"
-        )
+        assert (
+            max_len <= 800
+        ), f"no drawer document may exceed CHUNK_SIZE=800; got max_len={max_len}"
         # 3 entries with the middle entry split into >= 2 chunks → >= 4 drawers
-        assert len(docs) >= 4, (
-            f"oversized middle entry must produce multiple drawers; got {len(docs)} total drawers"
-        )
+        assert (
+            len(docs) >= 4
+        ), f"oversized middle entry must produce multiple drawers; got {len(docs)} total drawers"
 
     def test_incremental_appends_new_entry_only(self, tmp_path):
         """Regression for #1539: incremental ingest must add exactly the
@@ -858,9 +985,9 @@ class TestDiaryIngest:
 
         state = json.loads(_state_file_for(str(palace_dir), diary_dir.resolve()).read_text())
         key = "diary|2026-04-13.md"
-        assert state[key]["entry_count"] == 3, (
-            f"watermark must equal entry count; got {state[key]['entry_count']}"
-        )
+        assert (
+            state[key]["entry_count"] == 3
+        ), f"watermark must equal entry count; got {state[key]['entry_count']}"
 
         text = (diary_dir / "2026-04-13.md").read_text()
         assert len(_split_entries(text)) == state[key]["entry_count"]
@@ -893,9 +1020,9 @@ class TestDiaryIngest:
 
         indices = sorted(m["chunk_index"] for m in all_drawers["metadatas"])
         # Global counter: 0, 1, 2, ... contiguous across all entries.
-        assert indices == list(range(len(indices))), (
-            f"chunk_index must be contiguous 0..N-1 globally; got {indices}"
-        )
+        assert indices == list(
+            range(len(indices))
+        ), f"chunk_index must be contiguous 0..N-1 globally; got {indices}"
         # All chunks have the same source_file (filter target for neighbor
         # expansion). Verify the searcher-required pair (source_file +
         # chunk_index) is consistent on every drawer.
@@ -954,9 +1081,9 @@ class TestDiaryIngest:
 
         ingest_diaries(str(diary_dir), str(palace_dir), force=True)
         col = get_collection(str(palace_dir))
-        assert col.count() == 2, (
-            f"expected 2 drawers (one per header-only entry); got {col.count()}"
-        )
+        assert (
+            col.count() == 2
+        ), f"expected 2 drawers (one per header-only entry); got {col.count()}"
         docs = col.get()["documents"]
         # Each drawer holds the header line itself.
         joined = "\n".join(docs)
@@ -1027,9 +1154,9 @@ class TestDiaryIngest:
         # confirm nothing landed for this source file.
         real_col = real_get_collection(str(palace_dir))
         rows = real_col.get(where={"source_file": str(diary_dir / "2026-05-18.md")})
-        assert rows["ids"] == [], (
-            f"failed batched upsert must leave no partial drawers; got {rows['ids']}"
-        )
+        assert (
+            rows["ids"] == []
+        ), f"failed batched upsert must leave no partial drawers; got {rows['ids']}"
 
 
 # ── cross-wing tunnels ───────────────────────────────────────────────
@@ -1195,9 +1322,9 @@ class TestTunnels:
 
         assert not errors, f"worker raised: {errors}"
         tunnels = list_tunnels()
-        assert len(tunnels) == 5, (
-            f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
-        )
+        assert (
+            len(tunnels) == 5
+        ), f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
 
     def test_created_at_is_timezone_aware(self):
         """Regression: created_at must be tz-aware UTC, not naive."""

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -141,9 +141,9 @@ class TestMineLock:
         # Sort by entry time and verify the second entry is after the first exit.
         intervals.sort(key=lambda iv: iv[1])
         (_, enter_a, exit_a), (_, enter_b, exit_b) = intervals
-        assert (
-            enter_a < exit_a <= enter_b < exit_b
-        ), f"critical sections overlapped — lock failed to serialize: {intervals}"
+        assert enter_a < exit_a <= enter_b < exit_b, (
+            f"critical sections overlapped — lock failed to serialize: {intervals}"
+        )
 
 
 # ── build_closet_lines ─────────────────────────────────────────────────
@@ -261,9 +261,9 @@ class TestBuildClosetLines:
             parts = line.split("|")
             assert len(parts) == 4, f"expected 4 segments, got {line!r}"
             date_line_seg = parts[2]
-            assert (
-                date_line_seg == "2026-05-21:L42-L78"
-            ), f"date+line segment wrong: {date_line_seg!r}"
+            assert date_line_seg == "2026-05-21:L42-L78", (
+                f"date+line segment wrong: {date_line_seg!r}"
+            )
             assert parts[3].startswith("→")
 
     def test_falls_back_to_3_segment_format_when_metas_missing(self):
@@ -292,9 +292,9 @@ class TestBuildClosetLines:
         ]
         lines = build_closet_lines("/x.md", ["d1"], content, "w", "r", drawer_metas=metas)
         for line in lines:
-            assert (
-                len(line.split("|")) == 3
-            ), f"meta without line keys should fall back to 3-seg; got {line!r}"
+            assert len(line.split("|")) == 3, (
+                f"meta without line keys should fall back to 3-seg; got {line!r}"
+            )
 
     def test_date_segment_uses_filed_at_date_portion_only(self):
         """The date portion is the YYYY-MM-DD prefix of filed_at, not the
@@ -342,9 +342,9 @@ class TestBuildClosetLines:
         for line in lines:
             parts = line.split("|")
             assert len(parts) == 4, f"expected 4 segments: {line!r}"
-            assert (
-                parts[2] == "2024-11-08:L42-L78"
-            ), f"closet date segment did not prefer content_date: {parts[2]!r}"
+            assert parts[2] == "2024-11-08:L42-L78", (
+                f"closet date segment did not prefer content_date: {parts[2]!r}"
+            )
 
 
 # ── upsert_closet_lines ───────────────────────────────────────────────
@@ -443,15 +443,15 @@ class TestMinerClosetRebuild:
         second_docs = "\n".join(second_pass["documents"]).lower()
         assert "only topic now" in second_docs
         for i in range(15):
-            assert (
-                f"topic {i}\n" not in second_docs
-            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+            assert f"topic {i}\n" not in second_docs, (
+                f"stale 'Topic {i}' from first mine survived the rebuild"
+            )
         # Numbered closets that existed only in the larger first run must be gone.
         leftover = first_ids - set(second_pass["ids"])
         for stale_id in leftover:
-            assert not col.get(ids=[stale_id])[
-                "ids"
-            ], f"orphan closet {stale_id} from larger first run survived purge"
+            assert not col.get(ids=[stale_id])["ids"], (
+                f"orphan closet {stale_id} from larger first run survived purge"
+            )
 
 
 # ── _extract_drawer_ids_from_closet ───────────────────────────────────
@@ -830,9 +830,9 @@ class TestDiaryIngest:
 
         # No state file inside the user's diary dir.
         for entry in diary_dir.iterdir():
-            assert (
-                "diary_ingest" not in entry.name
-            ), f"state file leaked into user diary dir: {entry}"
+            assert "diary_ingest" not in entry.name, (
+                f"state file leaked into user diary dir: {entry}"
+            )
 
         # State file does exist under ~/.mempalace/state/.
         state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
@@ -930,13 +930,13 @@ class TestDiaryIngest:
         docs = drawers["documents"]
 
         max_len = max(len(d) for d in docs)
-        assert (
-            max_len <= 800
-        ), f"no drawer document may exceed CHUNK_SIZE=800; got max_len={max_len}"
+        assert max_len <= 800, (
+            f"no drawer document may exceed CHUNK_SIZE=800; got max_len={max_len}"
+        )
         # 3 entries with the middle entry split into >= 2 chunks → >= 4 drawers
-        assert (
-            len(docs) >= 4
-        ), f"oversized middle entry must produce multiple drawers; got {len(docs)} total drawers"
+        assert len(docs) >= 4, (
+            f"oversized middle entry must produce multiple drawers; got {len(docs)} total drawers"
+        )
 
     def test_incremental_appends_new_entry_only(self, tmp_path):
         """Regression for #1539: incremental ingest must add exactly the
@@ -985,9 +985,9 @@ class TestDiaryIngest:
 
         state = json.loads(_state_file_for(str(palace_dir), diary_dir.resolve()).read_text())
         key = "diary|2026-04-13.md"
-        assert (
-            state[key]["entry_count"] == 3
-        ), f"watermark must equal entry count; got {state[key]['entry_count']}"
+        assert state[key]["entry_count"] == 3, (
+            f"watermark must equal entry count; got {state[key]['entry_count']}"
+        )
 
         text = (diary_dir / "2026-04-13.md").read_text()
         assert len(_split_entries(text)) == state[key]["entry_count"]
@@ -1020,9 +1020,9 @@ class TestDiaryIngest:
 
         indices = sorted(m["chunk_index"] for m in all_drawers["metadatas"])
         # Global counter: 0, 1, 2, ... contiguous across all entries.
-        assert indices == list(
-            range(len(indices))
-        ), f"chunk_index must be contiguous 0..N-1 globally; got {indices}"
+        assert indices == list(range(len(indices))), (
+            f"chunk_index must be contiguous 0..N-1 globally; got {indices}"
+        )
         # All chunks have the same source_file (filter target for neighbor
         # expansion). Verify the searcher-required pair (source_file +
         # chunk_index) is consistent on every drawer.
@@ -1081,9 +1081,9 @@ class TestDiaryIngest:
 
         ingest_diaries(str(diary_dir), str(palace_dir), force=True)
         col = get_collection(str(palace_dir))
-        assert (
-            col.count() == 2
-        ), f"expected 2 drawers (one per header-only entry); got {col.count()}"
+        assert col.count() == 2, (
+            f"expected 2 drawers (one per header-only entry); got {col.count()}"
+        )
         docs = col.get()["documents"]
         # Each drawer holds the header line itself.
         joined = "\n".join(docs)
@@ -1154,9 +1154,9 @@ class TestDiaryIngest:
         # confirm nothing landed for this source file.
         real_col = real_get_collection(str(palace_dir))
         rows = real_col.get(where={"source_file": str(diary_dir / "2026-05-18.md")})
-        assert (
-            rows["ids"] == []
-        ), f"failed batched upsert must leave no partial drawers; got {rows['ids']}"
+        assert rows["ids"] == [], (
+            f"failed batched upsert must leave no partial drawers; got {rows['ids']}"
+        )
 
 
 # ── cross-wing tunnels ───────────────────────────────────────────────
@@ -1322,9 +1322,9 @@ class TestTunnels:
 
         assert not errors, f"worker raised: {errors}"
         tunnels = list_tunnels()
-        assert (
-            len(tunnels) == 5
-        ), f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
+        assert len(tunnels) == 5, (
+            f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
+        )
 
     def test_created_at_is_timezone_aware(self):
         """Regression: created_at must be tz-aware UTC, not naive."""

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -453,6 +453,55 @@ class TestMinerClosetRebuild:
                 f"orphan closet {stale_id} from larger first run survived purge"
             )
 
+    def test_production_miner_emits_4_segment_pointers_with_content_date(self, tmp_path):
+        """Regression for PR #1584 Igor review Issue #1.
+
+        Before the wiring fix, ``build_closet_lines`` learned the
+        ``drawer_metas`` kwarg but no production caller passed it — so the
+        Tier 6a 4-segment pointer (``topic|entities|YYYY-MM-DD:Lstart-Lend|
+        →drawers``) was emitted by tests only, not by real mines. This
+        test pins the end-to-end wiring: a real ``mine()`` of a file with
+        a recognizable date in its filename must produce closet documents
+        containing the 4-segment pointer with that filename-derived date.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "mempalace.yaml").write_text(
+            yaml.dump({"wing": "proj", "rooms": [{"name": "general", "description": "x"}]})
+        )
+        # Filename carries an unambiguous content date.
+        target = project / "2024-11-08-conversation.md"
+        target.write_text(
+            "# Brands of dog food\n\n"
+            "We talked about which brands work best for Osian's dog.\n"
+            "Decided to try a few organic options this month.\n" + ("Filler line.\n" * 20)
+        )
+
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace), wing_override="proj", agent="test")
+
+        col = get_closets_collection(str(palace))
+        result = col.get(where={"source_file": str(target)})
+        assert result["ids"], "production mine must write closets"
+
+        # At least one closet document must contain the 4-segment Tier 6a
+        # pointer for the date this file is from (2024-11-08).
+        joined = "\n".join(result["documents"] or [])
+        assert "2024-11-08:L" in joined, (
+            f"production miner did not emit Tier 6a 4-segment pointer; closet documents: {joined!r}"
+        )
+        # Each non-empty pointer line carrying a date locator must have 4
+        # pipe-separated segments — proving build_closet_lines was called
+        # with drawer_metas (regression for Issue #1).
+        for doc in result["documents"] or []:
+            for line in (doc or "").splitlines():
+                if "2024-11-08:L" in line and "→" in line:
+                    parts = line.split("|")
+                    assert len(parts) == 4, (
+                        f"closet line with date locator must be 4 segments, "
+                        f"got {len(parts)}: {line!r}"
+                    )
+
 
 # ── _extract_drawer_ids_from_closet ───────────────────────────────────
 

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -99,14 +99,14 @@ def test_mine_computes_hallways_for_wing_post_mine(monkeypatch):
         # Must have been called exactly once, with our wing name + a live
         # collection. We don't pin min_count — the integration may pick a
         # default that differs from the function's own default.
-        assert len(hallway_calls) == 1, (
-            f"expected compute_hallways_for_wing to be called once, got {len(hallway_calls)}"
-        )
+        assert (
+            len(hallway_calls) == 1
+        ), f"expected compute_hallways_for_wing to be called once, got {len(hallway_calls)}"
         call = hallway_calls[0]
         assert call["wing"] == "test_project"
-        assert call["col"] is not None, (
-            "must pass the live collection so hallways can query drawers"
-        )
+        assert (
+            call["col"] is not None
+        ), "must pass the live collection so hallways can query drawers"
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -553,12 +553,12 @@ def test_entity_metadata_matches_known_names_case_insensitively(monkeypatch):
     # Lowercase mentions of seeded names must still be tagged.
     result = miner._extract_entities_for_metadata("aya talked to lumi today about the palace.")
     matched = set(result.split(";")) if result else set()
-    assert "Aya" in matched, (
-        f"lowercase 'aya' must match the seeded 'Aya' (case-insensitive). Got: {matched!r}"
-    )
-    assert "Lumi" in matched, (
-        f"lowercase 'lumi' must match the seeded 'Lumi' (case-insensitive). Got: {matched!r}"
-    )
+    assert (
+        "Aya" in matched
+    ), f"lowercase 'aya' must match the seeded 'Aya' (case-insensitive). Got: {matched!r}"
+    assert (
+        "Lumi" in matched
+    ), f"lowercase 'lumi' must match the seeded 'Lumi' (case-insensitive). Got: {matched!r}"
 
     # Mixed case must also match
     result_mixed = miner._extract_entities_for_metadata("Aya saw lumi. AYA waved.")
@@ -1618,3 +1618,255 @@ def test_mine_does_not_remove_other_processes_pid_file(tmp_path):
 
     assert pid_file.exists(), "Foreign PID entries must not be removed"
     assert pid_file.read_text().strip() == str(other_pid)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 6a — chunk_text line-range emission + _build_drawer_metadata line keys
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestChunkTextLineRanges:
+    """Tier 6a — chunk_text emits 1-indexed (line_start, line_end) per chunk.
+
+    Closet pointer lines need to carry "where in the source file" info so
+    retrieval can jump straight to the relevant span instead of opening the
+    whole drawer. Line ranges live on the chunk dict, get plumbed through
+    ``_build_drawer_metadata`` into drawer metadata, then read by
+    ``build_closet_lines`` to emit ``YYYY-MM-DD:Lstart-Lend`` segments.
+    """
+
+    def test_each_chunk_carries_line_range(self):
+        from mempalace.miner import chunk_text
+
+        content = "\n".join(f"line {i}" for i in range(1, 401))  # 400 lines
+        chunks = chunk_text(content, "/x.md", chunk_size=800, chunk_overlap=80)
+        assert chunks, "should produce at least one chunk for a 400-line file"
+        for c in chunks:
+            assert "line_start" in c, f"chunk missing line_start: {c.keys()}"
+            assert "line_end" in c, f"chunk missing line_end: {c.keys()}"
+            assert isinstance(c["line_start"], int) and c["line_start"] >= 1
+            assert isinstance(c["line_end"], int) and c["line_end"] >= c["line_start"]
+
+    def test_first_chunk_starts_at_line_1(self):
+        from mempalace.miner import chunk_text
+
+        content = "\n".join(f"line {i}" for i in range(1, 200))
+        chunks = chunk_text(content, "/x.md", chunk_size=600, chunk_overlap=60)
+        assert chunks[0]["line_start"] == 1
+
+    def test_last_chunk_end_covers_final_line(self):
+        from mempalace.miner import chunk_text
+
+        total_lines = 300
+        content = "\n".join(f"line {i}" for i in range(1, total_lines + 1))
+        chunks = chunk_text(content, "/x.md", chunk_size=500, chunk_overlap=50)
+        # Last chunk's line_end must reach the final line of the source.
+        assert (
+            chunks[-1]["line_end"] >= total_lines
+        ), f"last chunk ends at L{chunks[-1]['line_end']}, expected >= L{total_lines}"
+
+    def test_single_chunk_spans_all_lines_for_small_input(self):
+        from mempalace.miner import chunk_text
+
+        content = "alpha\nbeta\ngamma\ndelta\nepsilon"  # 5 lines, well under chunk_size
+        chunks = chunk_text(content, "/x.md", chunk_size=2000, chunk_overlap=100, min_chunk_size=5)
+        assert len(chunks) == 1
+        assert chunks[0]["line_start"] == 1
+        assert chunks[0]["line_end"] == 5
+
+
+class TestBuildDrawerMetadataLineRange:
+    """Tier 6a — _build_drawer_metadata stores optional line_start / line_end.
+
+    When chunk metadata carries line range info, the drawer record carries it
+    too. When it doesn't (legacy callers, older miners), the function omits
+    the keys entirely — backward compatible.
+    """
+
+    def test_includes_line_range_when_provided(self):
+        from mempalace.miner import _build_drawer_metadata
+
+        meta = _build_drawer_metadata(
+            wing="wing_x",
+            room="room_y",
+            source_file="/file.md",
+            chunk_index=0,
+            agent="cedar",
+            content="some content here for entity scanning",
+            source_mtime=None,
+            line_start=42,
+            line_end=78,
+        )
+        assert meta.get("line_start") == 42
+        assert meta.get("line_end") == 78
+
+    def test_omits_line_range_when_not_provided(self):
+        from mempalace.miner import _build_drawer_metadata
+
+        meta = _build_drawer_metadata(
+            wing="wing_x",
+            room="room_y",
+            source_file="/file.md",
+            chunk_index=0,
+            agent="cedar",
+            content="some content",
+            source_mtime=None,
+        )
+        assert "line_start" not in meta
+        assert "line_end" not in meta
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 6a content-date extraction — hierarchy: filename → frontmatter →
+# content body → filesystem mtime → fallback to filed_at
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractContentDate:
+    """Content-date extraction returns ISO 'YYYY-MM-DD' or None.
+
+    Priority order (first match wins):
+      1. Filename patterns (via dateutil fuzzy parse on the stem)
+      2. YAML frontmatter date / created / published field
+      3. Content body, first ~10 lines:
+         - ISO substrings, Claude preambles, natural-language dates
+         - Locale auto-disambiguation when slash-separated dates appear
+      4. Filesystem mtime
+      5. None (caller falls back to filed_at)
+    """
+
+    def test_filename_iso_extracts(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "2024-11-08.md"
+        f.write_text("body content with no date inside")
+        assert _extract_content_date(str(f), f.read_text()) == "2024-11-08"
+
+    def test_filename_natural_language_with_ordinal_extracts(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "April-6th-2011-notes.md"
+        f.write_text("body content")
+        assert _extract_content_date(str(f), f.read_text()) == "2011-04-06"
+
+    def test_filename_compact_dash_format_extracts(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "Nov-8-2024.md"
+        f.write_text("body content")
+        assert _extract_content_date(str(f), f.read_text()) == "2024-11-08"
+
+    def test_yaml_frontmatter_date_field_extracts(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = (
+            "---\n"
+            "title: Some Notes\n"
+            "date: 2024-11-08\n"
+            "tags: [diary]\n"
+            "---\n\n"
+            "Body content here.\n"
+        )
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2024-11-08"
+
+    def test_yaml_frontmatter_created_field_extracts(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = "---\ncreated: 2023-07-15\n---\n\nbody\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2023-07-15"
+
+    def test_claude_session_preamble_extracts(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "transcript.md"
+        content = "Session resumed from compact on 2024-11-08\n" "User: hey lumi\n" "Lumi: hi aya\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2024-11-08"
+
+    def test_iso_date_in_first_line_extracts(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = "# Notes from 2024-11-08\n\nWe talked about brands of dog food.\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2024-11-08"
+
+    def test_natural_language_date_in_content_extracts(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = "Notes from November 8, 2024 — what we talked about today.\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2024-11-08"
+
+    def test_ambiguous_slash_date_locks_dd_mm_when_day_over_12_appears(self, tmp_path):
+        """04/11/22 + 25/03/21 in the same file → locale locks to DD/MM."""
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        # 25/03/21 cannot be MM/DD (no month 25) → file locale must be DD/MM
+        # Therefore 04/11/22 → 4 November 2022 → "2022-11-04"
+        content = "Started writing on 04/11/22.\n" "Earlier notes from 25/03/21 referenced.\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2022-11-04"
+
+    def test_ambiguous_slash_date_defaults_to_mm_dd_without_disambiguator(self, tmp_path):
+        """04/11/22 with no day-over-12 disambiguator → default to US MM/DD/YY → 2022-04-11."""
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = "Note from 04/11/22 about something.\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2022-04-11"
+
+    def test_filename_wins_over_content_date(self, tmp_path):
+        """Priority: filename pattern fires before content scan."""
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "2020-01-01.md"
+        content = "but the content says 2024-11-08 inside\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2020-01-01"
+
+    def test_frontmatter_wins_over_content_body(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = (
+            "---\ndate: 2020-01-01\n---\n\n"
+            "Body talks about 2024-11-08 but frontmatter is older.\n"
+        )
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2020-01-01"
+
+    def test_mtime_fallback_when_no_dates_found(self, tmp_path):
+        """When filename / frontmatter / content all yield nothing, fall back to mtime."""
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        f.write_text("just a sentence with no date markers at all\n")
+        # Set mtime to a known value (2023-07-15 12:00 UTC)
+        import os
+
+        target = 1689422400.0  # 2023-07-15 12:00 UTC
+        os.utime(str(f), (target, target))
+        result = _extract_content_date(str(f), f.read_text())
+        assert result == "2023-07-15", f"expected mtime fallback, got {result!r}"
+
+    def test_returns_none_when_nothing_extractable_and_file_missing(self):
+        """Graceful when source_file path doesn't exist (e.g., test fixtures)."""
+        from mempalace.miner import _extract_content_date
+
+        # No filename pattern, no content dates, no real file → None
+        result = _extract_content_date("/nonexistent/untitled.md", "just plain text\n")
+        assert result is None
+
+    def test_returns_none_for_empty_content_and_missing_file(self):
+        from mempalace.miner import _extract_content_date
+
+        result = _extract_content_date("/nonexistent/untitled.md", "")
+        assert result is None

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -99,14 +99,14 @@ def test_mine_computes_hallways_for_wing_post_mine(monkeypatch):
         # Must have been called exactly once, with our wing name + a live
         # collection. We don't pin min_count — the integration may pick a
         # default that differs from the function's own default.
-        assert (
-            len(hallway_calls) == 1
-        ), f"expected compute_hallways_for_wing to be called once, got {len(hallway_calls)}"
+        assert len(hallway_calls) == 1, (
+            f"expected compute_hallways_for_wing to be called once, got {len(hallway_calls)}"
+        )
         call = hallway_calls[0]
         assert call["wing"] == "test_project"
-        assert (
-            call["col"] is not None
-        ), "must pass the live collection so hallways can query drawers"
+        assert call["col"] is not None, (
+            "must pass the live collection so hallways can query drawers"
+        )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -553,12 +553,12 @@ def test_entity_metadata_matches_known_names_case_insensitively(monkeypatch):
     # Lowercase mentions of seeded names must still be tagged.
     result = miner._extract_entities_for_metadata("aya talked to lumi today about the palace.")
     matched = set(result.split(";")) if result else set()
-    assert (
-        "Aya" in matched
-    ), f"lowercase 'aya' must match the seeded 'Aya' (case-insensitive). Got: {matched!r}"
-    assert (
-        "Lumi" in matched
-    ), f"lowercase 'lumi' must match the seeded 'Lumi' (case-insensitive). Got: {matched!r}"
+    assert "Aya" in matched, (
+        f"lowercase 'aya' must match the seeded 'Aya' (case-insensitive). Got: {matched!r}"
+    )
+    assert "Lumi" in matched, (
+        f"lowercase 'lumi' must match the seeded 'Lumi' (case-insensitive). Got: {matched!r}"
+    )
 
     # Mixed case must also match
     result_mixed = miner._extract_entities_for_metadata("Aya saw lumi. AYA waved.")
@@ -1661,9 +1661,9 @@ class TestChunkTextLineRanges:
         content = "\n".join(f"line {i}" for i in range(1, total_lines + 1))
         chunks = chunk_text(content, "/x.md", chunk_size=500, chunk_overlap=50)
         # Last chunk's line_end must reach the final line of the source.
-        assert (
-            chunks[-1]["line_end"] >= total_lines
-        ), f"last chunk ends at L{chunks[-1]['line_end']}, expected >= L{total_lines}"
+        assert chunks[-1]["line_end"] >= total_lines, (
+            f"last chunk ends at L{chunks[-1]['line_end']}, expected >= L{total_lines}"
+        )
 
     def test_single_chunk_spans_all_lines_for_small_input(self):
         from mempalace.miner import chunk_text
@@ -1761,12 +1761,7 @@ class TestExtractContentDate:
 
         f = tmp_path / "untitled.md"
         content = (
-            "---\n"
-            "title: Some Notes\n"
-            "date: 2024-11-08\n"
-            "tags: [diary]\n"
-            "---\n\n"
-            "Body content here.\n"
+            "---\ntitle: Some Notes\ndate: 2024-11-08\ntags: [diary]\n---\n\nBody content here.\n"
         )
         f.write_text(content)
         assert _extract_content_date(str(f), content) == "2024-11-08"
@@ -1783,7 +1778,7 @@ class TestExtractContentDate:
         from mempalace.miner import _extract_content_date
 
         f = tmp_path / "transcript.md"
-        content = "Session resumed from compact on 2024-11-08\n" "User: hey lumi\n" "Lumi: hi aya\n"
+        content = "Session resumed from compact on 2024-11-08\nUser: hey lumi\nLumi: hi aya\n"
         f.write_text(content)
         assert _extract_content_date(str(f), content) == "2024-11-08"
 
@@ -1810,7 +1805,7 @@ class TestExtractContentDate:
         f = tmp_path / "untitled.md"
         # 25/03/21 cannot be MM/DD (no month 25) → file locale must be DD/MM
         # Therefore 04/11/22 → 4 November 2022 → "2022-11-04"
-        content = "Started writing on 04/11/22.\n" "Earlier notes from 25/03/21 referenced.\n"
+        content = "Started writing on 04/11/22.\nEarlier notes from 25/03/21 referenced.\n"
         f.write_text(content)
         assert _extract_content_date(str(f), content) == "2022-11-04"
 
@@ -1837,8 +1832,7 @@ class TestExtractContentDate:
 
         f = tmp_path / "untitled.md"
         content = (
-            "---\ndate: 2020-01-01\n---\n\n"
-            "Body talks about 2024-11-08 but frontmatter is older.\n"
+            "---\ndate: 2020-01-01\n---\n\nBody talks about 2024-11-08 but frontmatter is older.\n"
         )
         f.write_text(content)
         assert _extract_content_date(str(f), content) == "2020-01-01"

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -1864,3 +1864,115 @@ class TestExtractContentDate:
 
         result = _extract_content_date("/nonexistent/untitled.md", "")
         assert result is None
+
+    # ── Negative cases — verbatim from Igor's PR #1584 review ──────────────
+    # Per Igor (2026-05-22 11:18 UTC): dateutil.parser.parse(fuzzy=True)
+    # hallucinates dates on benign inputs. These tests pin the fix: junk
+    # filenames and digit-bearing-but-not-date content must NOT yield a
+    # fabricated date. Each input here returned a confident wrong date
+    # before the fix; each must return None after.
+
+    def test_no_hallucination_junk_filename_with_trailing_digit(self):
+        """Filename like 'tmp_random_file_5' returned '2026-05-05' before fix."""
+        from mempalace.miner import _extract_content_date
+
+        # /nonexistent ensures mtime fallback returns None (so any non-None
+        # result would be a hallucinated date, not a real mtime).
+        result = _extract_content_date("/nonexistent/tmp_random_file_5.md", "")
+        assert result is None, f"junk filename hallucinated date {result!r}"
+
+    def test_no_hallucination_untitled_with_index(self):
+        """Filename like 'untitled-1' returned '2026-05-01' before fix."""
+        from mempalace.miner import _extract_content_date
+
+        result = _extract_content_date("/nonexistent/untitled-1.md", "")
+        assert result is None, f"untitled-N hallucinated date {result!r}"
+
+    def test_no_hallucination_filename_year_only(self):
+        """Filename like 'notes.2024.md' returned '2024-05-22' before fix
+        (year extracted, month+day fabricated from today).
+        """
+        from mempalace.miner import _extract_content_date
+
+        result = _extract_content_date("/nonexistent/notes.2024.md", "")
+        assert result is None, (
+            f"year-only filename hallucinated date {result!r}; "
+            "year + month-name OR year-month-day required"
+        )
+
+    def test_no_hallucination_filename_year_and_month_only(self):
+        """Filename like '2024-06.md' returned '2024-06-22' before fix
+        (year+month extracted, day fabricated from today).
+
+        A filename must carry a complete year+month+day OR a recognizable
+        month-name token to be accepted as a content date — partial
+        year-month with day padded from today is hallucination.
+        """
+        from mempalace.miner import _extract_content_date
+
+        result = _extract_content_date("/nonexistent/2024-06.md", "")
+        assert result is None, f"year-month-only filename hallucinated date {result!r}"
+
+    def test_no_hallucination_content_with_issue_number(self):
+        """Content 'Bug fix for issue 42 in module 7' returned '2042-07-22'
+        before fix.
+        """
+        from mempalace.miner import _extract_content_date
+
+        content = "Bug fix for issue 42 in module 7\n\nMore body text here.\n"
+        result = _extract_content_date("/nonexistent/issue.md", content)
+        assert result is None, f"issue-number content hallucinated date {result!r}"
+
+    def test_no_hallucination_content_with_count(self):
+        """Content 'Tested with 1000 drawers' returned '1000-05-22' before fix
+        (year 1000 AD!).
+        """
+        from mempalace.miner import _extract_content_date
+
+        content = "Tested with 1000 drawers in this configuration.\n"
+        result = _extract_content_date("/nonexistent/test.md", content)
+        assert result is None, f"count-in-content hallucinated date {result!r}"
+
+    def test_no_hallucination_content_with_version_number(self):
+        """Content 'Version 3.3.6 released' returned '2006-03-03' before fix."""
+        from mempalace.miner import _extract_content_date
+
+        content = "Version 3.3.6 released today with new features.\n"
+        result = _extract_content_date("/nonexistent/release.md", content)
+        assert result is None, f"version-number content hallucinated date {result!r}"
+
+    # ── Two-digit year boundary (per Igor smaller-item #4) ─────────────────
+    # The stdlib convention is 70-99 → 19xx, 00-69 → 20xx. Pin the boundary.
+
+    def test_two_digit_year_69_is_2069(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        # 25/03/69 — day > 12 forces DD/MM, then 69 → 2069
+        content = "Plan from 25/03/69 timeline.\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2069-03-25"
+
+    def test_two_digit_year_70_is_1970(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = "Note from 25/03/70.\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "1970-03-25"
+
+    def test_two_digit_year_99_is_1999(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = "Reference from 25/12/99 archives.\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "1999-12-25"
+
+    def test_two_digit_year_00_is_2000(self, tmp_path):
+        from mempalace.miner import _extract_content_date
+
+        f = tmp_path / "untitled.md"
+        content = "Y2K reference: 25/01/00.\n"
+        f.write_text(content)
+        assert _extract_content_date(str(f), content) == "2000-01-25"


### PR DESCRIPTION
Closet pointer lines gain a 4th pipe-separated segment of shape ``YYYY-MM-DD:Lstart-Lend`` so retrieval can jump straight to the right span in the source file instead of opening the whole drawer. The date is selected via a content-aware hierarchy so legacy ingests (where ``filed_at`` is misleading) still produce honest pointers when the content itself carries a date.

The legacy 3-segment format remains the fallback for drawers without the new metadata, so existing palaces keep working without a re-mine.

## Pointer shape

Before:
  topic|entities|→drawer_ids

After (when drawer metadata carries line range + a date):
  topic|entities|2024-11-08:L42-L78|→drawer_ids

Backward compat: when ``drawer_metas`` is not passed, or the first meta lacks ``line_start`` / ``line_end``, ``build_closet_lines`` emits the legacy 3-segment form unchanged.

## Date-source hierarchy (NEW)

A new helper ``mempalace.miner._extract_content_date(source_file, content)`` selects a date once per file and stores it as ``content_date`` on every drawer mined from that file. Priority order, first match wins:

  1. **Filename** — ISO regex on stem, then dateutil fuzzy parse for natural-language formats. Handles ``2024-11-08.md``, ``April-6th-2011-notes.md``, ``Nov-8-2024.md``, etc.

  2. **YAML frontmatter** — looks at ``date`` / ``created`` / ``published`` fields. yaml.safe_load already parses ISO dates as ``datetime.date`` objects; dateutil handles string values.

  3. **Content body, first ~10 lines** — a. ISO regex (``YYYY-MM-DD`` / ``YYYY/MM/DD`` / ``YYYY.MM.DD``) b. Slash dates with locale auto-disambiguation: if any first-number > 12 appears anywhere in the head, lock the file's locale to DD/MM (the only consistent reading); otherwise default to US MM/DD for two-digit-year compactness. c. dateutil fuzzy parse for natural-language (``November 8, 2024``, ``8th November 2024``, etc.)

  4. **Filesystem mtime** — ``os.path.getmtime`` formatted as ``YYYY-MM-DD``.

  5. **None** — caller (``_build_drawer_metadata``) leaves ``content_date`` absent; ``build_closet_lines`` falls back to the ``filed_at`` ingestion timestamp's date portion.

``_build_date_line_segment`` in ``palace.py`` now prefers ``content_date`` when present, otherwise uses ``filed_at[:10]``. This is the load-bearing change that makes Tier 6a meaningful for legacy content — a Nov 8 2024 transcript mined today now emits ``2024-11-08:L42-L78`` instead of ``2026-05-22:L42-L78``.

## Changes

1. ``mempalace/miner.py::chunk_text`` — each chunk dict now also carries ``line_start`` / ``line_end`` (1-indexed line numbers in the stripped source). Computed via ``content[:offset].count("\n") + 1`` — approximate locator accurate to ±1 line at chunk boundaries.

2. ``mempalace/miner.py::_extract_content_date`` (NEW) + helpers (``_try_filename_date``, ``_try_frontmatter_date``, ``_try_content_body_date``, ``_try_mtime_date``). Pure functions, no I/O beyond what's named. Uses lazy imports of ``dateutil`` and ``yaml`` to keep top-level import surface unchanged.

3. ``mempalace/miner.py::_build_drawer_metadata`` — gains ``line_start`` / ``line_end`` / ``content_date`` optional kwargs. When provided, stored in drawer metadata; when omitted, keys are absent from the dict — backward compatible.

4. ``mempalace/miner.py`` batched-upsert path — calls ``_extract_content_date(source_file, content)`` ONCE per file (not once per chunk) and passes the result through to every chunk's ``_build_drawer_metadata`` call.

5. ``mempalace/format_miner.py::_file_chunks_locked`` — gains a ``content`` param so the format-miner path can also run ``_extract_content_date`` on the full extracted text. Plumbs ``content_date`` into every batched drawer's metadata. Caller passes ``text`` (the full extracted markdown).

6. ``mempalace/palace.py::build_closet_lines`` — accepts optional ``drawer_metas`` (parallel to ``drawer_ids``). When present and the first meta has both ``line_start`` and ``line_end``, the new segment is spliced in; otherwise legacy 3-segment form. Helper ``_build_date_line_segment`` prefers ``content_date`` over ``filed_at`` for the date portion.

## Tests added (RED-first, then GREEN)

  tests/test_miner.py::TestChunkTextLineRanges          (4 tests)
  tests/test_miner.py::TestBuildDrawerMetadataLineRange (2 tests)
  tests/test_miner.py::TestExtractContentDate           (15 tests)
    - filename ISO / natural-language / compact
    - YAML frontmatter date / created
    - Claude session preamble
    - ISO + natural-language content body
    - Slash-date locale disambiguation (DD/MM lock vs default MM/DD)
    - Priority order (filename > frontmatter > content > mtime)
    - mtime fallback
    - Graceful None returns for missing file / empty content

  tests/test_closets.py::TestBuildClosetLines           (5 new tests)
    - includes_date_line_segment_when_metas_provided
    - falls_back_to_3_segment_format_when_metas_missing  (compat)
    - falls_back_to_3_segment_format_when_metas_lack_line_keys (compat)
    - date_segment_uses_filed_at_date_portion_only
    - content_date_preferred_over_filed_at               (new — Tier 6a hierarchy)

26 new tests total. All RED before this commit, all GREEN after.

## Verification

  pytest tests/test_miner.py::TestChunkTextLineRanges
         tests/test_miner.py::TestBuildDrawerMetadataLineRange
         tests/test_miner.py::TestExtractContentDate
         tests/test_closets.py::TestBuildClosetLines
    → 32 passed

  pytest tests/test_miner.py tests/test_closets.py
         tests/test_format_miner.py tests/test_palace.py
    → 230 passed, 2 skipped, 0 regressions in directly-affected files

  ruff check + ruff format --check
    → All checks passed, 5 files already formatted

  End-to-end smoke test on a YAML-frontmatter file (date: 2024-11-08,
  mined "today"):
    content_date extracted: 2024-11-08
    chunks produced: 1
    drawer meta: content_date=2024-11-08, filed_at='2026-05-22...', lines=1-15
    closet pointer:
      "conversation with lumi about brands of dog food|Filler;Lumi;Aya|2024-11-08:L1-L15|→drawer_a,drawer_b"
    → content_date correctly preferred over filed_at end-to-end.

  OrbStack triple-Linux verify (Py 3.9 / 3.11 / 3.13)
    → 32 targeted Tier 6a + content-date tests pass on each.


## What does this PR do?

Adds date+line locators to closet pointers with a content-aware date hierarchy (filename → frontmatter → content body → mtime → filed_at). See commit body for full design.

## How to test

- pytest tests/test_miner.py tests/test_closets.py tests/test_format_miner.py tests/test_palace.py
 - Try mining a file with YAML frontmatter `date: 2024-11-08` and verify closet pointers reflect that date, not today's filed_at.
  


## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`) (32 new + 230 in directly-affected files)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)
