### PR TITLE
feat: HTTP transport + mine --remote-url

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.venv
+.pytest_cache
+__pycache__
+*.pyc
+tests/
+scripts/
+docs/
+.github/

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,55 @@
+name: Build container image
+
+on:
+  push:
+    branches:
+      - feat/http-transport
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=long
+            type=raw,value=http-transport,enable=${{ github.ref_name == 'feat/http-transport' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,6 +51,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,48 @@
-FROM python:3.11-slim AS builder
+# syntax=docker/dockerfile:1.7
+FROM python:3.12-slim-bookworm AS builder
 
 WORKDIR /build
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml README.md ./
 COPY mempalace ./mempalace
 RUN pip install --no-cache-dir --prefix=/install .
 
-FROM python:3.11-slim
+FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.12 \
+        python3-pip \
+        ca-certificates \
+        curl \
+        libgomp1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python3
 
-COPY --from=builder /install /usr/local
+# Ubuntu's python3.12 reads from /usr/local/lib/python3.12/dist-packages
+# but the builder's pip writes to /install/lib/python3.12/site-packages.
+# Copy binaries into /usr/local (entry_points, headers, etc) and merge the
+# packages into the path Ubuntu's Python actually searches.
+COPY --from=builder /install/bin /usr/local/bin
+COPY --from=builder /install/lib/python3.12/site-packages /usr/local/lib/python3.12/dist-packages
+
 COPY mempalace /app/mempalace
 
 WORKDIR /app
-RUN useradd -u 1000 -m mempalace && \
-    mkdir -p /home/mempalace/.mempalace && \
-    chown -R mempalace:mempalace /home/mempalace
 
-USER mempalace
+# Default rootless UID per home-operations/containers standard.
+# k8s runtime may override via securityContext.runAsUser / fsGroup.
+USER 65534:65534
+
 ENV PYTHONUNBUFFERED=1
-ENV MEMPALACE_PALACE_PATH=/home/mempalace/.mempalace/palace
+# Palace lives on a PVC mounted at /data. HOME also points here so the
+# existing WAL path (~/.mempalace/wal) resolves inside the mount.
+ENV HOME=/data
+ENV MEMPALACE_PALACE_PATH=/data/palace
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.11-slim AS builder
+
+WORKDIR /build
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md ./
+COPY mempalace ./mempalace
+RUN pip install --no-cache-dir --prefix=/install .
+
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
+COPY mempalace /app/mempalace
+
+WORKDIR /app
+RUN useradd -u 1000 -m mempalace && \
+    mkdir -p /home/mempalace/.mempalace && \
+    chown -R mempalace:mempalace /home/mempalace
+
+USER mempalace
+ENV PYTHONUNBUFFERED=1
+ENV MEMPALACE_PALACE_PATH=/home/mempalace/.mempalace/palace
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:8080/healthz || exit 1
+
+ENTRYPOINT ["python", "-m", "mempalace.mcp_server"]
+CMD ["--serve-http", "--host", "0.0.0.0", "--port", "8080", "--auth", "none"]

--- a/docs/DEPLOYMENT-NOTES.md
+++ b/docs/DEPLOYMENT-NOTES.md
@@ -2,7 +2,33 @@
 
 ## Container image produced by Plan 1
 
-- **Tag used for Plan 2 initial deploy:** `ghcr.io/gavinmcfall/mempalace@sha256:5826a4fcdbbe67dee0863660fab24ff316b348694eff210fbda8cab8e1772eec`
+- **Tag used for Plan 2 initial deploy:** `ghcr.io/gavinmcfall/mempalace@sha256:0b25f34f1bfbde78f78634e4ba49a9fc23ae4e57b8302a7b88febd59a895423b`
 - **Moving tag (dev only):** `ghcr.io/gavinmcfall/mempalace:http-transport`
+- **Superseded digest (earlier Task 17 build, content-equivalent):** `ghcr.io/gavinmcfall/mempalace@sha256:5826a4fcdbbe67dee0863660fab24ff316b348694eff210fbda8cab8e1772eec`
+
+The canonical digest is the latest successful GHCR build on `feat/http-transport`. The earlier digest is preserved here for traceability; it came from the first successful Task 17 run against the same Dockerfile and source tree.
 
 Always pin by digest in Plan 2's HelmRelease, never by moving tag.
+
+## Plan 1 validation record
+
+- **All tests green on branch `feat/http-transport`:** YES
+- **Test count at close-out:** 715 passed, 1 deselected (benchmarks ignored)
+- **Image digest at end of Plan 1:** `ghcr.io/gavinmcfall/mempalace@sha256:0b25f34f1bfbde78f78634e4ba49a9fc23ae4e57b8302a7b88febd59a895423b`
+- **Date closed:** 2026-04-14
+- **Suppression comments introduced:**
+  - `# noqa: S310` on `urllib.request.urlopen` in `mempalace/auth/oidc_jwt.py` — intentional, documented (JWKS fetch over HTTPS with timeout).
+  - `# noqa: BLE001` on the top-level `except Exception` in `mempalace/transport/stdio.py` — intentional; this is the transport main loop which must log and continue on a single malformed request rather than crash the server.
+- **Commits on branch (vs upstream/develop):** 18
+
+### Exit criteria confirmed
+
+- [x] feat/http-transport branch pushed to gavinmcfall/mempalace
+- [x] All tests pass locally and in CI
+- [x] Container image pinned by sha256 digest in this file
+- [x] `docker run` of pulled image responds to `/healthz` and `/mcp` correctly
+- [x] Parity test passes against captured stdio reference
+- [x] 100-writer stress test passes
+- [x] No suppression comments introduced beyond the two documented above
+
+Ready for Plan 2 (k8s deployment).

--- a/docs/DEPLOYMENT-NOTES.md
+++ b/docs/DEPLOYMENT-NOTES.md
@@ -1,0 +1,8 @@
+# Deployment notes
+
+## Container image produced by Plan 1
+
+- **Tag used for Plan 2 initial deploy:** `ghcr.io/gavinmcfall/mempalace@sha256:5826a4fcdbbe67dee0863660fab24ff316b348694eff210fbda8cab8e1772eec`
+- **Moving tag (dev only):** `ghcr.io/gavinmcfall/mempalace:http-transport`
+
+Always pin by digest in Plan 2's HelmRelease, never by moving tag.

--- a/docs/DEPLOYMENT-NOTES.md
+++ b/docs/DEPLOYMENT-NOTES.md
@@ -59,3 +59,33 @@ Ready for Plan 2 (k8s deployment).
 - `persistence.tmp`: `emptyDir` mounted at `/tmp`
 - `persistence.data`: PVC mounted at `/data` (ceph-block, >=15Gi)
 
+
+## Plan 2 validation record
+
+- **Date closed:** 2026-04-14
+- **Deployed image digest:** ghcr.io/gavinmcfall/mempalace@sha256:53b56e8c4b54486e9bdce23a3a35606722abd0f1a01378127215eeee027c9fbd
+- **Reachable at:** https://mempalace.nerdz.cloud
+- **Auth:** bearer-static (OIDC deferred to Plan 2.5)
+- **Palace:** fresh empty, Ceph RBD PVC `mempalace` (15 Gi)
+- **Backups:** VolSync — `mempalace` (NFS, sync window minute 25) and `mempalace-b2` (Backblaze B2, sync window minute 49); both healthy with recent successful syncs
+- **MCP round-trip verified:** initialize → add_drawer → search → pod restart → search (drawer survived)
+- **Bearer identity (all callers):** `static-client` — will be per-device OIDC identities in Plan 2.5
+
+### Deviations from original plan
+- Switched from OIDC-JWT to bearer-static (Plan 2.5 will revisit)
+- Added ExternalSecret (onepassword-connect) pulling `mempalace` item's `MEMPALACE_TOKEN` field
+- ExternalSecret shape corrected in a follow-up PR #1827 (dataFrom extract pattern, matches mem0)
+- VolSync minutes: 25 / 49 (collision avoidance — see PR #1825)
+
+### Exit criteria met
+- [x] Flux reconciles cleanly
+- [x] Pod 1/1 Ready
+- [x] healthz OK over Cloudflare Tunnel
+- [x] /mcp 401 without auth / 200 with valid token
+- [x] add_drawer + search round-trip
+- [x] WAL identity + schema_version
+- [x] Palace persists pod restart
+- [x] VolSync ReplicationSources active
+- [x] /metrics Prometheus format
+
+Ready for informal soak + Plan 2.5 (OIDC) + Plan 3 (cutover).

--- a/docs/DEPLOYMENT-NOTES.md
+++ b/docs/DEPLOYMENT-NOTES.md
@@ -32,3 +32,30 @@ Always pin by digest in Plan 2's HelmRelease, never by moving tag.
 - [x] No suppression comments introduced beyond the two documented above
 
 Ready for Plan 2 (k8s deployment).
+
+## Plan 1.5 hardening record
+
+- **Date closed:** 2026-04-14
+- **Ubuntu 24.04 runtime, Python 3.12**
+- **Default UID:** 65534 (rootless per home-operations/containers)
+- **Architectures:** linux/amd64, linux/arm64
+- **readOnlyRootFilesystem verified:** YES (requires emptyDir at /tmp in k8s)
+- **Palace mount path:** `/data` (PVC mount), with `MEMPALACE_PALACE_PATH=/data/palace` and `HOME=/data`
+- **New image digest (canonical for Plan 2):** `ghcr.io/gavinmcfall/mempalace@sha256:53b56e8c4b54486e9bdce23a3a35606722abd0f1a01378127215eeee027c9fbd`
+- **Superseded Plan 1 digest:** `ghcr.io/gavinmcfall/mempalace@sha256:0b25f34f1bfbde78f78634e4ba49a9fc23ae4e57b8302a7b88febd59a895423b`
+
+### Adaptations applied during Plan 1.5
+
+- Plan called for builder on `python:3.11-slim-bookworm` + runtime on Ubuntu 24.04 (Python 3.12). That cross-version setup failed at runtime with `ModuleNotFoundError: No module named 'chromadb'` because pip produced `cp311-cp311` wheels that Python 3.12 cannot import. Builder was switched to `python:3.12-slim-bookworm` to match.
+- Second issue: Ubuntu's packaged `python3.12` reads from `/usr/local/lib/python3.12/dist-packages`, but `pip install --prefix=/install` writes to `site-packages`. The Dockerfile now copies `/install/bin` into `/usr/local/bin` and `/install/lib/python3.12/site-packages` into `/usr/local/lib/python3.12/dist-packages` so Ubuntu's Python resolves modules correctly.
+- Volume ownership: `docker run` with a named volume created as root causes `PermissionError: [Errno 13]` when UID 65534 tries to write `/data/.mempalace`. Locally we `chown -R 65534:65534 /data` before starting the container. In k8s this is handled natively by `securityContext.fsGroup: 568`.
+
+### K8s runtime contract (for Plan 2)
+
+- `securityContext.runAsUser: 568` (home-ops convention) — overrides the image's 65534 default
+- `securityContext.runAsGroup: 568`
+- `securityContext.fsGroup: 568` — palace files will be owned by this group
+- `securityContext.readOnlyRootFilesystem: true`
+- `persistence.tmp`: `emptyDir` mounted at `/tmp`
+- `persistence.data`: PVC mounted at `/data` (ceph-block, >=15Gi)
+

--- a/docs/superpowers/plans/2026-06-09-mine-remote-url.md
+++ b/docs/superpowers/plans/2026-06-09-mine-remote-url.md
@@ -1,0 +1,1033 @@
+# mine --remote-url Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--remote-url` and `--remote-token` flags to `mempalace mine` so drawers are POSTed to a remote HTTP mempalace server instead of written to local ChromaDB.
+
+**Architecture:** A new `RemoteCollection` class implements the existing `BaseCollection` interface. `mine()` and `mine_convos()` receive an optional `remote_url`/`remote_token`; when set, they use `RemoteCollection` instead of calling `get_collection(palace_path)`. All existing mine logic is unchanged. A local state file (`~/.mempalace/remote_state/{hash}.json`) tracks which source files have been fully sent so re-runs skip them without querying the server.
+
+**Tech Stack:** Python stdlib only (`urllib.request`, `json`, `hashlib`). Tests use `unittest.mock`. No new dependencies.
+
+---
+
+### Task 1: `RemoteCollection` — core class
+
+**Files:**
+- Create: `mempalace/backends/remote.py`
+- Test: `tests/test_remote_collection.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_remote_collection.py`:
+
+```python
+"""Tests for RemoteCollection."""
+import json
+import os
+import urllib.error
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_response(body: dict, status: int = 200):
+    """Build a mock urllib response."""
+    raw = json.dumps(body).encode()
+    resp = MagicMock()
+    resp.read.return_value = raw
+    resp.status = status
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _http_error(code: int):
+    return urllib.error.HTTPError(url="http://x", code=code, msg="", hdrs=None, fp=None)
+
+
+@pytest.fixture()
+def col(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.backends.remote import RemoteCollection
+    return RemoteCollection(url="http://palace.test", token="tok")
+
+
+def test_upsert_posts_add_drawer(col):
+    resp = _make_response({"result": {"success": True, "drawer_id": "x"}})
+    with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+        col.upsert(
+            documents=["hello world"],
+            ids=["drawer_foo_bar_abc123"],
+            metadatas=[{"wing": "foo", "room": "bar", "source_file": "/f.jsonl", "added_by": "mine"}],
+        )
+    mock_open.assert_called_once()
+    payload = json.loads(mock_open.call_args[0][0].data)
+    assert payload["params"]["name"] == "mempalace_add_drawer"
+    assert payload["params"]["arguments"]["wing"] == "foo"
+    assert payload["params"]["arguments"]["content"] == "hello world"
+
+
+def test_upsert_registry_skips_http_marks_done(col):
+    with patch("urllib.request.urlopen") as mock_open:
+        col.upsert(
+            documents=["[registry] /f.jsonl"],
+            ids=["_reg_abc"],
+            metadatas=[{"wing": "w", "room": "_registry", "source_file": "/f.jsonl",
+                        "added_by": "mine", "ingest_mode": "registry"}],
+        )
+    mock_open.assert_not_called()
+    assert "/f.jsonl" in col._state["source_files"]
+
+
+def test_already_exists_is_not_an_error(col):
+    resp = _make_response({"result": {"success": True, "reason": "already_exists"}})
+    with patch("urllib.request.urlopen", return_value=resp):
+        col.upsert(
+            documents=["hello"],
+            ids=["d1"],
+            metadatas=[{"wing": "w", "room": "r", "source_file": "/f.jsonl", "added_by": "mine"}],
+        )
+    # Should not raise
+
+
+def test_get_returns_empty_when_file_not_in_state(col):
+    result = col.get(where={"source_file": "/unknown.jsonl"})
+    assert result["ids"] == []
+
+
+def test_get_returns_hit_when_file_in_state(col):
+    col.mark_file_done("/known.jsonl")
+    result = col.get(where={"source_file": "/known.jsonl"})
+    assert result["ids"] == ["/known.jsonl"]
+
+
+def test_mark_file_done_persists_across_instances(col, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    col.mark_file_done("/f.jsonl")
+
+    from mempalace.backends.remote import RemoteCollection
+    col2 = RemoteCollection(url="http://palace.test", token="tok")
+    assert "/f.jsonl" in col2._state["source_files"]
+
+
+def test_mark_file_done_idempotent(col):
+    col.mark_file_done("/f.jsonl")
+    col.mark_file_done("/f.jsonl")
+    assert col._state["source_files"].count("/f.jsonl") == 1
+
+
+def test_401_raises_with_clear_message(col):
+    with patch("urllib.request.urlopen", side_effect=_http_error(401)):
+        with pytest.raises(RuntimeError, match="401"):
+            col.upsert(
+                documents=["x"],
+                ids=["d1"],
+                metadatas=[{"wing": "w", "room": "r", "source_file": "/f", "added_by": "mine"}],
+            )
+
+
+def test_connection_error_retries_once_then_raises(col):
+    err = urllib.error.URLError("connection refused")
+    with patch("urllib.request.urlopen", side_effect=err):
+        with patch("time.sleep") as mock_sleep:
+            with pytest.raises(urllib.error.URLError):
+                col.upsert(
+                    documents=["x"],
+                    ids=["d1"],
+                    metadatas=[{"wing": "w", "room": "r", "source_file": "/f", "added_by": "mine"}],
+                )
+        mock_sleep.assert_called_once_with(2)
+
+
+def test_delete_is_noop(col):
+    # Should not raise, should not call HTTP
+    with patch("urllib.request.urlopen") as mock_open:
+        col.delete(where={"source_file": "/f"})
+    mock_open.assert_not_called()
+
+
+def test_query_raises(col):
+    with pytest.raises(NotImplementedError):
+        col.query(query_texts=["x"], n_results=5)
+
+
+def test_count_raises(col):
+    with pytest.raises(NotImplementedError):
+        col.count()
+```
+
+- [ ] **Step 2: Run tests — confirm they all fail**
+
+```bash
+cd /home/gavin/my_other_repos/mempalace
+python -m pytest tests/test_remote_collection.py -v 2>&1 | head -30
+```
+
+Expected: `ModuleNotFoundError: No module named 'mempalace.backends.remote'`
+
+- [ ] **Step 3: Implement `RemoteCollection`**
+
+Create `mempalace/backends/remote.py`:
+
+```python
+"""RemoteCollection — sends drawers to a remote mempalace HTTP server."""
+
+import hashlib
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .base import BaseCollection
+
+logger = logging.getLogger(__name__)
+
+_STATE_DIR = Path.home() / ".mempalace" / "remote_state"
+
+
+class RemoteCollection(BaseCollection):
+    """BaseCollection implementation that POSTs drawers to a remote HTTP MCP server."""
+
+    def __init__(self, url: str, token: str) -> None:
+        self._url = url.rstrip("/")
+        self._token = token
+        state_key = hashlib.sha256(url.encode()).hexdigest()[:16]
+        self._state_path = _STATE_DIR / f"{state_key}.json"
+        self._state = self._load_state()
+
+    # ── State file ──────────────────────────────────────────────────────
+
+    def _load_state(self) -> dict:
+        try:
+            data = json.loads(self._state_path.read_text(encoding="utf-8"))
+            if isinstance(data.get("source_files"), list):
+                return data
+        except Exception:
+            pass
+        return {"url": self._url, "source_files": []}
+
+    def _save_state(self) -> None:
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = self._state_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._state, indent=2, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(self._state_path)
+
+    def mark_file_done(self, source_file: str) -> None:
+        """Record source_file as fully sent. Idempotent."""
+        if source_file not in self._state["source_files"]:
+            self._state["source_files"].append(source_file)
+            self._save_state()
+
+    # ── HTTP ─────────────────────────────────────────────────────────────
+
+    def _post(self, tool_name: str, arguments: Dict[str, Any]) -> dict:
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 1,
+                "params": {"name": tool_name, "arguments": arguments},
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self._url}/mcp",
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        for attempt in range(2):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as e:
+                if e.code == 401:
+                    raise RuntimeError(
+                        "Remote palace returned 401 — check --remote-token or MEMPALACE_TOKEN"
+                    ) from e
+                raise
+            except (urllib.error.URLError, OSError):
+                if attempt == 0:
+                    time.sleep(2)
+                    continue
+                raise
+        raise RuntimeError("unreachable")  # pragma: no cover
+
+    # ── BaseCollection interface ─────────────────────────────────────────
+
+    def upsert(
+        self,
+        *,
+        documents: List[str],
+        ids: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        if metadatas is None:
+            metadatas = [{}] * len(documents)
+        for doc, _id, meta in zip(documents, ids, metadatas):
+            if meta.get("ingest_mode") == "registry":
+                source_file = meta.get("source_file", "")
+                if source_file:
+                    self.mark_file_done(source_file)
+                continue
+            result = self._post(
+                "mempalace_add_drawer",
+                {
+                    "wing": meta.get("wing", "general"),
+                    "room": meta.get("room", "general"),
+                    "content": doc,
+                    "source_file": meta.get("source_file", ""),
+                    "added_by": meta.get("added_by", "mine"),
+                },
+            )
+            inner = result.get("result", result)
+            if inner.get("reason") == "already_exists":
+                logger.debug("drawer already_exists: %s", _id)
+
+    def add(
+        self,
+        *,
+        documents: List[str],
+        ids: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        self.upsert(documents=documents, ids=ids, metadatas=metadatas)
+
+    def get(self, *, where: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
+        source_file = (where or {}).get("source_file")
+        if source_file and source_file in self._state["source_files"]:
+            return {"ids": [source_file], "documents": [], "metadatas": []}
+        return {"ids": [], "documents": [], "metadatas": []}
+
+    def delete(self, **kwargs: Any) -> None:
+        pass
+
+    def query(self, **kwargs: Any) -> Dict[str, Any]:
+        raise NotImplementedError("RemoteCollection does not support query()")
+
+    def count(self) -> int:
+        raise NotImplementedError("RemoteCollection does not support count()")
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+python -m pytest tests/test_remote_collection.py -v
+```
+
+Expected: all 11 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/backends/remote.py tests/test_remote_collection.py
+git commit -m "feat(backends): add RemoteCollection for HTTP mine target"
+```
+
+---
+
+### Task 2: Export `RemoteCollection` and add palace factory
+
+**Files:**
+- Modify: `mempalace/backends/__init__.py`
+- Modify: `mempalace/palace.py`
+- Test: `tests/test_remote_collection.py` (extend)
+
+- [ ] **Step 1: Write failing test for the factory**
+
+Append to `tests/test_remote_collection.py`:
+
+```python
+def test_get_remote_collection_returns_remote_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.palace import get_remote_collection
+    from mempalace.backends.remote import RemoteCollection
+    col = get_remote_collection("http://palace.test", "tok")
+    assert isinstance(col, RemoteCollection)
+
+
+def test_get_remote_collection_strips_trailing_slash(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.palace import get_remote_collection
+    col = get_remote_collection("http://palace.test/", "tok")
+    assert col._url == "http://palace.test"
+```
+
+- [ ] **Step 2: Run — confirm failure**
+
+```bash
+python -m pytest tests/test_remote_collection.py::test_get_remote_collection_returns_remote_instance -v
+```
+
+Expected: `ImportError: cannot import name 'get_remote_collection'`
+
+- [ ] **Step 3: Update `backends/__init__.py`**
+
+```python
+"""Storage backend implementations for MemPalace."""
+
+from .base import BaseCollection
+from .chroma import ChromaBackend, ChromaCollection
+from .remote import RemoteCollection
+
+__all__ = ["BaseCollection", "ChromaBackend", "ChromaCollection", "RemoteCollection"]
+```
+
+- [ ] **Step 4: Add factory to `palace.py`**
+
+Add after the existing `get_collection` function (after line 50):
+
+```python
+def get_remote_collection(url: str, token: str) -> "RemoteCollection":
+    """Get a collection that writes to a remote HTTP mempalace server."""
+    from .backends.remote import RemoteCollection
+    return RemoteCollection(url=url, token=token)
+```
+
+- [ ] **Step 5: Run — confirm tests pass**
+
+```bash
+python -m pytest tests/test_remote_collection.py -v
+```
+
+Expected: all 13 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mempalace/backends/__init__.py mempalace/palace.py tests/test_remote_collection.py
+git commit -m "feat(palace): add get_remote_collection factory"
+```
+
+---
+
+### Task 3: Wire `convo_miner.py`
+
+**Files:**
+- Modify: `mempalace/convo_miner.py`
+- Test: `tests/test_convo_miner_unit.py` (extend)
+
+- [ ] **Step 1: Read the existing convo_miner unit tests to understand patterns**
+
+```bash
+head -60 tests/test_convo_miner_unit.py
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Append to `tests/test_convo_miner_unit.py`:
+
+```python
+def test_mine_convos_uses_remote_collection_when_remote_url_set(tmp_path, monkeypatch):
+    """When remote_url is passed, mine_convos uses RemoteCollection, not get_collection."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.convo_miner import mine_convos
+    from mempalace.backends.remote import RemoteCollection
+
+    collected = []
+
+    class CapturingRemote(RemoteCollection):
+        def upsert(self, *, documents, ids, metadatas=None):
+            collected.extend(documents)
+        def get(self, *, where=None, **kwargs):
+            return {"ids": [], "documents": [], "metadatas": []}
+
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(
+        '{"type":"message","message":{"role":"user","content":"hello world"}}\n'
+        '{"type":"message","message":{"role":"assistant","content":"hi there"}}\n'
+    )
+
+    with patch("mempalace.convo_miner.get_remote_collection", return_value=CapturingRemote("http://x", "t")):
+        mine_convos(
+            convo_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+            remote_token="t",
+        )
+
+    assert len(collected) > 0
+
+
+def test_mine_convos_remote_token_from_env(tmp_path, monkeypatch):
+    """MEMPALACE_TOKEN env var is used when remote_token is not passed."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("MEMPALACE_TOKEN", "env-token")
+    from mempalace.convo_miner import mine_convos
+    from mempalace.backends.remote import RemoteCollection
+
+    captured_token = []
+
+    with patch("mempalace.convo_miner.get_remote_collection") as mock_factory:
+        mock_col = MagicMock(spec=RemoteCollection)
+        mock_col.get.return_value = {"ids": [], "documents": [], "metadatas": []}
+        mock_factory.return_value = mock_col
+        mine_convos(
+            convo_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+        )
+    mock_factory.assert_called_once_with("http://x", "env-token")
+
+
+def test_mine_convos_raises_when_remote_url_but_no_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MEMPALACE_TOKEN", raising=False)
+    from mempalace.convo_miner import mine_convos
+
+    with pytest.raises(RuntimeError, match="remote-url requires a token"):
+        mine_convos(
+            convo_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+        )
+```
+
+- [ ] **Step 3: Run — confirm failure**
+
+```bash
+python -m pytest tests/test_convo_miner_unit.py -k "remote" -v
+```
+
+Expected: `TypeError: mine_convos() got an unexpected keyword argument 'remote_url'`
+
+- [ ] **Step 4: Modify `convo_miner.py`**
+
+Add import at top of file (after existing imports):
+
+```python
+import os
+```
+
+*(already present — skip if so)*
+
+Change the `mine_convos` signature and collection setup. Find the current signature:
+
+```python
+def mine_convos(
+    convo_dir: str,
+    palace_path: str,
+    wing: str = None,
+    agent: str = "mempalace",
+    limit: int = 0,
+    dry_run: bool = False,
+    extract_mode: str = "exchange",
+):
+```
+
+Replace with:
+
+```python
+def mine_convos(
+    convo_dir: str,
+    palace_path: str,
+    wing: str = None,
+    agent: str = "mempalace",
+    limit: int = 0,
+    dry_run: bool = False,
+    extract_mode: str = "exchange",
+    remote_url: str = None,
+    remote_token: str = None,
+):
+```
+
+Find the import line at the top of `convo_miner.py`:
+
+```python
+from .palace import SKIP_DIRS, get_collection, file_already_mined
+```
+
+Replace with:
+
+```python
+from .palace import SKIP_DIRS, get_collection, get_remote_collection, file_already_mined
+```
+
+Find the collection setup inside `mine_convos` (currently around line 310):
+
+```python
+    collection = get_collection(palace_path) if not dry_run else None
+```
+
+Replace with:
+
+```python
+    if not dry_run:
+        if remote_url:
+            token = remote_token or os.environ.get("MEMPALACE_TOKEN", "")
+            if not token:
+                raise RuntimeError(
+                    "remote-url requires a token — pass --remote-token or set MEMPALACE_TOKEN"
+                )
+            collection = get_remote_collection(remote_url, token)
+        else:
+            collection = get_collection(palace_path)
+    else:
+        collection = None
+```
+
+Find where `palace_path` is printed (around line 305):
+
+```python
+    print(f"  Palace:  {palace_path}")
+```
+
+Replace with:
+
+```python
+    print(f"  Palace:  {remote_url or palace_path}")
+```
+
+After the chunk-filing loop for each file (find the line that prints the progress line):
+
+```python
+        print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+```
+
+Add after it:
+
+```python
+        if hasattr(collection, "mark_file_done"):
+            collection.mark_file_done(source_file)
+```
+
+- [ ] **Step 5: Run — confirm tests pass**
+
+```bash
+python -m pytest tests/test_convo_miner_unit.py -v
+```
+
+Expected: all tests pass including the 3 new remote ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mempalace/convo_miner.py tests/test_convo_miner_unit.py
+git commit -m "feat(convo_miner): add remote_url/remote_token support"
+```
+
+---
+
+### Task 4: Wire `miner.py`
+
+**Files:**
+- Modify: `mempalace/miner.py`
+- Test: `tests/test_miner.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_miner.py`:
+
+```python
+def test_mine_uses_remote_collection_when_remote_url_set(tmp_path, monkeypatch):
+    """When remote_url is passed, mine uses RemoteCollection."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.miner import mine
+    from unittest.mock import patch, MagicMock
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"ids": [], "documents": [], "metadatas": []}
+
+    (tmp_path / "hello.txt").write_text("this is some content for testing the miner remote path")
+
+    with patch("mempalace.miner.get_remote_collection", return_value=mock_col):
+        mine(
+            project_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+            remote_token="tok",
+        )
+
+    assert mock_col.upsert.called or mock_col.get.called
+
+
+def test_mine_raises_when_remote_url_but_no_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MEMPALACE_TOKEN", raising=False)
+    from mempalace.miner import mine
+
+    with pytest.raises(RuntimeError, match="remote-url requires a token"):
+        mine(
+            project_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+        )
+```
+
+- [ ] **Step 2: Run — confirm failure**
+
+```bash
+python -m pytest tests/test_miner.py -k "remote" -v
+```
+
+Expected: `TypeError: mine() got an unexpected keyword argument 'remote_url'`
+
+- [ ] **Step 3: Modify `miner.py`**
+
+Find the `mine` function import at top:
+
+```python
+from .palace import SKIP_DIRS, get_collection, file_already_mined
+```
+
+Replace with:
+
+```python
+from .palace import SKIP_DIRS, get_collection, get_remote_collection, file_already_mined
+```
+
+Find the `mine` signature:
+
+```python
+def mine(
+    project_dir: str,
+    palace_path: str,
+    wing_override: str = None,
+    agent: str = "mempalace",
+    limit: int = 0,
+    dry_run: bool = False,
+    respect_gitignore: bool = True,
+    include_ignored: list = None,
+):
+```
+
+Replace with:
+
+```python
+def mine(
+    project_dir: str,
+    palace_path: str,
+    wing_override: str = None,
+    agent: str = "mempalace",
+    limit: int = 0,
+    dry_run: bool = False,
+    respect_gitignore: bool = True,
+    include_ignored: list = None,
+    remote_url: str = None,
+    remote_token: str = None,
+):
+```
+
+Find the `Palace:` print line and collection setup:
+
+```python
+    print(f"  Palace:  {palace_path}")
+    ...
+    if not dry_run:
+        collection = get_collection(palace_path)
+    else:
+        collection = None
+```
+
+Replace with:
+
+```python
+    print(f"  Palace:  {remote_url or palace_path}")
+    ...
+    if not dry_run:
+        if remote_url:
+            token = remote_token or os.environ.get("MEMPALACE_TOKEN", "")
+            if not token:
+                raise RuntimeError(
+                    "remote-url requires a token — pass --remote-token or set MEMPALACE_TOKEN"
+                )
+            collection = get_remote_collection(remote_url, token)
+        else:
+            collection = get_collection(palace_path)
+    else:
+        collection = None
+```
+
+Ensure `import os` is present at the top of `miner.py` (check — add if missing).
+
+Find the per-file print line in the `mine` loop:
+
+```python
+            if not dry_run:
+                print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
+```
+
+Add after it:
+
+```python
+            if not dry_run and hasattr(collection, "mark_file_done"):
+                collection.mark_file_done(str(filepath))
+```
+
+- [ ] **Step 4: Run — confirm tests pass**
+
+```bash
+python -m pytest tests/test_miner.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/miner.py tests/test_miner.py
+git commit -m "feat(miner): add remote_url/remote_token support"
+```
+
+---
+
+### Task 5: CLI flags
+
+**Files:**
+- Modify: `mempalace/cli.py`
+- Test: `tests/test_cli.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_cli.py`:
+
+```python
+def test_mine_remote_url_flag_passed_to_mine_convos(tmp_path, monkeypatch):
+    """--remote-url and --remote-token are forwarded to mine_convos."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace import cli
+    from unittest.mock import patch
+
+    with patch("mempalace.cli.mine_convos") as mock_mine:
+        cli.main([
+            "mine", str(tmp_path),
+            "--mode", "convos",
+            "--remote-url", "http://palace.test",
+            "--remote-token", "secret",
+        ])
+
+    mock_mine.assert_called_once()
+    kwargs = mock_mine.call_args[1] if mock_mine.call_args[1] else {}
+    args = mock_mine.call_args[0] if mock_mine.call_args[0] else ()
+    # Accept either positional or keyword
+    call_args = mock_mine.call_args
+    assert call_args is not None
+    # remote_url should be "http://palace.test"
+    all_args = {**dict(zip(
+        ["convo_dir", "palace_path", "wing", "agent", "limit", "dry_run", "extract_mode",
+         "remote_url", "remote_token"],
+        call_args.args
+    )), **(call_args.kwargs or {})}
+    assert all_args.get("remote_url") == "http://palace.test"
+    assert all_args.get("remote_token") == "secret"
+
+
+def test_mine_remote_url_with_palace_prints_warning(tmp_path, monkeypatch, capsys):
+    """Using --remote-url with --palace prints a warning."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace import cli
+    from unittest.mock import patch
+
+    with patch("mempalace.cli.mine_convos"):
+        cli.main([
+            "mine", str(tmp_path),
+            "--mode", "convos",
+            "--palace", str(tmp_path / "palace"),
+            "--remote-url", "http://palace.test",
+            "--remote-token", "tok",
+        ])
+
+    out = capsys.readouterr().out + capsys.readouterr().err
+    # Warning should appear somewhere in output
+    # (checked via stderr in implementation)
+```
+
+- [ ] **Step 2: Run — confirm failure**
+
+```bash
+python -m pytest tests/test_cli.py -k "remote_url" -v
+```
+
+Expected: `error: unrecognized arguments: --remote-url`
+
+- [ ] **Step 3: Add CLI flags to `cli.py`**
+
+In `cli.py`, find the end of the `mine` subparser arguments (just before `# search`):
+
+```python
+    p_mine.add_argument(
+        "--dry-run", action="store_true", help="Show what would be filed without filing"
+    )
+    p_mine.add_argument(
+        "--extract",
+        ...
+    )
+
+    # search
+```
+
+Add after the `--extract` argument:
+
+```python
+    p_mine.add_argument(
+        "--remote-url",
+        default=None,
+        metavar="URL",
+        help="Send drawers to a remote mempalace HTTP server instead of local palace",
+    )
+    p_mine.add_argument(
+        "--remote-token",
+        default=None,
+        metavar="TOKEN",
+        help="Bearer token for --remote-url (default: MEMPALACE_TOKEN env var)",
+    )
+```
+
+In `cmd_mine`, find the `if args.mode == "convos":` block:
+
+```python
+    if args.mode == "convos":
+        from .convo_miner import mine_convos
+
+        mine_convos(
+            convo_dir=args.dir,
+            palace_path=palace_path,
+            wing=args.wing,
+            agent=args.agent,
+            limit=args.limit,
+            dry_run=args.dry_run,
+            extract_mode=args.extract,
+        )
+    else:
+        from .miner import mine
+
+        mine(
+            project_dir=args.dir,
+            palace_path=palace_path,
+            wing_override=args.wing,
+            agent=args.agent,
+            limit=args.limit,
+            dry_run=args.dry_run,
+            respect_gitignore=not args.no_gitignore,
+            include_ignored=include_ignored,
+        )
+```
+
+Replace with:
+
+```python
+    remote_url = getattr(args, "remote_url", None)
+    remote_token = getattr(args, "remote_token", None)
+
+    if remote_url and args.palace:
+        import sys
+        print(
+            "Warning: --palace is ignored when --remote-url is set",
+            file=sys.stderr,
+        )
+
+    if args.mode == "convos":
+        from .convo_miner import mine_convos
+
+        mine_convos(
+            convo_dir=args.dir,
+            palace_path=palace_path,
+            wing=args.wing,
+            agent=args.agent,
+            limit=args.limit,
+            dry_run=args.dry_run,
+            extract_mode=args.extract,
+            remote_url=remote_url,
+            remote_token=remote_token,
+        )
+    else:
+        from .miner import mine
+
+        mine(
+            project_dir=args.dir,
+            palace_path=palace_path,
+            wing_override=args.wing,
+            agent=args.agent,
+            limit=args.limit,
+            dry_run=args.dry_run,
+            respect_gitignore=not args.no_gitignore,
+            include_ignored=include_ignored,
+            remote_url=remote_url,
+            remote_token=remote_token,
+        )
+```
+
+- [ ] **Step 4: Run — confirm tests pass**
+
+```bash
+python -m pytest tests/test_cli.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/cli.py tests/test_cli.py
+git commit -m "feat(cli): add --remote-url and --remote-token to mine"
+```
+
+---
+
+### Task 6: Full test suite + verify
+
+**Files:** None — validation only.
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+python -m pytest tests/ -v --ignore=tests/benchmarks -x 2>&1 | tail -30
+```
+
+Expected: all tests pass. No regressions.
+
+- [ ] **Step 2: Smoke-test the CLI help**
+
+```bash
+python -m mempalace.cli mine --help 2>&1 | grep -E "remote-url|remote-token"
+```
+
+Expected:
+```
+  --remote-url URL      Send drawers to a remote mempalace HTTP server instead of local palace
+  --remote-token TOKEN  Bearer token for --remote-url (default: MEMPALACE_TOKEN env var)
+```
+
+- [ ] **Step 3: Smoke-test against the live k8s instance (manual)**
+
+```bash
+source ~/.secrets
+export MEMPALACE_TOKEN="$MEMPALACE_TOKEN_VALUE"  # from k8s secret
+
+# Dry-run first
+python -m mempalace.cli mine ~/.claude/projects \
+  --mode convos \
+  --remote-url https://mempalace.${SECRET_DOMAIN} \
+  --remote-token "$MEMPALACE_TOKEN" \
+  --limit 5 \
+  --dry-run
+
+# Then real run on a small batch
+python -m mempalace.cli mine ~/.claude/projects \
+  --mode convos \
+  --remote-url https://mempalace.${SECRET_DOMAIN} \
+  --remote-token "$MEMPALACE_TOKEN" \
+  --limit 10
+```
+
+Verify drawers appeared on the server:
+
+```bash
+mempalace hook run --hook session-start --harness claude-code  # check status output
+```
+
+Or via MCP: call `mempalace_status` and confirm drawer count increased.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add .claude/.verified
+git commit -m "test: verify mine --remote-url full suite passes"
+```

--- a/docs/superpowers/specs/2026-06-08-mine-remote-url-design.md
+++ b/docs/superpowers/specs/2026-06-08-mine-remote-url-design.md
@@ -1,0 +1,155 @@
+# Design: `mine --remote-url`
+
+**Date:** 2026-06-08
+**Status:** Approved
+**Branch:** feat/http-transport
+
+## Problem
+
+`mempalace mine` writes drawers directly to a local ChromaDB palace. When the canonical palace lives in k8s (served over HTTP), the workstation cannot write to it — the palace PVC is RWO and held by the running server pod.
+
+## Goal
+
+Allow `mine` to send drawers to a remote mempalace HTTP server instead of writing to local ChromaDB. This makes the k8s instance the single source of truth with no Syncthing, no CronJob, and no PVC sharing.
+
+## Non-Goals
+
+- Streaming or batched bulk-ingest endpoint (drawers are sent one at a time via existing `mempalace_add_drawer`)
+- Remote `search`, `query`, or `status` via the mine path
+- Any k8s or Syncthing changes
+
+## CLI
+
+```bash
+mempalace mine ~/.claude/projects --mode convos \
+  --remote-url https://mempalace.example.com \
+  --remote-token $MEMPALACE_TOKEN
+
+# Token can also come from env var (fallback if --remote-token not passed)
+export MEMPALACE_TOKEN=secret
+mempalace mine ~/.claude/projects --mode convos \
+  --remote-url https://mempalace.example.com
+```
+
+`--palace` is silently ignored when `--remote-url` is set (a warning is printed).
+
+## Architecture
+
+```
+cli.py (cmd_mine)
+  │
+  ├─ remote_url set?
+  │     yes → get_remote_collection(url, token)  → RemoteCollection
+  │     no  → get_collection(palace_path)         → ChromaCollection (unchanged)
+  │
+  └─ pass collection to mine() / mine_convos()
+           │
+           └─ add_drawer(collection, ...) → collection.upsert()
+                                                │
+                                    RemoteCollection.upsert()
+                                                │
+                                    POST /mcp  mempalace_add_drawer
+                                                │
+                                    k8s mempalace server
+```
+
+Existing `mine()` and `mine_convos()` are unchanged except for one new parameter each (`remote_url`/`remote_token`) that controls which collection factory is used.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `mempalace/backends/remote.py` | **New.** `RemoteCollection` class. |
+| `mempalace/backends/__init__.py` | Export `RemoteCollection`. |
+| `mempalace/palace.py` | Add `get_remote_collection(url, token)` factory. |
+| `mempalace/convo_miner.py` | Accept `remote_url`, `remote_token`; swap collection factory. |
+| `mempalace/miner.py` | Same. |
+| `mempalace/cli.py` | Add `--remote-url`, `--remote-token` to `mine` subparser. |
+
+## `RemoteCollection` (`backends/remote.py`)
+
+Implements `BaseCollection`. Stateless except for the local skip-tracking file.
+
+### Method behaviour
+
+| Method | Behaviour |
+|--------|-----------|
+| `upsert(documents, ids, metadatas)` | POST `mempalace_add_drawer` per document. Logs `already_exists` at DEBUG. Raises `RuntimeError` on HTTP error. |
+| `get(where, ...)` | Reads local state file. Returns `{"ids": [path]}` if `source_file` in state, else `{"ids": []}`. Only the `where={"source_file": ...}` pattern is supported (what `file_already_mined` uses). |
+| `delete(where, ...)` | No-op. Server-side idempotency handles re-mines via content-hash drawer IDs. |
+| `add(...)` | Delegates to `upsert`. |
+| `query(...)` | Raises `NotImplementedError`. |
+| `count()` | Raises `NotImplementedError`. |
+
+### HTTP call format
+
+```
+POST {url}/mcp
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "id": 1,
+  "params": {
+    "name": "mempalace_add_drawer",
+    "arguments": {
+      "wing": "projects",
+      "room": "general",
+      "content": "...",
+      "source_file": "/path/to/file.jsonl",
+      "added_by": "mine"
+    }
+  }
+}
+```
+
+The server's `tool_add_drawer` deduplicates by content hash. Sending a drawer that already exists returns `{"success": true, "reason": "already_exists"}` — not an error.
+
+### Local state file (skip tracking)
+
+Path: `~/.mempalace/remote_state/{sha256_of_url[:16]}.json`
+
+```json
+{
+  "url": "https://mempalace.example.com",
+  "source_files": [
+    "/home/gavin/.claude/projects/foo/bar.jsonl"
+  ]
+}
+```
+
+- Loaded at mine start. Written atomically after each file completes.
+- `file_already_mined` for remote: checks `source_file in state["source_files"]`.
+- `_register_file` for remote (0-chunk sentinel): adds path to state without sending any drawers.
+- If the state file is missing or corrupt, it is recreated empty (re-mines all files; server deduplicates).
+
+## Error Handling
+
+- **401 Unauthorized:** Raise immediately with a clear message ("check --remote-token or MEMPALACE_TOKEN").
+- **Connection error / timeout:** Retry once after 2 s, then raise. Do not mark the file as done in state.
+- **Server 500:** Log the error and skip the file (do not add to state). Mine continues with remaining files.
+- **`already_exists` response:** Treat as success. Add to state. Log at DEBUG.
+
+## Token Resolution Order
+
+1. `--remote-token` CLI flag
+2. `MEMPALACE_TOKEN` environment variable
+3. Error: "remote-url requires a token"
+
+## Testing
+
+- Unit tests in `tests/test_remote_collection.py` using `responses` or `httpx` mock.
+- Test: successful upsert → HTTP call made, file added to state.
+- Test: file already in state → no HTTP call made.
+- Test: server returns `already_exists` → treated as success.
+- Test: 401 → raises with clear message.
+- Test: connection error → retries once, then raises.
+- Test: `--remote-url` + `--palace` together → warning printed, palace ignored.
+
+## Out of Scope (Future)
+
+- Bulk/batched ingest endpoint (send N drawers in one HTTP call)
+- Remote `search` fallback
+- Progress bar / ETA for large backlogs

--- a/mempalace/auth/__init__.py
+++ b/mempalace/auth/__init__.py
@@ -1,0 +1,22 @@
+"""Pluggable auth middleware for the HTTP transport.
+
+All middlewares implement the AuthMiddleware protocol and either return an identity
+string (on success) or raise AuthError (on failure). The HTTP transport maps AuthError
+to HTTP 401 with a structured JSON error.
+"""
+from typing import Protocol
+
+
+class AuthError(Exception):
+    """Raised when authentication fails."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class AuthMiddleware(Protocol):
+    """Validates an Authorization header, returns identity or raises AuthError."""
+
+    def validate(self, authorization_header: str | None) -> str:
+        ...

--- a/mempalace/auth/bearer_static.py
+++ b/mempalace/auth/bearer_static.py
@@ -1,0 +1,28 @@
+"""Bearer-static auth: a single shared secret read from an env var."""
+import os
+
+from mempalace.auth import AuthError
+
+
+class BearerStaticAuth:
+    """Validate a fixed bearer token from an environment variable.
+
+    OSS-friendly default: no external dependencies, no OIDC required.
+    All clients presenting the correct token are mapped to identity 'static-client'.
+    """
+
+    def __init__(self, token_env: str = "MEMPALACE_TOKEN") -> None:
+        self._token_env = token_env
+
+    def validate(self, authorization_header: str | None) -> str:
+        if not authorization_header:
+            raise AuthError("missing authorization header")
+        parts = authorization_header.split(" ", 1)
+        if len(parts) != 2 or parts[0] != "Bearer":
+            raise AuthError("unsupported authorization scheme")
+        expected = os.environ.get(self._token_env)
+        if not expected:
+            raise AuthError("server misconfigured: token env var unset")
+        if parts[1] != expected:
+            raise AuthError("invalid token")
+        return "static-client"

--- a/mempalace/auth/oidc_jwt.py
+++ b/mempalace/auth/oidc_jwt.py
@@ -1,0 +1,66 @@
+"""OIDC JWT auth: validates bearer tokens against a JWKS endpoint.
+
+The middleware accepts either a pre-fetched JWKS dict (for tests) or an issuer URL
+from which it will fetch and cache JWKS at runtime.
+"""
+import time
+from typing import Any
+from urllib.request import urlopen
+
+from authlib.jose import JsonWebKey, jwt
+from authlib.jose.errors import JoseError
+
+from mempalace.auth import AuthError
+
+
+class OIDCJWTAuth:
+    def __init__(
+        self,
+        issuer: str,
+        audience: str,
+        jwks: dict[str, Any] | None = None,
+        jwks_ttl_seconds: int = 3600,
+    ) -> None:
+        self._issuer = issuer.rstrip("/") + "/"
+        self._audience = audience
+        self._jwks_cache: dict[str, Any] | None = jwks
+        self._jwks_ttl = jwks_ttl_seconds
+        self._jwks_fetched_at = time.time() if jwks else 0.0
+
+    def _jwks(self) -> dict[str, Any]:
+        if (
+            self._jwks_cache is None
+            or time.time() - self._jwks_fetched_at > self._jwks_ttl
+        ):
+            url = self._issuer + ".well-known/jwks.json"
+            with urlopen(url, timeout=5) as resp:  # noqa: S310
+                import json
+                self._jwks_cache = json.loads(resp.read().decode())
+            self._jwks_fetched_at = time.time()
+        return self._jwks_cache
+
+    def validate(self, authorization_header: str | None) -> str:
+        if not authorization_header:
+            raise AuthError("missing authorization header")
+        parts = authorization_header.split(" ", 1)
+        if len(parts) != 2 or parts[0] != "Bearer":
+            raise AuthError("unsupported authorization scheme")
+        token = parts[1]
+        try:
+            key = JsonWebKey.import_key_set(self._jwks())
+            claims = jwt.decode(
+                token,
+                key,
+                claims_options={
+                    "iss": {"essential": True, "value": self._issuer},
+                    "aud": {"essential": True, "value": self._audience},
+                    "exp": {"essential": True},
+                },
+            )
+            claims.validate()
+        except JoseError as e:
+            raise AuthError(f"token validation failed: {e}") from e
+        sub = claims.get("sub")
+        if not sub:
+            raise AuthError("token missing sub claim")
+        return str(sub)

--- a/mempalace/backends/__init__.py
+++ b/mempalace/backends/__init__.py
@@ -2,5 +2,6 @@
 
 from .base import BaseCollection
 from .chroma import ChromaBackend, ChromaCollection
+from .remote import RemoteCollection
 
-__all__ = ["BaseCollection", "ChromaBackend", "ChromaCollection"]
+__all__ = ["BaseCollection", "ChromaBackend", "ChromaCollection", "RemoteCollection"]

--- a/mempalace/backends/remote.py
+++ b/mempalace/backends/remote.py
@@ -13,9 +13,6 @@ from .base import BaseCollection
 
 logger = logging.getLogger(__name__)
 
-_STATE_DIR = Path.home() / ".mempalace" / "remote_state"
-
-
 class RemoteCollection(BaseCollection):
     """BaseCollection implementation that POSTs drawers to a remote HTTP MCP server."""
 
@@ -23,7 +20,8 @@ class RemoteCollection(BaseCollection):
         self._url = url.rstrip("/")
         self._token = token
         state_key = hashlib.sha256(url.encode()).hexdigest()[:16]
-        self._state_path = _STATE_DIR / f"{state_key}.json"
+        state_dir = Path.home() / ".mempalace" / "remote_state"
+        self._state_path = state_dir / f"{state_key}.json"
         self._state = self._load_state()
 
     # ── State file ──────────────────────────────────────────────────────
@@ -38,7 +36,7 @@ class RemoteCollection(BaseCollection):
         return {"url": self._url, "source_files": []}
 
     def _save_state(self) -> None:
-        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self._state_path.with_suffix(".tmp")
         tmp.write_text(json.dumps(self._state, indent=2, ensure_ascii=False), encoding="utf-8")
         tmp.replace(self._state_path)
@@ -97,7 +95,7 @@ class RemoteCollection(BaseCollection):
         metadatas: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
         if metadatas is None:
-            metadatas = [{}] * len(documents)
+            metadatas = [{} for _ in range(len(documents))]
         for doc, _id, meta in zip(documents, ids, metadatas):
             if meta.get("ingest_mode") == "registry":
                 source_file = meta.get("source_file", "")
@@ -130,7 +128,7 @@ class RemoteCollection(BaseCollection):
     def get(self, *, where: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
         source_file = (where or {}).get("source_file")
         if source_file and source_file in self._state["source_files"]:
-            return {"ids": [source_file], "documents": [], "metadatas": []}
+            return {"ids": [source_file], "documents": [""], "metadatas": [{}]}
         return {"ids": [], "documents": [], "metadatas": []}
 
     def delete(self, **kwargs: Any) -> None:

--- a/mempalace/backends/remote.py
+++ b/mempalace/backends/remote.py
@@ -1,0 +1,143 @@
+"""RemoteCollection — sends drawers to a remote mempalace HTTP server."""
+
+import hashlib
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .base import BaseCollection
+
+logger = logging.getLogger(__name__)
+
+_STATE_DIR = Path.home() / ".mempalace" / "remote_state"
+
+
+class RemoteCollection(BaseCollection):
+    """BaseCollection implementation that POSTs drawers to a remote HTTP MCP server."""
+
+    def __init__(self, url: str, token: str) -> None:
+        self._url = url.rstrip("/")
+        self._token = token
+        state_key = hashlib.sha256(url.encode()).hexdigest()[:16]
+        self._state_path = _STATE_DIR / f"{state_key}.json"
+        self._state = self._load_state()
+
+    # ── State file ──────────────────────────────────────────────────────
+
+    def _load_state(self) -> dict:
+        try:
+            data = json.loads(self._state_path.read_text(encoding="utf-8"))
+            if isinstance(data.get("source_files"), list):
+                return data
+        except Exception:
+            pass
+        return {"url": self._url, "source_files": []}
+
+    def _save_state(self) -> None:
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = self._state_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._state, indent=2, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(self._state_path)
+
+    def mark_file_done(self, source_file: str) -> None:
+        """Record source_file as fully sent. Idempotent."""
+        if source_file not in self._state["source_files"]:
+            self._state["source_files"].append(source_file)
+            self._save_state()
+
+    # ── HTTP ─────────────────────────────────────────────────────────────
+
+    def _post(self, tool_name: str, arguments: Dict[str, Any]) -> dict:
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 1,
+                "params": {"name": tool_name, "arguments": arguments},
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self._url}/mcp",
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        for attempt in range(2):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as e:
+                if e.code == 401:
+                    raise RuntimeError(
+                        "Remote palace returned 401 — check --remote-token or MEMPALACE_TOKEN"
+                    ) from e
+                raise
+            except (urllib.error.URLError, OSError):
+                if attempt == 0:
+                    time.sleep(2)
+                    continue
+                raise
+        raise RuntimeError("unreachable")  # pragma: no cover
+
+    # ── BaseCollection interface ─────────────────────────────────────────
+
+    def upsert(
+        self,
+        *,
+        documents: List[str],
+        ids: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        if metadatas is None:
+            metadatas = [{}] * len(documents)
+        for doc, _id, meta in zip(documents, ids, metadatas):
+            if meta.get("ingest_mode") == "registry":
+                source_file = meta.get("source_file", "")
+                if source_file:
+                    self.mark_file_done(source_file)
+                continue
+            result = self._post(
+                "mempalace_add_drawer",
+                {
+                    "wing": meta.get("wing", "general"),
+                    "room": meta.get("room", "general"),
+                    "content": doc,
+                    "source_file": meta.get("source_file", ""),
+                    "added_by": meta.get("added_by", "mine"),
+                },
+            )
+            inner = result.get("result", result)
+            if inner.get("reason") == "already_exists":
+                logger.debug("drawer already_exists: %s", _id)
+
+    def add(
+        self,
+        *,
+        documents: List[str],
+        ids: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        self.upsert(documents=documents, ids=ids, metadatas=metadatas)
+
+    def get(self, *, where: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
+        source_file = (where or {}).get("source_file")
+        if source_file and source_file in self._state["source_files"]:
+            return {"ids": [source_file], "documents": [], "metadatas": []}
+        return {"ids": [], "documents": [], "metadatas": []}
+
+    def delete(self, **kwargs: Any) -> None:
+        pass
+
+    def query(self, **kwargs: Any) -> Dict[str, Any]:
+        raise NotImplementedError("RemoteCollection does not support query()")
+
+    def count(self) -> int:
+        raise NotImplementedError("RemoteCollection does not support count()")

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -71,8 +71,23 @@ def cmd_mine(args):
     for raw in args.include_ignored or []:
         include_ignored.extend(part.strip() for part in raw.split(",") if part.strip())
 
+    remote_url = getattr(args, "remote_url", None)
+    remote_token = getattr(args, "remote_token", None)
+
+    if remote_url and args.palace:
+        print(
+            "Warning: --palace is ignored when --remote-url is set",
+            file=sys.stderr,
+        )
+
     if args.mode == "convos":
         from .convo_miner import mine_convos
+
+        extra = {}
+        if remote_url is not None:
+            extra["remote_url"] = remote_url
+        if remote_token is not None:
+            extra["remote_token"] = remote_token
 
         mine_convos(
             convo_dir=args.dir,
@@ -82,9 +97,16 @@ def cmd_mine(args):
             limit=args.limit,
             dry_run=args.dry_run,
             extract_mode=args.extract,
+            **extra,
         )
     else:
         from .miner import mine
+
+        extra = {}
+        if remote_url is not None:
+            extra["remote_url"] = remote_url
+        if remote_token is not None:
+            extra["remote_token"] = remote_token
 
         mine(
             project_dir=args.dir,
@@ -95,6 +117,7 @@ def cmd_mine(args):
             dry_run=args.dry_run,
             respect_gitignore=not args.no_gitignore,
             include_ignored=include_ignored,
+            **extra,
         )
 
 
@@ -413,7 +436,7 @@ def cmd_compress(args):
         print("  (dry run -- nothing stored)")
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="MemPalace — Give your AI a memory. No API key required.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -469,6 +492,18 @@ def main():
         choices=["exchange", "general"],
         default="exchange",
         help="Extraction strategy for convos mode: 'exchange' (default) or 'general' (5 memory types)",
+    )
+    p_mine.add_argument(
+        "--remote-url",
+        default=None,
+        metavar="URL",
+        help="Send drawers to a remote mempalace HTTP server instead of local palace",
+    )
+    p_mine.add_argument(
+        "--remote-token",
+        default=None,
+        metavar="TOKEN",
+        help="Bearer token for --remote-url (default: MEMPALACE_TOKEN env var)",
     )
 
     # search
@@ -575,7 +610,7 @@ def main():
 
     sub.add_parser("status", help="Show what's been filed")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not args.command:
         parser.print_help()

--- a/mempalace/concurrency.py
+++ b/mempalace/concurrency.py
@@ -1,0 +1,13 @@
+"""Write-path serialisation.
+
+Single asyncio.Lock guards all chromadb / sqlite mutations from the HTTP transport.
+The stdio transport does not need this (single-threaded event loop), but acquires it
+anyway for consistency.
+
+Design note: this is a coarse lock, not a queue. Writes block concurrently arriving
+writes for the duration of the index mutation + WAL write. For a personal-scale system
+(<1 Hz sustained writes) this is adequate. Revisit if contention ever becomes visible.
+"""
+import asyncio
+
+writer_lock: asyncio.Lock = asyncio.Lock()

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import SKIP_DIRS, get_collection, get_remote_collection, file_already_mined
 
 
 # File types that might contain conversations
@@ -280,6 +280,8 @@ def mine_convos(
     limit: int = 0,
     dry_run: bool = False,
     extract_mode: str = "exchange",
+    remote_url: str = None,
+    remote_token: str = None,
 ):
     """Mine a directory of conversation files into the palace.
 
@@ -302,12 +304,23 @@ def mine_convos(
     print(f"  Wing:    {wing}")
     print(f"  Source:  {convo_path}")
     print(f"  Files:   {len(files)}")
-    print(f"  Palace:  {palace_path}")
+    print(f"  Palace:  {remote_url or palace_path}")
     if dry_run:
         print("  DRY RUN — nothing will be filed")
     print(f"{'-' * 55}\n")
 
-    collection = get_collection(palace_path) if not dry_run else None
+    if not dry_run:
+        if remote_url:
+            token = remote_token or os.environ.get("MEMPALACE_TOKEN", "")
+            if not token:
+                raise RuntimeError(
+                    "remote-url requires a token — pass --remote-token or set MEMPALACE_TOKEN"
+                )
+            collection = get_remote_collection(remote_url, token)
+        else:
+            collection = get_collection(palace_path)
+    else:
+        collection = None
 
     total_drawers = 0
     files_skipped = 0
@@ -406,6 +419,8 @@ def mine_convos(
 
         total_drawers += drawers_added
         print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+        if hasattr(collection, "mark_file_done"):
+            collection.mark_file_done(source_file)
 
     print(f"\n{'=' * 55}")
     print("  Done.")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -21,6 +21,7 @@ Tools (maintenance):
 """
 
 import argparse
+import contextvars
 import os
 import sys
 import json
@@ -88,6 +89,11 @@ try:
 except (OSError, NotImplementedError):
     pass
 _WAL_FILE = _WAL_DIR / "write_log.jsonl"
+# Original import-time WAL path.  _wal_log() re-resolves from HOME on each
+# call so that test harnesses swapping HOME (and the production process if
+# HOME ever changed) land in the right place; but if a test explicitly
+# monkeypatches _WAL_FILE to a different value, we honour that override.
+_WAL_FILE_DEFAULT = _WAL_FILE
 # Pre-create WAL file with restricted permissions to avoid race condition
 if not _WAL_FILE.exists():
     _WAL_FILE.touch(mode=0o600)
@@ -102,6 +108,18 @@ _WAL_REDACT_KEYS = frozenset(
     {"content", "content_preview", "document", "entry", "entry_preview", "query", "text"}
 )
 
+# WAL schema version — bump when the on-disk entry shape changes in a
+# backwards-incompatible way.  Readers (replicas, audit tooling) parse this.
+_WAL_SCHEMA_VERSION = "1"
+
+# Per-call identity for WAL attribution.  Set at the top of handle_request(),
+# read by _wal_log().  Defaults to "anonymous" for the stdio path, where
+# callers do not supply an identity.  A ContextVar keeps the value
+# request-scoped without threading a parameter through every tool handler.
+_wal_identity: "contextvars.ContextVar[str]" = contextvars.ContextVar(
+    "mempalace_identity", default="anonymous"
+)
+
 
 def _wal_log(operation: str, params: dict, result: dict = None):
     """Append a write operation to the write-ahead log."""
@@ -113,13 +131,28 @@ def _wal_log(operation: str, params: dict, result: dict = None):
         else:
             safe_params[k] = v
     entry = {
+        "schema_version": _WAL_SCHEMA_VERSION,
         "timestamp": datetime.now().isoformat(),
+        "identity": _wal_identity.get(),
         "operation": operation,
         "params": safe_params,
         "result": result,
     }
+    # Pick the WAL path: an explicit monkeypatch of _WAL_FILE wins;
+    # otherwise re-resolve from the current HOME so tests that swap HOME
+    # (and any runtime HOME change) land in the right place.
+    if _WAL_FILE != _WAL_FILE_DEFAULT:
+        wal_file = _WAL_FILE
+        wal_dir = wal_file.parent
+    else:
+        wal_dir = Path(os.path.expanduser("~/.mempalace/wal"))
+        wal_file = wal_dir / "write_log.jsonl"
     try:
-        fd = os.open(str(_WAL_FILE), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+        wal_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    try:
+        fd = os.open(str(wal_file), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
         with os.fdopen(fd, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, default=str) + "\n")
     except Exception as e:
@@ -1403,7 +1436,12 @@ SUPPORTED_PROTOCOL_VERSIONS = [
 ]
 
 
-def handle_request(request):
+def handle_request(request, identity: str = "anonymous"):
+    # Bind the caller's identity for the duration of this request so the
+    # WAL writer can attribute writes without threading a parameter through
+    # every tool handler.  stdio callers do not supply identity and get
+    # "anonymous"; future HTTP transport will pass an authenticated subject.
+    _wal_identity.set(identity or "anonymous")
     method = request.get("method") or ""
     params = request.get("params") or {}
     req_id = request.get("id")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1068,6 +1068,19 @@ def tool_reconnect():
 
 # ==================== MCP PROTOCOL ====================
 
+# Tool names whose handlers mutate palace state. The HTTP transport (see
+# mempalace.transport.http) serialises these through writer_lock to prevent
+# concurrent index corruption and interleaved WAL writes. Stdio doesn't need
+# this (single-threaded event loop), but the set is still authoritative.
+WRITE_TOOL_NAMES: frozenset[str] = frozenset({
+    "mempalace_add_drawer",
+    "mempalace_delete_drawer",
+    "mempalace_update_drawer",
+    "mempalace_diary_write",
+    "mempalace_kg_add",
+    "mempalace_kg_invalidate",
+})
+
 TOOLS = {
     "mempalace_status": {
         "description": "Palace overview — total drawers, wing and room counts",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1548,24 +1548,13 @@ def handle_request(request, identity: str = "anonymous"):
 
 
 def main():
-    logger.info("MemPalace MCP Server starting...")
-    while True:
-        try:
-            line = sys.stdin.readline()
-            if not line:
-                break
-            line = line.strip()
-            if not line:
-                continue
-            request = json.loads(line)
-            response = handle_request(request)
-            if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
-                sys.stdout.flush()
-        except KeyboardInterrupt:
-            break
-        except Exception as e:
-            logger.error(f"Server error: {e}")
+    """Entry point for `python -m mempalace.mcp_server`. Dispatches to the selected transport.
+
+    Argument parsing for --serve-http and auth flags is added in Task 12.
+    For now: keep 100% backward compatible — default to stdio.
+    """
+    from mempalace.transport.stdio import serve
+    serve()
 
 
 if __name__ == "__main__":

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -51,6 +51,22 @@ def _parse_args():
         metavar="PATH",
         help="Path to the palace directory (overrides config file and env var)",
     )
+    parser.add_argument("--serve-http", action="store_true", help="Serve MCP over HTTP instead of stdio")
+    parser.add_argument("--port", type=int, default=8080, help="HTTP port (with --serve-http)")
+    parser.add_argument("--host", default="0.0.0.0", help="HTTP bind host (with --serve-http)")
+    parser.add_argument(
+        "--auth",
+        choices=["none", "bearer-static", "oidc-jwt"],
+        default="none",
+        help="Auth mode for HTTP transport",
+    )
+    parser.add_argument("--issuer", help="OIDC issuer URL (with --auth oidc-jwt)")
+    parser.add_argument("--audience", help="Expected token audience (with --auth oidc-jwt)")
+    parser.add_argument(
+        "--token-env",
+        default="MEMPALACE_TOKEN",
+        help="Env var holding the static bearer token (with --auth bearer-static)",
+    )
     args, unknown = parser.parse_known_args()
     if unknown:
         logger.debug("Ignoring unknown args: %s", unknown)
@@ -1561,13 +1577,28 @@ def handle_request(request, identity: str = "anonymous"):
 
 
 def main():
-    """Entry point for `python -m mempalace.mcp_server`. Dispatches to the selected transport.
+    """Entry point for `python -m mempalace.mcp_server`. Dispatches to the selected transport."""
+    args = _parse_args()
+    if args.serve_http:
+        from mempalace.transport.http import build_app
+        from mempalace.auth.bearer_static import BearerStaticAuth
+        from mempalace.auth.oidc_jwt import OIDCJWTAuth
+        import uvicorn
 
-    Argument parsing for --serve-http and auth flags is added in Task 12.
-    For now: keep 100% backward compatible — default to stdio.
-    """
-    from mempalace.transport.stdio import serve
-    serve()
+        if args.auth == "bearer-static":
+            auth = BearerStaticAuth(token_env=args.token_env)
+        elif args.auth == "oidc-jwt":
+            if not args.issuer or not args.audience:
+                raise SystemExit("--auth oidc-jwt requires --issuer and --audience")
+            auth = OIDCJWTAuth(issuer=args.issuer, audience=args.audience)
+        else:
+            auth = None
+
+        app = build_app(auth=auth)
+        uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    else:
+        from mempalace.transport.stdio import serve
+        serve()
 
 
 if __name__ == "__main__":

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 
-from .palace import SKIP_DIRS, get_collection, file_already_mined
+from .palace import SKIP_DIRS, get_collection, get_remote_collection, file_already_mined
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -544,6 +544,8 @@ def mine(
     dry_run: bool = False,
     respect_gitignore: bool = True,
     include_ignored: list = None,
+    remote_url: str = None,
+    remote_token: str = None,
 ):
     """Mine a project directory into the palace."""
 
@@ -567,7 +569,7 @@ def mine(
     print(f"  Wing:    {wing}")
     print(f"  Rooms:   {', '.join(r['name'] for r in rooms)}")
     print(f"  Files:   {len(files)}")
-    print(f"  Palace:  {palace_path}")
+    print(f"  Palace:  {remote_url or palace_path}")
     if dry_run:
         print("  DRY RUN — nothing will be filed")
     if not respect_gitignore:
@@ -577,7 +579,15 @@ def mine(
     print(f"{'─' * 55}\n")
 
     if not dry_run:
-        collection = get_collection(palace_path)
+        if remote_url:
+            token = remote_token or os.environ.get("MEMPALACE_TOKEN", "")
+            if not token:
+                raise RuntimeError(
+                    "remote-url requires a token — pass --remote-token or set MEMPALACE_TOKEN"
+                )
+            collection = get_remote_collection(remote_url, token)
+        else:
+            collection = get_collection(palace_path)
     else:
         collection = None
 
@@ -602,6 +612,8 @@ def mine(
             room_counts[room] += 1
             if not dry_run:
                 print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
+            if not dry_run and hasattr(collection, "mark_file_done"):
+                collection.mark_file_done(str(filepath))
 
     print(f"\n{'=' * 55}")
     print("  Done.")

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -50,6 +50,12 @@ def get_collection(
     )
 
 
+def get_remote_collection(url: str, token: str) -> "RemoteCollection":
+    """Get a collection that writes to a remote HTTP mempalace server."""
+    from .backends.remote import RemoteCollection
+    return RemoteCollection(url=url, token=token)
+
+
 def file_already_mined(collection, source_file: str, check_mtime: bool = False) -> bool:
     """Check if a file has already been filed in the palace.
 

--- a/mempalace/transport/__init__.py
+++ b/mempalace/transport/__init__.py
@@ -1,0 +1,8 @@
+"""Transport layer — how the MCP JSON-RPC dispatcher receives and returns bytes.
+
+Two concrete transports:
+  - stdio  (default, backward compatible): sys.stdin / sys.stdout
+  - http   (new): FastAPI + uvicorn
+
+Both share the same handle_request() dispatcher from mempalace.mcp_server.
+"""

--- a/mempalace/transport/http.py
+++ b/mempalace/transport/http.py
@@ -1,0 +1,63 @@
+"""HTTP transport — FastAPI app mounting the MCP JSON-RPC dispatcher."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import FastAPI, Header, Request
+from fastapi.responses import JSONResponse
+
+from mempalace.auth import AuthError, AuthMiddleware
+from mempalace.concurrency import writer_lock
+from mempalace.mcp_server import WRITE_TOOL_NAMES, handle_request
+
+logger = logging.getLogger("mempalace.transport.http")
+
+
+def build_app(auth: AuthMiddleware | None) -> FastAPI:
+    app = FastAPI(title="MemPalace MCP", version="http-transport")
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/readyz")
+    async def readyz() -> dict[str, str]:
+        # Future: verify chromadb client + sqlite + JWKS reachability.
+        return {"status": "ready"}
+
+    @app.post("/mcp")
+    async def mcp(request: Request, authorization: str | None = Header(default=None)) -> JSONResponse:
+        if auth is None:
+            identity = "anonymous"
+        else:
+            try:
+                identity = auth.validate(authorization)
+            except AuthError as e:
+                logger.warning(f"auth_failure reason={e.reason}")
+                return JSONResponse(
+                    status_code=401,
+                    content={"error": "unauthorized", "reason": e.reason},
+                )
+
+        payload: Any = await request.json()
+        tool_name = _extract_tool_name(payload)
+
+        if tool_name in WRITE_TOOL_NAMES:
+            async with writer_lock:
+                response = handle_request(payload, identity=identity)
+        else:
+            response = handle_request(payload, identity=identity)
+
+        return JSONResponse(content=response)
+
+    return app
+
+
+def _extract_tool_name(payload: dict[str, Any]) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    params = payload.get("params") or {}
+    if isinstance(params, dict):
+        return params.get("name")
+    return None

--- a/mempalace/transport/http.py
+++ b/mempalace/transport/http.py
@@ -2,16 +2,34 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from fastapi import FastAPI, Header, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
 
 from mempalace.auth import AuthError, AuthMiddleware
 from mempalace.concurrency import writer_lock
 from mempalace.mcp_server import WRITE_TOOL_NAMES, handle_request
 
 logger = logging.getLogger("mempalace.transport.http")
+
+REQUESTS = Counter(
+    "mempalace_http_requests_total",
+    "Total HTTP requests",
+    ["method", "tool", "identity", "status"],
+)
+DURATION = Histogram(
+    "mempalace_tool_duration_seconds",
+    "Tool call duration",
+    ["tool"],
+)
+AUTH_FAILURES = Counter(
+    "mempalace_auth_failures_total",
+    "Auth failures",
+    ["reason"],
+)
 
 
 def build_app(auth: AuthMiddleware | None) -> FastAPI:
@@ -26,15 +44,36 @@ def build_app(auth: AuthMiddleware | None) -> FastAPI:
         # Future: verify chromadb client + sqlite + JWKS reachability.
         return {"status": "ready"}
 
+    @app.get("/metrics")
+    async def metrics() -> PlainTextResponse:
+        return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    @app.get("/mcp/sse")
+    async def mcp_sse() -> PlainTextResponse:
+        # Placeholder — streaming transport reserved for future implementation.
+        return PlainTextResponse(
+            ":reserved-for-future-streaming\n\n",
+            media_type="text/event-stream",
+            status_code=200,
+        )
+
     @app.post("/mcp")
     async def mcp(request: Request, authorization: str | None = Header(default=None)) -> JSONResponse:
-        if auth is None:
-            identity = "anonymous"
-        else:
+        tool_name: str | None = None
+        identity = "anonymous"
+
+        if auth is not None:
             try:
                 identity = auth.validate(authorization)
             except AuthError as e:
                 logger.warning(f"auth_failure reason={e.reason}")
+                AUTH_FAILURES.labels(reason=e.reason).inc()
+                REQUESTS.labels(
+                    method="POST",
+                    tool="unknown",
+                    identity="anonymous",
+                    status="401",
+                ).inc()
                 return JSONResponse(
                     status_code=401,
                     content={"error": "unauthorized", "reason": e.reason},
@@ -42,13 +81,24 @@ def build_app(auth: AuthMiddleware | None) -> FastAPI:
 
         payload: Any = await request.json()
         tool_name = _extract_tool_name(payload)
+        tool_label = tool_name or "unknown"
 
-        if tool_name in WRITE_TOOL_NAMES:
-            async with writer_lock:
+        start = time.perf_counter()
+        try:
+            if tool_name in WRITE_TOOL_NAMES:
+                async with writer_lock:
+                    response = handle_request(payload, identity=identity)
+            else:
                 response = handle_request(payload, identity=identity)
-        else:
-            response = handle_request(payload, identity=identity)
+        finally:
+            DURATION.labels(tool=tool_label).observe(time.perf_counter() - start)
 
+        REQUESTS.labels(
+            method="POST",
+            tool=tool_label,
+            identity=identity,
+            status="200",
+        ).inc()
         return JSONResponse(content=response)
 
     return app

--- a/mempalace/transport/stdio.py
+++ b/mempalace/transport/stdio.py
@@ -1,0 +1,30 @@
+"""Stdio transport — reads JSON-RPC lines from stdin, writes responses to stdout."""
+import json
+import logging
+import sys
+
+from mempalace.mcp_server import handle_request
+
+logger = logging.getLogger("mempalace.transport.stdio")
+
+
+def serve() -> None:
+    """Run the stdio JSON-RPC loop. Returns when stdin is closed."""
+    logger.info("MemPalace stdio transport starting...")
+    while True:
+        try:
+            line = sys.stdin.readline()
+            if not line:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            request = json.loads(line)
+            response = handle_request(request)
+            if response is not None:
+                sys.stdout.write(json.dumps(response) + "\n")
+                sys.stdout.flush()
+        except KeyboardInterrupt:
+            break
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"stdio transport error: {e}")

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ classifiers = [
 dependencies = [
     "chromadb>=0.5.0,<0.7",
     "pyyaml>=6.0,<7",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "authlib>=1.3",
+    "prometheus-client>=0.20",
 ]
 
 [project.urls]
@@ -38,11 +42,25 @@ Repository = "https://github.com/milla-jovovich/mempalace"
 mempalace = "mempalace:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "ruff>=0.4.0",
+    "psutil>=5.9",
+    "pytest-asyncio>=0.23",
+    "httpx>=0.27",
+]
 spellcheck = ["autocorrect>=2.0"]
 
 [dependency-groups]
-dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "ruff>=0.4.0",
+    "psutil>=5.9",
+    "pytest-asyncio>=0.23",
+    "httpx>=0.27",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/capture_stdio_reference.py
+++ b/scripts/capture_stdio_reference.py
@@ -1,0 +1,35 @@
+"""Capture stdio responses for parity queries. Writes JSONL."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+QUERIES = json.loads(Path("tests/fixtures/parity_queries.json").read_text())
+OUT = Path("tests/fixtures/parity_stdio_responses.jsonl")
+
+
+def main() -> None:
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "mempalace.mcp_server"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    with OUT.open("w") as f:
+        for i, q in enumerate(QUERIES, start=1):
+            req = {
+                "jsonrpc": "2.0",
+                "id": i,
+                "method": "tools/call",
+                "params": q,
+            }
+            proc.stdin.write(json.dumps(req) + "\n")
+            proc.stdin.flush()
+            resp = proc.stdout.readline()
+            f.write(resp)
+    proc.stdin.close()
+    proc.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/parity_queries.json
+++ b/tests/fixtures/parity_queries.json
@@ -1,0 +1,7 @@
+[
+  {"name": "mempalace_status", "arguments": {}},
+  {"name": "mempalace_list_wings", "arguments": {}},
+  {"name": "mempalace_get_taxonomy", "arguments": {}},
+  {"name": "mempalace_search", "arguments": {"query": "test", "limit": 3}},
+  {"name": "mempalace_list_rooms", "arguments": {"wing": "projects"}}
+]

--- a/tests/fixtures/parity_stdio_responses.jsonl
+++ b/tests/fixtures/parity_stdio_responses.jsonl
@@ -1,0 +1,5 @@
+{"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": "{\n  \"error\": \"No palace found\",\n  \"hint\": \"Run: mempalace init <dir> && mempalace mine <dir>\"\n}"}]}}
+{"jsonrpc": "2.0", "id": 2, "result": {"content": [{"type": "text", "text": "{\n  \"error\": \"No palace found\",\n  \"hint\": \"Run: mempalace init <dir> && mempalace mine <dir>\"\n}"}]}}
+{"jsonrpc": "2.0", "id": 3, "result": {"content": [{"type": "text", "text": "{\n  \"error\": \"No palace found\",\n  \"hint\": \"Run: mempalace init <dir> && mempalace mine <dir>\"\n}"}]}}
+{"jsonrpc": "2.0", "id": 4, "result": {"content": [{"type": "text", "text": "{\n  \"error\": \"No palace found\",\n  \"hint\": \"Run: mempalace init <dir> && mempalace mine <dir>\"\n}"}]}}
+{"jsonrpc": "2.0", "id": 5, "result": {"content": [{"type": "text", "text": "{\n  \"error\": \"No palace found\",\n  \"hint\": \"Run: mempalace init <dir> && mempalace mine <dir>\"\n}"}]}}

--- a/tests/test_auth_bearer.py
+++ b/tests/test_auth_bearer.py
@@ -1,0 +1,45 @@
+"""Tests for bearer-static auth middleware."""
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_token(monkeypatch):
+    monkeypatch.setenv("MEMPALACE_TOKEN", "s3cret")
+    yield
+
+
+def test_bearer_accepts_matching_token():
+    from mempalace.auth.bearer_static import BearerStaticAuth
+
+    auth = BearerStaticAuth(token_env="MEMPALACE_TOKEN")
+    identity = auth.validate("Bearer s3cret")
+    assert identity == "static-client"
+
+
+def test_bearer_rejects_wrong_token():
+    from mempalace.auth.bearer_static import BearerStaticAuth
+    from mempalace.auth import AuthError
+
+    auth = BearerStaticAuth(token_env="MEMPALACE_TOKEN")
+    with pytest.raises(AuthError):
+        auth.validate("Bearer wrong")
+
+
+def test_bearer_rejects_missing_header():
+    from mempalace.auth.bearer_static import BearerStaticAuth
+    from mempalace.auth import AuthError
+
+    auth = BearerStaticAuth(token_env="MEMPALACE_TOKEN")
+    with pytest.raises(AuthError):
+        auth.validate(None)
+
+
+def test_bearer_rejects_non_bearer_scheme():
+    from mempalace.auth.bearer_static import BearerStaticAuth
+    from mempalace.auth import AuthError
+
+    auth = BearerStaticAuth(token_env="MEMPALACE_TOKEN")
+    with pytest.raises(AuthError):
+        auth.validate("Basic abc123")

--- a/tests/test_auth_oidc.py
+++ b/tests/test_auth_oidc.py
@@ -1,0 +1,105 @@
+"""Tests for OIDC JWT auth middleware (JWKS-validated)."""
+import json
+import time
+
+import pytest
+from authlib.jose import JsonWebKey, jwt
+
+
+@pytest.fixture
+def signing_key():
+    key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    return key
+
+
+@pytest.fixture
+def jwks(signing_key):
+    """Public JWKS dict, as served by a real OIDC provider."""
+    pub = signing_key.as_dict(is_private=False)
+    pub["kid"] = "test-kid"
+    pub["use"] = "sig"
+    pub["alg"] = "RS256"
+    return {"keys": [pub]}
+
+
+def _mint_token(signing_key, claims: dict) -> str:
+    header = {"alg": "RS256", "typ": "JWT", "kid": "test-kid"}
+    return jwt.encode(header, claims, signing_key).decode()
+
+
+def test_oidc_accepts_valid_token(jwks, signing_key, monkeypatch):
+    from mempalace.auth.oidc_jwt import OIDCJWTAuth
+
+    auth = OIDCJWTAuth(
+        issuer="https://pocket-id.test/",
+        audience="mempalace-mcp",
+        jwks=jwks,
+    )
+    token = _mint_token(signing_key, {
+        "iss": "https://pocket-id.test/",
+        "aud": "mempalace-mcp",
+        "sub": "nerdzpc-wsl",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 300,
+    })
+    assert auth.validate(f"Bearer {token}") == "nerdzpc-wsl"
+
+
+def test_oidc_rejects_expired_token(jwks, signing_key):
+    from mempalace.auth.oidc_jwt import OIDCJWTAuth
+    from mempalace.auth import AuthError
+
+    auth = OIDCJWTAuth(
+        issuer="https://pocket-id.test/",
+        audience="mempalace-mcp",
+        jwks=jwks,
+    )
+    token = _mint_token(signing_key, {
+        "iss": "https://pocket-id.test/",
+        "aud": "mempalace-mcp",
+        "sub": "x",
+        "iat": int(time.time()) - 600,
+        "exp": int(time.time()) - 300,
+    })
+    with pytest.raises(AuthError):
+        auth.validate(f"Bearer {token}")
+
+
+def test_oidc_rejects_wrong_audience(jwks, signing_key):
+    from mempalace.auth.oidc_jwt import OIDCJWTAuth
+    from mempalace.auth import AuthError
+
+    auth = OIDCJWTAuth(
+        issuer="https://pocket-id.test/",
+        audience="mempalace-mcp",
+        jwks=jwks,
+    )
+    token = _mint_token(signing_key, {
+        "iss": "https://pocket-id.test/",
+        "aud": "wrong-audience",
+        "sub": "x",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 300,
+    })
+    with pytest.raises(AuthError):
+        auth.validate(f"Bearer {token}")
+
+
+def test_oidc_rejects_wrong_issuer(jwks, signing_key):
+    from mempalace.auth.oidc_jwt import OIDCJWTAuth
+    from mempalace.auth import AuthError
+
+    auth = OIDCJWTAuth(
+        issuer="https://pocket-id.test/",
+        audience="mempalace-mcp",
+        jwks=jwks,
+    )
+    token = _mint_token(signing_key, {
+        "iss": "https://attacker.test/",
+        "aud": "mempalace-mcp",
+        "sub": "x",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 300,
+    })
+    with pytest.raises(AuthError):
+        auth.validate(f"Bearer {token}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -693,3 +693,48 @@ def test_cmd_repair_trailing_slash_does_not_recurse():
     palace_path = os.path.expanduser(args.palace).rstrip(os.sep)
     backup_path = palace_path + ".backup"
     assert not backup_path.startswith(palace_path + os.sep)
+
+
+# ── --remote-url / --remote-token flags ────────────────────────────────
+
+
+def test_mine_remote_url_flag_passed_to_mine_convos(tmp_path, monkeypatch):
+    """--remote-url and --remote-token are forwarded to mine_convos."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace import cli
+
+    with patch("mempalace.convo_miner.mine_convos") as mock_mine:
+        cli.main([
+            "mine", str(tmp_path),
+            "--mode", "convos",
+            "--remote-url", "http://palace.test",
+            "--remote-token", "secret",
+        ])
+
+    mock_mine.assert_called_once()
+    call_args = mock_mine.call_args
+    all_args = {**dict(zip(
+        ["convo_dir", "palace_path", "wing", "agent", "limit", "dry_run", "extract_mode",
+         "remote_url", "remote_token"],
+        call_args.args
+    )), **(call_args.kwargs or {})}
+    assert all_args.get("remote_url") == "http://palace.test"
+    assert all_args.get("remote_token") == "secret"
+
+
+def test_mine_remote_url_with_palace_prints_warning(tmp_path, monkeypatch, capsys):
+    """Using --remote-url with --palace prints a warning to stderr."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace import cli
+
+    with patch("mempalace.convo_miner.mine_convos"):
+        cli.main([
+            "--palace", str(tmp_path / "palace"),
+            "mine", str(tmp_path),
+            "--mode", "convos",
+            "--remote-url", "http://palace.test",
+            "--remote-token", "tok",
+        ])
+
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err or "warning" in captured.err.lower()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,36 @@
+"""Tests for the write-path serialisation lock."""
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_writer_lock_serialises_writes():
+    from mempalace.concurrency import writer_lock
+
+    events = []
+
+    async def writer(name: str, delay: float):
+        async with writer_lock:
+            events.append(f"{name}-enter")
+            await asyncio.sleep(delay)
+            events.append(f"{name}-exit")
+
+    await asyncio.gather(writer("a", 0.05), writer("b", 0.05), writer("c", 0.05))
+
+    assert events[0].endswith("-enter")
+    assert events[1].endswith("-exit")
+    assert events[2].endswith("-enter")
+    assert events[3].endswith("-exit")
+    assert events[4].endswith("-enter")
+    assert events[5].endswith("-exit")
+
+
+@pytest.mark.asyncio
+async def test_writer_lock_is_reentrant_safe_for_single_task():
+    from mempalace.concurrency import writer_lock
+
+    async with writer_lock:
+        released = writer_lock.locked()
+    assert released is True
+    assert writer_lock.locked() is False

--- a/tests/test_concurrency_stress.py
+++ b/tests/test_concurrency_stress.py
@@ -1,0 +1,49 @@
+"""Stress test: 100 concurrent writes produce 100 WAL entries, no corruption."""
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_100_concurrent_writes(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path / "palace"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "palace").mkdir()
+
+    from mempalace.transport.http import build_app
+
+    app = build_app(auth=None)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async def one_write(i: int):
+            resp = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": i,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "mempalace_add_drawer",
+                        "arguments": {
+                            "wing": "stress",
+                            "room": "test",
+                            "content": f"stress-write-{i}",
+                        },
+                    },
+                },
+            )
+            assert resp.status_code == 200
+
+        await asyncio.gather(*[one_write(i) for i in range(100)])
+
+    wal_files = sorted((tmp_path / ".mempalace" / "wal").glob("*.jsonl"))
+    assert wal_files, "no WAL file produced"
+    entries = []
+    for f in wal_files:
+        entries.extend(json.loads(line) for line in f.read_text().splitlines() if line)
+    assert len(entries) == 100, f"expected 100 WAL entries, got {len(entries)}"
+    assert all(e.get("schema_version") == "1" for e in entries)

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -111,3 +111,69 @@ class TestScanConvos:
     def test_scan_empty_dir(self, tmp_path):
         files = scan_convos(str(tmp_path))
         assert files == []
+
+
+def test_mine_convos_uses_remote_collection_when_remote_url_set(tmp_path, monkeypatch):
+    """When remote_url is passed, mine_convos uses RemoteCollection, not get_collection."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.convo_miner import mine_convos
+    from mempalace.backends.remote import RemoteCollection
+    from unittest.mock import patch, MagicMock
+
+    collected = []
+
+    class CapturingRemote(RemoteCollection):
+        def upsert(self, *, documents, ids, metadatas=None):
+            collected.extend(documents)
+        def get(self, *, where=None, **kwargs):
+            return {"ids": [], "documents": [], "metadatas": []}
+
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(
+        '{"type":"message","message":{"role":"user","content":"hello world"}}\n'
+        '{"type":"message","message":{"role":"assistant","content":"hi there"}}\n'
+    )
+
+    with patch("mempalace.convo_miner.get_remote_collection", return_value=CapturingRemote("http://x", "t")):
+        mine_convos(
+            convo_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+            remote_token="t",
+        )
+
+    assert len(collected) > 0
+
+
+def test_mine_convos_remote_token_from_env(tmp_path, monkeypatch):
+    """MEMPALACE_TOKEN env var is used when remote_token is not passed."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("MEMPALACE_TOKEN", "env-token")
+    from mempalace.convo_miner import mine_convos
+    from mempalace.backends.remote import RemoteCollection
+    from unittest.mock import patch, MagicMock
+
+    with patch("mempalace.convo_miner.get_remote_collection") as mock_factory:
+        mock_col = MagicMock(spec=RemoteCollection)
+        mock_col.get.return_value = {"ids": [], "documents": [], "metadatas": []}
+        mock_factory.return_value = mock_col
+        mine_convos(
+            convo_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+        )
+    mock_factory.assert_called_once_with("http://x", "env-token")
+
+
+def test_mine_convos_raises_when_remote_url_but_no_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MEMPALACE_TOKEN", raising=False)
+    from mempalace.convo_miner import mine_convos
+    import pytest
+
+    with pytest.raises(RuntimeError, match="remote-url requires a token"):
+        mine_convos(
+            convo_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+        )

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,0 +1,49 @@
+"""Verify the HTTP transport enforces the provided auth middleware."""
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from mempalace.auth.bearer_static import BearerStaticAuth
+
+
+@pytest.fixture(autouse=True)
+def set_token(monkeypatch):
+    monkeypatch.setenv("MEMPALACE_TOKEN", "s3cret")
+    yield
+
+
+@pytest.mark.asyncio
+async def test_mcp_post_without_auth_returns_401():
+    from mempalace.transport.http import build_app
+
+    app = build_app(auth=BearerStaticAuth())
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_mcp_post_with_wrong_token_returns_401():
+    from mempalace.transport.http import build_app
+
+    app = build_app(auth=BearerStaticAuth())
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/mcp",
+            headers={"Authorization": "Bearer wrong"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_mcp_post_with_valid_token_returns_200():
+    from mempalace.transport.http import build_app
+
+    app = build_app(auth=BearerStaticAuth())
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/mcp",
+            headers={"Authorization": "Bearer s3cret"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        )
+    assert resp.status_code == 200

--- a/tests/test_http_smoke.py
+++ b/tests/test_http_smoke.py
@@ -1,0 +1,14 @@
+"""Smoke test: HTTP transport starts and /healthz responds."""
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_healthz_returns_ok():
+    from mempalace.transport.http import build_app
+
+    app = build_app(auth=None)  # healthz is unauth'd
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,16 @@
+"""Metrics endpoint exposes Prometheus format."""
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.mark.asyncio
+async def test_metrics_exposes_prometheus_format():
+    from mempalace.transport.http import build_app
+
+    app = build_app(auth=None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/metrics")
+    assert resp.status_code == 200
+    assert "text/plain" in resp.headers["content-type"]
+    body = resp.text
+    assert "mempalace_http_requests_total" in body

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -296,3 +296,48 @@ def test_status_missing_palace_does_not_create_empty_collection(tmp_path, capsys
     out = capsys.readouterr().out
     assert "No palace found" in out
     assert not palace_path.exists()
+
+
+def test_mine_uses_remote_collection_when_remote_url_set(tmp_path, monkeypatch):
+    """When remote_url is passed, mine uses RemoteCollection."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.miner import mine
+    from unittest.mock import patch, MagicMock
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"ids": [], "documents": [], "metadatas": []}
+
+    (tmp_path / "hello.txt").write_text("this is some content for testing the miner remote path")
+    write_file(
+        tmp_path / "mempalace.yaml",
+        "wing: test_remote\nrooms:\n  - name: general\n    description: General\n",
+    )
+
+    with patch("mempalace.miner.get_remote_collection", return_value=mock_col):
+        mine(
+            project_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+            remote_token="tok",
+        )
+
+    assert mock_col.upsert.called or mock_col.get.called
+
+
+def test_mine_raises_when_remote_url_but_no_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MEMPALACE_TOKEN", raising=False)
+    from mempalace.miner import mine
+    import pytest
+
+    write_file(
+        tmp_path / "mempalace.yaml",
+        "wing: test_remote\nrooms:\n  - name: general\n    description: General\n",
+    )
+
+    with pytest.raises(RuntimeError, match="remote-url requires a token"):
+        mine(
+            project_dir=str(tmp_path),
+            palace_path=str(tmp_path / "palace"),
+            remote_url="http://x",
+        )

--- a/tests/test_remote_collection.py
+++ b/tests/test_remote_collection.py
@@ -1,0 +1,134 @@
+"""Tests for RemoteCollection."""
+import json
+import os
+import urllib.error
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_response(body: dict, status: int = 200):
+    """Build a mock urllib response."""
+    raw = json.dumps(body).encode()
+    resp = MagicMock()
+    resp.read.return_value = raw
+    resp.status = status
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _http_error(code: int):
+    return urllib.error.HTTPError(url="http://x", code=code, msg="", hdrs=None, fp=None)
+
+
+@pytest.fixture()
+def col(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.backends.remote import RemoteCollection
+    return RemoteCollection(url="http://palace.test", token="tok")
+
+
+def test_upsert_posts_add_drawer(col):
+    resp = _make_response({"result": {"success": True, "drawer_id": "x"}})
+    with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+        col.upsert(
+            documents=["hello world"],
+            ids=["drawer_foo_bar_abc123"],
+            metadatas=[{"wing": "foo", "room": "bar", "source_file": "/f.jsonl", "added_by": "mine"}],
+        )
+    mock_open.assert_called_once()
+    payload = json.loads(mock_open.call_args[0][0].data)
+    assert payload["params"]["name"] == "mempalace_add_drawer"
+    assert payload["params"]["arguments"]["wing"] == "foo"
+    assert payload["params"]["arguments"]["content"] == "hello world"
+
+
+def test_upsert_registry_skips_http_marks_done(col):
+    with patch("urllib.request.urlopen") as mock_open:
+        col.upsert(
+            documents=["[registry] /f.jsonl"],
+            ids=["_reg_abc"],
+            metadatas=[{"wing": "w", "room": "_registry", "source_file": "/f.jsonl",
+                        "added_by": "mine", "ingest_mode": "registry"}],
+        )
+    mock_open.assert_not_called()
+    assert "/f.jsonl" in col._state["source_files"]
+
+
+def test_already_exists_is_not_an_error(col):
+    resp = _make_response({"result": {"success": True, "reason": "already_exists"}})
+    with patch("urllib.request.urlopen", return_value=resp):
+        col.upsert(
+            documents=["hello"],
+            ids=["d1"],
+            metadatas=[{"wing": "w", "room": "r", "source_file": "/f.jsonl", "added_by": "mine"}],
+        )
+    # Should not raise
+
+
+def test_get_returns_empty_when_file_not_in_state(col):
+    result = col.get(where={"source_file": "/unknown.jsonl"})
+    assert result["ids"] == []
+
+
+def test_get_returns_hit_when_file_in_state(col):
+    col.mark_file_done("/known.jsonl")
+    result = col.get(where={"source_file": "/known.jsonl"})
+    assert result["ids"] == ["/known.jsonl"]
+
+
+def test_mark_file_done_persists_across_instances(col, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    col.mark_file_done("/f.jsonl")
+
+    from mempalace.backends.remote import RemoteCollection
+    col2 = RemoteCollection(url="http://palace.test", token="tok")
+    assert "/f.jsonl" in col2._state["source_files"]
+
+
+def test_mark_file_done_idempotent(col):
+    col.mark_file_done("/f.jsonl")
+    col.mark_file_done("/f.jsonl")
+    assert col._state["source_files"].count("/f.jsonl") == 1
+
+
+def test_401_raises_with_clear_message(col):
+    with patch("urllib.request.urlopen", side_effect=_http_error(401)):
+        with pytest.raises(RuntimeError, match="401"):
+            col.upsert(
+                documents=["x"],
+                ids=["d1"],
+                metadatas=[{"wing": "w", "room": "r", "source_file": "/f", "added_by": "mine"}],
+            )
+
+
+def test_connection_error_retries_once_then_raises(col):
+    err = urllib.error.URLError("connection refused")
+    with patch("urllib.request.urlopen", side_effect=err):
+        with patch("time.sleep") as mock_sleep:
+            with pytest.raises(urllib.error.URLError):
+                col.upsert(
+                    documents=["x"],
+                    ids=["d1"],
+                    metadatas=[{"wing": "w", "room": "r", "source_file": "/f", "added_by": "mine"}],
+                )
+        mock_sleep.assert_called_once_with(2)
+
+
+def test_delete_is_noop(col):
+    # Should not raise, should not call HTTP
+    with patch("urllib.request.urlopen") as mock_open:
+        col.delete(where={"source_file": "/f"})
+    mock_open.assert_not_called()
+
+
+def test_query_raises(col):
+    with pytest.raises(NotImplementedError):
+        col.query(query_texts=["x"], n_results=5)
+
+
+def test_count_raises(col):
+    with pytest.raises(NotImplementedError):
+        col.count()

--- a/tests/test_remote_collection.py
+++ b/tests/test_remote_collection.py
@@ -132,3 +132,18 @@ def test_query_raises(col):
 def test_count_raises(col):
     with pytest.raises(NotImplementedError):
         col.count()
+
+
+def test_get_remote_collection_returns_remote_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.palace import get_remote_collection
+    from mempalace.backends.remote import RemoteCollection
+    col = get_remote_collection("http://palace.test", "tok")
+    assert isinstance(col, RemoteCollection)
+
+
+def test_get_remote_collection_strips_trailing_slash(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.palace import get_remote_collection
+    col = get_remote_collection("http://palace.test/", "tok")
+    assert col._url == "http://palace.test"

--- a/tests/test_transport_parity.py
+++ b/tests/test_transport_parity.py
@@ -1,0 +1,35 @@
+"""Parity test: HTTP transport returns the same responses as stdio for fixture queries."""
+import json
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+QUERIES = json.loads(Path("tests/fixtures/parity_queries.json").read_text())
+REFERENCES = [
+    json.loads(line)
+    for line in Path("tests/fixtures/parity_stdio_responses.jsonl").read_text().splitlines()
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query,reference", list(zip(QUERIES, REFERENCES, strict=True)))
+async def test_http_matches_stdio(query, reference):
+    from mempalace.transport.http import build_app
+
+    app = build_app(auth=None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": reference["id"],
+                "method": "tools/call",
+                "params": query,
+            },
+        )
+    assert resp.status_code == 200
+    http_response = resp.json()
+    assert http_response.get("result") == reference.get("result"), (
+        f"parity mismatch for {query['name']}"
+    )

--- a/tests/test_wal_schema.py
+++ b/tests/test_wal_schema.py
@@ -1,0 +1,88 @@
+"""Tests that WAL entries include schema_version and identity fields."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def tmp_palace(monkeypatch):
+    """Point MemPalace at a fresh palace + WAL dir."""
+    with tempfile.TemporaryDirectory() as d:
+        palace = Path(d) / "palace"
+        palace.mkdir()
+        wal = Path(d) / "wal"
+        wal.mkdir()
+        monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace))
+        monkeypatch.setenv("HOME", d)  # so ~/.mempalace/wal resolves here
+        yield {"palace": palace, "wal": wal, "home": Path(d)}
+
+
+def _latest_wal_entry(wal_dir: Path) -> dict:
+    files = sorted(wal_dir.glob("*.jsonl"))
+    assert files, f"no WAL files in {wal_dir}"
+    lines = files[-1].read_text().strip().splitlines()
+    assert lines, "WAL file empty"
+    return json.loads(lines[-1])
+
+
+def test_wal_entry_has_schema_version(tmp_palace):
+    from mempalace import mcp_server
+
+    mcp_server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "mempalace_add_drawer",
+                "arguments": {
+                    "wing": "test",
+                    "room": "test",
+                    "content": "hello",
+                },
+            },
+        }
+    )
+    wal_dir = tmp_palace["home"] / ".mempalace" / "wal"
+    entry = _latest_wal_entry(wal_dir)
+    assert entry.get("schema_version") == "1"
+
+
+def test_wal_entry_has_identity_field(tmp_palace):
+    from mempalace import mcp_server
+
+    mcp_server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "mempalace_add_drawer",
+                "arguments": {"wing": "t", "room": "t", "content": "x"},
+            },
+        },
+        identity="nerdzpc-wsl",
+    )
+    entry = _latest_wal_entry(tmp_palace["home"] / ".mempalace" / "wal")
+    assert entry.get("identity") == "nerdzpc-wsl"
+
+
+def test_wal_identity_defaults_to_anonymous(tmp_palace):
+    from mempalace import mcp_server
+
+    mcp_server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "mempalace_add_drawer",
+                "arguments": {"wing": "t", "room": "t", "content": "x"},
+            },
+        }
+    )
+    entry = _latest_wal_entry(tmp_palace["home"] / ".mempalace" / "wal")
+    assert entry.get("identity") == "anonymous"

--- a/tests/test_write_tool_names.py
+++ b/tests/test_write_tool_names.py
@@ -1,0 +1,23 @@
+"""Verify WRITE_TOOL_NAMES enumerates every write tool and is a frozenset."""
+from mempalace.mcp_server import TOOLS, WRITE_TOOL_NAMES
+
+
+def test_write_tool_names_is_frozenset():
+    assert isinstance(WRITE_TOOL_NAMES, frozenset)
+
+
+def test_write_tool_names_all_exist_in_tools():
+    missing = WRITE_TOOL_NAMES - set(TOOLS.keys())
+    assert not missing, f"WRITE_TOOL_NAMES includes unknown tools: {missing}"
+
+
+def test_known_writes_are_listed():
+    """Sanity: the canonical write tools from the spec appear."""
+    expected = {
+        "mempalace_add_drawer",
+        "mempalace_delete_drawer",
+        "mempalace_diary_write",
+        "mempalace_kg_add",
+        "mempalace_kg_invalidate",
+    }
+    assert expected.issubset(WRITE_TOOL_NAMES)


### PR DESCRIPTION
## Summary

- **HTTP transport**: serves MCP over HTTP with bearer-static and OIDC-JWT auth, `/healthz`, `/readyz`, `/metrics`, write-path serialisation via `writer_lock`
- **Multi-arch Docker image**: hardened Dockerfile (home-operations/containers standard), GHCR publish via CI, linux/amd64 + linux/arm64
- **`mine --remote-url`**: new `RemoteCollection` backend routes `mine` drawer writes to a remote HTTP mempalace server instead of local ChromaDB — enables workstation → k8s sync without Syncthing or PVC sharing

## Key files

| File | Change |
|------|--------|
| `mempalace/backends/remote.py` | New — `RemoteCollection` (JSON-RPC POST, local skip-tracking state file) |
| `mempalace/transport/http.py` | New — FastAPI HTTP transport |
| `mempalace/transport/stdio.py` | Refactored out of mcp_server.py |
| `mempalace/auth/` | New — bearer-static and OIDC-JWT middleware |
| `mempalace/cli.py` | `--serve-http`, `--remote-url`, `--remote-token` flags |
| `mempalace/convo_miner.py` | `remote_url`/`remote_token` params |
| `mempalace/miner.py` | `remote_url`/`remote_token` params |
| `Dockerfile` | Multi-stage hardened image |

## Test plan

- [x] 736 tests passing (`pytest tests/ --ignore=tests/benchmarks`)
- [x] HTTP transport smoke tests (healthz, auth enforcement, parity with stdio)
- [x] 100-writer stress test for write-path serialisation
- [x] `RemoteCollection` unit tests — state persistence, idempotency, 401 handling, retry-once on connection error
- [x] CLI flag forwarding tests
- [ ] Smoke-test `mine --remote-url` against live k8s instance after merge