### PR TITLE
chore(release): 3.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.3.6",
+      "version": "3.4.0",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.3.6",
+  "version": "3.4.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.3.6",
+  "version": "3.4.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 MIT — see [LICENSE](LICENSE).
 
 <!-- Link Definitions -->
-[version-shield]: https://img.shields.io/badge/version-3.3.6-4dc9f6?style=flat-square&labelColor=0a0e14
+[version-shield]: https://img.shields.io/badge/version-3.4.0-4dc9f6?style=flat-square&labelColor=0a0e14
 [release-link]: https://github.com/MemPalace/mempalace/releases
 [python-shield]: https://img.shields.io/badge/python-3.9+-7dd8f8?style=flat-square&labelColor=0a0e14&logo=python&logoColor=7dd8f8
 [python-link]: https://www.python.org/

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.3.6"
+__version__ = "3.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.3.6"
+version = "3.4.0"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps all five version manifests `3.3.6 -> 3.4.0` **plus the README version badge** (a sixth version location enforced by `test_readme_claims.py::TestVersionBadge`, outside version-guard's 5-file set — that's what failed #1704).

Replaces #1704, which was on a `release/3.4.0` branch that the "Protect release branches" ruleset blocks from follow-up pushes.

**Release plan:** merge this → merge `develop → main` → draft a **v3.4.0-rc1** pre-release on `main` (exercise the Trusted-Publishing pipeline, then `pip install` the RC from PyPI and build a palace to verify the published artifact) → cut stable **v3.4.0**.

Highlights since v3.3.6: pluggable vector backends (qdrant/pgvector/sqlite_exact), Docker image, `mempalace migrate-wings`, known-systems lexicon, embeddinggemma↔ChromaDB-1.5.x fix, drawer_id collision + WAL kill-switch fixes, PyPI Trusted Publishing.

Pre-flight: all 5 manifests + README badge agree at 3.4.0; `mempalace-mcp` entry point aligned.