### PR TITLE
fix(miner): count only new work toward --limit, not already-mined skips (#1535)

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -594,15 +594,14 @@ def _mine_convos_impl(
     wing = _resolve_wing(convo_path, wing)
 
     files = scan_convos(convo_dir)
-    if limit > 0:
-        files = files[:limit]
 
     print(f"\n{'=' * 55}")
     print("  MemPalace Mine — Conversations")
     print(f"{'=' * 55}")
     print(f"  Wing:    {wing}")
     print(f"  Source:  {convo_path}")
-    print(f"  Files:   {len(files)}")
+    limit_suffix = f" (limit: {limit} new)" if limit > 0 else ""
+    print(f"  Files:   {len(files)}{limit_suffix}")
     print(f"  Palace:  {palace_path}")
     if dry_run:
         print("  DRY RUN — nothing will be filed")
@@ -620,10 +619,13 @@ def _mine_convos_impl(
     )
 
     total_drawers = 0
+    files_mined = 0
     files_skipped = 0
+    files_processed = 0
     room_counts = defaultdict(int)
 
     for i, filepath in enumerate(files, 1):
+        files_processed = i
         source_file = str(filepath)
 
         # Skip if already filed at current NORMALIZE_VERSION
@@ -684,6 +686,9 @@ def _mine_convos_impl(
                     room_counts[c.get("memory_type", "general")] += 1
             else:
                 room_counts[room] += 1
+            files_mined += 1
+            if limit > 0 and files_mined >= limit:
+                break
             continue
 
         if extract_mode != "general":
@@ -701,14 +706,17 @@ def _mine_convos_impl(
             room_counts[r] += n
 
         total_drawers += drawers_added
+        files_mined += 1
         print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+        if limit > 0 and files_mined >= limit:
+            break
 
     if not dry_run:
         _validate_palace_fts5_after_mine(palace_path)
 
     print(f"\n{'=' * 55}")
     print("  Done.")
-    print(f"  Files processed: {len(files) - files_skipped}")
+    print(f"  Files processed: {files_processed - files_skipped}")
     print(f"  Files skipped (already filed): {files_skipped}")
     print(f"  Drawers filed: {total_drawers}")
     if room_counts:

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -507,7 +507,7 @@ def scan_formats(directory: Union[Path, str]) -> list[Path]:
 
 
 def _print_mine_summary(
-    files: list,
+    files_seen: int,
     files_with_text: int,
     files_skipped: int,
     files_errored: int,
@@ -523,7 +523,7 @@ def _print_mine_summary(
     print(f"\n{'=' * 55}")
     print("  Summary")
     print(f"{'-' * 55}")
-    print(f"  Files seen:        {len(files)}")
+    print(f"  Files seen:        {files_seen}")
     print(f"  Files extracted:   {files_with_text}")
     print(f"  Files skipped:     {files_skipped}")
     print(f"  Files errored:     {files_errored}")
@@ -789,9 +789,11 @@ def mine_formats(
     files: list = []
     collection = None
     total_drawers = 0
+    files_mined = 0
     files_skipped = 0
     files_with_text = 0
     files_errored = 0
+    files_processed = 0
     status_counts: dict = defaultdict(int)
 
     try:
@@ -799,15 +801,14 @@ def mine_formats(
         # ``~/docs`` and relative inputs work consistently. Per PR #1555 review
         # (Copilot #10).
         files = scan_formats(format_path)
-        if limit > 0:
-            files = files[:limit]
 
         print(f"\n{'=' * 55}")
         print("  MemPalace Mine — Format extraction")
         print(f"{'=' * 55}")
         print(f"  Wing:    {wing}")
         print(f"  Source:  {format_path}")
-        print(f"  Files:   {len(files)}")
+        limit_suffix = f" (limit: {limit} new)" if limit > 0 else ""
+        print(f"  Files:   {len(files)}{limit_suffix}")
         print(f"  Palace:  {palace_path}")
         if dry_run:
             print("  DRY RUN — nothing will be filed")
@@ -816,6 +817,7 @@ def mine_formats(
         collection = get_collection(palace_path) if not dry_run else None
 
         for i, filepath in enumerate(files, 1):
+            files_processed = i
             source_file = str(filepath)
 
             # Per-file try/except so one bad file can't crash the whole mine.
@@ -876,6 +878,9 @@ def mine_formats(
                 if dry_run:
                     print(f"    [DRY RUN] {filepath.name} → {len(chunks)} drawers")
                     total_drawers += len(chunks)
+                    files_mined += 1
+                    if limit > 0 and files_mined >= limit:
+                        break
                     continue
 
                 drawers_added, skipped = _file_chunks_locked(
@@ -893,7 +898,10 @@ def mine_formats(
                     continue
 
                 total_drawers += drawers_added
+                files_mined += 1
                 print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+                if limit > 0 and files_mined >= limit:
+                    break
             except Exception as exc:
                 # Log and continue — one malformed file shouldn't kill the
                 # whole mine. Mirrors miner.py's per-file recovery.
@@ -973,7 +981,7 @@ def mine_formats(
                 logger.debug("mine_formats: _cleanup_mine_pid_file failed", exc_info=True)
 
     _print_mine_summary(
-        files=files,
+        files_seen=files_processed,
         files_with_text=files_with_text,
         files_skipped=files_skipped,
         files_errored=files_errored,

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1623,9 +1623,6 @@ def _mine_impl(
             respect_gitignore=respect_gitignore,
             include_ignored=include_ignored,
         )
-    if limit > 0:
-        files = files[:limit]
-
     from .embedding import describe_device
 
     print(f"\n{'=' * 55}")
@@ -1633,7 +1630,8 @@ def _mine_impl(
     print(f"{'=' * 55}")
     print(f"  Wing:    {wing}")
     print(f"  Rooms:   {', '.join(r['name'] for r in rooms)}")
-    print(f"  Files:   {len(files)}")
+    limit_suffix = f" (limit: {limit} new)" if limit > 0 else ""
+    print(f"  Files:   {len(files)}{limit_suffix}")
     print(f"  Palace:  {palace_path}")
     print(f"  Device:  {describe_device()}")
     if dry_run:
@@ -1652,6 +1650,7 @@ def _mine_impl(
         closets_col = None
 
     total_drawers = 0
+    files_mined = 0
     files_skipped = 0
     files_skipped_chunk_cap = 0
     files_processed = 0
@@ -1699,8 +1698,11 @@ def _mine_impl(
             else:
                 total_drawers += drawers
                 room_counts[room] += 1
+                files_mined += 1
                 if not dry_run:
                     print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
+                if limit > 0 and files_mined >= limit:
+                    break
 
         if not dry_run:
             # Cross-wing topic tunnels: after every file in this wing has been
@@ -1753,7 +1755,7 @@ def _mine_impl(
 
         print(f"\n{'=' * 55}")
         print("  Done.")
-        print(f"  Files processed: {len(files) - files_skipped}")
+        print(f"  Files processed: {files_processed - files_skipped}")
         # The residual skip bucket label depends on mode: dry-run bypasses
         # the already-mined check, so the only paths producing (0, room,
         # None) under dry_run are OSError / too-short / post-lock re-check

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -416,3 +416,41 @@ def test_resolve_wing_empty_string_treated_as_no_wing(tmp_path):
     target = tmp_path / ".gemini" / "tmp"
     target.mkdir(parents=True)
     assert _resolve_wing(target, wing="") == "wing_api"
+
+
+def test_mine_convos_limit_skips_already_mined(capsys):
+    """--limit N counts only new work, not already-mined skips (#1535)."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        convo_text = (
+            "> What is topic {i}?\n"
+            "Topic {i} is about something important and interesting enough "
+            "to produce at least one exchange chunk for the test.\n\n"
+            "> Tell me more about topic {i}.\n"
+            "Sure, topic {i} has many facets worth exploring in detail.\n"
+        )
+        for i in range(4):
+            with open(os.path.join(tmpdir, f"chat_{i}.txt"), "w") as f:
+                f.write(convo_text.format(i=i))
+
+        palace_path = os.path.join(tmpdir, "palace")
+
+        mine_convos(tmpdir, palace_path, wing="test")
+        capsys.readouterr()
+
+        for i in range(4, 7):
+            with open(os.path.join(tmpdir, f"chat_{i}.txt"), "w") as f:
+                f.write(convo_text.format(i=i))
+
+        mine_convos(tmpdir, palace_path, wing="test", limit=2)
+        out = capsys.readouterr().out
+
+        assert "Files processed: 2" in out
+        assert "Drawers filed:" in out
+        for line in out.split("\n"):
+            if "Drawers filed:" in line:
+                filed = int(line.split(":")[1].strip())
+                assert filed > 0, f"limit=2 should mine new files, got {filed}"
+                break
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_format_miner.py
+++ b/tests/test_format_miner.py
@@ -801,6 +801,36 @@ def test_mine_formats_respects_limit(_mine_formats_mocks):
     assert p_md.call_count == 2
 
 
+def test_mine_formats_limit_skips_already_mined(_mine_formats_mocks):
+    """--limit N counts only new work, not already-mined skips (#1535)."""
+    from unittest.mock import patch
+    from mempalace.format_miner import mine_formats
+
+    tmp = _mine_formats_mocks["tmp_path"]
+    files = []
+    for i in range(6):
+        p = tmp / f"f{i}.pdf"
+        p.write_bytes(b"%PDF-1.4 stub")
+        files.append(p)
+
+    call_idx = 0
+
+    def fake_already_mined(collection, source_file, **kwargs):
+        nonlocal call_idx
+        call_idx += 1
+        return call_idx <= 4
+
+    _mine_formats_mocks["file_already_mined"].side_effect = fake_already_mined
+    with (
+        patch("mempalace.format_miner.scan_formats", return_value=files),
+        patch(
+            "mempalace.format_miner._extract_via_markitdown", return_value="long text " * 50
+        ) as p_md,
+    ):
+        mine_formats(format_dir=str(tmp), palace_path=str(tmp / "palace"), limit=1)
+    assert p_md.call_count == 1
+
+
 def test_mine_formats_wing_defaults_from_directory_name(_mine_formats_mocks):
     """When wing=None, the directory's basename becomes the wing."""
     from unittest.mock import patch

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -2185,3 +2185,129 @@ def test_file_already_mined_handles_multiple_groups_under_one_source_file(tmp_pa
         "must iterate all groups for the source_file (mirroring the existing "
         "paginated pattern in the extract_mode-is-set branch)."
     )
+
+
+# ── --limit skips already-mined files (#1535) ──────────────────────────
+
+
+def test_mine_limit_skips_already_mined_files(tmp_path, capsys):
+    """--limit N should count only NEW work, not already-mined skips (#1535)."""
+    from unittest.mock import patch
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    _make_minable_project(project_root, n_files=10)
+    palace_path = project_root / "palace"
+
+    call_count = 0
+
+    def fake_process_file(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 8:
+            return (0, "general", None)
+        return (3, "general", None)
+
+    with patch("mempalace.miner.process_file", side_effect=fake_process_file):
+        mine(str(project_root), str(palace_path), limit=5)
+
+    out = capsys.readouterr().out
+    assert "Drawers filed: 6" in out
+    assert call_count == 10
+
+
+def test_mine_limit_stops_after_n_new_files(tmp_path, capsys):
+    """--limit 3 on 5 unmined files mines exactly 3 and stops."""
+    from unittest.mock import patch
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    _make_minable_project(project_root, n_files=5)
+    palace_path = project_root / "palace"
+
+    call_count = 0
+
+    def fake_process_file(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return (2, "general", None)
+
+    with patch("mempalace.miner.process_file", side_effect=fake_process_file):
+        mine(str(project_root), str(palace_path), limit=3)
+
+    assert call_count == 3
+    out = capsys.readouterr().out
+    assert "Drawers filed: 6" in out
+
+
+def test_mine_limit_zero_mines_all(tmp_path, capsys):
+    """--limit 0 (default) processes every file."""
+    from unittest.mock import patch
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    _make_minable_project(project_root, n_files=4)
+    palace_path = project_root / "palace"
+
+    call_count = 0
+
+    def fake_process_file(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return (1, "general", None)
+
+    with patch("mempalace.miner.process_file", side_effect=fake_process_file):
+        mine(str(project_root), str(palace_path), limit=0)
+
+    assert call_count == 4
+    out = capsys.readouterr().out
+    assert "Drawers filed: 4" in out
+
+
+def test_mine_limit_dry_run(tmp_path, capsys):
+    """--dry-run --limit N counts new files toward the limit."""
+    from unittest.mock import patch
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    _make_minable_project(project_root, n_files=5)
+    palace_path = project_root / "palace"
+
+    call_count = 0
+
+    def fake_process_file(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return (2, "general", None)
+
+    with patch("mempalace.miner.process_file", side_effect=fake_process_file):
+        mine(str(project_root), str(palace_path), limit=3, dry_run=True)
+
+    assert call_count == 3
+
+
+def test_mine_limit_summary_counts(tmp_path, capsys):
+    """Summary arithmetic is correct when limit causes early exit."""
+    from unittest.mock import patch
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    _make_minable_project(project_root, n_files=8)
+    palace_path = project_root / "palace"
+
+    call_idx = 0
+
+    def fake_process_file(*args, **kwargs):
+        nonlocal call_idx
+        call_idx += 1
+        if call_idx % 2 == 0:
+            return (0, "general", None)
+        return (3, "general", None)
+
+    with patch("mempalace.miner.process_file", side_effect=fake_process_file):
+        mine(str(project_root), str(palace_path), limit=2)
+
+    out = capsys.readouterr().out
+    assert "Files processed: 2" in out
+    assert "Drawers filed: 6" in out
+    assert "(limit: 2 new)" in out


### PR DESCRIPTION
## What does this PR do?

Fixes #1535. `--limit N` now counts only files that produce new drawers, not files already mined.

Before this fix, `_mine_impl` (and `_mine_convos_impl`, `mine_formats`) truncated the file list via `files = files[:limit]` before the processing loop. Files that `file_already_mined` would skip still consumed a slot, so a budget-bounded run on a mostly-mined corpus could finish with 0 new drawers despite unmined files existing later in walk order.

The fix removes the pre-loop truncation and adds a counter-based break: `files_mined` increments only when a file produces drawers, and the loop exits when the counter reaches the limit. All three miners (project, conversation, format) are patched.

Thanks to @domijin for the detailed repro and root-cause analysis.

## How to test

```
uv run python -m pytest tests/test_miner.py -k "limit" -v
uv run python -m pytest tests/test_convo_miner.py::test_mine_convos_limit_skips_already_mined -v
uv run python -m pytest tests/test_format_miner.py -k "limit" -v
uv run python -m pytest tests/ -q --ignore=tests/benchmarks
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
