### PR TITLE
fix(embedding): add embed_query/embed_documents to EmbeddinggemmaONNX for ChromaDB 1.5.x

### DIFF
--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -191,6 +191,9 @@ class EmbeddinggemmaONNX:
         model_path = hf_hub_download(
             _EMBEDDINGGEMMA_REPO, subfolder="onnx", filename=_EMBEDDINGGEMMA_ONNX
         )
+        hf_hub_download(
+            _EMBEDDINGGEMMA_REPO, subfolder="onnx", filename=_EMBEDDINGGEMMA_ONNX + "_data"
+        )
         tok_path = hf_hub_download(_EMBEDDINGGEMMA_REPO, filename="tokenizer.json")
 
         self._session = ort.InferenceSession(model_path, providers=self._providers)
@@ -222,6 +225,14 @@ class EmbeddinggemmaONNX:
         # MTEB methodology assumes; ChromaDB's distance is configured for it).
         norms = np.linalg.norm(sent_emb, axis=1, keepdims=True) + 1e-12
         return (sent_emb / norms).tolist()
+
+    def embed_query(self, input: list[str]) -> list[list[float]]:  # noqa: A002 — ChromaDB EF protocol
+        """Embed query documents (ChromaDB EF protocol)."""
+        return self(input)
+
+    def embed_documents(self, input: list[str]) -> list[list[float]]:  # noqa: A002
+        """Embed a batch of documents (ChromaDB EF protocol)."""
+        return self(input)
 
 
 def get_embedding_function(device: Optional[str] = None, model: Optional[str] = None):

--- a/tests/test_embeddinggemma.py
+++ b/tests/test_embeddinggemma.py
@@ -126,7 +126,7 @@ def test_lazy_load_runs_once(patched_lazy_load):
     ef(["one"])
     ef(["two"])
     ef(["three"])
-    assert patched_lazy_load["hf_hub_download"] == 2  # model + tokenizer, once total
+    assert patched_lazy_load["hf_hub_download"] == 3  # model + weights + tokenizer, once
     assert patched_lazy_load["InferenceSession"] == 1
     assert patched_lazy_load["Tokenizer.from_file"] == 1
 


### PR DESCRIPTION
## Bug

ChromaDB 1.5.x calls `embedding_function.embed_query(input=...)` via keyword argument during `collection.query()`. `EmbeddinggemmaONNX` lacked both `embed_query` and `embed_documents` methods, causing:

```
TypeError: embed_query() got an unexpected keyword argument input
```

whenever semantic search was triggered.

## Fix

This PR adds the two methods required by the ChromaDB EF protocol, using `input` (the ChromaDB kwarg name, noqa A002) so that palace search works correctly with the `embeddinggemma` model.

Also downloads the companion `_data` ONNX file alongside the main model to prevent runtime InferenceSession failures.

## Related

Fixes silent search failures when `embedding_model` is set to `"embeddinggemma"`.
