### PR TITLE
ci(publish): build + publish in one job (fix BlobNotFound artifact handoff)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,12 @@ name: Publish to PyPI
 #     so this lets a maintainer run the publish for any existing tag from the
 #     Actions tab ("Run workflow" → enter the tag, e.g. v3.4.0).
 #
-# Either way the checks below run on purpose, so this pipeline is self-contained
-# and never uploads a tag that isn't on main or doesn't match the version manifest.
+# Build + publish run in ONE job on purpose: a two-job split hands the wheel
+# between jobs via upload/download-artifact, which failed repeatedly with
+# `BlobNotFound` on the same-run download. Building and publishing in the same
+# job removes that handoff entirely. The job is gated by the `pypi` environment
+# (manual approval), and the checks below keep it self-contained — it never
+# uploads a tag that isn't on main or doesn't match the version manifest.
 #
 # One-time setup required before the first run (see docs/RELEASING.md):
 #   1. PyPI → Manage project `mempalace` → Publishing → Add a trusted publisher:
@@ -34,9 +38,17 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build + pre-publish checks
+  publish:
+    name: Build + publish to PyPI
     runs-on: ubuntu-latest
+    # The `pypi` environment gate (required reviewer) pauses the whole job until
+    # approved, and scopes the OIDC trust on the PyPI side.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mempalace
+    permissions:
+      contents: read # checkout
+      id-token: write # mint the short-lived OIDC token for Trusted Publishing
     steps:
       - name: Resolve the release tag
         id: tag
@@ -107,31 +119,6 @@ jobs:
         run: |
           python -m pip install --upgrade build
           python -m build
-
-      - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-  publish:
-    name: Publish to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    # Binds the upload to the protected `pypi` environment — the run pauses here
-    # until a required reviewer approves. This is also where the OIDC trust is
-    # scoped on the PyPI side.
-    environment:
-      name: pypi
-      url: https://pypi.org/p/mempalace
-    permissions:
-      id-token: write # mint the short-lived OIDC token for Trusted Publishing
-    steps:
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Why

The v3.3.6 publish runs failed **twice**, both at the publish job's `download-artifact` step with `BlobNotFound`. The build job built `mempalace-3.3.6.tar.gz`+`.whl` and uploaded a valid 25 MB `dist` artifact (confirmed in the run's artifact list), but the **cross-job download** consistently failed — a GitHub v4 artifact-service flake. The PyPI upload step never ran, so nothing was published.

## What

Collapse the two-job (build → publish) split into a **single `publish` job** that builds and publishes in the same workspace, so there's no upload/download-artifact handoff to fail. `pypa/gh-action-pypi-publish` reads straight from `dist/`.

Unchanged: `pypi` environment approval gate, OIDC `id-token: write`, the `workflow_dispatch` manual trigger + validated `refs/tags/` checkout, and the on-`main` + `tag == version.py` checks. The PyPI trusted-publisher config keys on workflow filename + environment, not job structure, so it still matches.

**Trade-off:** the build now runs behind the approval gate (you approve, then it builds + publishes) instead of before it. The post-publish validation (`pip install` + build a palace) is unchanged.

## Self-review (done before pushing)

- Exactly one job; `environment: pypi` + `permissions: {contents: read, id-token: write}`.
- No raw `${{ }}` in any `run:` (inputs via `env:`, quoted `"$TAG"`); checkout `ref: refs/tags/<validated-tag>`.
- Tag regex requires `vMAJOR.MINOR.PATCH[-suffix]` (rejects `v3`, `main`, injection).