### PR TITLE
fix(mcp): preserve room/wing casing on case-only update

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1701,7 +1701,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
                 return {"success": False, "error": str(e)}
             # Preserve existing casing when the caller passes a case-only
             # variant (LLM clients often "autocorrect" acronyms like ps5→PS5).
-            if wing.lower() != (old_meta.get("wing") or "").lower():
+            if wing.lower() != str(old_meta.get("wing") or "").lower():
                 new_meta["wing"] = wing
         if room is not None:
             try:
@@ -1710,7 +1710,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
                 return {"success": False, "error": str(e)}
             # Preserve existing casing when the caller passes a case-only
             # variant (LLM clients often "autocorrect" acronyms like ps5→PS5).
-            if room.lower() != (old_meta.get("room") or "").lower():
+            if room.lower() != str(old_meta.get("room") or "").lower():
                 new_meta["room"] = room
 
         _wal_log(

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1696,14 +1696,22 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
         new_meta = dict(old_meta)
         if wing is not None:
             try:
-                new_meta["wing"] = sanitize_name(wing, "wing")
+                wing = sanitize_name(wing, "wing")
             except ValueError as e:
                 return {"success": False, "error": str(e)}
+            # Preserve existing casing when the caller passes a case-only
+            # variant (LLM clients often "autocorrect" acronyms like ps5→PS5).
+            if wing.lower() != (old_meta.get("wing") or "").lower():
+                new_meta["wing"] = wing
         if room is not None:
             try:
-                new_meta["room"] = sanitize_name(room, "room")
+                room = sanitize_name(room, "room")
             except ValueError as e:
                 return {"success": False, "error": str(e)}
+            # Preserve existing casing when the caller passes a case-only
+            # variant (LLM clients often "autocorrect" acronyms like ps5→PS5).
+            if room.lower() != (old_meta.get("room") or "").lower():
+                new_meta["room"] = room
 
         _wal_log(
             "update_drawer",


### PR DESCRIPTION
When `tool_update_drawer` receives a `room` or `wing` argument that differs from the stored value only in casing (e.g. `ps5-enhanced-player` vs `PS5-enhanced-player`), the server now preserves the original stored casing instead of overwriting it.

**Root cause:** LLM clients (Claude, Codex) routinely autocorrect acronyms when generating tool calls — turning `ps5` into `PS5`, `api` into `API`, etc. The server treated any non-None value as an intentional rename, silently fragmenting drawers across two same-named-but-differently-cased rooms.

**Fix:** Compare new value against existing value case-insensitively. If they match, keep the original. If they genuinely differ, apply the change normally.

**Tests:** 2483 pass, 0 regressions. Verified:
- Case-only room/wing change → preserved original
- Genuinely different room/wing → updated correctly  
- Omitted room/wing (None) → still preserved as before

Fixes #1621