### PR TITLE
feat(backends): embedder-identity contract + three-state enforcement (RFC 001)

### DIFF
--- a/mempalace/backends/base.py
+++ b/mempalace/backends/base.py
@@ -15,7 +15,7 @@ conformance suite land in follow-up PRs.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Protocol, runtime_checkable
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +74,15 @@ class EmbedderIdentityMismatchError(BackendError):
     """Raised when the stored embedder model name differs from the current one."""
 
 
+class EmbedderIdentityUnknownWarning(UserWarning):
+    """Emitted on first open of a collection with no recorded embedder identity.
+
+    Legacy palaces created before identity tracking carry no model name. Per
+    RFC 001 the right behavior is warn-not-fail: the identity is recorded on
+    the next write and subsequent opens become strict.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Value objects
 # ---------------------------------------------------------------------------
@@ -114,6 +123,91 @@ class PalaceRef:
     id: str
     local_path: Optional[str] = None
     namespace: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EmbedderIdentity:
+    """Identity of the embedder that produced a collection's vectors (RFC 001).
+
+    ``model_name`` is the stable identity persisted alongside a collection and
+    checked on subsequent opens. ``dimension`` is the vector width. A
+    ``dimension`` of ``0`` means *unknown / not probed* — comparisons treat it
+    as "no dimension signal" rather than a real zero-width vector, so a cheap
+    read-path check can compare model names without loading the model.
+    """
+
+    model_name: str
+    dimension: int = 0
+
+
+@runtime_checkable
+class Embedder(Protocol):
+    """Minimal embedder contract (RFC 001, normative for identity checking).
+
+    The fuller embedder RFC (batching/async/pooling) is additive; identity
+    enforcement depends only on these three members.
+    """
+
+    model_name: str
+    dimension: int
+
+    def embed(self, texts: list[str]) -> list[list[float]]: ...
+
+
+def check_embedder_identity(
+    stored: Optional[EmbedderIdentity],
+    current: Optional[EmbedderIdentity],
+    *,
+    force_model_swap: bool = False,
+) -> str:
+    """Three-state embedder-identity check (RFC 001).
+
+    Returns the resolved state and raises on a hard, unforced conflict:
+
+    * ``"unknown"`` — no identity recorded yet (legacy collection), or the
+      current embedder is nameless. The caller warns and records on write.
+    * ``"known_match"`` — stored name (and dimension, when both known) equal
+      the current embedder. Proceed normally.
+    * ``"known_mismatch"`` — names or dimensions differ. Without
+      ``force_model_swap`` this raises (:class:`EmbedderIdentityMismatchError`
+      for a model swap, :class:`DimensionMismatchError` for a width change,
+      which is checked first because mismatched vectors are physically
+      unusable). With ``force_model_swap`` it returns the state so the caller
+      can re-record the identity and log the swap.
+
+    A ``dimension`` of ``0`` on either side means "unknown" and is skipped, so
+    a model-name-only check (cheap read path) still works.
+    """
+    if current is None or not current.model_name:
+        return "unknown"
+    if stored is None:
+        return "unknown"
+
+    dim_conflict = bool(stored.dimension and current.dimension) and (
+        stored.dimension != current.dimension
+    )
+    name_conflict = stored.model_name != current.model_name
+
+    if not dim_conflict and not name_conflict:
+        return "known_match"
+
+    if force_model_swap:
+        return "known_mismatch"
+
+    if dim_conflict:
+        raise DimensionMismatchError(
+            f"collection was built with a {stored.dimension}-dim embedder "
+            f"({stored.model_name!r}) but the current embedder is "
+            f"{current.dimension}-dim ({current.model_name!r}); the stored "
+            "vectors are incompatible. Re-embed the palace to switch models."
+        )
+    raise EmbedderIdentityMismatchError(
+        f"collection was built with embedder {stored.model_name!r} but the "
+        f"current embedder is {current.model_name!r}. Searching across a model "
+        "swap silently degrades recall. Re-embed the palace, or run "
+        "`mempalace palace set-embedder --model <name> --force` to record the "
+        "new identity if you know the vectors are compatible."
+    )
 
 
 @dataclass(frozen=True)
@@ -311,6 +405,36 @@ class BaseCollection(ABC):
         this to report their actual space so core ranking converts correctly.
         """
         return "cosine"
+
+    def get_stored_embedder_identity(self) -> Optional[EmbedderIdentity]:
+        """Return the embedder identity recorded for this collection, if any.
+
+        Returns ``None`` when nothing is recorded — a legacy collection, or a
+        backend that does not yet persist identity. Core treats ``None`` as the
+        ``unknown`` state (warn, do not fail). Backends override this and
+        :meth:`set_embedder_identity` against their own metadata store.
+        """
+        return None
+
+    def set_embedder_identity(self, identity: EmbedderIdentity) -> None:
+        """Persist this collection's embedder identity. Default: no-op.
+
+        A backend without an identity slot inherits the no-op default and so
+        stays permanently ``unknown`` (safe — it simply never enforces). The
+        enforcement choke point calls this when recording on first write or
+        on an explicit, forced model swap.
+        """
+        return None
+
+    def effective_embedder_identity(self) -> Optional[EmbedderIdentity]:
+        """The identity of the embedder this collection actually uses.
+
+        For ``server_embedder`` backends that ignore the injected embedder,
+        this reports the server-side embedder so the same identity rules apply
+        (RFC 001). Defaults to ``None`` — the collection is embedded by the
+        injected/core embedder, and the caller supplies the current identity.
+        """
+        return None
 
     def lexical_search(
         self,

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1741,6 +1741,70 @@ class ChromaCollection(BaseCollection):
             return space
         return "l2"
 
+    # ------------------------------------------------------------------
+    # Embedder identity (RFC 001)
+    #
+    # Stored in a small sidecar JSON in the palace dir rather than the Chroma
+    # collection metadata: ``collection.modify(metadata=...)`` replaces the
+    # whole dict and some Chroma versions reject re-passing the immutable
+    # ``hnsw:*`` construction keys, so mutating it on every open is fragile.
+    # The sidecar is keyed by collection name (a palace may hold several).
+    # This is complementary to Chroma's own embedding-function-name check —
+    # the core check runs at open time and yields the clean cross-backend
+    # error before Chroma's read-time rejection fires.
+    # ------------------------------------------------------------------
+    def _embedder_sidecar_path(self) -> Optional[str]:
+        if not self._palace_path:
+            return None
+        return os.path.join(self._palace_path, "mempalace_embedder.json")
+
+    def get_stored_embedder_identity(self):
+        from .base import EmbedderIdentity
+
+        path = self._embedder_sidecar_path()
+        name = self._collection_name()
+        if not path or not name or not os.path.isfile(path):
+            return None
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        entry = data.get(name)
+        if not isinstance(entry, dict) or not entry.get("model_name"):
+            return None
+        return EmbedderIdentity(
+            model_name=str(entry["model_name"]),
+            dimension=int(entry.get("dimension") or 0),
+        )
+
+    def set_embedder_identity(self, identity) -> None:
+        path = self._embedder_sidecar_path()
+        name = self._collection_name()
+        if not path or not name or not identity or not identity.model_name:
+            return
+        data: dict = {}
+        if os.path.isfile(path):
+            try:
+                with open(path, encoding="utf-8") as f:
+                    loaded = json.load(f)
+                if isinstance(loaded, dict):
+                    data = loaded
+            except (OSError, json.JSONDecodeError):
+                data = {}
+        data[name] = {
+            "model_name": str(identity.model_name),
+            "dimension": int(identity.dimension or 0),
+        }
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+            os.chmod(path, 0o600)
+        except (OSError, NotImplementedError):
+            pass
+
 
 # ---------------------------------------------------------------------------
 # Backend

--- a/mempalace/backends/embedding_wrapper.py
+++ b/mempalace/backends/embedding_wrapper.py
@@ -57,6 +57,18 @@ class EmbeddingCollection(BaseCollection):
         # base "cosine" default and mask a wrapped non-cosine backend.
         return self._inner.distance_metric
 
+    # Same shadowing reason as ``distance_metric``: these are concrete methods
+    # on ``BaseCollection``, so ``__getattr__`` never delegates them. Forward
+    # explicitly to the wrapped backend collection's identity store.
+    def get_stored_embedder_identity(self):
+        return self._inner.get_stored_embedder_identity()
+
+    def set_embedder_identity(self, identity) -> None:
+        return self._inner.set_embedder_identity(identity)
+
+    def effective_embedder_identity(self):
+        return self._inner.effective_embedder_identity()
+
     def add(self, *, documents, ids, metadatas=None, embeddings=None):
         documents = _as_list(documents)
         ids = _as_list(ids)

--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -686,6 +686,12 @@ class PgVectorCollection(BaseCollection):
     def _marker_exists(self) -> bool:
         return self._backend._marker_exists(self._palace)
 
+    def get_stored_embedder_identity(self):
+        return self._backend._get_embedder_identity(self._palace, self._collection_name)
+
+    def set_embedder_identity(self, identity) -> None:
+        self._backend._set_embedder_identity(self._palace, self._collection_name, identity)
+
     def _ensure_table(self, dimension: int) -> None:
         if dimension <= 0:
             raise ValueError("embedding dimension must be positive")
@@ -1132,7 +1138,60 @@ class PgVectorBackend(BaseBackend):
             "palace_id": palace.id,
             "pgvector": self._marker_target(palace, config),
         }
+        # Preserve recorded embedder identities across marker rewrites — a
+        # rebuilt marker must not wipe per-collection model-name tracking.
+        try:
+            existing = self._read_marker(palace)
+        except BackendMismatchError:
+            existing = None
+        if isinstance(existing, dict) and isinstance(existing.get("embedders"), dict):
+            marker["embedders"] = existing["embedders"]
         marker_path = self._marker_path(palace.local_path)
+        with open(marker_path, "w", encoding="utf-8") as f:
+            json.dump(marker, f, indent=2, ensure_ascii=False)
+        try:
+            os.chmod(marker_path, 0o600)
+        except (OSError, NotImplementedError):
+            pass
+
+    def _get_embedder_identity(self, palace: PalaceRef, collection_name: str):
+        from .base import EmbedderIdentity
+
+        try:
+            marker = self._read_marker(palace)
+        except BackendMismatchError:
+            return None
+        if not isinstance(marker, dict):
+            return None
+        embedders = marker.get("embedders")
+        if not isinstance(embedders, dict):
+            return None
+        entry = embedders.get(collection_name)
+        if not isinstance(entry, dict) or not entry.get("model_name"):
+            return None
+        return EmbedderIdentity(
+            model_name=str(entry["model_name"]),
+            dimension=int(entry.get("dimension") or 0),
+        )
+
+    def _set_embedder_identity(self, palace: PalaceRef, collection_name: str, identity) -> None:
+        if not palace.local_path or not identity or not identity.model_name:
+            return
+        marker_path = self._marker_path(palace.local_path)
+        if not os.path.isfile(marker_path):
+            return
+        try:
+            marker = self._read_marker(palace) or {}
+        except BackendMismatchError:
+            return
+        embedders = marker.get("embedders")
+        if not isinstance(embedders, dict):
+            embedders = {}
+        embedders[collection_name] = {
+            "model_name": str(identity.model_name),
+            "dimension": int(identity.dimension or 0),
+        }
+        marker["embedders"] = embedders
         with open(marker_path, "w", encoding="utf-8") as f:
             json.dump(marker, f, indent=2, ensure_ascii=False)
         try:

--- a/mempalace/backends/sqlite_exact.py
+++ b/mempalace/backends/sqlite_exact.py
@@ -322,6 +322,36 @@ class SQLiteExactCollection(BaseCollection):
         row = cur.execute("SELECT value FROM meta WHERE key = 'fts5_available'").fetchone()
         return bool(row and row[0] == "1")
 
+    def _embedder_meta_key(self) -> str:
+        return f"embedder_model:{self._collection_name}"
+
+    def get_stored_embedder_identity(self):
+        from .base import EmbedderIdentity
+
+        with self._cursor() as cur:
+            try:
+                cid = self._collection_id(cur)
+            except CollectionNotInitializedError:
+                return None
+            row = cur.execute(
+                "SELECT value FROM meta WHERE key = ?",
+                (self._embedder_meta_key(),),
+            ).fetchone()
+            if not row or not row[0]:
+                return None
+            dim = self._collection_dimension(cur, cid) or 0
+            return EmbedderIdentity(model_name=str(row[0]), dimension=int(dim))
+
+    def set_embedder_identity(self, identity) -> None:
+        if not identity or not identity.model_name:
+            return
+        with self._cursor() as cur:
+            cur.execute(
+                "INSERT INTO meta(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (self._embedder_meta_key(), str(identity.model_name)),
+            )
+
     def _replace_fts(self, cur, collection_id: int, doc_id: str, document: str) -> None:
         if not self._fts_available(cur):
             return

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -831,6 +831,53 @@ def cmd_status(args):
     status(palace_path=palace_path)
 
 
+def cmd_palace_set_embedder(args):
+    """Record (or force-override) a palace's embedder identity (RFC 001).
+
+    Resolves the ``unknown`` state for a legacy palace, or records a specific
+    model with ``--model``. It records identity on the palace only; it does not
+    change the configured model — when the two differ it prints how to align
+    ``MEMPALACE_EMBEDDING_MODEL``. ``--force`` overwrites an existing,
+    differently-named identity.
+    """
+    from .backends.base import EmbedderIdentityMismatchError
+    from .palace import set_palace_embedder_identity
+
+    config = MempalaceConfig()
+    palace_path = os.path.abspath(
+        os.path.expanduser(args.palace) if args.palace else config.palace_path
+    )
+    model = getattr(args, "model", None)
+    try:
+        old, new = set_palace_embedder_identity(
+            palace_path,
+            model=model,
+            force=getattr(args, "force", False),
+            backend=_backend_arg(args),
+        )
+    except EmbedderIdentityMismatchError as exc:
+        print(f"  ✗ {exc}")
+        raise SystemExit(2) from exc
+    if old is None:
+        print(f"  ✓ recorded embedder identity: {new.model_name} (dim={new.dimension})")
+    elif old.model_name == new.model_name:
+        print(f"  ✓ embedder identity unchanged: {new.model_name} (dim={new.dimension})")
+    else:
+        print(
+            f"  ✓ embedder identity changed: {old.model_name} → {new.model_name} "
+            f"(dim={new.dimension})"
+        )
+    # set-embedder records the palace's identity; it does not change the
+    # configured model. If they differ, the next normal open would mismatch —
+    # tell the user how to align them.
+    configured = config.embedding_model
+    if new.model_name and configured and new.model_name != configured:
+        print(
+            f"  ⚠ configured model is {configured!r}; set MEMPALACE_EMBEDDING_MODEL="
+            f"{new.model_name} (or run onboarding) so normal opens of this palace match."
+        )
+
+
 def cmd_repair_status(args):
     """Read-only HNSW capacity health check (#1222)."""
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
@@ -1693,6 +1740,31 @@ def main():
         help="Storage backend to use for status (default: config/env/detected/chroma)",
     )
 
+    p_palace = sub.add_parser("palace", help="Palace maintenance commands")
+    palace_sub = p_palace.add_subparsers(dest="palace_action")
+    p_set_embedder = palace_sub.add_parser(
+        "set-embedder",
+        help="Record/override the palace's embedder identity (resolve 'unknown', or switch models)",
+    )
+    p_set_embedder.add_argument(
+        "--model",
+        default=None,
+        help="Embedder model to record (default: current configured model). "
+        "Records identity on the palace only; does not change the configured "
+        "model (prints how to align MEMPALACE_EMBEDDING_MODEL if they differ).",
+    )
+    p_set_embedder.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing identity that names a different model "
+        "(only if you know the stored vectors are compatible)",
+    )
+    p_set_embedder.add_argument(
+        "--backend",
+        default=None,
+        help="Storage backend (default: config/env/detected/chroma)",
+    )
+
     args = parser.parse_args()
     _apply_backend_arg(args)
 
@@ -1715,6 +1787,13 @@ def main():
             return
         args.name = name
         cmd_instructions(args)
+        return
+
+    if args.command == "palace":
+        if getattr(args, "palace_action", None) == "set-embedder":
+            cmd_palace_set_embedder(args)
+        else:
+            p_palace.print_help()
         return
 
     dispatch = {

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -287,3 +287,59 @@ def describe_device(device: Optional[str] = None) -> str:
         device = MempalaceConfig().embedding_device
     _, effective = _resolve_providers(device)
     return effective
+
+
+# Probed vector widths, keyed by resolved model name. Populated once per
+# process the first time an identity is resolved for a model.
+_DIM_CACHE: dict = {}
+
+
+def current_model_name(model: Optional[str] = None) -> str:
+    """Resolve the canonical embedder model name (cheap, no model load).
+
+    This is the configured ``embedding_model`` (``"minilm"`` /
+    ``"embeddinggemma"`` / ...), not the embedding function's internal
+    ``name()`` (which is spoofed to ``"default"`` for ChromaDB compatibility).
+    """
+    if model is not None:
+        return str(model).strip().lower()
+    from .config import MempalaceConfig
+
+    return MempalaceConfig().embedding_model
+
+
+def probe_dimension(device: Optional[str] = None, model: Optional[str] = None) -> int:
+    """Return the embedder's output dimension by embedding a short probe.
+
+    Model-agnostic — works for any model without a hardcoded table — and
+    cached per resolved model name so the probe is paid at most once per
+    process. Returns ``0`` if the probe fails (treated as "dimension unknown"
+    by the identity check, so a probe failure never blocks normal operation).
+    """
+    name = current_model_name(model)
+    cached = _DIM_CACHE.get(name)
+    if cached is not None:
+        return cached
+    try:
+        ef = get_embedding_function(device=device, model=model)
+        vectors = ef(input=["probe"])
+        dim = len(vectors[0]) if vectors and vectors[0] is not None else 0
+    except Exception:
+        logger.debug("Embedding dimension probe failed for model=%s", name, exc_info=True)
+        dim = 0
+    _DIM_CACHE[name] = dim
+    return dim
+
+
+def get_embedder_identity(device: Optional[str] = None, model: Optional[str] = None):
+    """Resolve the current embedder identity (RFC 001).
+
+    ``model_name`` from config (cheap); ``dimension`` from a cached one-time
+    probe. Returns an :class:`~mempalace.backends.base.EmbedderIdentity`.
+    """
+    from .backends.base import EmbedderIdentity
+
+    return EmbedderIdentity(
+        model_name=current_model_name(model),
+        dimension=probe_dimension(device=device, model=model),
+    )

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -70,13 +70,109 @@ _EXPLICIT_BACKEND_ENV = "MEMPALACE_BACKEND_EXPLICIT"
 NORMALIZE_VERSION = 2
 
 
+# (palace_id, collection_name, model_name) tuples already validated this
+# process, so the identity check (one metadata read) runs at most once per
+# collection per run — keeps the hot get_collection path cheap.
+_VALIDATED_IDENTITY: set = set()
+
+
+def _enforce_embedder_identity(collection, palace_path, collection_name, *, create) -> None:
+    """Check (and, for a brand-new collection, record) embedder identity (RFC 001).
+
+    Check at open so a model swap fails fast — before any query silently
+    returns degraded results. Record only when the collection is brand-new and
+    empty: recording the *current* model on a legacy palace that already holds
+    vectors from an unknown model would mislabel it, so populated-but-unrecorded
+    collections warn instead and are resolved with
+    ``mempalace palace set-embedder``.
+
+    Bookkeeping must never break memory operations: only the deliberate
+    identity/dimension mismatch propagates; every other error is swallowed.
+    """
+    import warnings
+
+    from .backends.base import (
+        DimensionMismatchError,
+        EmbedderIdentity,
+        EmbedderIdentityMismatchError,
+        EmbedderIdentityUnknownWarning,
+        check_embedder_identity,
+    )
+    from .embedding import current_model_name
+
+    # A server_embedder backend embeds with its own model and ignores the
+    # injected/core embedder, so its effective identity — not the configured
+    # model — is what must be checked and recorded. Fall back to the configured
+    # model name for the normal (core-embedder) case.
+    current: Optional[EmbedderIdentity] = None
+    try:
+        effective = collection.effective_embedder_identity()
+    except Exception:
+        effective = None
+    if effective is not None and getattr(effective, "model_name", ""):
+        current = effective
+    else:
+        try:
+            model_name = current_model_name()
+        except Exception:
+            return
+        if not model_name:
+            return  # nameless embedder — cannot enforce identity
+        current = EmbedderIdentity(model_name=model_name, dimension=0)
+
+    model_name = current.model_name
+    key = (str(palace_path), str(collection_name), model_name)
+    if key in _VALIDATED_IDENTITY:
+        return
+
+    try:
+        stored = collection.get_stored_embedder_identity()
+    except Exception:
+        logger.debug("embedder-identity read failed for %s", collection_name, exc_info=True)
+        return
+    try:
+        state = check_embedder_identity(stored, current)
+    except (EmbedderIdentityMismatchError, DimensionMismatchError):
+        raise  # deliberate, user-facing — the whole point of the contract
+    except Exception:
+        return
+
+    if state == "unknown" and stored is None:
+        try:
+            count = collection.count()
+        except Exception:
+            count = None
+        if count == 0:
+            if create:
+                try:
+                    collection.set_embedder_identity(current)
+                except Exception:
+                    logger.debug("embedder-identity record failed", exc_info=True)
+        elif count:
+            warnings.warn(
+                f"palace collection {collection_name!r} has no recorded embedder "
+                f"identity; assuming the current model {model_name!r}. Run "
+                "`mempalace palace set-embedder --model <name>` to record it.",
+                EmbedderIdentityUnknownWarning,
+                stacklevel=2,
+            )
+
+    _VALIDATED_IDENTITY.add(key)
+
+
 def get_collection(
     palace_path: str,
     collection_name: Optional[str] = None,
     create: bool = True,
     backend: Optional[str] = None,
+    _skip_identity_check: bool = False,
 ):
-    """Get the palace collection through the backend layer."""
+    """Get the palace collection through the backend layer.
+
+    ``_skip_identity_check`` bypasses the embedder-identity enforcement so the
+    ``set-embedder`` override path can open a palace whose recorded model
+    differs from the current one (the very state it exists to repair).
+    """
     if collection_name is None:
         from .config import get_configured_collection_name
 
@@ -98,8 +194,69 @@ def get_collection(
             create=create,
         )
     if "requires_explicit_embeddings" in getattr(backend_obj, "capabilities", frozenset()):
-        return EmbeddingCollection(collection)
+        collection = EmbeddingCollection(collection)
+    if not _skip_identity_check:
+        _enforce_embedder_identity(collection, palace_path, collection_name, create=create)
     return collection
+
+
+def set_palace_embedder_identity(
+    palace_path: str,
+    model: Optional[str] = None,
+    *,
+    force: bool = False,
+    backend: Optional[str] = None,
+    collection_name: Optional[str] = None,
+):
+    """Record (or force-override) a palace collection's embedder identity (RFC 001).
+
+    Backs ``mempalace palace set-embedder``. Returns ``(old, new)`` identities.
+    Without ``force``, refuses to overwrite an existing identity that names a
+    different model (the user must confirm they know the vectors are
+    compatible). Opens with the identity check skipped so a mismatched palace —
+    the exact state being repaired — can be opened at all.
+    """
+    from .backends.base import EmbedderIdentity, EmbedderIdentityMismatchError
+    from .config import MempalaceConfig
+    from .embedding import get_embedder_identity
+
+    configured = MempalaceConfig().embedding_model
+    target = (model or configured or "").strip().lower()
+    if not target:
+        # No model given and none configured — there is nothing to record, and
+        # recording a nameless identity is a silent no-op in every backend.
+        raise ValueError(
+            "no embedder model to record: pass --model NAME or configure MEMPALACE_EMBEDDING_MODEL"
+        )
+    if target == (configured or "").strip().lower():
+        # Recording the in-use model — probe its dimension (already loaded).
+        new = get_embedder_identity()
+    else:
+        # Explicit override of a non-configured model: record the name only,
+        # never load a foreign model (which can be a large download) just to
+        # probe a dimension. The model-name check is the actual protection.
+        new = EmbedderIdentity(model_name=target, dimension=0)
+    collection = get_collection(
+        palace_path,
+        collection_name=collection_name,
+        create=True,
+        backend=backend,
+        _skip_identity_check=True,
+    )
+    try:
+        old = collection.get_stored_embedder_identity()
+    except Exception:
+        old = None
+    if old is not None and old.model_name != new.model_name and not force:
+        raise EmbedderIdentityMismatchError(
+            f"palace already records embedder {old.model_name!r}; pass --force to "
+            f"overwrite it with {new.model_name!r} (only if the vectors are compatible)"
+        )
+    collection.set_embedder_identity(new)
+    # Reset the per-process validation cache so a re-open re-checks against the
+    # newly recorded identity rather than a stale verdict.
+    _VALIDATED_IDENTITY.clear()
+    return old, new
 
 
 def get_closets_collection(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,15 @@ markers = [
     "slow: tests that take more than 30 seconds",
     "stress: destructive scale tests (100K+ drawers)",
 ]
+filterwarnings = [
+    # Many tests build raw-chromadb palaces directly (no recorded embedder
+    # identity), which correctly emits this on open. The behavior itself is
+    # asserted in tests/test_embedder_identity.py; ignore the fixture noise.
+    # Matched by message (not by class path) so pytest does not import the
+    # mempalace package at config time — importing it before coverage starts
+    # would drop module-level lines from the report.
+    "ignore:palace collection.*has no recorded embedder identity",
+]
 
 [tool.coverage.run]
 source = ["mempalace"]

--- a/tests/test_embedder_identity.py
+++ b/tests/test_embedder_identity.py
@@ -1,0 +1,310 @@
+"""Embedder-identity persistence and three-state enforcement (RFC 001).
+
+A same-dimension model swap (e.g. two 384-d models) silently corrupts
+retrieval on the explicit-embedding backends, which have no native model
+check. The contract records the model name and refuses a swap on open. These
+tests avoid loading any embedding model: the enforcement *check* path needs
+only the configured model name (cheap), and persistence is exercised with
+``EmbedderIdentity`` objects and explicit vectors.
+"""
+
+import os
+import warnings
+
+import pytest
+
+from mempalace.backends.base import (
+    DimensionMismatchError,
+    EmbedderIdentity,
+    EmbedderIdentityMismatchError,
+    EmbedderIdentityUnknownWarning,
+    PalaceRef,
+    check_embedder_identity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Three-state helper
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_when_nothing_stored():
+    assert check_embedder_identity(None, EmbedderIdentity("minilm", 384)) == "unknown"
+
+
+def test_unknown_when_current_is_nameless():
+    stored = EmbedderIdentity("minilm", 384)
+    assert check_embedder_identity(stored, EmbedderIdentity("", 384)) == "unknown"
+    assert check_embedder_identity(stored, None) == "unknown"
+
+
+def test_known_match():
+    a = EmbedderIdentity("minilm", 384)
+    assert check_embedder_identity(a, a) == "known_match"
+
+
+def test_match_skips_unknown_dimension():
+    # dimension 0 means "not probed" and must not be treated as a real conflict.
+    assert (
+        check_embedder_identity(EmbedderIdentity("minilm", 384), EmbedderIdentity("minilm", 0))
+        == "known_match"
+    )
+
+
+def test_model_swap_raises_identity_error():
+    with pytest.raises(EmbedderIdentityMismatchError):
+        check_embedder_identity(EmbedderIdentity("minilm", 384), EmbedderIdentity("gemma", 384))
+
+
+def test_dimension_change_raises_dimension_error_first():
+    # Width change is physically unusable — checked before the name swap.
+    with pytest.raises(DimensionMismatchError):
+        check_embedder_identity(EmbedderIdentity("a", 384), EmbedderIdentity("b", 768))
+
+
+def test_force_returns_mismatch_without_raising():
+    assert (
+        check_embedder_identity(
+            EmbedderIdentity("minilm", 384),
+            EmbedderIdentity("gemma", 384),
+            force_model_swap=True,
+        )
+        == "known_mismatch"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-backend persistence roundtrip (no model loads)
+# ---------------------------------------------------------------------------
+
+
+def _sqlite_collection(tmp_path):
+    from mempalace.backends.sqlite_exact import SQLiteExactBackend
+
+    backend = SQLiteExactBackend()
+    ref = PalaceRef(id=str(tmp_path), local_path=str(tmp_path))
+    return backend.get_collection(palace=ref, collection_name="mempalace_drawers", create=True)
+
+
+def _chroma_collection(tmp_path):
+    from mempalace.backends.chroma import ChromaBackend
+
+    backend = ChromaBackend()
+    ref = PalaceRef(id=str(tmp_path), local_path=str(tmp_path))
+    return backend.get_collection(palace=ref, collection_name="mempalace_drawers", create=True)
+
+
+def test_sqlite_identity_roundtrip(tmp_path):
+    col = _sqlite_collection(tmp_path)
+    assert col.get_stored_embedder_identity() is None
+    col.add(documents=["x"], ids=["a"], metadatas=[{}], embeddings=[[0.1, 0.2, 0.3, 0.4]])
+    col.set_embedder_identity(EmbedderIdentity("minilm", 4))
+    got = col.get_stored_embedder_identity()
+    assert got is not None and got.model_name == "minilm" and got.dimension == 4
+
+
+def test_sqlite_set_identity_ignores_nameless(tmp_path):
+    col = _sqlite_collection(tmp_path)
+    col.add(documents=["x"], ids=["a"], metadatas=[{}], embeddings=[[0.1, 0.2, 0.3, 0.4]])
+    col.set_embedder_identity(EmbedderIdentity("", 4))
+    assert col.get_stored_embedder_identity() is None
+
+
+def test_chroma_identity_roundtrip_via_sidecar(tmp_path):
+    col = _chroma_collection(tmp_path)
+    assert col.get_stored_embedder_identity() is None
+    col.set_embedder_identity(EmbedderIdentity("minilm", 384))
+    got = col.get_stored_embedder_identity()
+    assert got is not None and got.model_name == "minilm" and got.dimension == 384
+    assert os.path.isfile(os.path.join(str(tmp_path), "mempalace_embedder.json"))
+
+
+def test_pgvector_marker_preserves_identity_across_rewrite(tmp_path):
+    # The marker is rebuilt on every collection create; identity must survive.
+    from mempalace.backends.pgvector import PgVectorBackend, _PgVectorConfig
+
+    backend = PgVectorBackend()
+    cfg = _PgVectorConfig(dsn="postgresql://example", namespace=None)
+    ref = PalaceRef(id=str(tmp_path), local_path=str(tmp_path))
+    backend._write_marker(ref, cfg)
+    backend._set_embedder_identity(ref, "mempalace_drawers", EmbedderIdentity("minilm", 384))
+    backend._write_marker(ref, cfg)  # rebuild must not wipe embedders
+    got = backend._get_embedder_identity(ref, "mempalace_drawers")
+    assert got is not None and got.model_name == "minilm" and got.dimension == 384
+
+
+def test_embeddingcollection_delegates_identity_not_shadowed():
+    # BaseCollection defines these as concrete methods, so __getattr__ never
+    # delegates them — the wrapper needs explicit forwarding or it silently
+    # reports the no-op default and masks the wrapped backend's identity.
+    from mempalace.backends.base import BaseCollection
+    from mempalace.backends.embedding_wrapper import EmbeddingCollection
+
+    class _Inner(BaseCollection):
+        def __init__(self):
+            self._ident = None
+
+        def add(self, **k): ...
+        def upsert(self, **k): ...
+        def query(self, **k): ...
+        def get(self, **k): ...
+        def delete(self, **k): ...
+        def count(self):
+            return 0
+
+        def get_stored_embedder_identity(self):
+            return self._ident
+
+        def set_embedder_identity(self, identity):
+            self._ident = identity
+
+    inner = _Inner()
+    wrapped = EmbeddingCollection(inner)
+    wrapped.set_embedder_identity(EmbedderIdentity("minilm", 384))
+    assert inner._ident is not None and inner._ident.model_name == "minilm"
+    assert wrapped.get_stored_embedder_identity().model_name == "minilm"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement via palace.get_collection (sqlite_exact, no model load)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clear_identity_cache():
+    from mempalace import palace
+
+    palace._VALIDATED_IDENTITY.clear()
+    yield
+    palace._VALIDATED_IDENTITY.clear()
+
+
+def _seed_sqlite_with_identity(tmp_path, model):
+    col = _sqlite_collection(tmp_path)
+    col.add(documents=["x"], ids=["a"], metadatas=[{}], embeddings=[[0.1, 0.2, 0.3, 0.4]])
+    if model is not None:
+        col.set_embedder_identity(EmbedderIdentity(model, 4))
+    return col
+
+
+def test_enforcement_match_does_not_raise(tmp_path, monkeypatch, clear_identity_cache):
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "minilm")
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    from mempalace import palace as P
+
+    _seed_sqlite_with_identity(tmp_path, "minilm")
+    P._VALIDATED_IDENTITY.clear()
+    # Should not raise.
+    P.get_collection(str(tmp_path), collection_name="mempalace_drawers", create=False)
+
+
+def test_enforcement_model_swap_raises(tmp_path, monkeypatch, clear_identity_cache):
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "minilm")
+    from mempalace import palace as P
+
+    _seed_sqlite_with_identity(tmp_path, "minilm")
+    P._VALIDATED_IDENTITY.clear()
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "embeddinggemma")
+    with pytest.raises(EmbedderIdentityMismatchError):
+        P.get_collection(str(tmp_path), collection_name="mempalace_drawers", create=False)
+
+
+def test_enforcement_brand_new_records_current_model(tmp_path, monkeypatch, clear_identity_cache):
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "minilm")
+    from mempalace import palace as P
+
+    col = P.get_collection(str(tmp_path), collection_name="mempalace_drawers", create=True)
+    got = col.get_stored_embedder_identity()
+    assert got is not None and got.model_name == "minilm"
+
+
+def test_enforcement_legacy_with_data_warns(tmp_path, monkeypatch, clear_identity_cache):
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "minilm")
+    from mempalace import palace as P
+
+    _seed_sqlite_with_identity(tmp_path, None)  # data, but no recorded identity
+    P._VALIDATED_IDENTITY.clear()
+    with pytest.warns(EmbedderIdentityUnknownWarning):
+        P.get_collection(str(tmp_path), collection_name="mempalace_drawers", create=False)
+
+
+def test_enforcement_nameless_model_is_a_noop(tmp_path, monkeypatch, clear_identity_cache):
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "minilm")
+    from mempalace import palace as P
+
+    _seed_sqlite_with_identity(tmp_path, None)
+    P._VALIDATED_IDENTITY.clear()
+    # A nameless current embedder cannot enforce — no raise, no warning.
+    monkeypatch.setattr("mempalace.embedding.current_model_name", lambda model=None: "")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        P.get_collection(str(tmp_path), collection_name="mempalace_drawers", create=False)
+
+
+# ---------------------------------------------------------------------------
+# set_palace_embedder_identity override path
+# ---------------------------------------------------------------------------
+
+
+def test_set_palace_identity_override_requires_force(tmp_path, monkeypatch, clear_identity_cache):
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "minilm")
+    from mempalace import palace as P
+
+    _seed_sqlite_with_identity(tmp_path, "minilm")
+    # Recording a different model without force is refused.
+    with pytest.raises(EmbedderIdentityMismatchError):
+        P.set_palace_embedder_identity(str(tmp_path), model="embeddinggemma", force=False)
+    # With force it goes through, recording the name only (no foreign load).
+    old, new = P.set_palace_embedder_identity(str(tmp_path), model="embeddinggemma", force=True)
+    assert old.model_name == "minilm" and new.model_name == "embeddinggemma"
+
+
+def test_set_palace_identity_empty_target_raises(tmp_path, monkeypatch):
+    # No model given and none configured: recording is a no-op in every backend,
+    # so refuse rather than claim a phantom success.
+    monkeypatch.setattr("mempalace.config.MempalaceConfig.embedding_model", property(lambda s: ""))
+    from mempalace import palace as P
+
+    with pytest.raises(ValueError):
+        P.set_palace_embedder_identity(str(tmp_path), model=None)
+
+
+def test_enforcement_prefers_effective_identity(monkeypatch, clear_identity_cache):
+    # A server_embedder collection reports its own effective identity; the
+    # configured model must be ignored in favor of it. Here effective and
+    # stored disagree, so enforcement raises even though config says "minilm".
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "minilm")
+    from mempalace import palace as P
+
+    class _ServerCol:
+        def effective_embedder_identity(self):
+            return EmbedderIdentity("server-model", 768)
+
+        def get_stored_embedder_identity(self):
+            return EmbedderIdentity("other-model", 768)
+
+        def count(self):
+            return 5
+
+        def set_embedder_identity(self, identity):
+            raise AssertionError("must not record on a mismatch")
+
+    with pytest.raises(EmbedderIdentityMismatchError):
+        P._enforce_embedder_identity(_ServerCol(), "/tmp/x", "c", create=False)
+
+
+def test_chroma_corrupt_sidecar_returns_none(tmp_path):
+    # A malformed sidecar (non-dict JSON) must not raise — degrade to unknown.
+    col = _chroma_collection(tmp_path)
+    path = os.path.join(str(tmp_path), "mempalace_embedder.json")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write('["not", "a", "dict"]')
+    assert col.get_stored_embedder_identity() is None
+    # And a subsequent set still works (overwrites the junk).
+    col.set_embedder_identity(EmbedderIdentity("minilm", 384))
+    assert col.get_stored_embedder_identity().model_name == "minilm"


### PR DESCRIPTION
## Summary

Implements the embedder-identity contract from RFC 001 (#743) — the "hard dependency" tracked in #1724.

The explicit-embedding backends (`pgvector`, `qdrant`, `sqlite_exact`) embed through `EmbeddingCollection` and persisted **nothing** about which model produced their vectors. Swapping two same-dimension models (`minilm` ↔ `embeddinggemma`, both 384-d) silently corrupted retrieval with no error — the worst failure class for a verbatim-recall system. This records the model name on write and refuses a swap on open.

## What changed

- **Contract** (`backends/base.py`): `EmbedderIdentity` dataclass, an `Embedder` protocol, `EmbedderIdentityUnknownWarning`, and a pure three-state `check_embedder_identity()` — `known_match` / `known_mismatch` (raises `EmbedderIdentityMismatchError`, or `DimensionMismatchError` for a width change, checked first) / `unknown`. `BaseCollection` gains optional `get`/`set`/`effective_embedder_identity` hooks (default: no-op → permanently `unknown`, which is safe).
- **Identity source** (`embedding.py`): `current_model_name()` (cheap, from config — the canonical name, not the EF's spoofed `"default"`) and `get_embedder_identity()` (dimension from a one-time cached probe).
- **Persistence**, one slot per backend: `sqlite_exact` `meta` table · `pgvector` marker JSON (preserved across marker rewrites) · `chroma` sidecar JSON in the palace dir. `EmbeddingCollection` forwards the hooks explicitly — `BaseCollection` defines them as concrete methods, so `__getattr__` would otherwise shadow the wrapped backend (same trap caught on the previous metric PR).
- **Enforcement** at `palace.get_collection`: a recorded model that differs from the current one raises (fail fast, before any silently-degraded query); a brand-new empty collection records the current model; a populated-but-unrecorded **legacy** palace warns and is resolved with the CLI. The check uses only the configured model name, so it needs **no model load**. A per-process cache keeps the hot path at one metadata read. Identity bookkeeping never breaks memory ops — only the deliberate mismatch propagates.
- **CLI**: `mempalace palace set-embedder [--model NAME] [--force]` records or force-overrides identity. It does **not** mutate global config and never loads a foreign model (an explicit `--model` override records the name with `dimension=0`).

## Scope / notes

- **Chroma** already self-protects via ChromaDB's embedding-function-name check; this layer complements it (and gives a uniform `get_stored_embedder_identity` for tooling) without touching the fragile collection metadata.
- **Legacy palaces are safe by construction**: no recorded identity → `unknown` → warn, never a hard fail. The check only raises once an identity has been recorded and the model then changes.
- **Qdrant** identity persistence is deferred (remote-only, no local metadata slot) and tracked in #1730. It stays `unknown`/safe until then.

## Tests

`tests/test_embedder_identity.py` (18 tests, no model loads): the three-state helper; per-backend persistence roundtrips (sqlite, chroma sidecar, pgvector marker-preservation — all connection-free); `EmbeddingCollection` delegation; and enforcement via `palace.get_collection` (match / model-swap-raises / brand-new-records / legacy-warns / nameless-noop / forced override). Full suite green: **2469 passed, 82.45% coverage**, `ruff check` + `format --check` clean.

Closes #1724. Refs #743, #1730.
