### PR TITLE
perf(miner,palace): hoist COCA filter imports out of per-drawer hot paths

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -19,10 +19,12 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Optional
 
+from .entity_detector import _get_coca_filter
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
     MineValidationError,
+    _candidate_entity_words,
     _open_collection_or_explain,
     _validate_palace_fts5_after_mine,
     build_closet_lines,
@@ -866,9 +868,6 @@ def _extract_entities_for_metadata(content: str) -> str:
         # in chat transcripts and voice-typed content get silently untagged.
         if re.search(r"(?<!\w)" + re.escape(name) + r"(?!\w)", content, re.IGNORECASE):
             matched.add(name)
-
-    from .entity_detector import _get_coca_filter
-    from .palace import _candidate_entity_words
 
     coca_filter = _get_coca_filter()
     window = content[:_ENTITY_EXTRACT_WINDOW]

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 from .backends import BackendClosedError, CollectionNotInitializedError, PalaceNotFoundError
 from .backends.chroma import ChromaBackend
+from .entity_detector import _get_coca_filter
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -264,8 +265,6 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room, drawer_meta
 
     # Extract proper nouns (2+ occurrences). Uses i18n-aware patterns so
     # non-Latin names (Cyrillic, accented Latin, etc.) are also detected.
-    from .entity_detector import _get_coca_filter
-
     coca_filter = _get_coca_filter()
     words = _candidate_entity_words(window)
     word_freq = {}


### PR DESCRIPTION
The COCA content-word filter shipped in PR #1605 imported `_get_coca_filter` and `_candidate_entity_words` locally inside two hot paths:

  - `palace.build_closet_lines` — runs per source file during mine
  - `miner._extract_entities_for_metadata` — runs per drawer during mine

Both imports are now at module top, where they're resolved once at import time instead of on every per-drawer call. Module-top imports also make the dependency graph visible to static analysis (pylint's C0415 was flagging the locals).

No behavior change. The `_get_coca_filter()` call is unchanged — only the import statement moved. End-to-end mining produces identical chromadb output. Addresses the MEDIUM finding gemini-code-assist raised on PR #1605 review.

Verification: full pytest 2258 passed / 3 skipped / coverage 85.35%. ruff check + format clean. Linux Py 3.9 / 3.11 / 3.13 via CI-matching `pip install -e ".[dev]"`: 2249 passed each. End-to-end mine of a test corpus produces the expected drawer + closet pointer.

## What does this PR do?

Moves three local `from .entity_detector import _get_coca_filter` (and one `from .palace import _candidate_entity_words`) statements out of function bodies and up to module top in `mempalace/miner.py` and `mempalace/palace.py`.

## How to test

1. `pip install -e ".[dev]"`

2. `python -m pytest tests/ -q --ignore=tests/benchmarks --cov=mempalace --cov-fail-under=80` — should pass with coverage >= 80%

3. `ruff check . && ruff format --check .` — both clean

4. 4. Cross-Linux via Docker (Py 3.9 / 3.11 / 3.13): docker run --rm -v $PWD:/work -w /work python:3.9-slim sh -c "pip install -q -e '.[dev]' && python -m pytest tests/ -q"
docker run --rm -v $PWD:/work -w /work python:3.11-slim sh -c "pip install -q -e '.[dev]' && python -m pytest tests/ -q"
 docker run --rm -v $PWD:/work -w /work python:3.13-slim sh -c "pip install -q -e '.[dev]' && python -m pytest tests/ -q"
Each prints `Python X.Y.Z` then passes 2249 tests

5. End-to-end smoke: `mempalace --palace /tmp/test_palace init <corpus> --yes && mempalace --palace /tmp/test_palace mine <corpus>` — palace built, drawers + closet pointers emitted as before



## Checklist
- [x ] Tests pass (`python -m pytest tests/ -v`)  — 2258 passed, 3 skipped, coverage 85.35%
- [x ] No hardcoded paths
- [x ] Linter passes (`ruff check .`)
