### PR TITLE
ci: add PyPI trusted-publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,102 @@
+name: Publish to PyPI
+
+# Publishes mempalace to PyPI via Trusted Publishing (OIDC — no stored token).
+#
+# Trigger: a GitHub Release is *published* (not merely drafted). Creating the
+# Release also creates the `v*` tag, so the usual version-guard.yml runs in
+# parallel; the checks below are duplicated here on purpose so this pipeline is
+# self-contained and never uploads on a tag that version-guard didn't gate.
+#
+# One-time setup required before the first run (see docs/RELEASING.md):
+#   1. PyPI → Manage project `mempalace` → Publishing → Add a trusted publisher:
+#        Owner: MemPalace   Repository: mempalace
+#        Workflow: publish.yml   Environment: pypi
+#   2. GitHub → repo Settings → Environments → New environment `pypi`,
+#      add yourself as a Required reviewer (this is the manual approval gate).
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build + pre-publish checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # No explicit ref: on a release event the default checkout is already
+          # the release tag's commit (github.ref = refs/tags/<tag>). This avoids
+          # interpolating the event-controlled tag_name into a checkout ref
+          # (ref-injection). fetch-depth: 0 gives the ancestry check full history.
+          fetch-depth: 0
+
+      - name: Verify the release tag is on main
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          tag_sha=$(git rev-parse HEAD)  # the checked-out release tag commit
+          main_sha=$(git rev-parse FETCH_HEAD)
+          if git merge-base --is-ancestor "$tag_sha" "$main_sha"; then
+            echo "Tag $TAG ($tag_sha) is reachable from main — OK."
+          else
+            echo "::error::Release tag $TAG is not an ancestor of main. Releases must be cut from main."
+            exit 1
+          fi
+
+      - name: Verify the tag matches the version manifest
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # version.py is the source of truth (per CLAUDE.md); version-guard.yml
+          # separately enforces that pyproject + the three plugin manifests agree.
+          py_version=$(grep -E '^__version__' mempalace/version.py | cut -d'"' -f2)
+          tag_version="${TAG#v}"
+          if [[ "$tag_version" != "$py_version" ]]; then
+            echo "::error::tag $TAG does not match mempalace/version.py ($py_version). Bump the version files before releasing."
+            exit 1
+          fi
+          echo "Tag $TAG matches manifest version $py_version — OK."
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Binds the upload to the protected `pypi` environment — the run pauses here
+    # until a required reviewer approves. This is also where the OIDC trust is
+    # scoped on the PyPI side.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mempalace
+    permissions:
+      id-token: write  # mint the short-lived OIDC token for Trusted Publishing
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,10 @@ name: Publish to PyPI
 
 # Publishes mempalace to PyPI via Trusted Publishing (OIDC — no stored token).
 #
-# Trigger: a GitHub Release is *published* (not merely drafted). Creating the
-# Release also creates the `v*` tag, so the usual version-guard.yml runs in
-# parallel; the checks below are duplicated here on purpose so this pipeline is
-# self-contained and never uploads on a tag that version-guard didn't gate.
+# Trigger: a GitHub Release is *published* (not merely drafted). The release may
+# create the `v*` tag or be cut from an existing one — either way the checks
+# below run here on purpose, so this pipeline is self-contained and never
+# uploads a tag that isn't on main or doesn't match the version manifest.
 #
 # One-time setup required before the first run (see docs/RELEASING.md):
 #   1. PyPI → Manage project `mempalace` → Publishing → Add a trusted publisher:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -29,3 +29,59 @@ If `pyproject.toml` has no match, **stop** — the entry point is missing and
 any fresh `pip install` will ship a broken plugin config. Investigate whether
 the release branch was cut before
 [#340](https://github.com/MemPalace/mempalace/pull/340) landed on `develop`.
+
+## Publishing to PyPI
+
+Releases publish automatically via the
+[`publish.yml`](../.github/workflows/publish.yml) workflow, using PyPI
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC). There
+is **no API token** stored anywhere — GitHub mints a short-lived identity at
+upload time. The workflow fires when a **GitHub Release is published**, builds
+the sdist + wheel, and pauses for manual approval on the `pypi` environment
+before uploading.
+
+### One-time setup (owners only)
+
+Done once per project; both steps require PyPI owner / GitHub admin rights.
+
+1. **PyPI trusted publisher** — on PyPI, go to **Manage project `mempalace`
+   → Publishing → Add a trusted publisher** and enter exactly:
+
+   | Field | Value |
+   | --- | --- |
+   | Owner | `MemPalace` |
+   | Repository name | `mempalace` |
+   | Workflow filename | `publish.yml` |
+   | Environment name | `pypi` |
+
+2. **GitHub environment** — in the repo, **Settings → Environments → New
+   environment** named `pypi`. Add yourself (and any other release approvers)
+   under **Required reviewers**. This is the manual gate the workflow waits on
+   before the upload step runs.
+
+### Cutting a release
+
+1. Land everything for the release on `develop`, then merge `develop → main`.
+   Releases publish **only from `main`** — the workflow refuses any tag whose
+   commit is not an ancestor of `main`.
+2. Bump the version in **all five** sources so `version-guard.yml` stays green
+   (it is the single source of truth at `mempalace/version.py`, mirrored in
+   `pyproject.toml`, `.claude-plugin/marketplace.json`,
+   `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json`). Commit to
+   `main`.
+3. Run the **entry-point alignment check** above.
+4. On GitHub, **Releases → Draft a new release**:
+   - **Target:** `main`
+   - **Tag:** `vX.Y.Z` (must equal `mempalace/version.py`; the workflow and
+     `version-guard.yml` both reject a mismatch)
+   - Write the release notes, then **Publish release**.
+5. The `publish.yml` run validates the tag (on `main`, matches the manifest),
+   builds, and then waits for approval on the `pypi` environment. Approve it to
+   upload to PyPI. Watch the run land the new version on
+   <https://pypi.org/project/mempalace/>.
+
+To stage a release candidate without shipping to end users, tag a semver
+pre-release (`vX.Y.Z-rc1`) — `version-guard.yml` skips the strict manifest
+match for pre-release tags. (Note: a published GitHub Release still triggers
+`publish.yml`; use a **draft** release, or a plain pushed tag, for dry runs you
+don't want uploaded.)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -61,14 +61,14 @@ Done once per project; both steps require PyPI owner / GitHub admin rights.
 
 ### Cutting a release
 
-1. Land everything for the release on `develop`, then merge `develop → main`.
+1. Bump the version in **all five** sources on `develop` so `version-guard.yml`
+   stays green (it is the single source of truth at `mempalace/version.py`,
+   mirrored in `pyproject.toml`, `.claude-plugin/marketplace.json`,
+   `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json`).
+2. Land everything for the release on `develop`, then merge `develop → main`.
    Releases publish **only from `main`** — the workflow refuses any tag whose
-   commit is not an ancestor of `main`.
-2. Bump the version in **all five** sources so `version-guard.yml` stays green
-   (it is the single source of truth at `mempalace/version.py`, mirrored in
-   `pyproject.toml`, `.claude-plugin/marketplace.json`,
-   `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json`). Commit to
-   `main`.
+   commit is not an ancestor of `main`. Don't commit the bump directly to
+   `main`: it bypasses branch protection and leaves `develop` behind.
 3. Run the **entry-point alignment check** above.
 4. On GitHub, **Releases → Draft a new release**:
    - **Target:** `main`


### PR DESCRIPTION
## What

Adds automated PyPI publishing via **Trusted Publishing (OIDC)** — no API token stored anywhere. Releases publish when a **GitHub Release is published**, gated by a manual approval on the `pypi` environment.

## How it works

- **`build` job** (read-only token): verifies the release tag's commit is reachable from `main`, verifies `vX.Y.Z` matches `mempalace/version.py`, then builds the sdist + wheel and uploads them as an artifact.
- **`publish` job** (`environment: pypi`, `id-token: write`): downloads the artifact and uploads via `pypa/gh-action-pypi-publish`. The environment's required reviewers must approve before upload runs.

So the published artifact is always **main's code** (the build checks out the release tag, which the ancestry guard requires to be on `main`); only the workflow definition lives on the default branch, as GitHub requires for `release` events to fire.

## Already configured (out of band)

- PyPI trusted publisher for project `mempalace` (owner `MemPalace`, repo `mempalace`, workflow `publish.yml`, environment `pypi`).
- `pypi` environment: required reviewers + `main` branch and `v*` tag deploy policies.

## Notes

- This PR touches no version files and no `version-guard` paths — it's inert until a Release is published.
- Full one-time setup + per-release runbook documented in `docs/RELEASING.md`.