### PR TITLE
fix(mcp): drop top-level anyOf from diary_write schema

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2668,12 +2668,8 @@ TOOLS = {
                 },
             },
             # agent_name is always required; 'entry' or its alias 'content' must
-            # be present (the server remaps content->entry at dispatch).
+            # be present — validated at dispatch (content is remapped to entry).
             "required": ["agent_name"],
-            "anyOf": [
-                {"required": ["entry"]},
-                {"required": ["content"]},
-            ],
         },
         "handler": tool_diary_write,
     },


### PR DESCRIPTION
Removes the top-level `anyOf` from `mempalace_diary_write` input_schema that causes Anthropic API and Codex to reject the entire MCP tools array with:

```
Invalid schema for function "mempalace_diary_write": schema must have
type "object" and not have "oneOf"/"anyOf"/"allOf"/"enum"/"not" at the top level.
```

The `content` → `entry` alias remapping already happens at dispatch (the existing code at line ~2888 pops `content` and fills `entry`), so the schema-level `anyOf` was expressing a constraint the runtime already enforces. Removing it changes zero behavior — callers passing `entry`, `content`, or both all work exactly as before.

Tests: all 31 diary tests pass, all 155 tool/schema tests pass, ruff clean.

Fixes #1728
Fixes #1711