### PR TITLE
fix(mcp): retry stale-index transient in tool_search

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -300,7 +300,15 @@ def _is_transient_index_error(result) -> bool:
     if not isinstance(result, dict):
         return False
     err = result.get("error", "")
-    return isinstance(err, str) and ("Error finding id" in err or "Internal error" in err)
+    if not isinstance(err, str):
+        return False
+    err_l = err.lower()
+    return (
+        "error finding id" in err_l
+        or "internal error" in err_l
+        or "stale-index" in err_l
+        or "stale index" in err_l
+    )
 
 
 def _force_chroma_cache_reset() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1025,6 +1025,34 @@ class TestSearchTool:
         assert "error" in result
         assert "index_recovered" not in result
 
+    def test_search_retries_once_on_stale_index_error(self, monkeypatch, config, kg):
+        """Stale-index errors should trigger one cache-reset retry."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        calls = {"n": 0}
+        reset_calls = {"n": 0}
+
+        def fake_search(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {"error": "Search error: stale-index detected; retry recommended"}
+            return {"results": [{"text": "ok", "wing": "w", "room": "r"}]}
+
+        def fake_reset():
+            reset_calls["n"] += 1
+
+        monkeypatch.setattr(mcp_server, "search_memories", fake_search)
+        monkeypatch.setattr(mcp_server, "_force_chroma_cache_reset", fake_reset)
+        monkeypatch.setattr(mcp_server.time, "sleep", lambda _: None)
+
+        result = mcp_server.tool_search(query="anything")
+
+        assert calls["n"] == 2
+        assert reset_calls["n"] == 1
+        assert "results" in result
+        assert result.get("index_recovered") is True
+
     def test_list_drawers_rejects_invalid_wing(self, monkeypatch, config, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace import mcp_server


### PR DESCRIPTION
## What does this PR do?

Extends `tool_search` transient-index retry classification to also catch stale-index variants that were not previously retried.

- Updates `_is_transient_index_error()` in `mempalace/mcp_server.py` to treat `stale-index` / `stale index` (case-insensitive) as transient.
- Keeps existing retry behavior unchanged: one cache reset + one retry.
- Adds regression test `test_search_retries_once_on_stale_index_error` in `tests/test_mcp_server.py`.

Closes #1634.

## How to test

- `uv run pytest tests/test_mcp_server.py -k "search_retries_once_on_stale_index_error or search_retries_once_on_hnsw_flush_transient or search_does_not_retry_on_non_transient_error" -v`
- `uv run ruff check mempalace/mcp_server.py tests/test_mcp_server.py`

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
