### PR TITLE
fix(palace): file_already_mined iterates all groups when source_file has multiple parent_drawer_id mining passes

### DIFF
--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -741,47 +741,51 @@ def file_already_mined(
     treated as exchange-mode drawers.
     """
     try:
-        stored_meta = None
-        if extract_mode is None:
-            results = collection.get(where={"source_file": source_file}, limit=1)
-            if not results.get("ids"):
-                return False
-            stored_meta = results.get("metadatas", [{}])[0] or {}
-        else:
-            offset = 0
-            while True:
-                results = collection.get(
-                    where={"source_file": source_file},
-                    limit=1000,
-                    offset=offset,
-                    include=["metadatas"],
-                )
-                ids = results.get("ids") or []
-                metadatas = results.get("metadatas") or []
-                stored_meta = next(
-                    (
-                        meta or {}
-                        for meta in metadatas
-                        if _metadata_matches_extract_mode(meta or {}, extract_mode)
-                    ),
-                    None,
-                )
-                if stored_meta is not None or not ids:
-                    break
-                offset += len(ids)
-        if stored_meta is None:
-            return False
-        # Pre-v2 drawers have no version field — treat them as stale.
-        stored_version = stored_meta.get("normalize_version", 1)
-        if stored_version < NORMALIZE_VERSION:
-            return False
-        if check_mtime:
-            stored_mtime = stored_meta.get("source_mtime")
-            if stored_mtime is None:
-                return False
-            current_mtime = os.path.getmtime(source_file)
-            return abs(float(stored_mtime) - current_mtime) < 0.001
-        return True
+        # Under the additive-mining model, a single ``source_file`` can have
+        # multiple ``parent_drawer_id`` groups in the palace — one per
+        # mining pass — each with its own stored ``source_mtime`` and
+        # ``normalize_version``. The function must return True if ANY stored
+        # group is current (matching version + matching mtime when checked),
+        # because ChromaDB's ``get(..., limit=1)`` has undefined ordering
+        # across multiple matching rows: a ``limit=1`` shortcut picks
+        # whichever row ChromaDB orders first and only checks that one,
+        # causing spurious re-mines whenever the stale group is returned.
+        # Iterating via the same paginated pattern used in the
+        # extract_mode-is-set branch lets the function short-circuit on the
+        # first matching group regardless of ordering.
+        current_mtime = os.path.getmtime(source_file) if check_mtime else None
+        offset = 0
+        while True:
+            results = collection.get(
+                where={"source_file": source_file},
+                limit=1000,
+                offset=offset,
+                include=["metadatas"],
+            )
+            ids = results.get("ids") or []
+            metadatas = results.get("metadatas") or []
+            for meta in metadatas:
+                meta = meta or {}
+                # extract_mode scoping (was the existing ``else`` branch):
+                if extract_mode is not None and not _metadata_matches_extract_mode(
+                    meta, extract_mode
+                ):
+                    continue
+                # Pre-v2 drawers have no version field — treat them as stale.
+                stored_version = meta.get("normalize_version", 1)
+                if stored_version < NORMALIZE_VERSION:
+                    continue
+                if not check_mtime:
+                    return True
+                stored_mtime = meta.get("source_mtime")
+                if stored_mtime is None:
+                    continue
+                if abs(float(stored_mtime) - current_mtime) < 0.001:
+                    return True
+            if not ids:
+                break
+            offset += len(ids)
+        return False
     except Exception:
         return False
 

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -1976,3 +1976,79 @@ class TestExtractContentDate:
         content = "Y2K reference: 25/01/00.\n"
         f.write_text(content)
         assert _extract_content_date(str(f), content) == "2000-01-25"
+
+
+def test_file_already_mined_handles_multiple_groups_under_one_source_file(tmp_path):
+    """Under the additive-mining model, a single ``source_file`` can have
+    multiple ``parent_drawer_id`` groups in the palace — one per mining pass
+    — each with its own stored ``source_mtime``. ``file_already_mined`` must
+    return True if ANY group's stored mtime matches the file's current
+    mtime, regardless of which group ChromaDB's ``get(..., limit=1)`` happens
+    to return first.
+
+    Current code uses ``collection.get(where={"source_file": X}, limit=1)``
+    which has undefined ordering across multiple matching rows. When ChromaDB
+    returns a stale group (older mining pass with a different stored mtime),
+    the function returns False, the additive miner concludes the file changed,
+    and writes yet another duplicate group for a file that has not actually
+    changed. Steady state: duplicate groups accumulate without bound.
+
+    This test pins the failure space deterministically using a MockCollection
+    that always returns the stale group on limit=1 (worst-case ordering). A
+    correct implementation iterates all groups via the paginated pattern
+    already used in the ``extract_mode is not None`` branch.
+
+    Issue: follow-up to PR #1628 (the every-bare-source_file-query audit).
+    """
+    # Create a real file with known mtime.
+    test_file = tmp_path / "doc.md"
+    test_file.write_text("content that hasn't changed since the latest mine.")
+    current_mtime = os.path.getmtime(str(test_file))
+
+    # Build a MockCollection that simulates two parent_drawer_id groups
+    # under the same source_file with DIFFERENT stored mtimes:
+    #   group_A: stale, source_mtime = current_mtime - 100  (older pass)
+    #   group_B: current, source_mtime = current_mtime      (latest pass)
+    # The mock returns group_A for limit=1 calls (worst-case ordering) and
+    # returns BOTH groups for the paginated limit=1000 calls (what the fix
+    # must use).
+    stale_meta = {
+        "source_file": str(test_file),
+        "chunk_index": 0,
+        "parent_drawer_id": "drawer_group_A",
+        "source_mtime": current_mtime - 100.0,
+        "normalize_version": NORMALIZE_VERSION,
+    }
+    current_meta = {
+        "source_file": str(test_file),
+        "chunk_index": 0,
+        "parent_drawer_id": "drawer_group_B",
+        "source_mtime": current_mtime,
+        "normalize_version": NORMALIZE_VERSION,
+    }
+
+    class MockCollection:
+        """Simulates the ChromaDB get() contract for two parent_drawer_id
+        groups sharing one source_file. Returns the STALE group when called
+        with limit=1 (the worst-case-ordering shape that triggers the bug).
+        Returns BOTH groups (paginated) when called with limit=1000 — what
+        a correctly-iterating implementation must do."""
+
+        def get(self, where=None, limit=None, offset=0, include=None):
+            if limit == 1:
+                return {"ids": ["a_0"], "metadatas": [stale_meta]}
+            if offset == 0:
+                return {"ids": ["a_0", "b_0"], "metadatas": [stale_meta, current_meta]}
+            return {"ids": [], "metadatas": []}
+
+    col = MockCollection()
+
+    # EXPECTED: file_already_mined returns True because at least one stored
+    # group's mtime matches the current file mtime.
+    # CURRENT BUG: returns False because limit=1 grabs the stale group.
+    assert file_already_mined(col, str(test_file), check_mtime=True) is True, (
+        "file_already_mined returned False even though a group with matching "
+        "mtime exists. The limit=1 query picked the stale group; the function "
+        "must iterate all groups for the source_file (mirroring the existing "
+        "paginated pattern in the extract_mode-is-set branch)."
+    )


### PR DESCRIPTION
## Summary

Under the additive-mining model (drawer history preserved across re-mines), a single `source_file` can have multiple `parent_drawer_id` groups in the palace — one per mining pass — each with its own stored `source_mtime` and `normalize_version`.

`file_already_mined` (the function the project miner uses to decide whether a file needs to be re-mined) previously used `collection.get(where={"source_file": X}, limit=1)` and only checked the single returned row. ChromaDB does not guarantee ordering for `limit=1` across multiple matching rows, so the returned row was effectively arbitrary. When ChromaDB returned a stale group (older mining pass), the function returned False, the miner concluded the file had changed, and wrote yet another duplicate group of drawers for a file that had not actually changed.

This PR replaces the `limit=1` shortcut with the paginated-iteration pattern the `extract_mode is not None` branch has always used. The function now returns True if ANY stored group is current (matching version + matching mtime), regardless of which group ChromaDB orders first.

Closes #1653.

## What changes

- `mempalace/palace.py` — `file_already_mined` iterates all groups for the source_file in 1000-row pages, short-circuits on the first matching group. The two branches (`extract_mode is None` vs set) collapse into one loop that skips the extract_mode check when no mode is specified.
- `tests/test_miner.py` — adds `test_file_already_mined_handles_multiple_groups_under_one_source_file`, a deterministic regression test that uses a MockCollection to force worst-case ChromaDB ordering (returns stale group on `limit=1`) and asserts the function correctly returns True by iterating.

## How the fix works

```python
# Before — limit=1 shortcut, single row checked, ordering-dependent
results = collection.get(where={"source_file": X}, limit=1)
stored_meta = results.get("metadatas", [{}])[0] or {}
# ... check stored_meta version + mtime ...

# After — paginated iteration, short-circuit on first matching group
offset = 0
while True:
    results = collection.get(where={"source_file": X}, limit=1000, offset=offset, include=["metadatas"])
    for meta in results.get("metadatas") or []:
        # version check
        # mtime check (within 0.001s tolerance)
        if matches:
            return True
    if not (results.get("ids") or []):
        break
    offset += 1000
return False
```

Trade-off: average-case cost rises from O(1) `limit=1` query to O(N/1000) paginated scan. For typical sources (1–3 groups) the cost is unchanged because the loop short-circuits on the first matching group within the first page. For pathological sources with thousands of groups, the cost is O(pages-until-match) — still bounded, no longer flaky.

## Failure shape this prevents

```
t=0   file_mtime = 100
      mine() — writes group_A with stored source_mtime=100

t=1   user edits file, file_mtime becomes 200
      mine() — writes group_B with stored source_mtime=200

t=2   file unchanged since t=1
      mine() called → file_already_mined runs get(..., limit=1)
         - returns group_B → mtime 200 matches → True → skip → CORRECT
         - returns group_A → mtime 100 ≠ 200 → False → re-mine → WRONG
                              creates group_C, third duplicate

t=3   each spurious re-mine adds another group whose stale mtime can
      trigger the next spurious re-mine. Steady state: duplicate groups
      accumulate without bound for any file that has ever been edited.
```

Behavioral, not data-loss. Storage grows without bound; search results may show same content N times; closet pointers, hallway counts, and entity-frequency stats become inflated proportionally. Invisible until `mempalace status` reveals the bloat.

## Test plan

RED-then-GREEN pinned deterministically. The new test uses a MockCollection that simulates two `parent_drawer_id` groups under one `source_file`:

- stale group (older `source_mtime`) returned for `limit=1` calls (worst-case ordering)
- both groups returned for `limit=1000` paginated calls

Against pre-fix code: test FAILS (function returns False because `limit=1` picks stale group). Against post-fix code: test PASSES (iteration finds the current group).

| Env | Result |
|---|---|
| macOS Python 3.12 (local) | ✅ 2268 passed, 0 failed |
| Linux Python 3.9.25 (OrbStack) | ✅ 2260 passed, 0 failed |
| Linux Python 3.11.15 (OrbStack) | ✅ 2261 passed, 0 failed |
| Linux Python 3.13.13 (OrbStack) | ✅ 2261 passed, 0 failed |
| `ruff check` + `ruff format --check` | ✅ clean |

Existing 4 `file_already_mined` tests continue to pass:
- `test_file_already_mined_check_mtime`
- `test_file_already_mined_scopes_convo_extract_mode`
- `test_file_already_mined_extract_mode_paginates_large_sources`
- `test_file_already_mined_returns_false_for_stale_normalize_version`

## Backwards compatibility

- Public function signature unchanged
- Behavior for files with a single group is identical to before (single-page scan returns immediately on first match)
- Behavior for legacy palaces (pre-additive-mining, drawers without `parent_drawer_id`) is also unchanged — the function iterates one drawer and returns the same result it would have under `limit=1`

## Provenance

Surfaced during the per-query audit on PR #1628's amendment cycle (the search for every bare `where={"source_file": ...}` query in the repo). One of six sites identified; the other five are legitimately file-global in intent (closet purges, full-rebuild deletes, paginated mode-filtered scans). This site is the one whose failure mode mirrors the cross-group stitching pattern PR #1628 fixed at the searcher layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
