### PR TITLE
chore(release): 3.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.3.6",
+      "version": "3.4.0",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.3.6",
+  "version": "3.4.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.3.6",
+  "version": "3.4.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.3.6"
+__version__ = "3.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.3.6"
+version = "3.4.0"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps all five version manifests `3.3.6 -> 3.4.0` for the v3.4.0 release.

**Release plan:** merge this → merge `develop → main` → draft a **v3.4.0-rc1** pre-release on `main` (exercises the new Trusted-Publishing pipeline end-to-end, then we `pip install` the RC from PyPI and build a palace to verify the published artifact) → cut stable **v3.4.0** once the RC checks out.

Highlights since v3.3.6:
- **feat:** pluggable vector backends (qdrant, pgvector, sqlite_exact)
- **feat:** Docker image for the MCP server + CLI
- **feat:** `mempalace migrate-wings` — normalize legacy wing names
- **feat:** known-systems lexicon for compound product names
- **fix:** embeddinggemma works with ChromaDB 1.5.x (default-model search was silently broken)
- **fix:** drawer_id collision data-loss; WAL import side-effect / privacy kill-switch
- **ci:** PyPI Trusted Publishing pipeline

Pre-flight: all 5 manifests agree at 3.4.0; `mempalace-mcp` entry point aligned across pyproject + plugin configs.