### PR TITLE
fix(mcp): drop top-level anyOf from diary_write schema

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2662,13 +2662,10 @@ TOOLS = {
                     "description": "Alias for 'entry' — accepted because add_drawer uses 'content'. Provide either 'entry' or 'content'; 'entry' wins if both are given.",
                 },
             },
-            # agent_name is always required; 'entry' or its alias 'content' must
-            # be present (the server remaps content->entry at dispatch).
+            # 'entry' (or its alias 'content') is enforced at dispatch, not via a
+            # top-level anyOf: Anthropic rejects schemas with a top-level
+            # anyOf/oneOf/allOf and drops the whole tools array (400).
             "required": ["agent_name"],
-            "anyOf": [
-                {"required": ["entry"]},
-                {"required": ["content"]},
-            ],
         },
         "handler": tool_diary_write,
     },

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -537,6 +537,20 @@ class TestHandleRequest:
         assert "mempalace_add_drawer" in names
         assert "mempalace_kg_add" in names
 
+    def test_no_tool_schema_uses_top_level_combinator(self):
+        """Anthropic's Messages API rejects a tool whose input schema has a
+        top-level anyOf/oneOf/allOf and drops the entire tools array with a
+        400, killing the session (#1711). Cross-tool constraints must be
+        enforced at dispatch instead.
+        """
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request({"method": "tools/list", "id": 2, "params": {}})
+        for tool in resp["result"]["tools"]:
+            schema = tool["inputSchema"]
+            for keyword in ("anyOf", "oneOf", "allOf"):
+                assert keyword not in schema, f"{tool['name']} schema has top-level {keyword}"
+
     def test_null_arguments_does_not_hang(self, monkeypatch, config, palace_path, seeded_kg):
         """Sending arguments: null should return a result, not hang (#394)."""
         _patch_mcp_server(monkeypatch, config, seeded_kg)


### PR DESCRIPTION
## What does this PR do?

`mempalace_diary_write` declared a top-level `anyOf` in its `input_schema` to require either `entry` or `content`. Anthropic's Messages API rejects any tool whose input schema has a top-level `anyOf`/`oneOf`/`allOf` and returns a 400 for the whole `tools` array, so every MCP session failed to start (#1711). The same breakage was reported on Codex.

The either/or constraint is already enforced at dispatch: `content` is remapped to `entry` before the handler runs, and a missing value returns `-32602`. Dropping the combinator restores API compatibility without weakening validation.

Added a `tools/list` regression test asserting no tool schema exposes a top-level `anyOf`/`oneOf`/`allOf`.

Closes #1711

## How to test

```
uv run pytest tests/test_mcp_server.py -v
```

`test_no_tool_schema_uses_top_level_combinator` fails on the previous schema and passes with the fix. Existing dispatch tests (`test_diary_write_content_aliases_entry`, `test_missing_required_returns_32602_with_param_name`) confirm the entry/content behaviour is unchanged.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)