### PR TITLE
feat(searcher): metric-aware distance→similarity conversion (RFC 001 §10)

### DIFF
--- a/mempalace/backends/base.py
+++ b/mempalace/backends/base.py
@@ -301,6 +301,17 @@ class BaseCollection(ABC):
     def health(self) -> HealthStatus:
         return HealthStatus.healthy()
 
+    @property
+    def distance_metric(self) -> str:
+        """The space this collection's ``distances`` are reported in.
+
+        Defaults to the owning backend's declared metric (cosine for all
+        in-tree backends). Collections that can vary per-collection — e.g. a
+        legacy Chroma palace built without ``hnsw:space=cosine`` — override
+        this to report their actual space so core ranking converts correctly.
+        """
+        return "cosine"
+
     def lexical_search(
         self,
         *,
@@ -381,6 +392,12 @@ class BaseBackend(ABC):
     name: ClassVar[str]
     spec_version: ClassVar[str] = "1.0"
     capabilities: ClassVar[frozenset[str]] = frozenset()
+    #: The space ``query()`` reports ``distances`` in (RFC 001 §2.1).
+    #: One of ``"cosine"`` | ``"l2"`` | ``"ip"``. The contract for the
+    #: ``distances`` field is *lower = closer* regardless of metric; core
+    #: search converts distance→similarity off this declaration rather than
+    #: assuming cosine. All in-tree backends are cosine today.
+    distance_metric: ClassVar[str] = "cosine"
 
     @abstractmethod
     def get_collection(

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1724,6 +1724,23 @@ class ChromaCollection(BaseCollection):
         """
         return self._collection.metadata or {}
 
+    @property
+    def distance_metric(self) -> str:
+        """Report this collection's actual space from ``hnsw:space``.
+
+        MemPalace sets ``hnsw:space=cosine`` on every creation path, so a
+        healthy palace reports ``"cosine"``. When the key is absent, empty, or
+        an unrecognized value, the collection is genuinely using Chroma's HNSW
+        default — **L2** (Euclidean) — because cosine was never set on it. We
+        report ``"l2"`` in that case so core ranking maps the distances
+        correctly; reporting ``"cosine"`` here would reintroduce the
+        floor-every-result-to-zero misranking this property exists to fix.
+        """
+        space = str(self.metadata.get("hnsw:space", "") or "").lower()
+        if space in ("cosine", "l2", "ip"):
+            return space
+        return "l2"
+
 
 # ---------------------------------------------------------------------------
 # Backend

--- a/mempalace/backends/embedding_wrapper.py
+++ b/mempalace/backends/embedding_wrapper.py
@@ -49,6 +49,14 @@ class EmbeddingCollection(BaseCollection):
     def __getattr__(self, name):
         return getattr(self._inner, name)
 
+    @property
+    def distance_metric(self) -> str:
+        # Explicit delegation: ``BaseCollection`` defines ``distance_metric``
+        # as a property, so it resolves on this subclass and ``__getattr__``
+        # never fires — without this override the wrapper would report the
+        # base "cosine" default and mask a wrapped non-cosine backend.
+        return self._inner.distance_metric
+
     def add(self, *, documents, ids, metadatas=None, embeddings=None):
         documents = _as_list(documents)
         ids = _as_list(ids)

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -23,7 +23,12 @@ from collections import defaultdict
 
 from .config import MempalaceConfig
 from .palace import get_collection as _get_collection
-from .searcher import _first_or_empty, build_where_filter
+from .searcher import (
+    _distance_to_similarity,
+    _first_or_empty,
+    _metric_for_collection,
+    build_where_filter,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -283,11 +288,12 @@ class Layer3:
         if not docs:
             return "No results found."
 
+        metric = _metric_for_collection(col)
         lines = [f'## L3 — SEARCH RESULTS for "{query}"']
         for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
             meta = meta or {}
             doc = doc or ""
-            similarity = round(max(0.0, 1 - dist), 3)
+            similarity = round(_distance_to_similarity(dist, metric), 3)
             wing_name = meta.get("wing", "?")
             room_name = meta.get("room", "?")
             source = Path(meta.get("source_file", "")).name if meta.get("source_file") else ""
@@ -327,6 +333,7 @@ class Layer3:
         except Exception:
             return []
 
+        metric = _metric_for_collection(col)
         hits = []
         for doc, meta, dist in zip(
             _first_or_empty(results, "documents"),
@@ -346,7 +353,7 @@ class Layer3:
                     "wing": meta.get("wing", "unknown"),
                     "room": meta.get("room", "unknown"),
                     "source_file": Path(meta.get("source_file", "?")).name,
-                    "similarity": round(1 - dist, 3),
+                    "similarity": round(_distance_to_similarity(dist, metric), 3),
                     "metadata": meta,
                 }
             )

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -74,7 +74,11 @@ from .backends.chroma import (  # noqa: E402
 )
 from .backends import BackendMismatchError, PalaceRef, detect_backend_for_path  # noqa: E402
 from .query_sanitizer import sanitize_query  # noqa: E402
-from .searcher import search_memories  # noqa: E402
+from .searcher import (  # noqa: E402
+    _distance_to_similarity,
+    _metric_for_collection,
+    search_memories,
+)
 from .palace_graph import (  # noqa: E402
     traverse,
     find_tunnels,
@@ -1234,9 +1238,10 @@ def tool_check_duplicate(content: str, threshold: float = 0.9):
         )
         duplicates = []
         if results["ids"] and results["ids"][0]:
+            metric = _metric_for_collection(col)
             for i, drawer_id in enumerate(results["ids"][0]):
                 dist = results["distances"][0][i]
-                similarity = round(max(0.0, 1 - dist), 3)
+                similarity = round(_distance_to_similarity(dist, metric), 3)
                 if similarity >= threshold:
                     # Chroma 1.5.x can return None for partially-flushed rows;
                     # coerce to empty sentinels so downstream .get() is safe.

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -130,18 +130,70 @@ def _bm25_scores(
     return scores
 
 
+def _distance_to_similarity(distance, metric: str = "cosine") -> float:
+    """Map a backend-reported ``distance`` to a [0, 1]-ish similarity.
+
+    The backend contract for the ``distances`` field is *lower = closer*
+    regardless of metric (RFC 001, backend metric declaration), so every
+    mapping here is monotonic decreasing in ``distance``. The output stays
+    bounded so it is
+    commensurable with the min-max-normalized BM25 term in
+    :func:`_hybrid_rank`.
+
+    * ``cosine`` — distance ∈ [0, 2], 0 = identical: ``max(0, 1 - d)``.
+    * ``l2`` — Euclidean ∈ [0, ∞): ``1 / (1 + d)`` (1 at d=0, →0 as d→∞).
+    * ``ip`` — inner-product distance (e.g. pgvector ``<#>`` = -dot, lower =
+      closer), unbounded and signed: logistic squash ``1 / (1 + e^d)``.
+      Provisional until a real ip backend exercises it; no in-tree backend
+      uses ip today.
+
+    ``distance is None`` (vector-unknown, e.g. a BM25-only candidate) maps to
+    0.0 so the candidate scores on its BM25 contribution alone.
+    """
+    if distance is None:
+        return 0.0
+    m = (metric or "cosine").lower()
+    if m == "l2":
+        return 1.0 / (1.0 + max(0.0, distance))
+    if m == "ip":
+        # Clamp the exponent so a large positive distance can't overflow.
+        return 1.0 / (1.0 + math.exp(min(60.0, distance)))
+    # cosine (default)
+    return max(0.0, 1.0 - distance)
+
+
+def _metric_for_collection(col) -> str:
+    """Resolve a collection's declared distance metric, defaulting to cosine.
+
+    Reads the ``distance_metric`` exposed by the backend collection (the
+    RFC 001 backend metric declaration). ``EmbeddingCollection`` delegates the
+    attribute to its inner collection; legacy Chroma palaces report their
+    actual ``hnsw:space``.
+    Any failure falls back to ``"cosine"`` — the value all in-tree backends
+    use and the only metric MemPalace created palaces with historically.
+    """
+    try:
+        metric = getattr(col, "distance_metric", "cosine")
+    except Exception:
+        return "cosine"
+    metric = str(metric or "cosine").lower()
+    return metric if metric in ("cosine", "l2", "ip") else "cosine"
+
+
 def _hybrid_rank(
     results: list,
     query: str,
     vector_weight: float = 0.6,
     bm25_weight: float = 0.4,
+    metric: str = "cosine",
 ) -> list:
     """Re-rank ``results`` by a convex combination of vector similarity and BM25.
 
-    * Vector similarity uses absolute cosine sim ``max(0, 1 - distance)`` —
-      ChromaDB's hnsw cosine distance lives in ``[0, 2]`` (0 = identical).
-      Absolute (not relative-to-max) means adding/removing a candidate
-      can't reshuffle the others.
+    * Vector similarity is derived from each candidate's backend-reported
+      ``distance`` via :func:`_distance_to_similarity`, interpreted in the
+      collection's declared ``metric`` (per RFC 001) rather than assuming
+      cosine. Absolute (not relative-to-max) means adding/removing a
+      candidate can't reshuffle the others.
     * BM25 is real Okapi-BM25 with corpus-relative IDF over the candidates
       themselves. Since the absolute scale is unbounded, BM25 is min-max
       normalized within the candidate set so weights are commensurable.
@@ -164,11 +216,7 @@ def _hybrid_rank(
 
     scored = []
     for r, raw, norm in zip(results, bm25_raw, bm25_norm):
-        distance = r.get("distance")
-        if distance is None:
-            vec_sim = 0.0
-        else:
-            vec_sim = max(0.0, 1.0 - distance)
+        vec_sim = _distance_to_similarity(r.get("distance"), metric)
         r["bm25_score"] = round(raw, 3)
         scored.append((vector_weight * vec_sim + bm25_weight * norm, r))
 
@@ -350,11 +398,12 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     # The MCP tool path already hybridizes BM25 with vector sim via
     # `_hybrid_rank`; do the same here so CLI results match what agents
     # see via `mempalace_search`.
+    metric = _metric_for_collection(col)
     hits = [
         {"text": doc or "", "distance": float(dist), "metadata": meta or {}}
         for doc, meta, dist in zip(docs, metas, dists)
     ]
-    hits = _hybrid_rank(hits, query)
+    hits = _hybrid_rank(hits, query, metric=metric)
 
     print(f"\n{'=' * 60}")
     print(f'  Results for: "{query}"')
@@ -365,7 +414,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
     print(f"{'=' * 60}\n")
 
     for i, hit in enumerate(hits, 1):
-        vec_sim = round(max(0.0, 1 - hit["distance"]), 3)
+        vec_sim = round(_distance_to_similarity(hit["distance"], metric), 3)
         bm25 = hit.get("bm25_score", 0.0)
         meta = hit["metadata"]
         source = Path(meta.get("source_file", "?")).name
@@ -374,7 +423,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
         print(f"  [{i}] {wing_name} / {room_name}")
         print(f"      Source: {source}")
-        print(f"      Match:  cosine={vec_sim}  bm25={bm25}")
+        print(f"      Match:  {metric}_sim={vec_sim}  bm25={bm25}")
         print()
         # Print the verbatim text, indented
         for line in hit["text"].strip().split("\n"):
@@ -786,7 +835,7 @@ def _finalize_candidate_hits(
             "hint": "Use candidate_strategy='vector' or select a backend that supports lexical search.",
         }
 
-    hits = _hybrid_rank(hits, query)[:n_results]
+    hits = _hybrid_rank(hits, query, metric=_metric_for_collection(drawers_col))[:n_results]
     for h in hits:
         h.pop("_sort_key", None)
         h.pop("_source_file_full", None)
@@ -978,6 +1027,7 @@ def search_memories(
     if open_error:
         return open_error
 
+    metric = _metric_for_collection(drawers_col)
     where = build_where_filter(wing, room)
 
     # Hybrid retrieval: always query drawers directly (the floor), then use
@@ -1070,7 +1120,7 @@ def search_memories(
             "room": meta.get("room", "unknown"),
             "source_file": Path(source).name if source else "?",
             "created_at": meta.get("filed_at", "unknown"),
-            "similarity": round(max(0.0, 1 - effective_dist), 3),
+            "similarity": round(_distance_to_similarity(effective_dist, metric), 3),
             "distance": round(dist, 4),
             "effective_distance": round(effective_dist, 4),
             "closet_boost": round(boost, 3),

--- a/tests/test_distance_metric.py
+++ b/tests/test_distance_metric.py
@@ -1,0 +1,227 @@
+"""Tests for backend-declared distance metrics (RFC 001) and the
+metric-aware distance→similarity conversion in the searcher.
+
+Before this, the searcher hard-coded ``max(0, 1 - distance)`` everywhere,
+which is correct only for cosine. A backend reporting L2 or inner-product
+distances (or a legacy Chroma palace built without ``hnsw:space=cosine``)
+was silently mis-ranked — L2 distances routinely exceed 1.0 and floored
+every result's similarity to 0. The contract now lets a backend declare its
+metric and the searcher converts accordingly.
+"""
+
+import math
+import types
+
+import pytest
+
+from mempalace.backends.base import BaseBackend, BaseCollection
+from mempalace.backends.chroma import ChromaCollection
+from mempalace.searcher import (
+    _distance_to_similarity,
+    _hybrid_rank,
+    _metric_for_collection,
+)
+
+
+# ---------------------------------------------------------------------------
+# Contract surface
+# ---------------------------------------------------------------------------
+
+
+def test_basebackend_declares_cosine_default():
+    assert BaseBackend.distance_metric == "cosine"
+
+
+def test_basecollection_reports_cosine_default():
+    # A minimal concrete collection inherits the cosine default.
+    class _Col(BaseCollection):
+        def add(self, **k): ...
+        def upsert(self, **k): ...
+        def query(self, **k): ...
+        def get(self, **k): ...
+        def delete(self, **k): ...
+        def count(self):
+            return 0
+
+    assert _Col().distance_metric == "cosine"
+
+
+# ---------------------------------------------------------------------------
+# _distance_to_similarity — per-metric math
+# ---------------------------------------------------------------------------
+
+
+def test_cosine_conversion():
+    assert _distance_to_similarity(0.0, "cosine") == 1.0
+    assert _distance_to_similarity(2.0, "cosine") == 0.0
+    # cosine distance > 1 must floor at 0, never go negative.
+    assert _distance_to_similarity(1.5, "cosine") == 0.0
+
+
+def test_l2_conversion_is_monotonic_and_bounded():
+    assert _distance_to_similarity(0.0, "l2") == 1.0
+    assert _distance_to_similarity(1.0, "l2") == pytest.approx(0.5)
+    # Strictly decreasing, and a large L2 distance does NOT floor to 0 the
+    # way the old cosine formula did — that was the bug.
+    far = _distance_to_similarity(5.0, "l2")
+    near = _distance_to_similarity(1.0, "l2")
+    assert 0.0 < far < near < 1.0
+
+
+def test_l2_distance_above_one_keeps_signal():
+    # The regression this fixes: under cosine, d=1.7 -> 0.0 (no signal).
+    # Under a correctly-declared L2 metric, it stays positive and ordered.
+    assert _distance_to_similarity(1.7, "cosine") == 0.0
+    assert _distance_to_similarity(1.7, "l2") > 0.0
+
+
+def test_ip_conversion_monotonic_decreasing():
+    # Inner-product distance is signed/unbounded (lower = closer). Logistic
+    # squash keeps it in (0, 1) and monotonic.
+    assert _distance_to_similarity(-5.0, "ip") > _distance_to_similarity(0.0, "ip")
+    assert _distance_to_similarity(0.0, "ip") == pytest.approx(0.5)
+    assert _distance_to_similarity(0.0, "ip") > _distance_to_similarity(5.0, "ip")
+
+
+def test_ip_does_not_overflow_on_large_distance():
+    # Exponent is clamped so a huge positive distance can't raise OverflowError.
+    val = _distance_to_similarity(1e6, "ip")
+    assert val == pytest.approx(0.0, abs=1e-9)
+    assert not math.isinf(val) and not math.isnan(val)
+
+
+def test_none_distance_maps_to_zero():
+    # BM25-only candidates carry distance=None -> no vector signal.
+    assert _distance_to_similarity(None, "cosine") == 0.0
+    assert _distance_to_similarity(None, "l2") == 0.0
+
+
+def test_unknown_metric_falls_back_to_cosine():
+    assert _distance_to_similarity(0.3, "weird") == _distance_to_similarity(0.3, "cosine")
+    assert _distance_to_similarity(0.3, None) == _distance_to_similarity(0.3, "cosine")
+
+
+# ---------------------------------------------------------------------------
+# _metric_for_collection — resolution + delegation + safety
+# ---------------------------------------------------------------------------
+
+
+def test_metric_resolver_reads_declared_metric():
+    col = types.SimpleNamespace(distance_metric="l2")
+    assert _metric_for_collection(col) == "l2"
+
+
+def test_metric_resolver_normalizes_case_and_garbage():
+    assert _metric_for_collection(types.SimpleNamespace(distance_metric="L2")) == "l2"
+    assert _metric_for_collection(types.SimpleNamespace(distance_metric="nonsense")) == "cosine"
+    assert _metric_for_collection(types.SimpleNamespace(distance_metric=None)) == "cosine"
+
+
+def test_metric_resolver_defaults_when_absent():
+    assert _metric_for_collection(object()) == "cosine"
+
+
+def test_metric_resolver_follows_embeddingcollection_delegation():
+    inner = types.SimpleNamespace(distance_metric="ip")
+
+    class _Wrapper:
+        def __init__(self, i):
+            self._i = i
+
+        def __getattr__(self, name):
+            return getattr(self._i, name)
+
+    assert _metric_for_collection(_Wrapper(inner)) == "ip"
+
+
+def test_metric_resolver_survives_raising_attribute():
+    class _Boom:
+        @property
+        def distance_metric(self):
+            raise RuntimeError("backend down")
+
+    assert _metric_for_collection(_Boom()) == "cosine"
+
+
+def test_real_embeddingcollection_delegates_metric_not_shadowed():
+    # Regression: BaseCollection defines distance_metric as a property, so on
+    # the real EmbeddingCollection subclass it resolves directly and
+    # __getattr__ never fires. Without an explicit override the wrapper would
+    # report the base "cosine" default and mask a wrapped non-cosine backend.
+    from mempalace.backends.embedding_wrapper import EmbeddingCollection
+
+    class _Inner(BaseCollection):
+        distance_metric = "l2"
+
+        def add(self, **k): ...
+        def upsert(self, **k): ...
+        def query(self, **k): ...
+        def get(self, **k): ...
+        def delete(self, **k): ...
+        def count(self):
+            return 0
+
+    wrapped = EmbeddingCollection(_Inner())
+    assert wrapped.distance_metric == "l2"
+    assert _metric_for_collection(wrapped) == "l2"
+
+
+# ---------------------------------------------------------------------------
+# ChromaCollection — legacy L2 palace reports its real metric
+# ---------------------------------------------------------------------------
+
+
+def _chroma_col_with_metadata(meta):
+    fake_inner = types.SimpleNamespace(metadata=meta)
+    return ChromaCollection(fake_inner)
+
+
+def test_chroma_reports_cosine_when_set():
+    assert _chroma_col_with_metadata({"hnsw:space": "cosine"}).distance_metric == "cosine"
+
+
+def test_chroma_legacy_l2_palace_reports_l2():
+    # A pre-cosine palace: the property surfaces the real space so the
+    # searcher maps distances correctly instead of flooring to 0.
+    assert _chroma_col_with_metadata({"hnsw:space": "l2"}).distance_metric == "l2"
+
+
+def test_chroma_missing_or_unknown_metadata_reports_l2():
+    # Absent/empty/garbage hnsw:space means the collection never had cosine
+    # set, so it is genuinely using Chroma's HNSW default (L2). Reporting
+    # cosine here would reintroduce the floor-to-0 bug this fixes.
+    assert _chroma_col_with_metadata({}).distance_metric == "l2"
+    assert _chroma_col_with_metadata({"hnsw:space": ""}).distance_metric == "l2"
+    assert _chroma_col_with_metadata({"hnsw:space": "bogus"}).distance_metric == "l2"
+
+
+# ---------------------------------------------------------------------------
+# _hybrid_rank — ranking actually respects the metric
+# ---------------------------------------------------------------------------
+
+
+def test_hybrid_rank_l2_keeps_far_candidate_ranked_above_unknown():
+    # Two candidates with identical (zero) lexical overlap to the query, so
+    # only the vector term decides. Under cosine, a d=1.6 hit floors to 0 and
+    # ties a distance-None hit; under L2 it stays positive and ranks above.
+    results = [
+        {"text": "alpha", "distance": None},
+        {"text": "beta", "distance": 1.6},
+    ]
+    ranked = _hybrid_rank(results, "zzzznomatch", metric="l2")
+    assert ranked[0]["text"] == "beta"  # real vector signal beats vector-unknown
+
+
+def test_hybrid_rank_cosine_unchanged_behavior():
+    # Cosine path must be byte-for-byte the old behavior (max(0, 1-d)).
+    results = [
+        {"text": "near", "distance": 0.1},
+        {"text": "far", "distance": 0.9},
+    ]
+    ranked = _hybrid_rank(results, "zzzznomatch", metric="cosine")
+    assert ranked[0]["text"] == "near"
+    assert ranked[1]["text"] == "far"
+
+
+def test_hybrid_rank_empty_is_noop():
+    assert _hybrid_rank([], "q", metric="l2") == []

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -343,8 +343,10 @@ class TestSearchCLI:
         # Non-zero bm25 reported
         assert "bm25=" in first_block
         assert "bm25=0.0" not in first_block
-        # Cosine still reported for transparency
-        assert "cosine=" in first_block
+        # Metric-labeled vector similarity still reported for transparency.
+        # Label is now "<metric>_sim=" (honest about the backend's metric)
+        # rather than a hard-coded "cosine=".
+        assert "cosine_sim=" in first_block
 
     def test_search_warns_when_palace_uses_wrong_distance_metric(self, fake_palace_path, capsys):
         """Legacy palaces created without `hnsw:space=cosine` silently


### PR DESCRIPTION
## Summary

Makes the searcher's distance→similarity conversion **metric-aware** instead of hard-coding cosine, implementing the `searcher.py` item of RFC 001 §10 (#743).

The searcher hard-coded `max(0, 1 - distance)` for vector similarity in every ranking and `similarity`-reporting site. That formula is correct only for cosine distance. A backend that reports **L2** or **inner-product** distances — or a **legacy Chroma palace** created before `hnsw:space=cosine` was consistently set — was silently mis-ranked: L2 distances on normalized vectors routinely exceed 1.0, so `max(0, 1 - d)` floored every result's similarity to `0.0` and the user saw flat `Match: 0.0` with no signal that anything was wrong.

Flagged by two backend authors — kostadis-ntnx on the RFC and jphein on #1679.

## What changed

- **Contract (RFC 001 §2.1):** `BaseBackend.distance_metric` ClassVar (`"cosine"` default) and a `BaseCollection.distance_metric` property. The `distances` field contract is *lower = closer* for every metric.
- **Legacy-L2 fix:** `ChromaCollection.distance_metric` reads the collection's actual `hnsw:space`, so a pre-cosine palace reports `"l2"` and gets ranked correctly rather than floored to zero.
- **Conversion:** `_distance_to_similarity(distance, metric)` — cosine `max(0, 1-d)`, L2 `1/(1+d)`, inner-product logistic squash; all monotonic-decreasing and bounded so they stay commensurable with the min-max-normalized BM25 term. Plus `_metric_for_collection(col)` (delegates through `EmbeddingCollection`, falls back to cosine on anything unexpected).
- **Applied everywhere the assumption lived:** `_hybrid_rank` (both call sites), the CLI match display (now an honest `<metric>_sim=` label), the MCP `similarity` field, the L3 search in `layers.py`, and the dedup threshold — so reported similarities are consistent.

## Scope / safety

- **Cosine output is byte-for-byte preserved** — only non-cosine metrics change behavior. All in-tree backends (`chroma`, `pgvector`, `qdrant`, `sqlite_exact`) are cosine today, so this makes a previously-latent assumption an explicit, correct contract.
- The one user-visible change is the CLI label: `cosine=` → `cosine_sim=` (and `l2_sim=` etc. on non-cosine palaces).

## Tests

- New `tests/test_distance_metric.py` (20 tests): per-metric conversion math, monotonicity, None/garbage/overflow handling, metric resolution + `EmbeddingCollection` delegation, and `ChromaCollection` legacy-L2 reporting.
- Updated one display-label assertion in `tests/test_searcher.py`.
- Full related suite green (538 passed), `ruff check` + `ruff format --check` clean.

## On the BM25 sqlite fallback (the other half of the §10 note)

RFC 001 §10 also flagged `_bm25_only_via_sqlite` reading `chroma.sqlite3` directly. On inspection that path is **already backend-neutral by construction**: its only caller, `_vector_disabled_search`, gates on `backend_name != "chroma"` and returns a clear `"vector_disabled fallback is Chroma-only"` error, and the backend-neutral lexical path (`BaseCollection.lexical_search()` + `supports_lexical_search`) already exists for the union strategy. The sqlite bypass is *intentionally* Chroma-specific — it dodges segfaults from corrupt HNSW segments (#1222) by avoiding the chromadb client entirely; routing it through `BaseCollection` would re-introduce the client it exists to avoid. So no change there is the right call.

Closes #1726. Refs #743 (RFC 001 §2.1, §10).
