### PR TITLE
fix(backends): strip lone surrogates from documents at the ChromaDB chokepoint

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1059,6 +1059,12 @@ class ChromaCollection(BaseCollection):
             return None
         from ..config import strip_lone_surrogates
 
+        # chromadb accepts OneOrMany[Document]: a bare str is a single document,
+        # not an iterable of characters. Handle it explicitly so we don't split
+        # it into per-character documents — that would be exactly the kind of
+        # silent corruption this method exists to prevent.
+        if isinstance(documents, str):
+            return strip_lone_surrogates(documents)
         return [strip_lone_surrogates(d) if isinstance(d, str) else d for d in documents]
 
     def add(self, *, documents, ids, metadatas=None, embeddings=None):

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1038,8 +1038,34 @@ class ChromaCollection(BaseCollection):
             for m in metadatas
         ]
 
+    @staticmethod
+    def _sanitize_documents_for_chromadb(documents):
+        """Strip lone UTF-16 surrogates from every document before it reaches
+        the chromadb client.
+
+        A single lone surrogate (U+D800–U+DFFF) raises ``UnicodeEncodeError``
+        inside chromadb's encode path and aborts the *entire* add/upsert batch
+        with a ``-32000`` Internal Error, silently dropping every other row in
+        the same batch (#1235).
+
+        #1235 fixed this for the MCP write tools via ``sanitize_content``, but
+        the bulk ingest paths (miner, convo_miner, sweeper, diary_ingest) build
+        documents without routing through that helper and reach this backend
+        directly. Sanitising here makes the chokepoint catch-all complete: the
+        sibling :meth:`_sanitize_metadatas_for_chromadb` already guarantees this
+        for metadata one method over; documents get the same guarantee.
+        """
+        if documents is None:
+            return None
+        from ..config import strip_lone_surrogates
+
+        return [strip_lone_surrogates(d) if isinstance(d, str) else d for d in documents]
+
     def add(self, *, documents, ids, metadatas=None, embeddings=None):
-        kwargs: dict[str, Any] = {"documents": documents, "ids": ids}
+        kwargs: dict[str, Any] = {
+            "documents": self._sanitize_documents_for_chromadb(documents),
+            "ids": ids,
+        }
         sanitized = self._sanitize_metadatas_for_chromadb(metadatas)
         if sanitized is not None:
             kwargs["metadatas"] = sanitized
@@ -1049,7 +1075,10 @@ class ChromaCollection(BaseCollection):
             self._collection.add(**kwargs)
 
     def upsert(self, *, documents, ids, metadatas=None, embeddings=None):
-        kwargs: dict[str, Any] = {"documents": documents, "ids": ids}
+        kwargs: dict[str, Any] = {
+            "documents": self._sanitize_documents_for_chromadb(documents),
+            "ids": ids,
+        }
         sanitized = self._sanitize_metadatas_for_chromadb(metadatas)
         if sanitized is not None:
             kwargs["metadatas"] = sanitized
@@ -1070,7 +1099,7 @@ class ChromaCollection(BaseCollection):
             raise ValueError("update requires at least one of documents, metadatas, embeddings")
         kwargs: dict[str, Any] = {"ids": ids}
         if documents is not None:
-            kwargs["documents"] = documents
+            kwargs["documents"] = self._sanitize_documents_for_chromadb(documents)
         if metadatas is not None:
             kwargs["metadatas"] = metadatas
         if embeddings is not None:

--- a/tests/test_clean_lone_surrogates.py
+++ b/tests/test_clean_lone_surrogates.py
@@ -252,3 +252,13 @@ class TestBackendChokepointStripsDocuments:
         col.add(documents=["ship \U0001f680"], ids=["1"])
         _, kwargs = fake.calls[0]
         assert kwargs["documents"] == ["ship \U0001f680"]
+
+    def test_single_string_document_is_not_split_into_chars(self):
+        """chromadb accepts a bare str as one document (OneOrMany[Document]).
+        The sanitiser must keep it whole and clean, not split it into
+        per-character documents."""
+        fake, col = self._collection()
+        col.upsert(documents="one\udc95document", ids=["1"])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == "one�document"
+        assert isinstance(kwargs["documents"], str)

--- a/tests/test_clean_lone_surrogates.py
+++ b/tests/test_clean_lone_surrogates.py
@@ -177,3 +177,78 @@ class TestToolsAcceptSurrogates:
             topic="log",
         )
         assert result["success"] is True
+
+
+# ── Backend chokepoint (bulk ingest paths) ──────────────────────────────────
+
+
+class _CapturingCollection:
+    """Minimal chromadb.Collection stand-in that records the kwargs it receives,
+    so we can assert what actually reaches the chromadb client."""
+
+    def __init__(self):
+        self.calls = []
+
+    def add(self, **kwargs):
+        self.calls.append(("add", kwargs))
+
+    def upsert(self, **kwargs):
+        self.calls.append(("upsert", kwargs))
+
+    def update(self, **kwargs):
+        self.calls.append(("update", kwargs))
+
+
+class TestBackendChokepointStripsDocuments:
+    """#1235 sanitised the MCP write tools, but the bulk ingest paths
+    (miner, convo_miner, sweeper, diary_ingest) build documents without routing
+    through ``sanitize_content`` and reach ``ChromaCollection`` directly. A lone
+    surrogate in *document* text crashes the whole add/upsert batch (-32000),
+    silently dropping the other rows. The backend chokepoint must strip
+    documents, mirroring ``_sanitize_metadatas_for_chromadb``."""
+
+    @staticmethod
+    def _collection():
+        from mempalace.backends.chroma import ChromaCollection
+
+        fake = _CapturingCollection()
+        return fake, ChromaCollection(fake)
+
+    def test_add_strips_lone_surrogate_in_document(self):
+        fake, col = self._collection()
+        col.add(documents=["clean\udc95doc"], ids=["1"])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["clean�doc"]
+        kwargs["documents"][0].encode("utf-8")  # the crash path must not raise
+
+    def test_upsert_strips_lone_surrogate_in_document(self):
+        fake, col = self._collection()
+        col.upsert(documents=["a\ud800b"], ids=["1"], metadatas=[{"wing": "w"}])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["a�b"]
+
+    def test_update_strips_lone_surrogate_in_document(self):
+        fake, col = self._collection()
+        col.update(ids=["1"], documents=["x\udcffy"])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["x�y"]
+
+    def test_one_poison_message_does_not_drop_the_batch(self):
+        """A single bad row used to abort the entire batch, silently dropping
+        the others. After sanitising, every row survives."""
+        fake, col = self._collection()
+        col.upsert(
+            documents=["ok one", "poison\udc95row", "ok three"],
+            ids=["1", "2", "3"],
+        )
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["ok one", "poison�row", "ok three"]
+        assert len(kwargs["ids"]) == 3
+        for d in kwargs["documents"]:
+            d.encode("utf-8")  # must not raise
+
+    def test_real_emoji_and_none_metadata_preserved(self):
+        fake, col = self._collection()
+        col.add(documents=["ship \U0001f680"], ids=["1"])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["ship \U0001f680"]


### PR DESCRIPTION
## Problem
A single lone UTF-16 surrogate (U+D800–U+DFFF) in a document raises
`UnicodeEncodeError` inside chromadb and aborts the **entire** add/upsert batch
with a `-32000` Internal Error — silently dropping every other row in the same
batch. For the sweeper (batches of 64 messages from Claude Code sessions, the
path hooks fire automatically) one poisoned message loses up to 63 good ones.

## Root cause
#1235 fixed this for the **MCP write tools** via `sanitize_content`. But the
bulk ingest paths — `miner`, `convo_miner`, `sweeper`, `diary_ingest` — build
documents without routing through that helper and reach `ChromaCollection`
directly. The backend chokepoint already sanitises **metadata**
(`_sanitize_metadatas_for_chromadb`, whose docstring promises it's the
"catch-all... even if a caller's own sanitizer misses a case") — but it passes
`documents` through raw, so the promise doesn't hold for content.

## Fix
Add `_sanitize_documents_for_chromadb` (mirror of the metadata sanitiser) and
apply it in `add`/`upsert`/`update`. The chokepoint now guarantees UTF-8-safe
documents regardless of caller.

## Why it's safe
- IDs and dedup are untouched (IDs are computed upstream; sanitising the document
  body never changes them).
- Only illegal lone surrogates become U+FFFD — the same `errors="replace"`
  behaviour already used across the codebase.
- No new dependency; reuses `strip_lone_surrogates` from #1235.

## Tests
5 new tests in `test_clean_lone_surrogates.py` covering add/upsert/update, the
"one poison row doesn't drop the batch" case, and emoji/None passthrough.
Verified locally: `ruff check` clean, `ruff format` clean, the surrogate suite
(24 tests) and neighbouring backend suites (`test_backends.py`,
`test_chroma_collection_lock.py`, 87 tests) all pass.
