### PR TITLE
fix(status): count drawers from sqlite instead of cold-loading the HNSW index

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pickle
 import sqlite3
+from collections import defaultdict
 from numbers import Integral
 from pathlib import Path
 from typing import Any, Optional
@@ -634,6 +635,93 @@ def _sqlite_embedding_count(palace_path: str, collection_name: str) -> Optional[
             conn.close()
     except sqlite3.Error:
         return None
+
+
+def _sqlite_wing_room_counts(
+    palace_path: str, collection_name: str
+) -> Optional[tuple[int, dict[str, dict[str, int]]]]:
+    """Tally drawers by wing/room straight from ``chroma.sqlite3``.
+
+    Returns ``(total, {wing: {room: count}})`` or ``None`` when the read
+    cannot be trusted — missing DB file, the collection has not been
+    bootstrapped, or any sqlite error (including a sustained writer lock).
+    ``None`` signals the caller to fall back to the ChromaDB client path
+    (which also emits the right state-specific guidance for absent/empty
+    palaces).
+
+    The point of reading sqlite directly is to count drawers **without opening
+    the collection**, because opening it cold-loads the HNSW vector index. On
+    large palaces that load costs tens of seconds of CPU per call — a steep,
+    pointless tax for an inspection command that only needs metadata the
+    relational tables already hold (#1681). Wings/rooms live in plain
+    ``embedding_metadata`` rows, joined to ``embeddings`` on the
+    ``(id, key)`` primary key, so the tally is a bounded scan of the metadata
+    segment: sub-second warm, a few seconds cold on a multi-GB DB — versus the
+    ~60s the vector-index load costs.
+
+    Sibling readers that count the same way: :func:`_sqlite_embedding_count`
+    (total only) and ``mcp_server._tool_status_via_sqlite`` (independent
+    wing/room histograms for the #1222 fallback). This one cross-tabulates
+    wing→room to match the ChromaDB ``status()`` output shape.
+
+    Notes:
+    - ``busy_timeout`` lets a transient checkpoint lock resolve instead of
+      instantly demoting to the slow HNSW path; a *sustained* lock still
+      raises and falls back (slow but correct).
+    - ``s.scope = 'METADATA'`` makes the single-segment join explicit so a
+      future ChromaDB that also stored per-vector-segment rows could not
+      silently double every count.
+    - ``COALESCE`` over ``string_value``/``int_value``/``float_value`` matches
+      the ChromaDB path, which surfaces a numeric wing/room natively rather
+      than dropping it to ``"?"``.
+    """
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            # Wait out a transient writer/checkpoint lock rather than falling
+            # straight back to the expensive vector-index path (#1681).
+            conn.execute("PRAGMA busy_timeout = 3000")
+            # Distinguish "collection never bootstrapped" (-> None, so the
+            # caller can show the 'initialized but empty' message) from
+            # "collection exists with zero drawers" (-> a real 0 tally).
+            if (
+                conn.execute(
+                    "SELECT 1 FROM collections WHERE name = ?", (collection_name,)
+                ).fetchone()
+                is None
+            ):
+                return None
+            rows = conn.execute(
+                """
+                SELECT COALESCE(wm.string_value, CAST(wm.int_value AS TEXT),
+                                CAST(wm.float_value AS TEXT), '?') AS wing,
+                       COALESCE(rm.string_value, CAST(rm.int_value AS TEXT),
+                                CAST(rm.float_value AS TEXT), '?') AS room,
+                       COUNT(*) AS n
+                FROM embeddings e
+                JOIN segments s ON e.segment_id = s.id AND s.scope = 'METADATA'
+                JOIN collections c ON s.collection = c.id
+                LEFT JOIN embedding_metadata wm ON wm.id = e.id AND wm.key = 'wing'
+                LEFT JOIN embedding_metadata rm ON rm.id = e.id AND rm.key = 'room'
+                WHERE c.name = ?
+                GROUP BY wing, room
+                """,
+                (collection_name,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+
+    total = 0
+    wing_rooms: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for wing, room, n in rows:
+        wing_rooms[wing][room] += int(n)
+        total += int(n)
+    return total, wing_rooms
 
 
 def _pin_hnsw_threads(collection) -> None:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1911,7 +1911,23 @@ def _compute_entity_tunnels_for_wing(wing: str) -> int:
 
 
 def status(palace_path: str):
-    """Show what's been filed in the palace."""
+    """Show what's been filed in the palace.
+
+    Tallies drawers by wing/room directly from ``chroma.sqlite3`` so a routine
+    status check never cold-loads the HNSW vector index — a load that costs
+    tens of seconds of CPU per call on large palaces (#1681). Falls back to the
+    ChromaDB client path when the sqlite read is unavailable (missing DB,
+    un-bootstrapped collection, or an unexpected schema); the fallback also
+    emits the state-specific guidance for absent/empty palaces.
+    """
+    from .backends.chroma import _sqlite_wing_room_counts
+
+    counts = _sqlite_wing_room_counts(palace_path, "mempalace_drawers")
+    if counts is not None:
+        total, wing_rooms = counts
+        _print_status(total, wing_rooms)
+        return
+
     col = _open_collection_or_explain(palace_path)
     if col is None:
         return
@@ -1932,6 +1948,11 @@ def status(palace_path: str):
             wing_rooms[m.get("wing", "?")][m.get("room", "?")] += 1
         offset += len(batch)
 
+    _print_status(total, wing_rooms)
+
+
+def _print_status(total: int, wing_rooms: dict[str, dict[str, int]]) -> None:
+    """Render the wing/room histogram shared by both status code paths."""
     print(f"\n{'=' * 55}")
     print(f"  MemPalace Status — {total} drawers")
     print(f"{'=' * 55}\n")

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -810,6 +810,133 @@ def test_status_handles_none_metadata_without_crash(tmp_path, capsys):
     assert "WING: proj" in out
 
 
+def test_status_does_not_cold_load_vector_index(palace_path, seeded_collection, capsys):
+    """#1681 regression: a healthy ``status`` must NOT open the collection.
+
+    Opening it cold-loads the HNSW vector index, which costs ~60s of CPU per
+    call on large palaces. The counts come from chroma.sqlite3 instead. If
+    anyone reroutes the happy path back through the vector index, the sentinel
+    patched over ``_open_collection_or_explain`` fires. (Revert ``status`` to
+    its pre-fix body and this test fails loudly — that's the regression it
+    guards.)
+    """
+    from unittest.mock import MagicMock, patch
+
+    sentinel = MagicMock(side_effect=AssertionError("status cold-loaded the vector index"))
+    with patch("mempalace.miner._open_collection_or_explain", sentinel):
+        status(palace_path)
+
+    sentinel.assert_not_called()
+    out = capsys.readouterr().out
+    assert "MemPalace Status — 4 drawers" in out
+    assert "WING: project" in out
+    assert "WING: notes" in out
+
+
+def test_sqlite_wing_room_counts_exact_tally(palace_path, seeded_collection):
+    """The sqlite tally must equal the seeded drawers exactly — 2 project/
+    backend, 1 project/frontend, 1 notes/planning — with no double counting.
+
+    Guards the double ``LEFT JOIN embedding_metadata`` against fan-out: if the
+    join multiplied rows (e.g. a drawer carrying several metadata keys), the
+    total would exceed 4 and the room counts would inflate.
+    """
+    from mempalace.backends.chroma import _sqlite_wing_room_counts
+
+    result = _sqlite_wing_room_counts(palace_path, "mempalace_drawers")
+    assert result is not None
+    total, wing_rooms = result
+    assert total == 4
+    assert {w: dict(r) for w, r in wing_rooms.items()} == {
+        "project": {"backend": 2, "frontend": 1},
+        "notes": {"planning": 1},
+    }
+
+
+def test_status_falls_back_to_chroma_when_sqlite_unreadable(palace_path, seeded_collection, capsys):
+    """When the sqlite fast path returns ``None`` (exotic schema / read error),
+    ``status`` must fall back to the ChromaDB client path and still report the
+    correct tally — not crash or print nothing."""
+    from unittest.mock import patch
+
+    with patch("mempalace.backends.chroma._sqlite_wing_room_counts", return_value=None):
+        status(palace_path)
+
+    out = capsys.readouterr().out
+    assert "MemPalace Status — 4 drawers" in out
+    assert "WING: project" in out
+
+
+def test_sqlite_wing_room_counts_none_when_collection_absent(palace_path):
+    """DB exists but the drawers collection was never bootstrapped -> ``None``,
+    so ``status`` routes to the 'initialized but empty' message instead of
+    printing a misleading ``0 drawers`` tally (State C, #1498)."""
+    import chromadb
+
+    from mempalace.backends.chroma import _sqlite_wing_room_counts
+
+    chromadb.PersistentClient(path=palace_path)  # creates chroma.sqlite3, no collection
+    assert _sqlite_wing_room_counts(palace_path, "mempalace_drawers") is None
+
+
+def test_sqlite_wing_room_counts_numeric_wing_not_dropped(palace_path, collection):
+    """A drawer whose wing/room is stored numerically (int_value, not
+    string_value) must be tallied under its stringified value — matching the
+    ChromaDB path, which surfaces the native number — not silently bucketed
+    under '?'. Without the int/float COALESCE this row would vanish into '?'
+    while returning a non-None result that skips the fallback."""
+    from mempalace.backends.chroma import _sqlite_wing_room_counts
+
+    collection.add(
+        ids=["drawer_numeric_meta"],
+        documents=["a drawer filed with a numeric wing and room"],
+        metadatas=[{"wing": 2026, "room": 7}],
+    )
+    result = _sqlite_wing_room_counts(palace_path, "mempalace_drawers")
+    assert result is not None
+    _, wing_rooms = result
+    assert {w: dict(r) for w, r in wing_rooms.items()} == {"2026": {"7": 1}}
+
+
+def test_sqlite_wing_room_counts_partial_metadata_buckets_question_mark(palace_path, collection):
+    """A drawer with a wing but no room (and vice versa) must be counted under
+    '?' for the missing axis, never dropped. Guards the LEFT JOINs against
+    being narrowed to inner joins, which would silently discard partial
+    drawers and undercount the total."""
+    from mempalace.backends.chroma import _sqlite_wing_room_counts
+
+    collection.add(
+        ids=["drawer_wing_only", "drawer_room_only"],
+        documents=["has a wing but no room", "has a room but no wing"],
+        metadatas=[{"wing": "alpha"}, {"room": "beta"}],
+    )
+    result = _sqlite_wing_room_counts(palace_path, "mempalace_drawers")
+    assert result is not None
+    total, wing_rooms = result
+    assert total == 2  # neither drawer dropped
+    assert {w: dict(r) for w, r in wing_rooms.items()} == {
+        "alpha": {"?": 1},
+        "?": {"beta": 1},
+    }
+
+
+def test_sqlite_wing_room_counts_returns_none_on_locked_db(palace_path, seeded_collection):
+    """A sustained sqlite lock (writer holding the DB) must degrade to ``None``
+    so ``status`` falls back to the slow-but-correct ChromaDB path rather than
+    raising. busy_timeout waits out *transient* locks; a hard lock still ends
+    here. Simulated by forcing the read to raise OperationalError."""
+    import sqlite3 as _sqlite3
+    from unittest.mock import patch
+
+    from mempalace.backends.chroma import _sqlite_wing_room_counts
+
+    with patch(
+        "mempalace.backends.chroma.sqlite3.connect",
+        side_effect=_sqlite3.OperationalError("database is locked"),
+    ):
+        assert _sqlite_wing_room_counts(palace_path, "mempalace_drawers") is None
+
+
 def test_process_file_uses_bounded_upsert_batches(tmp_path, monkeypatch):
     from mempalace import miner
 


### PR DESCRIPTION
Closes #1681.

## What does this PR do?

`mempalace status` opened the ChromaDB collection purely to tally drawers by wing/room — and opening it cold-loads the ~586 MB HNSW vector index. On a 398k-drawer / 3.5 GB palace that costs **~60s of CPU on every call**, even though the counts live in `chroma.sqlite3`'s relational tables (`repair-status` already reads them in <1s; `status` was the outlier).

This reads the wing/room histogram directly from `chroma.sqlite3` via a new `_sqlite_wing_room_counts()` helper, falling back to the existing ChromaDB-client path when the sqlite read is unavailable (missing DB, un-bootstrapped collection, sustained writer lock, or unexpected schema) — preserving the state-specific guidance for absent/empty palaces.

**Measured on a 398,315-drawer / 3.5 GB palace: `status` CPU ~60s → ~1s.**

### Hardening (from review)
- `PRAGMA busy_timeout` so a transient checkpoint lock is waited out instead of instantly demoting to the slow path; a sustained lock still falls back (slow but correct).
- `COALESCE` over `string/int/float` so a numeric wing/room matches the ChromaDB path instead of dropping to `"?"`.
- Explicit `s.scope = 'METADATA'` so the segment join can't silently double-count on a future ChromaDB layout.
- Docstrings cite the sibling sqlite readers (`_sqlite_embedding_count`, `mcp_server._tool_status_via_sqlite`); consolidating the three into one shared helper is a reasonable follow-up.

## How to test

```
uv run pytest tests/test_miner.py -k "status or sqlite_wing_room" -v
```

11 tests, including:
- `test_status_does_not_cold_load_vector_index` — the core regression guard (proven failable: reverting `status()` to its pre-fix body fires the sentinel).
- `test_sqlite_wing_room_counts_exact_tally` — anti fan-out on the double `LEFT JOIN` (fixture drawers carry 6 metadata keys each).
- numeric-metadata, partial-metadata `"?"` bucketing, locked-DB fallback, collection-absent `None` routing.

Full suite: `uv run pytest tests/ -v --ignore=tests/benchmarks --cov=mempalace --cov-fail-under=80` → **2285 passed, 85% coverage**.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`) — pinned ruff 0.15.14