### PR TITLE
feat(hooks): add a final session-end save hook (#1341)

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -41,9 +41,10 @@ After installing the plugin, run the init command to complete setup (installs th
 
 ## Hooks
 
-MemPalace registers two hooks that run automatically:
+MemPalace registers three hooks that run automatically:
 
 - **Stop** -- Saves conversation context every 15 messages.
+- **SessionEnd** -- Runs one final clean-exit save before Claude Code closes the session.
 - **PreCompact** -- Preserves important memories before context compaction.
 
 Set the `MEMPAL_DIR` environment variable to a directory path to automatically run `mempalace mine` on that directory during each save trigger.

--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -12,6 +12,17 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mempal-session-end-hook.sh\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "hooks": [

--- a/.claude-plugin/hooks/mempal-session-end-hook.sh
+++ b/.claude-plugin/hooks/mempal-session-end-hook.sh
@@ -3,22 +3,23 @@
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
 run_mempalace_hook() {
   if command -v mempalace >/dev/null 2>&1; then
-    mempalace hook run "$@"
-    return $?
+    exec mempalace hook run "$@"
   fi
 
-  if command -v python3 >/dev/null 2>&1 && python3 -c "import mempalace" >/dev/null 2>&1; then
-    python3 -m mempalace hook run "$@"
-    return $?
+  MEMPAL_PYTHON_BIN="${MEMPAL_PYTHON:-}"
+  if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
+    MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
+  fi
+  if "$MEMPAL_PYTHON_BIN" -c "import mempalace" >/dev/null 2>&1; then
+    exec "$MEMPAL_PYTHON_BIN" -m mempalace hook run "$@"
   fi
 
   if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
-    python -m mempalace hook run "$@"
-    return $?
+    exec python -m mempalace hook run "$@"
   fi
 
   echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
-  return 1
+  exit 1
 }
 
-run_mempalace_hook --hook session-end --harness claude-code
+run_mempalace_hook --hook session-end --harness "${MEMPALACE_HOOK_HARNESS:-claude-code}"

--- a/.claude-plugin/hooks/mempal-session-end-hook.sh
+++ b/.claude-plugin/hooks/mempal-session-end-hook.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# MemPalace SessionEnd Hook — thin wrapper calling Python CLI
+# All logic lives in mempalace.hooks_cli for cross-harness extensibility
+run_mempalace_hook() {
+  if command -v mempalace >/dev/null 2>&1; then
+    mempalace hook run "$@"
+    return $?
+  fi
+
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import mempalace" >/dev/null 2>&1; then
+    python3 -m mempalace hook run "$@"
+    return $?
+  fi
+
+  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
+    python -m mempalace hook run "$@"
+    return $?
+  fi
+
+  echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
+  return 1
+}
+
+run_mempalace_hook --hook session-end --harness claude-code

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -65,11 +65,6 @@ Add to `.codex/hooks.json`:
     "command": "/absolute/path/to/hooks/mempal_save_hook.sh",
     "timeout": 30
   }],
-  "SessionEnd": [{
-    "type": "command",
-    "command": "mempalace hook run --hook session-end --harness codex",
-    "timeout": 30
-  }],
   "PreCompact": [{
     "type": "command",
     "command": "/absolute/path/to/hooks/mempal_precompact_hook.sh",
@@ -77,6 +72,8 @@ Add to `.codex/hooks.json`:
   }]
 }
 ```
+
+Codex CLI does not currently expose a `SessionEnd` hook event, so the clean-exit hook is Claude Code only for now.
 
 ## Configuration
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -11,6 +11,7 @@ It covers hook wiring, JSONL backup, and one-time backfill.
 | Hook | When It Fires | What Happens |
 |------|--------------|-------------|
 | **Save Hook** | Every 15 human messages | Auto-mines transcript (tool output included), then blocks the AI to save topics/decisions/quotes |
+| **SessionEnd Hook** | Clean session exit | Runs one final checkpoint save plus a final project mine before the harness exits |
 | **PreCompact Hook** | Right before context compaction | Auto-mines transcript, then emergency save — forces the AI to save EVERYTHING before losing context |
 
 **Two-layer capture:** Hooks auto-mine the JSONL transcript directly into the palace (capturing raw tool output — Bash results, search findings, build errors). They also block the AI with a reason message telling it to save verbatim tool output and key context. Belt and suspenders — tool output gets stored even if the AI summarizes instead of quoting.
@@ -30,6 +31,13 @@ Add to `.claude/settings.local.json`:
         "timeout": 30
       }]
     }],
+    "SessionEnd": [{
+      "hooks": [{
+        "type": "command",
+        "command": "/absolute/path/to/hooks/mempal_session_end_hook.sh",
+        "timeout": 30
+      }]
+    }],
     "PreCompact": [{
       "hooks": [{
         "type": "command",
@@ -43,7 +51,7 @@ Add to `.claude/settings.local.json`:
 
 Make them executable:
 ```bash
-chmod +x hooks/mempal_save_hook.sh hooks/mempal_precompact_hook.sh
+chmod +x hooks/mempal_save_hook.sh hooks/mempal_session_end_hook.sh hooks/mempal_precompact_hook.sh
 ```
 
 ## Install — Codex CLI (OpenAI)
@@ -55,6 +63,11 @@ Add to `.codex/hooks.json`:
   "Stop": [{
     "type": "command",
     "command": "/absolute/path/to/hooks/mempal_save_hook.sh",
+    "timeout": 30
+  }],
+  "SessionEnd": [{
+    "type": "command",
+    "command": "mempalace hook run --hook session-end --harness codex",
     "timeout": 30
   }],
   "PreCompact": [{

--- a/hooks/mempal_session_end_hook.sh
+++ b/hooks/mempal_session_end_hook.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 # MEMPALACE SESSION-END HOOK — Final save on clean exit
-#
-# Thin wrapper around the Python hook dispatcher so the clean-exit path
-# reuses the same save/mining logic as the first-class CLI hook.
 
-HOOK_HARNESS="${MEMPALACE_HOOK_HARNESS:-claude-code}"
+run_mempalace_hook() {
+  if command -v mempalace >/dev/null 2>&1; then
+    exec mempalace hook run "$@"
+  fi
 
-exec mempalace hook run --hook session-end --harness "$HOOK_HARNESS"
+  MEMPAL_PYTHON_BIN="${MEMPAL_PYTHON:-}"
+  if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
+    MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
+  fi
+  if "$MEMPAL_PYTHON_BIN" -c "import mempalace" >/dev/null 2>&1; then
+    exec "$MEMPAL_PYTHON_BIN" -m mempalace hook run "$@"
+  fi
+
+  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
+    exec python -m mempalace hook run "$@"
+  fi
+
+  echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
+  exit 1
+}
+
+run_mempalace_hook --hook session-end --harness "${MEMPALACE_HOOK_HARNESS:-claude-code}"

--- a/hooks/mempal_session_end_hook.sh
+++ b/hooks/mempal_session_end_hook.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# MEMPALACE SESSION-END HOOK — Final save on clean exit
+#
+# Thin wrapper around the Python hook dispatcher so the clean-exit path
+# reuses the same save/mining logic as the first-class CLI hook.
+
+HOOK_HARNESS="${MEMPALACE_HOOK_HARNESS:-claude-code}"
+
+exec mempalace hook run --hook session-end --harness "$HOOK_HARNESS"

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1595,7 +1595,7 @@ def main():
     p_hook_run.add_argument(
         "--hook",
         required=True,
-        choices=["session-start", "stop", "precompact"],
+        choices=["session-start", "stop", "session-end", "precompact"],
         help="Hook name to run",
     )
     p_hook_run.add_argument(

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -1,8 +1,8 @@
 """
-Hook logic for MemPalace — Python implementation of session-start, stop, and precompact hooks.
+Hook logic for MemPalace — Python implementation of session-start, stop, session-end, and precompact hooks.
 
 Reads JSON from stdin, outputs JSON to stdout.
-Supported hooks: session-start, stop, precompact
+Supported hooks: session-start, stop, session-end, precompact
 Supported harnesses: claude-code, codex (extensible to cursor, gemini, etc.)
 """
 
@@ -892,6 +892,52 @@ def _wing_from_transcript_path(transcript_path: str) -> str:
     return "wing_sessions"
 
 
+def _save_result_payload(result: dict) -> dict:
+    """Format a hook save result into a terminal-visible payload."""
+    count = result.get("count", 0)
+    if count <= 0:
+        return {}
+    themes = result.get("themes", [])
+    tag = f" \u2014 {', '.join(themes)}" if themes else ""
+    return {"systemMessage": f"\u2726 {count} memories woven into the palace{tag}"}
+
+
+def _run_session_save(
+    transcript_path: str,
+    session_id: str,
+    harness: str,
+    *,
+    toast: bool,
+    sync_project_mine: bool,
+) -> dict:
+    """Save the current session and run the matching ingest path."""
+    result = {"count": 0}
+    if transcript_path:
+        result = _save_diary_direct(
+            transcript_path,
+            session_id,
+            wing=_wing_from_transcript_path(transcript_path),
+            toast=toast,
+            agent_name=_diary_agent_for_harness(harness),
+        )
+        _ingest_transcript(transcript_path)
+    if sync_project_mine:
+        _mine_sync()
+    else:
+        _maybe_auto_ingest()
+    return result
+
+
+def _clear_session_last_save(session_id: str) -> None:
+    """Drop the per-session save marker after the session exits."""
+    try:
+        (STATE_DIR / f"{session_id}_last_save").unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
 def hook_stop(data: dict, harness: str):
     """Stop hook: block every N messages for auto-save."""
     if not _palace_root_exists():
@@ -953,21 +999,15 @@ def hook_stop(data: dict, harness: str):
             silent = True
             toast = False
 
-        project_wing = _wing_from_transcript_path(transcript_path)
-
         if silent:
             # Save directly via Python API — systemMessage renders in terminal
-            result = {"count": 0}
-            if transcript_path:
-                result = _save_diary_direct(
-                    transcript_path,
-                    session_id,
-                    wing=project_wing,
-                    toast=toast,
-                    agent_name=_diary_agent_for_harness(harness),
-                )
-                _ingest_transcript(transcript_path)
-            _maybe_auto_ingest()
+            result = _run_session_save(
+                transcript_path,
+                session_id,
+                harness,
+                toast=toast,
+                sync_project_mine=False,
+            )
             # Only advance save marker after successful save
             count = result.get("count", 0)
             if count > 0:
@@ -975,16 +1015,7 @@ def hook_stop(data: dict, harness: str):
                     last_save_file.write_text(str(exchange_count), encoding="utf-8")
                 except OSError:
                     pass
-                themes = result.get("themes", [])
-                if themes:
-                    tag = " \u2014 " + ", ".join(themes)
-                else:
-                    tag = ""
-                _output(
-                    {
-                        "systemMessage": f"\u2726 {count} memories woven into the palace{tag}",
-                    }
-                )
+                _output(_save_result_payload(result))
             else:
                 _output({})
         else:
@@ -995,6 +1026,7 @@ def hook_stop(data: dict, harness: str):
                 last_save_file.write_text(str(exchange_count), encoding="utf-8")
             except OSError:
                 pass
+            project_wing = _wing_from_transcript_path(transcript_path)
             if transcript_path:
                 _ingest_transcript(transcript_path)
             _maybe_auto_ingest()
@@ -1019,6 +1051,40 @@ def hook_session_start(data: dict, harness: str):
 
     # Pass through — no blocking on session start
     _output({})
+
+
+def hook_session_end(data: dict, harness: str):
+    """Session end hook: force one final save on clean exit."""
+    if not _palace_root_exists():
+        _output({})
+        return
+    parsed = _parse_harness_input(data, harness)
+    session_id = parsed["session_id"]
+    transcript_path = parsed["transcript_path"]
+
+    try:
+        config = MempalaceConfig()
+        if not config.hooks_auto_save:
+            _output({})
+            return
+
+        _log(f"SESSION END triggered for session {session_id}")
+
+        try:
+            toast = config.hook_desktop_toast
+        except Exception:
+            toast = False
+
+        result = _run_session_save(
+            transcript_path,
+            session_id,
+            harness,
+            toast=toast,
+            sync_project_mine=True,
+        )
+        _output(_save_result_payload(result))
+    finally:
+        _clear_session_last_save(session_id)
 
 
 def hook_precompact(data: dict, harness: str):
@@ -1064,6 +1130,7 @@ def run_hook(hook_name: str, harness: str):
     hooks = {
         "session-start": hook_session_start,
         "stop": hook_stop,
+        "session-end": hook_session_end,
         "precompact": hook_precompact,
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,11 +158,12 @@ def test_cmd_instructions_calls_run_instructions():
 # ── cmd_hook ───────────────────────────────────────────────────────────
 
 
-def test_cmd_hook_calls_run_hook():
-    args = argparse.Namespace(hook="session-start", harness="claude-code")
+@pytest.mark.parametrize("hook_name", ["session-start", "session-end"])
+def test_cmd_hook_calls_run_hook(hook_name):
+    args = argparse.Namespace(hook=hook_name, harness="claude-code")
     with patch("mempalace.hooks_cli.run_hook") as mock_run:
         cmd_hook(args)
-        mock_run.assert_called_once_with(hook_name="session-start", harness="claude-code")
+        mock_run.assert_called_once_with(hook_name=hook_name, harness="claude-code")
 
 
 # ── cmd_init ───────────────────────────────────────────────────────────
@@ -864,6 +865,18 @@ def test_main_hook_run_dispatches():
         patch(
             "sys.argv",
             ["mempalace", "hook", "run", "--hook", "session-start", "--harness", "claude-code"],
+        ),
+        patch("mempalace.cli.cmd_hook") as mock_cmd,
+    ):
+        main()
+        mock_cmd.assert_called_once()
+
+
+def test_main_hook_run_dispatches_session_end():
+    with (
+        patch(
+            "sys.argv",
+            ["mempalace", "hook", "run", "--hook", "session-end", "--harness", "claude-code"],
         ),
         patch("mempalace.cli.cmd_hook") as mock_cmd,
     ):

--- a/tests/test_hooks_bash_compat.py
+++ b/tests/test_hooks_bash_compat.py
@@ -141,6 +141,8 @@ class TestNoBash4OnlyBuiltins:
         src = _hook_src_no_comments(SESSION_END_HOOK)
         assert "mempalace hook run --hook session-end --harness" in src
         assert "MEMPALACE_HOOK_HARNESS" in src
+        assert "MEMPAL_PYTHON" in src
+        assert "python3" in src
 
 
 class TestSessionIdExtraction:

--- a/tests/test_hooks_bash_compat.py
+++ b/tests/test_hooks_bash_compat.py
@@ -28,6 +28,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
 PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
 SESSION_END_HOOK = REPO_ROOT / "hooks" / "mempal_session_end_hook.sh"
+PLUGIN_SESSION_END_HOOK = REPO_ROOT / ".claude-plugin" / "hooks" / "mempal-session-end-hook.sh"
 
 # Re-used by every parametrize decorator that runs the same test against
 # both hooks. ``ids=`` keeps pytest output readable (`...[save_hook]`
@@ -137,8 +138,23 @@ class TestNoBash4OnlyBuiltins:
         )
         assert p.returncode == 0, f"{SESSION_END_HOOK.name} syntax error: {p.stderr}"
 
+    def test_plugin_session_end_wrapper_syntax_clean(self):
+        p = subprocess.run(
+            ["bash", "-n", str(PLUGIN_SESSION_END_HOOK)],
+            capture_output=True,
+            text=True,
+        )
+        assert p.returncode == 0, f"{PLUGIN_SESSION_END_HOOK.name} syntax error: {p.stderr}"
+
     def test_session_end_wrapper_dispatches_through_cli(self):
         src = _hook_src_no_comments(SESSION_END_HOOK)
+        assert "mempalace hook run --hook session-end --harness" in src
+        assert "MEMPALACE_HOOK_HARNESS" in src
+        assert "MEMPAL_PYTHON" in src
+        assert "python3" in src
+
+    def test_plugin_session_end_wrapper_dispatches_through_cli(self):
+        src = _hook_src_no_comments(PLUGIN_SESSION_END_HOOK)
         assert "mempalace hook run --hook session-end --harness" in src
         assert "MEMPALACE_HOOK_HARNESS" in src
         assert "MEMPAL_PYTHON" in src

--- a/tests/test_hooks_bash_compat.py
+++ b/tests/test_hooks_bash_compat.py
@@ -27,6 +27,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
 PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
+SESSION_END_HOOK = REPO_ROOT / "hooks" / "mempal_session_end_hook.sh"
 
 # Re-used by every parametrize decorator that runs the same test against
 # both hooks. ``ids=`` keeps pytest output readable (`...[save_hook]`
@@ -127,6 +128,19 @@ class TestNoBash4OnlyBuiltins:
             text=True,
         )
         assert p.returncode == 0, f"{hook.name} syntax error: {p.stderr}"
+
+    def test_session_end_wrapper_syntax_clean(self):
+        p = subprocess.run(
+            ["bash", "-n", str(SESSION_END_HOOK)],
+            capture_output=True,
+            text=True,
+        )
+        assert p.returncode == 0, f"{SESSION_END_HOOK.name} syntax error: {p.stderr}"
+
+    def test_session_end_wrapper_dispatches_through_cli(self):
+        src = _hook_src_no_comments(SESSION_END_HOOK)
+        assert "mempalace hook run --hook session-end --harness" in src
+        assert "MEMPALACE_HOOK_HARNESS" in src
 
 
 class TestSessionIdExtraction:

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -26,6 +26,7 @@ from mempalace.hooks_cli import (
     _save_diary_direct,
     _validate_transcript_path,
     _wing_from_transcript_path,
+    hook_session_end,
     hook_stop,
     hook_session_start,
     hook_precompact,
@@ -1566,6 +1567,14 @@ def test_run_hook_dispatches_precompact(tmp_path):
     mock_output.assert_called_once_with({})
 
 
+def test_run_hook_dispatches_session_end():
+    stdin_data = json.dumps({"session_id": "run-test"})
+    with patch("sys.stdin", io.StringIO(stdin_data)):
+        with patch("mempalace.hooks_cli.hook_session_end") as mock_hook:
+            run_hook("session-end", "claude-code")
+    mock_hook.assert_called_once_with({"session_id": "run-test"}, "claude-code")
+
+
 # --- auto_save config toggle ---
 
 
@@ -1640,6 +1649,54 @@ def test_precompact_hook_enabled_by_default(tmp_path):
             )
     assert result == {}
     mock_mine.assert_called_once()
+
+
+def test_session_end_hook_disabled_by_config_clears_last_save(tmp_path):
+    last_save_file = tmp_path / "test_last_save"
+    last_save_file.write_text("15", encoding="utf-8")
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = False
+        result = _capture_hook_output(
+            hook_session_end,
+            {"session_id": "test", "transcript_path": ""},
+            state_dir=tmp_path,
+        )
+    assert result == {}
+    assert not last_save_file.exists()
+
+
+def test_session_end_hook_final_save_and_cleanup(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(3)],
+    )
+    last_save_file = tmp_path / "test_last_save"
+    last_save_file.write_text("2", encoding="utf-8")
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        with (
+            patch(
+                "mempalace.hooks_cli._save_diary_direct",
+                return_value={"count": 3, "themes": ["exit"]},
+            ) as mock_save,
+            patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+            patch("mempalace.hooks_cli._mine_sync") as mock_mine,
+        ):
+            result = _capture_hook_output(
+                hook_session_end,
+                {"session_id": "test", "transcript_path": str(transcript)},
+                state_dir=tmp_path,
+            )
+    assert result["systemMessage"].startswith("\u2726 3 memories woven into the palace")
+    assert "exit" in result["systemMessage"]
+    mock_save.assert_called_once_with(
+        str(transcript), "test", wing="wing_sessions", toast=False, agent_name="claude"
+    )
+    mock_ingest.assert_called_once_with(str(transcript))
+    mock_mine.assert_called_once()
+    assert not last_save_file.exists()
 
 
 def test_run_hook_unknown_hook():
@@ -1800,6 +1857,15 @@ def test_hook_session_start_does_not_create_palace_dir_when_absent(tmp_path, mon
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         hook_session_start({"session_id": "absent"}, "claude-code")
+    assert json.loads(buf.getvalue() or "{}") == {}
+    assert not fake_root.exists()
+
+
+def test_hook_session_end_does_not_create_palace_dir_when_absent(tmp_path, monkeypatch):
+    fake_root = _redirect_palace_root(monkeypatch, tmp_path)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        hook_session_end({"session_id": "absent", "transcript_path": ""}, "claude-code")
     assert json.loads(buf.getvalue() or "{}") == {}
     assert not fake_root.exists()
 

--- a/tests/test_hooks_shell.py
+++ b/tests/test_hooks_shell.py
@@ -32,6 +32,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
 PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
 SESSION_END_HOOK = REPO_ROOT / "hooks" / "mempal_session_end_hook.sh"
+PLUGIN_SESSION_END_HOOK = REPO_ROOT / ".claude-plugin" / "hooks" / "mempal-session-end-hook.sh"
 
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="bash hook scripts are POSIX-only")
@@ -244,6 +245,61 @@ exit 1
         fake = _write_fake_mempalace(tmp_path / "mempalace", args_file, stdin_file)
         result = _run_hook(
             SESSION_END_HOOK,
+            {"session_id": "abc", "transcript_path": ""},
+            env_overrides={
+                "HOME": str(tmp_path),
+                "MEMPALACE_HOOK_HARNESS": "codex",
+            },
+            path_prefix=[fake.parent],
+        )
+        assert result.returncode == 0
+        assert args_file.read_text() == "hook run --hook session-end --harness codex"
+
+
+class TestPluginSessionEndWrapper:
+    def test_dispatches_via_mempal_python_override(self, tmp_path):
+        args_file = tmp_path / "args.log"
+        stdin_file = tmp_path / "stdin.json"
+        shim = tmp_path / "python3"
+        shim.write_text(
+            f"""#!/bin/bash
+if [ "$1" = "-c" ]; then
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "mempalace" ]; then
+  printf '%s' "$*" > "{args_file}"
+  cat > "{stdin_file}"
+  printf '{{}}'
+  exit 0
+fi
+exit 1
+""",
+            encoding="utf-8",
+        )
+        shim.chmod(shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        payload = {"session_id": "abc", "transcript_path": ""}
+        result = _run_hook(
+            PLUGIN_SESSION_END_HOOK,
+            payload,
+            env_overrides={
+                "HOME": str(tmp_path),
+                "PATH": "",
+                "MEMPAL_PYTHON": str(shim),
+            },
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+        assert (
+            args_file.read_text() == "mempalace hook run --hook session-end --harness claude-code"
+        )
+        assert json.loads(stdin_file.read_text()) == payload
+
+    def test_dispatches_to_cli_with_harness_override(self, tmp_path):
+        args_file = tmp_path / "args.log"
+        stdin_file = tmp_path / "stdin.json"
+        fake = _write_fake_mempalace(tmp_path / "mempalace", args_file, stdin_file)
+        result = _run_hook(
+            PLUGIN_SESSION_END_HOOK,
             {"session_id": "abc", "transcript_path": ""},
             env_overrides={
                 "HOME": str(tmp_path),

--- a/tests/test_hooks_shell.py
+++ b/tests/test_hooks_shell.py
@@ -31,6 +31,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
 PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
+SESSION_END_HOOK = REPO_ROOT / "hooks" / "mempal_session_end_hook.sh"
 
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="bash hook scripts are POSIX-only")
@@ -105,6 +106,17 @@ def _run_hook(
     )
 
 
+def _write_fake_mempalace(path: Path, args_file: Path, stdin_file: Path) -> Path:
+    shim_src = f"""#!/bin/bash
+printf '%s' "$*" > "{args_file}"
+cat > "{stdin_file}"
+printf '{{}}'
+"""
+    path.write_text(shim_src)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
 # ── MEMPAL_PYTHON resolution contract ────────────────────────────────────
 
 
@@ -168,3 +180,39 @@ class TestMempalPythonOverride:
         assert "python3" in invocations, (
             f"fallback-to-PATH did not use the shimmed python3. Marker log: {invocations!r}"
         )
+
+
+class TestSessionEndWrapper:
+    def test_dispatches_to_cli_with_default_harness(self, tmp_path):
+        args_file = tmp_path / "args.log"
+        stdin_file = tmp_path / "stdin.json"
+        fake = _write_fake_mempalace(tmp_path / "mempalace", args_file, stdin_file)
+        payload = {"session_id": "abc", "transcript_path": ""}
+        result = _run_hook(
+            SESSION_END_HOOK,
+            payload,
+            env_overrides={"HOME": str(tmp_path)},
+            path_prefix=[fake.parent],
+        )
+        assert result.returncode == 0, (
+            f"session-end wrapper exited non-zero: stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert json.loads(result.stdout) == {}
+        assert args_file.read_text() == "hook run --hook session-end --harness claude-code"
+        assert json.loads(stdin_file.read_text()) == payload
+
+    def test_dispatches_to_cli_with_harness_override(self, tmp_path):
+        args_file = tmp_path / "args.log"
+        stdin_file = tmp_path / "stdin.json"
+        fake = _write_fake_mempalace(tmp_path / "mempalace", args_file, stdin_file)
+        result = _run_hook(
+            SESSION_END_HOOK,
+            {"session_id": "abc", "transcript_path": ""},
+            env_overrides={
+                "HOME": str(tmp_path),
+                "MEMPALACE_HOOK_HARNESS": "codex",
+            },
+            path_prefix=[fake.parent],
+        )
+        assert result.returncode == 0
+        assert args_file.read_text() == "hook run --hook session-end --harness codex"

--- a/tests/test_hooks_shell.py
+++ b/tests/test_hooks_shell.py
@@ -201,6 +201,43 @@ class TestSessionEndWrapper:
         assert args_file.read_text() == "hook run --hook session-end --harness claude-code"
         assert json.loads(stdin_file.read_text()) == payload
 
+    def test_dispatches_via_mempal_python_override(self, tmp_path):
+        args_file = tmp_path / "args.log"
+        stdin_file = tmp_path / "stdin.json"
+        shim = tmp_path / "python3"
+        shim.write_text(
+            f"""#!/bin/bash
+if [ "$1" = "-c" ]; then
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "mempalace" ]; then
+  printf '%s' "$*" > "{args_file}"
+  cat > "{stdin_file}"
+  printf '{{}}'
+  exit 0
+fi
+exit 1
+""",
+            encoding="utf-8",
+        )
+        shim.chmod(shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        payload = {"session_id": "abc", "transcript_path": ""}
+        result = _run_hook(
+            SESSION_END_HOOK,
+            payload,
+            env_overrides={
+                "HOME": str(tmp_path),
+                "PATH": "",
+                "MEMPAL_PYTHON": str(shim),
+            },
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+        assert (
+            args_file.read_text() == "mempalace hook run --hook session-end --harness claude-code"
+        )
+        assert json.loads(stdin_file.read_text()) == payload
+
     def test_dispatches_to_cli_with_harness_override(self, tmp_path):
         args_file = tmp_path / "args.log"
         stdin_file = tmp_path / "stdin.json"


### PR DESCRIPTION

## Problem

Short sessions that exit cleanly can still lose memories. If the stop counter never reaches `SAVE_INTERVAL` and `PreCompact` never fires, MemPalace has no clean-exit hook to take one final save/mining pass.

## Root cause

`mempalace/hooks_cli.py:1056` had no `hook_session_end(...)` implementation, and `mempalace/hooks_cli.py:1133` omitted `session-end` from the dispatcher entirely. `mempalace/cli.py:1598` also rejected `session-end` at the CLI boundary, so there was no clean-exit hook to wire. The per-session stop marker (`{session_id}_last_save`) was written by `hook_stop` but had no clean-exit cleanup path, so the missing hook also left the natural cleanup point unused.

## Fix

Add shared save helpers in `mempalace/hooks_cli.py:905` and `mempalace/hooks_cli.py:931`, then route the silent Stop path and the new `hook_session_end(...)` through the same checkpoint plumbing instead of duplicating the save stack. The new `hook_session_end(...)` at `mempalace/hooks_cli.py:1056` respects `hooks.auto_save`, performs one final direct checkpoint save plus transcript ingest and synchronous project mine, returns a normal hook payload, and clears `{session_id}_last_save` in a `finally` block so cleanup runs on every exit path. Wire `session-end` into the CLI choices at `mempalace/cli.py:1598`, add the Claude-facing wrapper at `hooks/mempal_session_end_hook.sh:1`, mirror the new clean-exit hook into the local Claude plugin distribution under `.claude-plugin/hooks/`, document the Claude wiring plus the current Codex `SessionEnd` limitation in `hooks/README.md:14`, and add focused regressions in `tests/test_hooks_cli.py:1570`, `tests/test_cli.py:161`, `tests/test_hooks_shell.py:184`, and `tests/test_hooks_bash_compat.py:132`.

## How to test

```text
uv run --group dev ruff check .
uv run --group dev ruff format --check .
uv run --group dev python -m pytest tests/test_hooks_cli.py tests/test_cli.py tests/test_hooks_shell.py tests/test_hooks_bash_compat.py -v
```

Focused verification passed on Windows: `194 passed, 34 skipped`.

The skipped cases are the POSIX-only shell-hook tests in `tests/test_hooks_shell.py` and `tests/test_hooks_bash_compat.py`, which are gated off on `os.name == "nt"` by design.

## Checklist

- [x] Focused hook/CLI tests pass (`uv run --group dev python -m pytest tests/test_hooks_cli.py tests/test_cli.py tests/test_hooks_shell.py tests/test_hooks_bash_compat.py -v`)
- [x] No hardcoded paths
- [x] Linter passes (`uv run --group dev ruff check .` and `uv run --group dev ruff format --check .`)
