### PR TITLE
fix(backends): lower HNSW bloat-guard thresholds to fix sub-50k persist (#1579)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -133,11 +133,10 @@ _HNSW_BLOAT_GUARD = {
     "hnsw:sync_threshold": 2,
 }
 
-# Missing index_metadata.pickle is normal only while a segment is still fresh
-# or effectively empty. Once data_level0.bin has non-trivial payload, a
-# missing metadata pickle means the segment was interrupted after writing HNSW
-# data but before writing its metadata. Letting Chroma open that shape can
-# segfault or hang in native HNSW code.
+# Below this size, data_level0.bin is too small for a meaningful HNSW graph.
+# Used by _hnsw_link_lists_is_usable_for_payload (empty link_lists is fine
+# when data is trivially small) and _missing_dimensionality_appears_recoverable
+# (don't attempt recovery on segments with negligible data).
 _HNSW_MISSING_METADATA_DATA_FLOOR = 1024
 
 
@@ -172,11 +171,14 @@ def _segment_appears_healthy(seg_dir: str) -> bool:
     ``0x2e`` (the protocol/terminator byte sequence chromadb serializes
     with).
 
-    Missing metadata is healthy only while the segment still looks fresh or
-    empty. If ``data_level0.bin`` already has non-trivial payload but
-    ``index_metadata.pickle`` is missing, the segment is partially flushed:
-    Chroma wrote vector data without the metadata it needs to reopen the
-    HNSW reader safely.
+    When metadata is missing, the segment is either *never-persisted*
+    (sub-threshold: fewer records than ``batch_size``, so chromadb never
+    triggered ``_persist()``) or *partially flushed* (persist started but
+    crashed).  The two are distinguished by ``link_lists.bin``: chromadb
+    writes link data during persist, so an empty/absent ``link_lists.bin``
+    together with absent metadata means no persist was ever attempted.
+    Note: ``data_level0.bin`` is pre-allocated at index creation and its
+    size does not indicate actual record count.
 
     Deliberately format-sniffs only; never deserializes. Deserialization
     can execute arbitrary code, and the byte-sniff is sufficient to
@@ -189,28 +191,23 @@ def _segment_appears_healthy(seg_dir: str) -> bool:
     files and quarantine_stale_hnsw would conservatively rename them
     out of the way.
     """
+    meta_path = os.path.join(seg_dir, "index_metadata.pickle")
+
+    if not os.path.isfile(meta_path):
+        link_path = os.path.join(seg_dir, "link_lists.bin")
+        try:
+            link_has_data = os.path.isfile(link_path) and os.path.getsize(link_path) > 0
+        except OSError:
+            return False
+        # Both absent → sub-threshold, never persisted.
+        # link_lists written but metadata not → interrupted persist.
+        return not link_has_data
+
     if not _hnsw_payload_appears_sane(seg_dir):
         return False
 
-    meta_path = os.path.join(seg_dir, "index_metadata.pickle")
-    if not os.path.isfile(meta_path):
-        data_path = os.path.join(seg_dir, "data_level0.bin")
-        try:
-            if (
-                os.path.isfile(data_path)
-                and os.path.getsize(data_path) > _HNSW_MISSING_METADATA_DATA_FLOOR
-            ):
-                return False
-        except OSError:
-            return False
-
-        # No metadata and no meaningful vector payload yet: fresh/empty segment.
-        return True
-
     try:
         size = os.path.getsize(meta_path)
-        # A real chromadb metadata file is at least tens of bytes; a
-        # smaller-than-floor file is almost certainly truncated.
         if size < 16:
             return False
         with open(meta_path, "rb") as f:
@@ -477,7 +474,7 @@ def _hnsw_element_count(palace_path: str, segment_id: str) -> Optional[int]:
 # DIVERGED the moment their queue exceeded 10% of sqlite_count, even
 # though chromadb is behaving correctly. The floor must scale with the
 # per-collection sync_threshold to distinguish real corruption (#1222 was
-# 176 613 missing of 192 997 — orders of magnitude past any reasonable
+# 176 613 missing of 192 997, orders of magnitude past any reasonable
 # sync_threshold) from expected steady-state lag.
 _HNSW_DIVERGENCE_FALLBACK_FLOOR = 2000
 _HNSW_DIVERGENCE_FRACTION = 0.10

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -105,29 +105,32 @@ def _hnsw_payload_appears_sane(seg_dir: str) -> bool:
     return ratio is None or ratio <= _HNSW_LINK_TO_DATA_MAX_RATIO
 
 
-# HNSW tuning to prevent link_lists.bin bloat on large mines (#344).
+# HNSW batch/sync thresholds applied at collection creation.
 #
-# With default params (batch_size=100, sync_threshold=1000, initial capacity
-# 1000), inserting tens of thousands of drawers triggers ~30 index resizes
-# and hundreds of persistDirty() calls. persistDirty uses relative seek
-# positioning in link_lists.bin; accumulated seek drift across resize cycles
-# causes the OS to extend the sparse file with zero-filled regions, each
-# cycle compounding the next. Result: link_lists.bin grows into hundreds of
-# GB sparse, after which `status`/`search`/`repair` segfault.
+# chromadb's Rust HNSW segment writes index_metadata.pickle and
+# link_lists.bin only when internal counters cross both thresholds
+# (batch_size gates _apply_batch; sync_threshold gates _persist).
+# Records below both thresholds stay in memory and are lost on exit.
 #
-# Setting large batch and sync thresholds at collection creation defers
-# persistence until a single large batch completes, breaking the resize+
-# persist feedback loop. Empirically validated on a 39,792-drawer rebuild
-# (palace 376 MB, link_lists.bin 0 bytes, no segfault) in 2026-04.
+# Previously 50k/50k to work around link_lists.bin sparse-file bloat
+# in pre-1.5.x Python chromadb (#344).  chromadb >=1.5.4 Rust bindings
+# (the minimum mempalace supports) do not exhibit that bloat; verified
+# at batch_size=2 with 20k records: link_lists.bin = 171 KB, no
+# sparse-file inflation.
 #
-# Note: chromadb 1.5.x exposes a `collection.modify(configuration={"hnsw":
-# {"batch_size": ..., "sync_threshold": ...}})` retrofit path for already-
-# created collections (`UpdateHNSWConfiguration` in chromadb's API), but
-# this PR doesn't pursue that — once link_lists.bin has bloated, the index
-# is already corrupt and the only known recovery is a fresh mine.
+# The 50k guard caused #1579: mines under 50k drawers never triggered
+# _persist(), leaving index_metadata.pickle absent and link_lists.bin
+# empty.  quarantine_stale_hnsw then renamed the segment on every cold
+# open after a 300s mtime gap, accumulating .drift-* directories.
+#
+# Lowered to 2 (empirical Rust-side minimum for chromadb >=1.5.4; the
+# Rust bindings reject 1 with InvalidArgumentError) so any mine of 2+
+# drawers triggers a natural persist.  Existing palaces created under
+# the old 50k guard keep those thresholds in their collection metadata
+# until the user runs repair --mode from-sqlite --archive-existing.
 _HNSW_BLOAT_GUARD = {
-    "hnsw:batch_size": 50_000,
-    "hnsw:sync_threshold": 50_000,
+    "hnsw:batch_size": 2,
+    "hnsw:sync_threshold": 2,
 }
 
 # Missing index_metadata.pickle is normal only while a segment is still fresh
@@ -467,14 +470,15 @@ def _hnsw_element_count(palace_path: str, segment_id: str) -> Optional[int]:
 # read the collection metadata (older palaces missing the row, sqlite
 # unreadable). 2000 = 2 × chromadb's default sync_threshold of 1000.
 #
-# Why dynamic: PR #1191 set ``hnsw:sync_threshold = 50_000`` to prevent
-# index bloat, which means flush-lag can grow up to 50K naturally. A
-# fixed 2000 floor would flag every actively-written palace as DIVERGED
-# the moment its queue exceeded 10% of sqlite_count, even though chromadb
-# is behaving correctly. The floor must scale with sync_threshold to
-# distinguish real corruption (#1222 was 176 613 missing of 192 997 —
-# orders of magnitude past 2 × any reasonable sync_threshold) from
-# expected steady-state lag.
+# Why dynamic: legacy palaces may still carry ``sync_threshold = 50_000``
+# (the pre-#1579 guard), so flush-lag can grow up to 50K on those palaces.
+# New palaces use sync_threshold=2 (#1579) and flush almost immediately.
+# A fixed 2000 floor would flag actively-written legacy palaces as
+# DIVERGED the moment their queue exceeded 10% of sqlite_count, even
+# though chromadb is behaving correctly. The floor must scale with the
+# per-collection sync_threshold to distinguish real corruption (#1222 was
+# 176 613 missing of 192 997 — orders of magnitude past any reasonable
+# sync_threshold) from expected steady-state lag.
 _HNSW_DIVERGENCE_FALLBACK_FLOOR = 2000
 _HNSW_DIVERGENCE_FRACTION = 0.10
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -30,6 +30,9 @@ from mempalace.backends.chroma import (
     quarantine_stale_hnsw,
 )
 
+# embeddinggemma-300m Matryoshka truncation (first 384 of 768 dims).
+_TEST_EMBED_DIM = 384
+
 
 class _FakeCollection:
     """Stand-in for a chromadb.Collection returning raw chroma-shaped dicts."""
@@ -394,8 +397,8 @@ def test_chroma_backend_creates_collection_with_cosine_distance(tmp_path):
 def test_chroma_backend_sets_hnsw_bloat_guard_on_creation(tmp_path):
     """HNSW batch/sync thresholds must land on freshly-created collection metadata.
 
-    Low thresholds (2/2 per #1579) ensure chromadb's Rust HNSW segment
-    persists index_metadata and link_lists after any mine of 2+ drawers.
+    Low thresholds (2/2 per #1579) make chromadb's Rust HNSW segment
+    persist index_metadata and link_lists after any mine of 2+ drawers.
     Asserting both keys land on the persisted metadata also covers the
     #1161 "config silently dropped" concern at CI time.
     """
@@ -441,7 +444,7 @@ def test_sub_threshold_mine_persists_hnsw_metadata(tmp_path):
         col.upsert(
             ids=["a", "b", "c"],
             documents=["doc a", "doc b", "doc c"],
-            embeddings=[[0.1] * 384, [0.2] * 384, [0.3] * 384],
+            embeddings=[[0.1] * _TEST_EMBED_DIM, [0.2] * _TEST_EMBED_DIM, [0.3] * _TEST_EMBED_DIM],
             metadatas=[{"wing": "t"}, {"wing": "t"}, {"wing": "t"}],
         )
     finally:
@@ -466,6 +469,40 @@ def test_sub_threshold_mine_persists_hnsw_metadata(tmp_path):
     # to run on every segment regardless of mtime delta, proving the fix directly.
     moved = quarantine_stale_hnsw(palace_path, stale_seconds=0.0)
     assert moved == [], f"quarantine fired on freshly-persisted segment: {moved}"
+
+
+def test_single_record_upsert_not_quarantined(tmp_path):
+    """A single-record upsert must not trigger quarantine.
+
+    With batch_size=2 chromadb only persists HNSW metadata after the second
+    record.  A one-record segment has no index_metadata.pickle and no
+    link_lists.bin data; _segment_appears_healthy must treat that combination
+    as sub-threshold (never persisted), not as corruption.
+    """
+    palace_path = str(tmp_path / "palace")
+    backend = ChromaBackend()
+    try:
+        col = backend.get_collection(palace_path, "mempalace_drawers", create=True)
+        col.upsert(
+            ids=["solo"],
+            documents=["only one drawer"],
+            embeddings=[[0.5] * _TEST_EMBED_DIM],
+            metadatas=[{"wing": "t"}],
+        )
+    finally:
+        backend.close()
+
+    for entry in (tmp_path / "palace").iterdir():
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        data = entry / "data_level0.bin"
+        if data.exists() and data.stat().st_size > 0:
+            assert _segment_appears_healthy(str(entry)), (
+                f"single-record segment flagged unhealthy: data={data.stat().st_size}B"
+            )
+
+    moved = quarantine_stale_hnsw(palace_path, stale_seconds=0.0)
+    assert moved == [], f"quarantine fired on single-record segment: {moved}"
 
 
 def test_get_collection_create_true_is_idempotent(tmp_path):
@@ -920,17 +957,18 @@ def test_quarantine_stale_hnsw_leaves_empty_segment_without_metadata_alone(tmp_p
 
 
 def test_segment_without_metadata_but_with_nontrivial_data_is_unhealthy(tmp_path):
-    """Data without index_metadata.pickle is a partial flush, not a fresh segment."""
+    """Interrupted persist: link_lists written but metadata absent is unhealthy."""
 
     seg = tmp_path / "abcd-1234-5678"
     seg.mkdir()
     (seg / "data_level0.bin").write_bytes(b"\0" * (_HNSW_MISSING_METADATA_DATA_FLOOR + 1))
+    (seg / "link_lists.bin").write_bytes(b"\x01" * 128)
 
     assert not _segment_appears_healthy(str(seg))
 
 
 def test_segment_without_metadata_and_tiny_data_is_still_treated_as_fresh(tmp_path):
-    """Tiny data payloads can occur before metadata has flushed; leave them alone."""
+    """No metadata and no link_lists means no persist was attempted; treat as fresh."""
 
     seg = tmp_path / "abcd-1234-5678"
     seg.mkdir()
@@ -940,7 +978,7 @@ def test_segment_without_metadata_and_tiny_data_is_still_treated_as_fresh(tmp_pa
 
 
 def test_quarantine_stale_hnsw_renames_missing_metadata_with_nontrivial_data(tmp_path):
-    """Regression for #1274: missing pickle + non-trivial data must quarantine."""
+    """Regression for #1274: missing pickle + link data must quarantine."""
 
     now = 1_700_000_000.0
     palace, seg = _make_palace_with_segment(
@@ -950,6 +988,7 @@ def test_quarantine_stale_hnsw_renames_missing_metadata_with_nontrivial_data(tmp
         meta_bytes=None,
     )
     (seg / "data_level0.bin").write_bytes(b"\0" * (_HNSW_MISSING_METADATA_DATA_FLOOR + 1))
+    (seg / "link_lists.bin").write_bytes(b"\x01" * 128)
     os.utime(seg / "data_level0.bin", (now - 7200, now - 7200))
 
     moved = quarantine_stale_hnsw(str(palace), stale_seconds=3600.0)
@@ -1607,7 +1646,7 @@ def test_get_collection_translates_ef_mismatch_to_helpful_error(tmp_path):
             return "embeddinggemma_300m"
 
         def __call__(self, input):
-            return [[0.0] * 384 for _ in input]
+            return [[0.0] * _TEST_EMBED_DIM for _ in input]
 
     original_resolver = backend._resolve_embedding_function
     backend._resolve_embedding_function = lambda: _ConflictingEF()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -454,7 +454,7 @@ def test_sub_threshold_mine_persists_hnsw_metadata(tmp_path):
         meta = entry / "index_metadata.pickle"
         link = entry / "link_lists.bin"
         data = entry / "data_level0.bin"
-        if data.exists() and data.stat().st_size > 1024:
+        if data.exists() and data.stat().st_size > _HNSW_MISSING_METADATA_DATA_FLOOR:
             assert meta.exists(), "index_metadata missing after sub-threshold upsert"
             assert link.exists() and link.stat().st_size > 0, "link_lists empty"
             assert _segment_appears_healthy(str(entry))

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -392,14 +392,12 @@ def test_chroma_backend_creates_collection_with_cosine_distance(tmp_path):
 
 
 def test_chroma_backend_sets_hnsw_bloat_guard_on_creation(tmp_path):
-    """The HNSW guard from #344 must land on freshly-created collection metadata.
+    """HNSW batch/sync thresholds must land on freshly-created collection metadata.
 
-    Without batch_size + sync_threshold, mining ~10K+ drawers triggers the
-    resize+persist drift that bloats link_lists.bin into hundreds of GB sparse
-    and segfaults `status` / `search` / `repair`. The guard belongs at
-    collection-creation time so every fresh palace gets it without needing
-    a runtime retrofit. Asserting both keys land on the persisted metadata
-    also covers the #1161 "config silently dropped" concern at CI time.
+    Low thresholds (2/2 per #1579) ensure chromadb's Rust HNSW segment
+    persists index_metadata and link_lists after any mine of 2+ drawers.
+    Asserting both keys land on the persisted metadata also covers the
+    #1161 "config silently dropped" concern at CI time.
     """
     palace_path = tmp_path / "palace"
 
@@ -411,8 +409,8 @@ def test_chroma_backend_sets_hnsw_bloat_guard_on_creation(tmp_path):
 
     client = chromadb.PersistentClient(path=str(palace_path))
     col = client.get_collection("mempalace_drawers")
-    assert col.metadata.get("hnsw:batch_size") == 50_000
-    assert col.metadata.get("hnsw:sync_threshold") == 50_000
+    assert col.metadata.get("hnsw:batch_size") == 2
+    assert col.metadata.get("hnsw:sync_threshold") == 2
 
 
 def test_chroma_backend_create_collection_sets_hnsw_bloat_guard(tmp_path):
@@ -423,8 +421,51 @@ def test_chroma_backend_create_collection_sets_hnsw_bloat_guard(tmp_path):
 
     client = chromadb.PersistentClient(path=str(palace_path))
     col = client.get_collection("mempalace_drawers")
-    assert col.metadata.get("hnsw:batch_size") == 50_000
-    assert col.metadata.get("hnsw:sync_threshold") == 50_000
+    assert col.metadata.get("hnsw:batch_size") == 2
+    assert col.metadata.get("hnsw:sync_threshold") == 2
+
+
+def test_sub_threshold_mine_persists_hnsw_metadata(tmp_path):
+    """Regression for #1579: small mines must persist HNSW metadata.
+
+    _HNSW_BLOAT_GUARD sets batch_size=2 and sync_threshold=2 so that any
+    upsert of 2+ records crosses both thresholds, triggering chromadb's
+    _apply_batch and _persist.  Without this, index_metadata and link_lists
+    stay empty and quarantine_stale_hnsw renames the segment on cold open.
+    """
+    palace_path = str(tmp_path / "palace")
+    backend = ChromaBackend()
+    try:
+        col = backend.get_collection(palace_path, "mempalace_drawers", create=True)
+
+        col.upsert(
+            ids=["a", "b", "c"],
+            documents=["doc a", "doc b", "doc c"],
+            embeddings=[[0.1] * 384, [0.2] * 384, [0.3] * 384],
+            metadatas=[{"wing": "t"}, {"wing": "t"}, {"wing": "t"}],
+        )
+    finally:
+        backend.close()
+
+    found_healthy_segment = False
+    for entry in (tmp_path / "palace").iterdir():
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        meta = entry / "index_metadata.pickle"
+        link = entry / "link_lists.bin"
+        data = entry / "data_level0.bin"
+        if data.exists() and data.stat().st_size > 1024:
+            assert meta.exists(), "index_metadata missing after sub-threshold upsert"
+            assert link.exists() and link.stat().st_size > 0, "link_lists empty"
+            assert _segment_appears_healthy(str(entry))
+            found_healthy_segment = True
+
+    assert found_healthy_segment, "no VECTOR segment with data found"
+
+    # stale_seconds=0.0 forces the stage-2 integrity gate (_segment_appears_healthy)
+    # to run on every segment regardless of mtime delta, proving the fix directly.
+    moved = quarantine_stale_hnsw(palace_path, stale_seconds=0.0)
+    assert moved == [], f"quarantine fired on freshly-persisted segment: {moved}"
 
 
 def test_get_collection_create_true_is_idempotent(tmp_path):
@@ -450,7 +491,7 @@ def test_get_collection_create_true_preserves_existing_metadata(tmp_path):
     backend.get_collection(palace, collection_name="mempalace_drawers", create=True)
     col = backend.get_collection(palace, collection_name="mempalace_drawers", create=True)
     assert col._collection.metadata["hnsw:space"] == "cosine"
-    assert col._collection.metadata.get("hnsw:batch_size") == 50_000
+    assert col._collection.metadata.get("hnsw:batch_size") == 2
 
 
 def test_fix_blob_seq_ids_converts_blobs_to_integers(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Lowers `_HNSW_BLOAT_GUARD` thresholds from 50,000 to 2 (both `hnsw:batch_size` and `hnsw:sync_threshold`).

chromadb's Rust HNSW segment only writes `index_metadata.pickle` and `link_lists.bin` when both internal counters cross their thresholds. With 50k/50k, any mine under 50,000 drawers (the vast majority) never triggered `_persist()`, leaving the segment without metadata. `quarantine_stale_hnsw` then renamed the segment on every cold open after a 300-second mtime gap, accumulating `.drift-*` directories indefinitely.

The 50k guard was added in #344 to prevent `link_lists.bin` sparse-file bloat in pre-1.5.x Python chromadb. Since mempalace requires `chromadb>=1.5.4` (Rust bindings), the bloat no longer occurs. Verified empirically: `batch_size=2` with 20,000 records produces `link_lists.bin` at 171 KB with no sparse-file inflation.

Existing palaces created under the old 50k guard retain those thresholds in their collection metadata until the user runs `mempalace repair --mode from-sqlite --archive-existing --yes`.

Also fixes the downstream symptoms reported in #1526 (Mode 2: silent empty index below batch threshold) and #1564 (single-writer sweep triggers stale quarantine) for new palaces created after this release; existing palaces require the repair command above.

### Single-record edge case (thanks @0xWinner98)

chromadb pre-allocates `data_level0.bin` at index creation (~168 KB for 384-dim embeddings) regardless of actual record count. The previous `_segment_appears_healthy` check compared `data_level0.bin` size against `_HNSW_MISSING_METADATA_DATA_FLOOR` (1024 bytes) to decide whether a segment without metadata was fresh or corrupt. A single-record upsert (below `batch_size=2`) legitimately has no metadata, but its pre-allocated `data_level0.bin` exceeds the floor, causing a false quarantine.

Fixed by restructuring `_segment_appears_healthy`: when `index_metadata.pickle` is absent, check `link_lists.bin` instead of `data_level0.bin` size. chromadb writes link data during persist, so empty/absent `link_lists.bin` + absent metadata = sub-threshold (never persisted). `link_lists.bin` with data + absent metadata = interrupted persist (quarantine).

Fixes #1579.

## How to test

```bash
# Fresh palace, mine a small directory
rm -rf /tmp/test_palace /tmp/repro
mkdir -p /tmp/repro && echo "test doc" > /tmp/repro/a.md && echo "second doc" > /tmp/repro/b.md
MEMPALACE_PALACE_PATH=/tmp/test_palace mempalace mine /tmp/repro --wing test

# Verify: pickle exists, no quarantine
find /tmp/test_palace -name "index_metadata.pickle"   # should find files
find /tmp/test_palace -name "*.drift-*" -type d        # should be empty
MEMPALACE_PALACE_PATH=/tmp/test_palace mempalace status # clean, no quarantine warning
MEMPALACE_PALACE_PATH=/tmp/test_palace mempalace search "test doc"  # results returned
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
