### PR TITLE
fix: preserve collection_name on MCP search retry

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -924,6 +924,7 @@ def tool_search(
             n_results=limit,
             max_distance=dist,
             vector_disabled=_vector_disabled,
+            collection_name=_config.collection_name,
         )
         if not _is_transient_index_error(result):
             result["index_recovered"] = True

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,7 @@ via monkeypatch to avoid touching real data.
 from datetime import datetime
 import json
 import os
+from types import SimpleNamespace
 import subprocess
 import sys
 from unittest.mock import MagicMock
@@ -984,6 +985,38 @@ class TestSearchTool:
         assert reset_calls["n"] == 1
         assert "results" in result
         assert result.get("index_recovered") is True
+
+    def test_search_retry_preserves_collection_name(self, monkeypatch, config, kg):
+        """Retry path must query the same configured collection both times."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(
+            mcp_server,
+            "_config",
+            SimpleNamespace(
+                palace_path=config.palace_path,
+                collection_name="custom_drawers",
+            ),
+        )
+        seen_collection_names = []
+
+        def fake_search(*args, **kwargs):
+            seen_collection_names.append(kwargs.get("collection_name"))
+            if len(seen_collection_names) == 1:
+                return {
+                    "error": "Search error: Error executing plan: Internal error: Error finding id"
+                }
+            return {"results": [{"text": "ok", "wing": "w", "room": "r"}]}
+
+        monkeypatch.setattr(mcp_server, "search_memories", fake_search)
+        monkeypatch.setattr(mcp_server, "_force_chroma_cache_reset", lambda: None)
+        monkeypatch.setattr(mcp_server.time, "sleep", lambda _: None)
+
+        result = mcp_server.tool_search(query="anything", wing="wing_api")
+
+        assert "results" in result
+        assert seen_collection_names == ["custom_drawers", "custom_drawers"]
 
     def test_search_does_not_retry_on_non_transient_error(self, monkeypatch, config, kg):
         """Validation / unrelated errors must not trigger the retry path."""


### PR DESCRIPTION
## What does this PR do?

Fixes transient-retry behavior in `mempalace_search` so the retry call preserves `collection_name`.

- Root cause: `tool_search` passed `collection_name` on the initial `search_memories(...)` call but dropped it on retry.
- Fix: pass `_config.collection_name` on the retry call as well.
- Adds regression test `test_search_retry_preserves_collection_name` to ensure both attempts use the same configured collection.

Closes #1623.

## How to test

1. Run focused regression slice:
   - `uv run pytest tests/test_mcp_server.py -k "search_retries_once_on_hnsw_flush_transient or search_retry_preserves_collection_name or search_with_wing_filter or search_with_room_filter" -q`
2. Verify retry uses configured collection through the new test.

Validation run for this PR:
- `uv run ruff check .` -> pass
- Focused pytest slice above -> pass (`4 passed`)
- Full suite command from contributing docs:
  - `uv run pytest tests/ -v --ignore=tests/benchmarks`
  - Current branch shows 4 unrelated existing failures in `tests/test_cli.py`, `tests/test_repair.py`, and `tests/test_searcher.py`.

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
