### PR TITLE
fix(chroma): stop false-positive HNSW quarantine of deferred-persist segments (#1579)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -104,11 +104,12 @@ def _hnsw_link_lists_is_usable_for_payload(seg_dir: str, *, pickle_present: bool
 
         link_size = os.path.getsize(link_path) if os.path.isfile(link_path) else 0
 
-        if link_size == 0 and not pickle_present:
-            # Deferred-persist: chromadb hasn't reached sync_threshold yet so
-            # neither link_lists.bin nor index_metadata.pickle have been written.
-            # This is healthy — the #344 ratio check still applies separately.
-            return True
+        if not pickle_present:
+            # Missing index_metadata.pickle is only healthy in the deferred-persist
+            # state, i.e. link_lists.bin is also empty/absent. A non-empty
+            # link_lists.bin with no pickle is an interrupted partial flush (chromadb
+            # writes link_lists before the pickle) and must be quarantined. (#1579, PR #1655 Gemini review)
+            return link_size == 0
 
         return link_size > 0
     except OSError:

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -71,13 +71,25 @@ def _hnsw_link_to_data_ratio(seg_dir: str) -> Optional[float]:
     return link_size / data_size
 
 
-def _hnsw_link_lists_is_usable_for_payload(seg_dir: str) -> bool:
+def _hnsw_link_lists_is_usable_for_payload(seg_dir: str, *, pickle_present: bool = True) -> bool:
     """Return False when a non-trivial HNSW payload lacks usable link lists.
 
-    A missing or empty link_lists.bin is acceptable only for a fresh/empty
-    segment. Once data_level0.bin has real payload, a zero-byte link_lists.bin
-    is not a harmless async-flush shape: ChromaDB can later hand the broken
-    graph to hnswlib and crash in native code.
+    Fix #1579 / #344: the check depends on whether index_metadata.pickle exists.
+
+    - pickle PRESENT + empty link_lists + non-trivial data → False (corrupt, #1457).
+      ChromaDB wrote vector data but the metadata/link-graph is incomplete. Letting
+      Chroma open this shape can crash in native HNSW code.
+    - pickle ABSENT + empty link_lists + non-trivial data → True (deferred-persist).
+      Small/incremental mines never reach hnsw:sync_threshold so chromadb never
+      calls persist() and never writes index_metadata.pickle. This is the NORMAL
+      state for any palace below the 50 000-entry sync_threshold, NOT corruption.
+      The #344 bloat check (ratio > _HNSW_LINK_TO_DATA_MAX_RATIO) still fires
+      independently on bloated link_lists regardless of pickle presence.
+
+    ``pickle_present`` must be supplied by the caller (``_segment_appears_healthy``)
+    which already has the pickle path available. Defaults to True (conservative —
+    treats absence of knowledge as "pickle present") for safety when called from
+    other contexts.
     """
     data_path = os.path.join(seg_dir, "data_level0.bin")
     link_path = os.path.join(seg_dir, "link_lists.bin")
@@ -90,14 +102,27 @@ def _hnsw_link_lists_is_usable_for_payload(seg_dir: str) -> bool:
         if data_size <= _HNSW_MISSING_METADATA_DATA_FLOOR:
             return True
 
-        return os.path.isfile(link_path) and os.path.getsize(link_path) > 0
+        link_size = os.path.getsize(link_path) if os.path.isfile(link_path) else 0
+
+        if link_size == 0 and not pickle_present:
+            # Deferred-persist: chromadb hasn't reached sync_threshold yet so
+            # neither link_lists.bin nor index_metadata.pickle have been written.
+            # This is healthy — the #344 ratio check still applies separately.
+            return True
+
+        return link_size > 0
     except OSError:
         return False
 
 
-def _hnsw_payload_appears_sane(seg_dir: str) -> bool:
-    """Return False when HNSW payload files are structurally implausible."""
-    if not _hnsw_link_lists_is_usable_for_payload(seg_dir):
+def _hnsw_payload_appears_sane(seg_dir: str, *, pickle_present: bool = True) -> bool:
+    """Return False when HNSW payload files are structurally implausible.
+
+    ``pickle_present`` is forwarded to ``_hnsw_link_lists_is_usable_for_payload``
+    so that the deferred-persist case (empty link_lists, no pickle) is not
+    misidentified as corruption. See #1579.
+    """
+    if not _hnsw_link_lists_is_usable_for_payload(seg_dir, pickle_present=pickle_present):
         return False
 
     ratio = _hnsw_link_to_data_ratio(seg_dir)
@@ -128,6 +153,38 @@ _HNSW_BLOAT_GUARD = {
     "hnsw:batch_size": 50_000,
     "hnsw:sync_threshold": 50_000,
 }
+
+
+def _hnsw_bloat_guard() -> dict:
+    """Return the HNSW metadata dict for collection creation.
+
+    Defaults to ``_HNSW_BLOAT_GUARD`` (batch_size=50_000, sync_threshold=50_000)
+    but honours ``MEMPALACE_HNSW_SYNC_THRESHOLD`` / ``MEMPALACE_HNSW_BATCH_SIZE``
+    env vars and ``hnsw_sync_threshold`` / ``hnsw_batch_size`` in ``config.json``.
+
+    Lowering the threshold allows smaller palaces to trigger chromadb's persist
+    path so ``index_metadata.pickle`` is written before process exit, preventing
+    the false-positive quarantine on cold open described in issue #1579. The
+    default of 50 000 is kept to preserve the #344 bloat protection.
+    """
+    try:
+        from ..config import MempalaceConfig
+
+        cfg = MempalaceConfig()
+        return {
+            "hnsw:batch_size": cfg.hnsw_batch_size,
+            "hnsw:sync_threshold": cfg.hnsw_sync_threshold,
+        }
+    except Exception as exc:
+        # Never let a config failure break collection creation — fall back to
+        # the hard-coded defaults that have been stable since PR #344.
+        logger.warning(
+            "HNSW threshold config failed to load; using hard-coded defaults %s",
+            _HNSW_BLOAT_GUARD,
+            exc_info=exc,
+        )
+        return dict(_HNSW_BLOAT_GUARD)
+
 
 # Missing index_metadata.pickle is normal only while a segment is still fresh
 # or effectively empty. Once data_level0.bin has non-trivial payload, a
@@ -168,11 +225,16 @@ def _segment_appears_healthy(seg_dir: str) -> bool:
     ``0x2e`` (the protocol/terminator byte sequence chromadb serializes
     with).
 
-    Missing metadata is healthy only while the segment still looks fresh or
-    empty. If ``data_level0.bin`` already has non-trivial payload but
-    ``index_metadata.pickle`` is missing, the segment is partially flushed:
-    Chroma wrote vector data without the metadata it needs to reopen the
-    HNSW reader safely.
+    Fix #1579: missing ``index_metadata.pickle`` with non-trivial
+    ``data_level0.bin`` and empty/absent ``link_lists.bin`` is the
+    NORMAL deferred-persist state for small/incremental mines that never
+    reached ``hnsw:sync_threshold``. This must NOT be quarantined.
+
+    The two cases where a segment IS unhealthy despite missing pickle:
+    1. Bloated ``link_lists.bin`` (ratio > _HNSW_LINK_TO_DATA_MAX_RATIO,
+       the #344 danger): link_lists present and much larger than data.
+    2. Pickle present but failing the format sniff (bytes don't match
+       chromadb's protocol-2 envelope): partial-flush corruption.
 
     Deliberately format-sniffs only; never deserializes. Deserialization
     can execute arbitrary code, and the byte-sniff is sufficient to
@@ -185,22 +247,20 @@ def _segment_appears_healthy(seg_dir: str) -> bool:
     files and quarantine_stale_hnsw would conservatively rename them
     out of the way.
     """
-    if not _hnsw_payload_appears_sane(seg_dir):
+    meta_path = os.path.join(seg_dir, "index_metadata.pickle")
+    pickle_present = os.path.isfile(meta_path)
+
+    # Pass pickle_present so the usability check can distinguish the
+    # deferred-persist case (no pickle + empty link_lists) from corruption
+    # (pickle present + empty link_lists). See #1579 and #344.
+    if not _hnsw_payload_appears_sane(seg_dir, pickle_present=pickle_present):
         return False
 
-    meta_path = os.path.join(seg_dir, "index_metadata.pickle")
-    if not os.path.isfile(meta_path):
-        data_path = os.path.join(seg_dir, "data_level0.bin")
-        try:
-            if (
-                os.path.isfile(data_path)
-                and os.path.getsize(data_path) > _HNSW_MISSING_METADATA_DATA_FLOOR
-            ):
-                return False
-        except OSError:
-            return False
-
-        # No metadata and no meaningful vector payload yet: fresh/empty segment.
+    if not pickle_present:
+        # Deferred-persist: chromadb never reached sync_threshold.
+        # _hnsw_payload_appears_sane already rejected the bloat case above,
+        # so arriving here means link_lists is either absent, empty, or
+        # within ratio bounds — all safe. Return healthy. #1579
         return True
 
     try:
@@ -1462,7 +1522,7 @@ class ChromaBackend(BaseBackend):
                     metadata={
                         "hnsw:space": hnsw_space,
                         "hnsw:num_threads": 1,
-                        **_HNSW_BLOAT_GUARD,
+                        **_hnsw_bloat_guard(),
                     },
                     **ef_kwargs,
                 )
@@ -1537,7 +1597,7 @@ class ChromaBackend(BaseBackend):
             metadata={
                 "hnsw:space": hnsw_space,
                 "hnsw:num_threads": 1,
-                **_HNSW_BLOAT_GUARD,
+                **_hnsw_bloat_guard(),
             },
             **ef_kwargs,
         )

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -561,6 +561,51 @@ class MempalaceConfig:
             pass
 
     @property
+    def hnsw_sync_threshold(self) -> int:
+        """HNSW ``sync_threshold`` used at collection creation.
+
+        Controls when chromadb flushes the HNSW index to disk. The default
+        of 50 000 defers persistence until a large batch completes, which
+        prevents the link_lists.bin bloat described in PR #344.
+
+        Operators with smaller palaces can lower this value
+        (e.g. ``MEMPALACE_HNSW_SYNC_THRESHOLD=500``) so that
+        ``index_metadata.pickle`` is written during a mine, preventing the
+        false-positive quarantine on cold open described in issue #1579.
+
+        Invalid values (zero, negative, non-numeric) fall back to 50 000.
+        """
+        env_val = os.environ.get("MEMPALACE_HNSW_SYNC_THRESHOLD")
+        if env_val is not None:
+            coerced = self._try_coerce_int(env_val, minimum=1)
+            if coerced is not None:
+                return coerced
+        coerced = self._try_coerce_int(
+            self._file_config.get("hnsw_sync_threshold", 50_000), minimum=1
+        )
+        return 50_000 if coerced is None else coerced
+
+    @property
+    def hnsw_batch_size(self) -> int:
+        """HNSW ``batch_size`` used at collection creation.
+
+        Works in tandem with ``hnsw_sync_threshold``: both should be raised
+        or lowered together. Default is 50 000 (matching the #344 bloat guard).
+
+        Override via ``MEMPALACE_HNSW_BATCH_SIZE`` env var or the
+        ``hnsw_batch_size`` key in ``config.json``.
+
+        Invalid values (zero, negative, non-numeric) fall back to 50 000.
+        """
+        env_val = os.environ.get("MEMPALACE_HNSW_BATCH_SIZE")
+        if env_val is not None:
+            coerced = self._try_coerce_int(env_val, minimum=1)
+            if coerced is not None:
+                return coerced
+        coerced = self._try_coerce_int(self._file_config.get("hnsw_batch_size", 50_000), minimum=1)
+        return 50_000 if coerced is None else coerced
+
+    @property
     def topic_tunnel_min_count(self):
         """Minimum number of overlapping confirmed topics required to create
         a cross-wing tunnel between two wings.

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -697,14 +697,21 @@ def test_quarantine_stale_hnsw_leaves_empty_segment_without_metadata_alone(tmp_p
     assert seg.exists()
 
 
-def test_segment_without_metadata_but_with_nontrivial_data_is_unhealthy(tmp_path):
-    """Data without index_metadata.pickle is a partial flush, not a fresh segment."""
+def test_segment_without_metadata_but_with_nontrivial_data_is_healthy_deferred_persist(tmp_path):
+    """Fix #1579: data present + no link_lists + no pickle is the NORMAL deferred-persist state.
+
+    Small/incremental mines never reach hnsw:sync_threshold so chromadb never
+    writes index_metadata.pickle. This segment is healthy — NOT a partial flush.
+    The old #1274 logic treated this as corrupt; #1579 corrects that.
+    The bloat-guard ratio check still fires if link_lists.bin is bloated.
+    """
 
     seg = tmp_path / "abcd-1234-5678"
     seg.mkdir()
     (seg / "data_level0.bin").write_bytes(b"\0" * (_HNSW_MISSING_METADATA_DATA_FLOOR + 1))
+    # No link_lists.bin, no index_metadata.pickle — deferred-persist shape.
 
-    assert not _segment_appears_healthy(str(seg))
+    assert _segment_appears_healthy(str(seg))
 
 
 def test_segment_without_metadata_and_tiny_data_is_still_treated_as_fresh(tmp_path):
@@ -717,8 +724,14 @@ def test_segment_without_metadata_and_tiny_data_is_still_treated_as_fresh(tmp_pa
     assert _segment_appears_healthy(str(seg))
 
 
-def test_quarantine_stale_hnsw_renames_missing_metadata_with_nontrivial_data(tmp_path):
-    """Regression for #1274: missing pickle + non-trivial data must quarantine."""
+def test_quarantine_leaves_deferred_persist_segment_in_place(tmp_path):
+    """Fix #1579: missing pickle + non-trivial data + no link_lists is deferred-persist.
+
+    This was previously quarantined as #1274 corruption but is actually the
+    NORMAL state for any palace that never reached hnsw:sync_threshold.
+    quarantine_stale_hnsw must leave it in place even when sqlite mtime is
+    much newer than the HNSW files.
+    """
 
     now = 1_700_000_000.0
     palace, seg = _make_palace_with_segment(
@@ -729,16 +742,13 @@ def test_quarantine_stale_hnsw_renames_missing_metadata_with_nontrivial_data(tmp
     )
     (seg / "data_level0.bin").write_bytes(b"\0" * (_HNSW_MISSING_METADATA_DATA_FLOOR + 1))
     os.utime(seg / "data_level0.bin", (now - 7200, now - 7200))
+    # No link_lists.bin — deferred-persist shape; _make_palace_with_segment
+    # does not write link_lists.bin, so this is already the right shape.
 
     moved = quarantine_stale_hnsw(str(palace), stale_seconds=3600.0)
 
-    assert len(moved) == 1
-    assert ".drift-" in moved[0]
-    assert not seg.exists()
-
-    drift_dirs = [p for p in palace.iterdir() if ".drift-" in p.name]
-    assert len(drift_dirs) == 1
-    assert (drift_dirs[0] / "data_level0.bin").exists()
+    assert moved == [], "deferred-persist segment must not be quarantined"
+    assert seg.exists()
 
 
 def test_quarantine_stale_hnsw_renames_truncated_metadata(tmp_path):
@@ -1407,3 +1417,70 @@ def test_palace_get_collection_uses_configured_collection_name(monkeypatch):
         "collection_name": "custom_drawers",
         "create": False,
     }
+
+
+# ── Fix A: configurable HNSW thresholds (#1579) ────────────────────────
+
+
+def test_sync_threshold_default_is_50000(tmp_path):
+    """With no env override, created collection must carry sync_threshold=50_000.
+
+    This is a regression guard: the default must never silently drop below
+    50_000 (the value validated by the #344 bloat regression suite).
+    """
+    palace_path = tmp_path / "palace"
+    ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=True,
+    )
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_collection("mempalace_drawers")
+    assert col.metadata.get("hnsw:sync_threshold") == 50_000
+
+
+def test_sync_threshold_env_override(tmp_path, monkeypatch):
+    """MEMPALACE_HNSW_SYNC_THRESHOLD env var must override the default at collection creation.
+
+    Large-palace operators who want deferred persistence to actually trigger
+    can lower this value so chromadb writes index_metadata.pickle before
+    the process exits, preventing false-positive quarantine on next open.
+    """
+    monkeypatch.setenv("MEMPALACE_HNSW_SYNC_THRESHOLD", "500")
+    palace_path = tmp_path / "palace"
+    ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=True,
+    )
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_collection("mempalace_drawers")
+    assert col.metadata.get("hnsw:sync_threshold") == 500
+
+
+def test_batch_size_env_override(tmp_path, monkeypatch):
+    """MEMPALACE_HNSW_BATCH_SIZE env var must override the default at collection creation."""
+    monkeypatch.setenv("MEMPALACE_HNSW_BATCH_SIZE", "1000")
+    palace_path = tmp_path / "palace"
+    ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=True,
+    )
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_collection("mempalace_drawers")
+    assert col.metadata.get("hnsw:batch_size") == 1000
+
+
+def test_hnsw_threshold_invalid_env_falls_back_to_default(tmp_path, monkeypatch):
+    """A garbage env value must fall back to the 50_000 default, not crash."""
+    monkeypatch.setenv("MEMPALACE_HNSW_SYNC_THRESHOLD", "not_a_number")
+    palace_path = tmp_path / "palace"
+    ChromaBackend().get_collection(
+        str(palace_path),
+        collection_name="mempalace_drawers",
+        create=True,
+    )
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_collection("mempalace_drawers")
+    assert col.metadata.get("hnsw:sync_threshold") == 50_000

--- a/tests/test_hnsw_payload_health.py
+++ b/tests/test_hnsw_payload_health.py
@@ -156,3 +156,138 @@ def test_quarantine_catches_zero_byte_link_lists_when_stale(tmp_path):
     moved_path = Path(moved[0])
     assert moved_path.exists()
     assert moved_path.name.startswith("11111111-2222-3333-4444-555555555555.drift-")
+
+
+# ── Fix B: deferred-persist (incremental mine) segments (#1579) ────────
+
+
+def test_deferred_persist_segment_not_quarantined(tmp_path):
+    """#1579: data_level0 present, link_lists empty, NO pickle → healthy deferred-persist.
+
+    Small/incremental mines never trigger hnsw:sync_threshold, so
+    index_metadata.pickle is never written. That is the NORMAL state,
+    not corruption. _segment_appears_healthy must return True for it.
+    """
+    seg_dir = tmp_path / "11111111-2222-3333-4444-555555555555"
+    seg_dir.mkdir(parents=True, exist_ok=True)
+    (seg_dir / "data_level0.bin").write_bytes(b"\0" * 167_600)
+    (seg_dir / "link_lists.bin").write_bytes(b"")
+    # NO index_metadata.pickle written
+
+    assert _segment_appears_healthy(str(seg_dir)), (
+        "deferred-persist segment (data present, link_lists empty, no pickle) "
+        "must be treated as healthy (fix #1579)"
+    )
+
+    # Also verify quarantine_stale_hnsw leaves it in place even when sqlite
+    # mtime is arbitrarily newer than the HNSW files.
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    db_path = palace / "chroma.sqlite3"
+    db_path.write_text("sqlite placeholder")
+
+    seg_dir2 = palace / "22222222-3333-4444-5555-666666666666"
+    seg_dir2.mkdir(parents=True, exist_ok=True)
+    (seg_dir2 / "data_level0.bin").write_bytes(b"\0" * 167_600)
+    (seg_dir2 / "link_lists.bin").write_bytes(b"")
+
+    hnsw_time = 1_700_000_000
+    sqlite_time = hnsw_time + 9_999
+    os.utime(seg_dir2 / "data_level0.bin", (hnsw_time, hnsw_time))
+    os.utime(db_path, (sqlite_time, sqlite_time))
+
+    moved = quarantine_stale_hnsw(str(palace), stale_seconds=300)
+    assert moved == [], (
+        "deferred-persist segment must not be quarantined even when stale_seconds exceeded"
+    )
+    assert seg_dir2.exists()
+
+
+def test_bloated_link_lists_still_quarantined(tmp_path):
+    """#344 regression guard: bloated link_lists (ratio > max) must still quarantine.
+
+    The deferred-persist fix must not loosen the #344 bloat detection path.
+    link_lists >> data_level0 is always structurally corrupt regardless of
+    whether pickle is present.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    db_path = palace / "chroma.sqlite3"
+    db_path.write_text("sqlite placeholder")
+
+    seg_dir = palace / "11111111-2222-3333-4444-555555555555"
+    seg_dir.mkdir(parents=True, exist_ok=True)
+    data_size = 1_000
+    link_size = int(data_size * (_HNSW_LINK_TO_DATA_MAX_RATIO + 1))
+    (seg_dir / "data_level0.bin").write_bytes(b"\0" * data_size)
+    (seg_dir / "link_lists.bin").write_bytes(b"\0" * link_size)
+    # No pickle — deferred-persist appearance, but link_lists is bloated
+
+    same_time = 1_700_000_000
+    os.utime(db_path, (same_time, same_time))
+    os.utime(seg_dir / "data_level0.bin", (same_time, same_time))
+
+    moved = quarantine_stale_hnsw(str(palace), stale_seconds=999_999)
+    assert len(moved) == 1, "bloated link_lists must still be quarantined even without pickle"
+    assert not seg_dir.exists()
+
+
+def test_corrupt_pickle_still_quarantined(tmp_path):
+    """#1579: pickle present but bad magic bytes → still quarantined.
+
+    The deferred-persist fix applies ONLY when pickle is absent.
+    A present-but-corrupt pickle is genuine corruption.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    db_path = palace / "chroma.sqlite3"
+    db_path.write_text("sqlite placeholder")
+
+    seg_dir = palace / "11111111-2222-3333-4444-555555555555"
+    _write_segment(
+        seg_dir,
+        data_size=2_000,
+        link_size=100,
+        write_metadata=False,
+    )
+    # Write a pickle with invalid magic bytes
+    (seg_dir / "index_metadata.pickle").write_bytes(b"\xff" + b"x" * 16 + b"\xff")
+
+    hnsw_time = 1_700_000_000
+    sqlite_time = hnsw_time + 1_000
+    os.utime(seg_dir / "data_level0.bin", (hnsw_time, hnsw_time))
+    os.utime(db_path, (sqlite_time, sqlite_time))
+
+    moved = quarantine_stale_hnsw(str(palace), stale_seconds=300)
+    assert len(moved) == 1, "corrupt pickle must still be quarantined"
+    assert not seg_dir.exists()
+
+
+def test_healthy_persisted_segment_unaffected(tmp_path):
+    """#1579: data + non-zero link_lists + valid pickle → healthy, not quarantined."""
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    db_path = palace / "chroma.sqlite3"
+    db_path.write_text("sqlite placeholder")
+
+    seg_dir = palace / "11111111-2222-3333-4444-555555555555"
+    _write_segment(
+        seg_dir,
+        data_size=2_000,
+        link_size=500,
+        write_metadata=True,
+    )
+
+    hnsw_time = 1_700_000_000
+    sqlite_time = hnsw_time + 9_999
+    os.utime(seg_dir / "data_level0.bin", (hnsw_time, hnsw_time))
+    os.utime(db_path, (sqlite_time, sqlite_time))
+
+    assert _segment_appears_healthy(str(seg_dir))
+
+    moved = quarantine_stale_hnsw(str(palace), stale_seconds=300)
+    assert moved == [], "healthy persisted segment must not be quarantined"
+    assert seg_dir.exists()

--- a/tests/test_hnsw_payload_health.py
+++ b/tests/test_hnsw_payload_health.py
@@ -265,6 +265,47 @@ def test_corrupt_pickle_still_quarantined(tmp_path):
     assert not seg_dir.exists()
 
 
+def test_partial_flush_missing_pickle_nonempty_links_still_quarantined(tmp_path):
+    """#1655 Gemini review: non-empty link_lists.bin + no pickle = interrupted partial flush.
+
+    chromadb writes link_lists.bin before index_metadata.pickle. A segment with
+    data above the floor, a non-empty (but not bloated) link_lists.bin, and no
+    pickle is an interrupted partial flush — NOT the benign deferred-persist state.
+    It must be quarantined.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    db_path = palace / "chroma.sqlite3"
+    db_path.write_text("sqlite placeholder")
+
+    seg_dir = palace / "11111111-2222-3333-4444-555555555555"
+    seg_dir.mkdir(parents=True, exist_ok=True)
+    # data above floor, link_lists non-empty but ratio << max (not a bloat hit)
+    data_size = 2_000
+    link_size = 200  # ratio = 0.1, well below _HNSW_LINK_TO_DATA_MAX_RATIO
+    (seg_dir / "data_level0.bin").write_bytes(b"\0" * data_size)
+    (seg_dir / "link_lists.bin").write_bytes(b"\0" * link_size)
+    # NO index_metadata.pickle — simulates interrupted flush
+
+    assert not _segment_appears_healthy(str(seg_dir)), (
+        "partial-flush segment (non-empty link_lists, no pickle) must be unhealthy"
+    )
+
+    hnsw_time = 1_700_000_000
+    sqlite_time = hnsw_time + 1_000
+    os.utime(seg_dir / "data_level0.bin", (hnsw_time, hnsw_time))
+    os.utime(db_path, (sqlite_time, sqlite_time))
+
+    moved = quarantine_stale_hnsw(str(palace), stale_seconds=300)
+    assert len(moved) == 1, "partial-flush segment must be quarantined"
+    assert not seg_dir.exists()
+
+    moved_path = Path(moved[0])
+    assert moved_path.exists()
+    assert moved_path.name.startswith("11111111-2222-3333-4444-555555555555.drift-")
+
+
 def test_healthy_persisted_segment_unaffected(tmp_path):
     """#1579: data + non-zero link_lists + valid pickle → healthy, not quarantined."""
     palace = tmp_path / "palace"


### PR DESCRIPTION
## What does this PR do?

Fixes #1579 — incremental/small mines never cross `hnsw:sync_threshold` (50_000, set by the #344 bloat guard), so chromadb never persists `index_metadata.pickle` and leaves an empty `link_lists.bin`. The HNSW integrity check treated that benign **deferred-persist** shape (`data_level0.bin` present + empty `link_lists.bin` + missing `index_metadata.pickle`) as corruption and quarantined the segment on every cold open, accumulating `.drift-*` directories indefinitely. The check was effectively backwards: #344's real danger is a *bloated* `link_lists.bin`, not an empty one.

**Fix B (the correction).** `_segment_appears_healthy` / `_hnsw_payload_appears_sane` / `_hnsw_link_lists_is_usable_for_payload` now treat `empty link_lists + missing pickle` as healthy (deferred persist). Both pre-existing protections are preserved and evaluated **before** the new healthy gate:
- **#344 anti-bloat** — a bloated `link_lists.bin` (ratio > `_HNSW_LINK_TO_DATA_MAX_RATIO`) still quarantines, regardless of pickle presence.
- **Corrupt pickle** — a present-but-malformed `index_metadata.pickle` (bad magic bytes) still quarantines, regardless of `link_lists` state.

**Fix A (opt-in, default unchanged).** `hnsw_sync_threshold` / `hnsw_batch_size` are now configurable via `config.json` or `MEMPALACE_HNSW_SYNC_THRESHOLD` / `MEMPALACE_HNSW_BATCH_SIZE`, defaulting to **50_000** (unchanged). Large palaces can opt into a lower threshold to actually persist the ANN index, without anyone inheriting the #344 bloat risk by default. A config-load failure logs a warning and falls back to the hard-coded defaults (no silent failure).

**Why not #1579's suggested forced-flush fix?** It is not possible on chromadb 1.5.7+ — that release replaced the Python HNSW segment with Rust bindings (`RustBindingsAPI`) that expose no Python-reachable segment manager or `_persist()`. Empirically (verified against 1.5.7 and 1.5.9), the only persist trigger is crossing `sync_threshold` during a single process's writes, and that counter is **per-process** — so incremental hook/session mines never persist regardless of total palace size. The durable fix therefore has to live at the quarantine layer. Details posted on #1579.

No new dependencies. Default behavior for existing palaces is unchanged except that the spurious quarantine no longer fires.

## How to test

```bash
uv run pytest tests/test_hnsw_payload_health.py tests/test_backends.py -v
```

New/updated coverage:
- `test_deferred_persist_segment_not_quarantined` — data present + empty link_lists + no pickle => healthy, not quarantined (fails on pre-fix code).
- `test_bloated_link_lists_still_quarantined` — #344 regression guard (still quarantines).
- `test_corrupt_pickle_still_quarantined` — bad-magic-byte pickle still quarantines.
- `test_healthy_persisted_segment_unaffected` — valid persisted segment untouched.
- Fix A: `test_sync_threshold_default_is_50000`, `test_sync_threshold_env_override`, `test_batch_size_env_override`, `test_hnsw_threshold_invalid_env_falls_back_to_default`.
- Two `test_backends.py` tests that encoded the old (buggy) behavior were flipped to assert the corrected behavior.

End-to-end manual verification (chromadb 1.5.9): fresh palace -> tiny mine reproduces the deferred-persist shape -> forced staleness (SQLite > 300s newer than HNSW) -> `mempalace status` produces **no quarantine and no `.drift-*` dir**, and search still returns results. Full suite: `2266 passed, 3 skipped`.

## Checklist
- [x] Tests pass (`uv run pytest tests/ -v` — 2266 passed, 3 skipped)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .` and `ruff format --check .`)

Closes #1579