### PR TITLE
fix(hooks): file stop-hook diary checkpoints under the harness agent identity (#1693)

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -651,12 +651,16 @@ def _save_diary_direct(
     session_id: str,
     wing: str = "",
     toast: bool = False,
+    *,
+    agent_name: str,
 ) -> dict:
     """Write a diary checkpoint by calling the tool function directly (no MCP roundtrip).
 
-    If `wing` is set, the entry lands in that wing (typically the project wing
-    derived from the transcript path). Otherwise falls back to `tool_diary_write`'s
-    default of `wing_session-hook`.
+    The entry is filed under `agent_name` so the agent that later calls
+    `mempalace_diary_read(agent_name=...)` discovers it (#1693). If `wing` is
+    set, the entry lands in that wing (typically the project wing derived from
+    the transcript path); a `diary_read` with an empty wing spans every wing
+    the agent wrote to, so project-derived wings stay discoverable.
 
     Returns {"count": N, "themes": [...]} on success, {"count": 0} on failure.
     """
@@ -679,7 +683,7 @@ def _save_diary_direct(
         from .mcp_server import tool_diary_write
 
         result = tool_diary_write(
-            agent_name="session-hook",
+            agent_name=agent_name,
             entry=entry,
             topic="checkpoint",
             wing=wing,
@@ -739,6 +743,20 @@ def _ingest_transcript(transcript_path: str):
 
 
 SUPPORTED_HARNESSES = {"claude-code", "codex"}
+
+
+def _diary_agent_for_harness(harness: str) -> str:
+    """Return the diary ``agent_name`` a session in ``harness`` reads under.
+
+    Stop-hook checkpoints must be filed beside the agent's own entries so
+    ``mempalace_diary_read(agent_name=...)`` surfaces them. The old code filed
+    them under a fixed ``"session-hook"`` identity that no reader ever queried,
+    hiding every checkpoint (#1693). A ``claude-code`` session reads its diary
+    as ``"claude"``; every other harness already reads under its own name, so
+    returning the harness name keeps a newly supported harness discoverable
+    instead of silently invisible again.
+    """
+    return "claude" if harness == "claude-code" else harness
 
 
 def _parse_harness_input(data: dict, harness: str) -> dict:
@@ -942,7 +960,11 @@ def hook_stop(data: dict, harness: str):
             result = {"count": 0}
             if transcript_path:
                 result = _save_diary_direct(
-                    transcript_path, session_id, wing=project_wing, toast=toast
+                    transcript_path,
+                    session_id,
+                    wing=project_wing,
+                    toast=toast,
+                    agent_name=_diary_agent_for_harness(harness),
                 )
                 _ingest_transcript(transcript_path)
             _maybe_auto_ingest()

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -13,6 +13,7 @@ import mempalace.hooks_cli as hooks_cli_mod
 from mempalace.hooks_cli import (
     SAVE_INTERVAL,
     _count_human_messages,
+    _diary_agent_for_harness,
     _extract_recent_messages,
     _get_mine_targets,
     _log,
@@ -22,6 +23,7 @@ from mempalace.hooks_cli import (
     _mine_sync,
     _parse_harness_input,
     _sanitize_session_id,
+    _save_diary_direct,
     _validate_transcript_path,
     _wing_from_transcript_path,
     hook_stop,
@@ -336,7 +338,9 @@ def test_stop_hook_saves_silently_at_interval(tmp_path):
     assert result["systemMessage"].startswith("\u2726 15 memories woven into the palace")
     assert "hooks" in result["systemMessage"]
     # tmp_path has no "-Projects-" segment, so _wing_from_transcript_path falls back to "wing_sessions"
-    mock_save.assert_called_once_with(str(transcript), "test", wing="wing_sessions", toast=False)
+    mock_save.assert_called_once_with(
+        str(transcript), "test", wing="wing_sessions", toast=False, agent_name="claude"
+    )
 
 
 def test_stop_hook_derives_wing_from_transcript_path(tmp_path):
@@ -355,7 +359,9 @@ def test_stop_hook_derives_wing_from_transcript_path(tmp_path):
             {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
             state_dir=tmp_path,
         )
-    mock_save.assert_called_once_with(str(transcript), "test", wing="wing_myproject", toast=False)
+    mock_save.assert_called_once_with(
+        str(transcript), "test", wing="wing_myproject", toast=False, agent_name="claude"
+    )
 
 
 def test_stop_hook_tracks_save_point(tmp_path):
@@ -381,6 +387,84 @@ def test_stop_hook_tracks_save_point(tmp_path):
         result = _capture_hook_output(hook_stop, data, state_dir=tmp_path)
     assert result == {}
     mock_save.assert_not_called()
+
+
+# --- #1693: hook checkpoints must be discoverable by diary_read ---
+
+
+def test_diary_agent_for_harness_maps_known_harnesses():
+    assert _diary_agent_for_harness("claude-code") == "claude"
+    assert _diary_agent_for_harness("codex") == "codex"
+
+
+def test_diary_agent_for_harness_unknown_falls_back_to_name():
+    """A future harness must never collapse to the legacy 'session-hook'
+    identity, which no diary_read(agent_name=...) call ever matches (#1693)."""
+    assert _diary_agent_for_harness("cursor") == "cursor"
+    for harness in ("claude-code", "codex", "cursor", "gemini"):
+        assert _diary_agent_for_harness(harness) != "session-hook"
+
+
+@pytest.mark.parametrize(
+    "harness,expected_agent",
+    [("claude-code", "claude"), ("codex", "codex")],
+)
+def test_stop_hook_files_checkpoint_under_harness_agent(tmp_path, harness, expected_agent):
+    """The Stop hook must file checkpoints under the agent identity that the
+    session's harness reads with, not the legacy hardcoded 'session-hook'
+    (#1693)."""
+    # _save_diary_direct is mocked below, so the transcript format is irrelevant
+    # here: _count_human_messages counts both harness shapes, and we assert only
+    # the harness -> agent_name routing, not transcript parsing.
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(SAVE_INTERVAL)],
+    )
+    with patch(
+        "mempalace.hooks_cli._save_diary_direct", return_value={"count": 5, "themes": []}
+    ) as mock_save:
+        _capture_hook_output(
+            hook_stop,
+            {"session_id": "test", "stop_hook_active": False, "transcript_path": str(transcript)},
+            harness=harness,
+            state_dir=tmp_path,
+        )
+    assert mock_save.call_args.kwargs["agent_name"] == expected_agent
+
+
+def test_stop_hook_checkpoint_visible_to_diary_read(monkeypatch, config, palace_path, kg, tmp_path):
+    """End-to-end regression for #1693: a checkpoint written by the Stop hook
+    save path is discoverable via diary_read under the harness agent identity,
+    and is not siloed under the legacy 'session-hook' identity."""
+    import chromadb
+
+    from mempalace import mcp_server
+    from mempalace.mcp_server import tool_diary_read
+
+    monkeypatch.setattr(mcp_server, "_config", config)
+    monkeypatch.setattr(mcp_server, "_get_kg", lambda *a, **kw: kg)
+    client = chromadb.PersistentClient(path=palace_path)
+    client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
+    del client
+
+    transcript = tmp_path / "session.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(5)],
+    )
+
+    agent = _diary_agent_for_harness("claude-code")
+    res = _save_diary_direct(str(transcript), "sess1", wing="wing_.claude", agent_name=agent)
+    assert res["count"] > 0
+
+    visible = tool_diary_read(agent_name="claude")
+    assert visible.get("total", 0) >= 1
+    assert "CHECKPOINT" in visible["entries"][0]["content"]
+
+    # The legacy identity no longer captures hook checkpoints.
+    legacy = tool_diary_read(agent_name="session-hook")
+    assert legacy.get("entries") == []
 
 
 # --- hook_session_start ---


### PR DESCRIPTION
## What does this PR do?

Fixes #1693.

Stop-hook diary checkpoints were never visible to `mempalace_diary_read`. The Stop hook saves through `_save_diary_direct` (`mempalace/hooks_cli.py`), which called `tool_diary_write` with a hardcoded `agent_name="session-hook"`. `tool_diary_read` filters Chroma metadata by `agent`, so a session calling `mempalace_diary_read(agent_name="claude")` matched nothing: every checkpoint was filed under an identity no reader ever queries.

The wing was not the barrier. `diary_read` with an empty wing already spans every wing the agent wrote to (#1145), so project-derived wings such as `wing_.claude` are reachable. The only mismatch was the `agent` metadata.

This PR derives the diary identity from the harness instead of hardcoding it:

- `claude-code` sessions read their diary as `claude`; `codex` reads as `codex`. Any future harness falls back to its own name, never the invisible `session-hook`.
- `hook_stop` passes that identity through `_save_diary_direct` into `tool_diary_write`.
- `agent_name` is now a required keyword argument on the internal helper, so a checkpoint can never be filed under an unintended identity by omission.

Existing data: checkpoints written before this change stay under `agent="session-hook"` (they were already invisible to `diary_read`). From now on every checkpoint is filed under the identity the agent reads with. No migration is bundled.

## How to test

Automated (`tests/test_hooks_cli.py`):

- `test_diary_agent_for_harness_maps_known_harnesses` / `_unknown_falls_back_to_name` cover the mapping and the "never session-hook" invariant.
- `test_stop_hook_files_checkpoint_under_harness_agent` (parametrized over `claude-code` and `codex`) asserts `hook_stop` routes the right identity.
- `test_stop_hook_checkpoint_visible_to_diary_read` is end to end: it writes a checkpoint through the hook save path into a real Chroma collection and confirms `diary_read(agent_name="claude")` returns it while `agent_name="session-hook"` returns nothing.

Manual, against the real binary:

```
printf '{"session_id":"s1","stop_hook_active":false,"transcript_path":"<transcript.jsonl>"}' \
  | mempalace hook run --hook stop --harness claude-code
```

Then `mempalace_diary_read(agent_name="claude")` returns the checkpoint (it returned nothing before this change).

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
