### PR TITLE
fix(hooks_cli): guard parents[3] access against shallow filesystem paths

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -75,13 +75,28 @@ def _mempalace_python() -> str:
         return env_python
     # This file lives at <venv>/lib/pythonX.Y/site-packages/mempalace/hooks_cli.py
     # or <project>/mempalace/hooks_cli.py (editable install).
-    venv_bin = Path(__file__).resolve().parents[3] / "bin" / "python"
-    if venv_bin.is_file():
-        return str(venv_bin)
+    #
+    # Both ``parents[3]`` and ``parents[1]`` access can raise IndexError when
+    # the package lives at a shallow filesystem path — Docker containers
+    # mounting at ``/work``, ``/opt/app``, or other minimal-prefix installs
+    # don't have 4 (or sometimes even 2) parent directories. Guard each
+    # access so we fall through to the next strategy instead of crashing
+    # the hook with an IndexError that would kill any Claude-Code session
+    # using mempalace.
+    resolved = Path(__file__).resolve()
+    try:
+        venv_bin = resolved.parents[3] / "bin" / "python"
+        if venv_bin.is_file():
+            return str(venv_bin)
+    except IndexError:
+        pass
     # Editable install: assumes project root has a venv/ sibling to mempalace/
-    project_venv = Path(__file__).resolve().parents[1] / "venv" / "bin" / "python"
-    if project_venv.is_file():
-        return str(project_venv)
+    try:
+        project_venv = resolved.parents[1] / "venv" / "bin" / "python"
+        if project_venv.is_file():
+            return str(project_venv)
+    except IndexError:
+        pass
     return sys.executable
 
 

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -76,27 +76,23 @@ def _mempalace_python() -> str:
     # This file lives at <venv>/lib/pythonX.Y/site-packages/mempalace/hooks_cli.py
     # or <project>/mempalace/hooks_cli.py (editable install).
     #
-    # Both ``parents[3]`` and ``parents[1]`` access can raise IndexError when
-    # the package lives at a shallow filesystem path — Docker containers
-    # mounting at ``/work``, ``/opt/app``, or other minimal-prefix installs
-    # don't have 4 (or sometimes even 2) parent directories. Guard each
-    # access so we fall through to the next strategy instead of crashing
-    # the hook with an IndexError that would kill any Claude-Code session
-    # using mempalace.
-    resolved = Path(__file__).resolve()
-    try:
-        venv_bin = resolved.parents[3] / "bin" / "python"
+    # ``parents[3]`` / ``parents[1]`` would raise IndexError when the package
+    # lives at a shallow filesystem path — Docker containers mounting at
+    # ``/work``, ``/opt/app``, or other minimal-prefix installs don't have 4
+    # (or sometimes even 2) parent directories. Use ``len(parents)`` to
+    # check the depth before indexing; LBYL is the standard Python idiom
+    # for bounded-integer lookups. Per PR #1580 review (gemini-code-assist,
+    # medium priority).
+    parents = Path(__file__).resolve().parents
+    if len(parents) > 3:
+        venv_bin = parents[3] / "bin" / "python"
         if venv_bin.is_file():
             return str(venv_bin)
-    except IndexError:
-        pass
     # Editable install: assumes project root has a venv/ sibling to mempalace/
-    try:
-        project_venv = resolved.parents[1] / "venv" / "bin" / "python"
+    if len(parents) > 1:
+        project_venv = parents[1] / "venv" / "bin" / "python"
         if project_venv.is_file():
             return str(project_venv)
-    except IndexError:
-        pass
     return sys.executable
 
 

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -85,30 +85,36 @@ def test_mempalace_python_handles_shallow_path_without_crashing(monkeypatch):
     """Regression: _mempalace_python must not raise IndexError when the
     package lives at a shallow filesystem path.
 
-    The function indexes ``Path(__file__).resolve().parents[3]`` to find the
-    venv root in a standard ``<venv>/lib/python3.X/site-packages/mempalace/``
-    install. In editable installs at a shallow path (Docker containers
-    mounting at ``/work``, ``/opt/app``, etc.), ``parents`` has fewer than
-    4 elements and the index raises ``IndexError``. Affected sites where
-    this surfaces: Docker-based dev, OrbStack-style cross-platform CI,
+    The function used to index ``Path(__file__).resolve().parents[3]`` to
+    find the venv root for the standard ``<venv>/lib/python3.X/site-packages/
+    mempalace/`` install. In editable installs at a shallow path (Docker
+    containers mounting at ``/work``, ``/opt/app``, etc.), ``parents`` has
+    fewer than 4 elements and the bare index would raise ``IndexError``.
+    Affected sites: Docker-based dev, OrbStack-style cross-platform CI,
     minimal-prefix production installs.
 
-    The fix guards the ``parents[3]`` access so the function falls through
-    to the editable-install case (parents[1]) and ultimately to
-    sys.executable, instead of crashing.
+    The fix uses ``len(parents)`` LBYL checks so the function falls through
+    to the editable-install branch (``parents[1]``) and ultimately to
+    ``sys.executable``, instead of crashing.
     """
+    from pathlib import Path as RealPath
     from unittest.mock import MagicMock, patch
 
-    from pathlib import Path as RealPath
+    # Build a fake parents sequence with only 3 elements (indices 0, 1, 2);
+    # ``parents[3]`` would raise IndexError if accessed. Production code
+    # uses ``len(parents) > 3`` LBYL guard to skip that branch, so the
+    # IndexError should never actually fire — but ``side_effect`` keeps it
+    # defensive against a future regression that drops the length check.
+    def get_item(idx):
+        if idx == 1:
+            return RealPath("/work/mempalace")
+        raise IndexError(idx)
 
-    # Build a fake Path whose .resolve().parents has only 3 elements
-    # (indexes 0, 1, 2 — so [3] would raise IndexError).
-    fake_path = MagicMock()
-    # parents[1] still works (editable-install branch)
     fake_parents = MagicMock()
-    fake_parents.__getitem__ = lambda self, idx: (
-        RealPath("/work/mempalace") if idx == 1 else (_ for _ in ()).throw(IndexError(idx))
-    )
+    fake_parents.__len__.return_value = 3
+    fake_parents.__getitem__.side_effect = get_item
+
+    fake_path = MagicMock()
     fake_path.resolve.return_value.parents = fake_parents
 
     with patch("mempalace.hooks_cli.Path", return_value=fake_path):

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -81,6 +81,44 @@ def test_mempalace_python_finds_venv():
     assert result and "python" in os.path.basename(result).lower()
 
 
+def test_mempalace_python_handles_shallow_path_without_crashing(monkeypatch):
+    """Regression: _mempalace_python must not raise IndexError when the
+    package lives at a shallow filesystem path.
+
+    The function indexes ``Path(__file__).resolve().parents[3]`` to find the
+    venv root in a standard ``<venv>/lib/python3.X/site-packages/mempalace/``
+    install. In editable installs at a shallow path (Docker containers
+    mounting at ``/work``, ``/opt/app``, etc.), ``parents`` has fewer than
+    4 elements and the index raises ``IndexError``. Affected sites where
+    this surfaces: Docker-based dev, OrbStack-style cross-platform CI,
+    minimal-prefix production installs.
+
+    The fix guards the ``parents[3]`` access so the function falls through
+    to the editable-install case (parents[1]) and ultimately to
+    sys.executable, instead of crashing.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from pathlib import Path as RealPath
+
+    # Build a fake Path whose .resolve().parents has only 3 elements
+    # (indexes 0, 1, 2 — so [3] would raise IndexError).
+    fake_path = MagicMock()
+    # parents[1] still works (editable-install branch)
+    fake_parents = MagicMock()
+    fake_parents.__getitem__ = lambda self, idx: (
+        RealPath("/work/mempalace") if idx == 1 else (_ for _ in ()).throw(IndexError(idx))
+    )
+    fake_path.resolve.return_value.parents = fake_parents
+
+    with patch("mempalace.hooks_cli.Path", return_value=fake_path):
+        # Must not raise; must return SOME string (either editable-venv
+        # fallback path or sys.executable).
+        result = _mempalace_python()
+        assert isinstance(result, str)
+        assert "python" in result.lower()
+
+
 # --- _sanitize_session_id ---
 
 


### PR DESCRIPTION
``_mempalace_python()`` in ``mempalace/hooks_cli.py`` uses ``Path(__file__).resolve().parents[3]`` to locate the venv Python interpreter in the standard install layout
``<venv>/lib/pythonX.Y/site-packages/mempalace/hooks_cli.py``. When the package lives at a shallow filesystem path — Docker containers mounting at ``/work``, ``/opt/app``, minimal-prefix production installs — ``parents`` has fewer than 4 elements and the index raises ``IndexError`` instead of falling through to the editable-install branch.

The crash was caught by OrbStack-based triple-Python CI verification on PR #1579: 16 tests in ``test_hooks_cli.py`` failed identically on Linux 3.9 / 3.11 / 3.13 with the same ``IndexError: 3`` from ``pathlib._PathBase.parents.__getitem__`` — and verified pre-existing on develop tip in the same container. The bug never surfaces in GitHub Actions CI runners (their workdir at
``/home/runner/work/mempalace/mempalace`` has plenty of parent directories) but it surfaces immediately for anyone:

  - running mempalace in editable mode inside a Docker dev container
  - shipping mempalace as part of an OCI image where the install prefix is ``/app`` or ``/opt/<name>``
  - using OrbStack / Colima / podman-machine for cross-version verification

## The fix

Wrap each ``parents[N]`` access in ``try/except IndexError`` so the helper falls through to the next strategy (editable-install → ``sys.executable``) instead of crashing the hook. Both ``parents[3]`` AND ``parents[1]`` are guarded — the latter is defensive against extreme cases like a file at root (``/file.py``, parents=[/]) — same class of bug.

## Test added (RED-first, then GREEN)

  tests/test_hooks_cli.py::test_mempalace_python_handles_shallow_path_without_crashing

Mocks ``Path(__file__).resolve()`` so ``parents[3]`` raises ``IndexError`` and ``parents[1]`` returns a real shallow path (``/work/mempalace``). Pre-commit: function raises ``IndexError: 3``. Post-commit: function returns a valid Python interpreter path (either editable-venv if present, otherwise ``sys.executable``).

## Verification

  pytest tests/test_hooks_cli.py
    → 110 passed, 1 skipped on macOS (the existing run)
    → 110 passed, 1 skipped on Linux 3.9 / 3.11 / 3.13 (OrbStack)
       — was 16 failed, 94 passed before this commit

  ruff check + ruff format --check (pinned 0.15.9)
    → All checks passed; 2 files already formatted

## What does this PR do?

## How to test

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)
