### PR TITLE
fix(mcp): remove root anyOf from diary_write schema (#1728)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2667,10 +2667,10 @@ TOOLS = {
                     "description": "Alias for 'entry' — accepted because add_drawer uses 'content'. Provide either 'entry' or 'content'; 'entry' wins if both are given.",
                 },
             },
-            # agent_name is always required; 'entry' or its alias 'content' must
-            # be present by dispatch time; keep the root schema composition-free
-            # for Anthropic-compatible MCP clients, then remap content->entry later.
-            "required": ["agent_name"],
+            # Keep the root schema composition-free for Anthropic-compatible MCP
+            # clients. Advertise the canonical 'entry' field as required while
+            # still accepting 'content' as a compatibility alias at dispatch.
+            "required": ["agent_name", "entry"],
         },
         "handler": tool_diary_write,
     },

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2668,9 +2668,9 @@ TOOLS = {
                 },
             },
             # Keep the root schema composition-free for Anthropic-compatible MCP
-            # clients. Advertise the canonical 'entry' field as required while
-            # still accepting 'content' as a compatibility alias at dispatch.
-            "required": ["agent_name", "entry"],
+            # clients, and leave 'content'-only compatibility intact by requiring
+            # only agent_name at schema level before dispatch remaps content->entry.
+            "required": ["agent_name"],
         },
         "handler": tool_diary_write,
     },

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2668,12 +2668,9 @@ TOOLS = {
                 },
             },
             # agent_name is always required; 'entry' or its alias 'content' must
-            # be present (the server remaps content->entry at dispatch).
+            # be present by dispatch time; keep the root schema composition-free
+            # for Anthropic-compatible MCP clients, then remap content->entry later.
             "required": ["agent_name"],
-            "anyOf": [
-                {"required": ["entry"]},
-                {"required": ["content"]},
-            ],
         },
         "handler": tool_diary_write,
     },

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -536,6 +536,11 @@ class TestHandleRequest:
         assert "mempalace_search" in names
         assert "mempalace_add_drawer" in names
         assert "mempalace_kg_add" in names
+        diary_write = next(t for t in tools if t["name"] == "mempalace_diary_write")
+        schema = diary_write["inputSchema"]
+        assert schema["required"] == ["agent_name"]
+        assert "content" in schema["properties"]
+        assert "anyOf" not in schema
 
     def test_null_arguments_does_not_hang(self, monkeypatch, config, palace_path, seeded_kg):
         """Sending arguments: null should return a result, not hang (#394)."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -538,7 +538,7 @@ class TestHandleRequest:
         assert "mempalace_kg_add" in names
         diary_write = next(t for t in tools if t["name"] == "mempalace_diary_write")
         schema = diary_write["inputSchema"]
-        assert schema["required"] == ["agent_name", "entry"]
+        assert schema["required"] == ["agent_name"]
         assert "content" in schema["properties"]
         assert "anyOf" not in schema
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -538,7 +538,7 @@ class TestHandleRequest:
         assert "mempalace_kg_add" in names
         diary_write = next(t for t in tools if t["name"] == "mempalace_diary_write")
         schema = diary_write["inputSchema"]
-        assert schema["required"] == ["agent_name"]
+        assert schema["required"] == ["agent_name", "entry"]
         assert "content" in schema["properties"]
         assert "anyOf" not in schema
 


### PR DESCRIPTION
## Problem

Anthropic-compatible MCP clients reject `mempalace_diary_write` before any tool call runs because its advertised `inputSchema` includes a root-level `anyOf`, which makes the whole MemPalace MCP server fail to load.

Fixes #1711.

Related: #1728, #1351, anthropics/claude-code#45106, taazkareem/clickup-mcp-server#5.

## Root cause

`mempalace/mcp_server.py:2644-2678` publishes `mempalace_diary_write` with a top-level `anyOf`, and `mempalace/mcp_server.py:2799-2805` returns that schema unchanged from `tools/list`. The runtime alias path at `mempalace/mcp_server.py:2883-2888` already rewrites `content` to `entry`, so the schema composition keyword is redundant and only breaks Anthropic/Codex compatibility.

## Fix

Remove the root-level `anyOf` from the advertised `mempalace_diary_write` schema while keeping the root object compatible with Anthropic/Codex. Keep `content` as a compatibility alias in the schema, require only `agent_name` at schema level so existing `content`-only callers remain valid, and retain the existing dispatch remap so `content` is normalized to `entry` before the handler runs. Add a `tools/list` regression in `tests/test_mcp_server.py` so the MCP-facing schema stays root-compatible and the alias remains exposed.

## How to test

```text
uv run ruff check .
uv run ruff format --check .
uv run pytest tests/test_mcp_server.py -v --ignore=tests/benchmarks
uv run pytest tests/ -v --ignore=tests/benchmarks
```

Focused MCP verification passed: `178 passed, 3 skipped`.

Repo-wide verification hit one pre-existing base-branch failure outside this diff: `tests/test_knowledge_graph.py::TestTripleOperations::test_invalidated_triple_allows_re_add`. The same failure reproduces on pristine `origin/develop@4ceb880`, so this PR does not introduce it.

## Checklist

- [x] Focused MCP tests pass (`uv run pytest tests/test_mcp_server.py -v --ignore=tests/benchmarks`)
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check .` and `uv run ruff format --check .`)
