### PR TITLE
fix(backends): keep post-deletion dim-None HNSW segments instead of quarantining (#1710)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -925,7 +925,12 @@ def _missing_dimensionality_appears_recoverable(
         return False
 
     label_count = len(id_to_label)
-    if int(total) != label_count or len(label_to_id) != label_count:
+    # total_elements_added is monotonic across every add, while id_to_label and
+    # label_to_id hold only live elements, so a segment that has had deletions
+    # carries total_elements_added > label_count. Require >= (not ==), otherwise
+    # every post-deletion dim-None segment is wrongly quarantined (#1710); the
+    # label-map size and bijection checks still reject inconsistent label maps.
+    if int(total) < label_count or len(label_to_id) != label_count:
         return False
     try:
         return all(label_to_id.get(label) == item_id for item_id, label in id_to_label.items())

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1467,6 +1467,35 @@ def test_quarantine_invalid_hnsw_metadata_keeps_consistent_missing_dimensionalit
     assert seg.exists()
 
 
+def test_quarantine_invalid_hnsw_metadata_keeps_post_deletion_missing_dimensionality(tmp_path):
+    """A deleted-from segment has total_elements_added > live label count (the
+    counter is monotonic); that dim-None shape is recoverable, not corruption (#1710).
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    seg = palace / "abcd-1234-5678"
+    seg.mkdir()
+    (seg / "data_level0.bin").write_bytes(b"x" * 2048)
+    (seg / "link_lists.bin").write_bytes(b"x" * 128)
+    with open(seg / "index_metadata.pickle", "wb") as f:
+        pickle.dump(
+            {
+                "dimensionality": None,
+                "total_elements_added": 5,
+                "max_seq_id": None,
+                "id_to_label": {"a": 1, "b": 2},
+                "label_to_id": {1: "a", 2: "b"},
+                "id_to_seq_id": {},
+            },
+            f,
+        )
+
+    moved = quarantine_invalid_hnsw_metadata(str(palace))
+
+    assert moved == []
+    assert seg.exists()
+
+
 def test_quarantine_invalid_hnsw_metadata_renames_mismatched_missing_dimensionality(tmp_path):
     palace = tmp_path / "palace"
     palace.mkdir()


### PR DESCRIPTION
## What does this PR do?

`quarantine_invalid_hnsw_metadata` renames an HNSW segment to `*.corrupt-*` when its
`index_metadata.pickle` has `dimensionality: None` together with labels, unless
`_missing_dimensionality_appears_recoverable` judges the pickle safe to keep. develop
already keeps such a segment when its bookkeeping is internally consistent, but the helper
required `total_elements_added == len(id_to_label)`, and that equality only holds for a
segment that has never had a delete.

`total_elements_added` is a monotonic counter of every element ever added, while
`id_to_label` and `label_to_id` track only the live elements. After any deletion
`total_elements_added` exceeds the live label count, so the helper classified the segment
as unrecoverable and quarantined it. When the WAL had already been pruned (as it is after
the flush that writes the dim-None pickle), that segment was the only copy of the vectors,
so a later cold start rebuilds an empty index: the rows still count, but vector search
returns nothing for them. That is the silent erosion QuiqueMH reported in #1710 (forensics:
`total_elements_added: 4826` against `4792` labels).

The change relaxes the counter check from `==` to `>=` (one operator, `!=` to `<`). The
label-map size check and the bijection check are untouched, so inconsistent label maps are
still quarantined, and an impossible `total_elements_added < len(id_to_label)` is still
rejected.

This closes the remaining reproducible case in #1710; the `total == labels` variant is
already kept by the helper on develop.

## How to test

New regression test:

    python -m pytest tests/test_backends.py -k post_deletion -q

It writes a dim-None pickle with `total_elements_added=5` over two live labels (three
deleted) and asserts the segment is kept rather than quarantined. It fails on develop and
passes with this change.

Checked end to end against real ChromaDB 1.5.7, 1.5.8 and 1.5.9: a collection that is
built, then has rows deleted and rows added, persists a pickle with `dimensionality=None`
and `total_elements_added > len(id_to_label)`. Before this change the guard quarantines
that segment and a later cold start finds it gone (count still reports the rows, but vector
search returns nothing); after it the segment is kept and a fresh process opens and queries
it with no error and no SIGSEGV on any of the three versions.

Full suite (`python -m pytest tests/ --ignore=tests/benchmarks`): 2431 passed, 5 skipped.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
