### PR TITLE
feat(mcp): expose list_hallways and delete_hallway tools

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -88,6 +88,10 @@ from .palace_graph import (  # noqa: E402
     delete_tunnel,
     follow_tunnels,
 )
+from .hallways import (  # noqa: E402
+    list_hallways,
+    delete_hallway,
+)
 
 from .knowledge_graph import KnowledgeGraph, DEFAULT_KG_PATH  # noqa: E402
 from .collision_scan import assert_no_collisions  # noqa: E402
@@ -1354,6 +1358,22 @@ def tool_delete_tunnel(tunnel_id: str):
     return delete_tunnel(tunnel_id)
 
 
+def tool_list_hallways(wing: str = None):
+    """List within-wing hallway records, optionally filtered by wing."""
+    try:
+        wing = _sanitize_optional_name(wing, "wing")
+    except ValueError as e:
+        return {"error": str(e)}
+    return list_hallways(wing)
+
+
+def tool_delete_hallway(hallway_id: str):
+    """Delete a hallway record by its ID."""
+    if not hallway_id or not isinstance(hallway_id, str):
+        return {"error": "hallway_id is required"}
+    return {"deleted": delete_hallway(hallway_id)}
+
+
 def tool_follow_tunnels(wing: str, room: str):
     """Follow explicit tunnels from a room to see connected drawers in other wings."""
     try:
@@ -2476,6 +2496,30 @@ TOOLS = {
             "required": ["tunnel_id"],
         },
         "handler": tool_delete_tunnel,
+    },
+    "mempalace_list_hallways": {
+        "description": "List within-wing hallway records (entity-to-entity co-occurrence links built at mine time). Optionally filter by wing.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "wing": {
+                    "type": "string",
+                    "description": "Filter hallways by wing",
+                },
+            },
+        },
+        "handler": tool_list_hallways,
+    },
+    "mempalace_delete_hallway": {
+        "description": "Delete a hallway record by its ID. Returns {deleted: bool}.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "hallway_id": {"type": "string", "description": "Hallway ID to delete"},
+            },
+            "required": ["hallway_id"],
+        },
+        "handler": tool_delete_hallway,
     },
     "mempalace_follow_tunnels": {
         "description": "Follow tunnels from a room to see what it connects to in other wings. Returns connected rooms with drawer previews.",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1512,6 +1512,108 @@ class TestWriteTools:
 
         assert result == {"error": msg}
 
+    # ── hallway MCP tools (mirror the tunnel pattern) ──
+
+    def _seed_hallways(self, monkeypatch, tmp_path):
+        """Point hallways._HALLWAY_FILE at a tmp file and seed two records."""
+        from mempalace import hallways
+
+        hallway_file = tmp_path / "hallways.json"
+        monkeypatch.setattr(hallways, "_HALLWAY_FILE", str(hallway_file))
+        seeded = [
+            {
+                "id": "hallway_wing_a_X_Y_aaaa",
+                "wing": "wing_a",
+                "entity_a": "X",
+                "entity_b": "Y",
+                "co_occurrence_count": 3,
+                "rooms": ["room1"],
+            },
+            {
+                "id": "hallway_wing_b_X_Z_bbbb",
+                "wing": "wing_b",
+                "entity_a": "X",
+                "entity_b": "Z",
+                "co_occurrence_count": 1,
+                "rooms": ["room2"],
+            },
+        ]
+        hallways._save_hallways(seeded)
+        return seeded
+
+    def test_tool_list_hallways_returns_all_without_filter(self, monkeypatch, tmp_path):
+        """tool_list_hallways with no wing returns every record."""
+        from mempalace import mcp_server
+
+        seeded = self._seed_hallways(monkeypatch, tmp_path)
+        result = mcp_server.tool_list_hallways()
+        assert isinstance(result, list)
+        assert len(result) == len(seeded)
+        ids = {h["id"] for h in result}
+        assert ids == {h["id"] for h in seeded}
+
+    def test_tool_list_hallways_filters_by_wing(self, monkeypatch, tmp_path):
+        """tool_list_hallways with wing returns only that wing's records."""
+        from mempalace import mcp_server
+
+        self._seed_hallways(monkeypatch, tmp_path)
+        result = mcp_server.tool_list_hallways(wing="wing_a")
+        assert len(result) == 1
+        assert result[0]["wing"] == "wing_a"
+
+    def test_tool_list_hallways_rejects_invalid_wing_name(self, monkeypatch, tmp_path):
+        """Invalid wing names go through _sanitize_optional_name and return a
+        structured error rather than crashing — mirrors tool_list_tunnels."""
+        from mempalace import mcp_server
+
+        self._seed_hallways(monkeypatch, tmp_path)
+        # Forward-slash is not a valid name character per sanitize_name.
+        result = mcp_server.tool_list_hallways(wing="wing/with/slashes")
+        assert isinstance(result, dict)
+        assert "error" in result
+
+    def test_tool_delete_hallway_removes_existing_record(self, monkeypatch, tmp_path):
+        """tool_delete_hallway removes the record and returns {deleted: True}."""
+        from mempalace import mcp_server
+
+        seeded = self._seed_hallways(monkeypatch, tmp_path)
+        target_id = seeded[0]["id"]
+        result = mcp_server.tool_delete_hallway(hallway_id=target_id)
+        assert result == {"deleted": True}
+        remaining = mcp_server.tool_list_hallways()
+        assert target_id not in {h["id"] for h in remaining}
+
+    def test_tool_delete_hallway_unknown_id_returns_false(self, monkeypatch, tmp_path):
+        """Deleting an ID that doesn't exist returns {deleted: False} without error."""
+        from mempalace import mcp_server
+
+        self._seed_hallways(monkeypatch, tmp_path)
+        result = mcp_server.tool_delete_hallway(hallway_id="hallway_does_not_exist")
+        assert result == {"deleted": False}
+
+    def test_tool_delete_hallway_requires_string_id(self):
+        """Missing or non-string hallway_id surfaces a structured error."""
+        from mempalace import mcp_server
+
+        assert mcp_server.tool_delete_hallway(hallway_id="") == {"error": "hallway_id is required"}
+        assert mcp_server.tool_delete_hallway(hallway_id=None) == {
+            "error": "hallway_id is required"
+        }
+
+    def test_hallway_tools_registered_in_tools_registry(self):
+        """Both new tools must appear in the public TOOLS registry so MCP clients can dispatch them."""
+        from mempalace import mcp_server
+
+        assert "mempalace_list_hallways" in mcp_server.TOOLS
+        assert "mempalace_delete_hallway" in mcp_server.TOOLS
+        assert (
+            mcp_server.TOOLS["mempalace_list_hallways"]["handler"] is mcp_server.tool_list_hallways
+        )
+        assert (
+            mcp_server.TOOLS["mempalace_delete_hallway"]["handler"]
+            is mcp_server.tool_delete_hallway
+        )
+
     def test_add_drawer_normal_content_single_drawer(self, monkeypatch, config, palace_path, kg):
         """Regression catch: content below CHUNK_SIZE produces exactly
         one drawer with ``chunks == 1``. Pre-#1539 contract preserved."""

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -319,6 +319,30 @@ Delete an explicit tunnel by its ID.
 
 ---
 
+### `mempalace_list_hallways`
+
+List within-wing hallway records (entity-to-entity co-occurrence links built at mine time). Optionally filter by wing.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `wing` | string | No | Filter hallways by wing |
+
+**Returns:** `[ { id, wing, entity_a, entity_b, co_occurrence_count, rooms, ... }, ... ]`
+
+---
+
+### `mempalace_delete_hallway`
+
+Delete a hallway record by its ID.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hallway_id` | string | **Yes** | Hallway ID to delete |
+
+**Returns:** `{ deleted: bool }`
+
+---
+
 ### `mempalace_follow_tunnels`
 
 Follow tunnels from a room to see what it connects to in other wings. Returns connected rooms with drawer previews.


### PR DESCRIPTION
## What does this PR do?

Closes #1739.

Wires the existing `hallways.list_hallways` and `hallways.delete_hallway` Python API into the MCP tool registry, mirroring the existing tunnel-tool pattern in `mcp_server.py`.

After 3.3.6 (#1558), hallways were being produced at mine time but were not retrievable through MCP — `list_tunnels` / `find_tunnels` / `follow_tunnels` / `create_tunnel` / `delete_tunnel` all had MCP wiring, hallways had none.

Two new tools:

- **`mempalace_list_hallways(wing: str | None = None)`** — wraps `hallways.list_hallways`. Optional `wing` filter routes through `_sanitize_optional_name` the same way `tool_list_tunnels` does, so invalid names surface a structured error rather than crashing.
- **`mempalace_delete_hallway(hallway_id: str)`** — wraps `hallways.delete_hallway` and returns `{"deleted": bool}` so callers can distinguish a successful delete from a no-op without re-reading the hallway list.

Pure pass-throughs of the existing Python API. No behavior change in the underlying hallway storage, no schema change to `hallways.json`.

## How to test

```bash
uv run pytest tests/test_mcp_server.py -k hallway -v
```

Should report 7 passed. Full file (`uv run pytest tests/test_mcp_server.py`) reports 188 passed.

Tests added in `TestWriteTools` (mirroring where the tunnel-tool tests live):

- `test_tool_list_hallways_returns_all_without_filter`
- `test_tool_list_hallways_filters_by_wing`
- `test_tool_list_hallways_rejects_invalid_wing_name`
- `test_tool_delete_hallway_removes_existing_record`
- `test_tool_delete_hallway_unknown_id_returns_false`
- `test_tool_delete_hallway_requires_string_id`
- `test_hallway_tools_registered_in_tools_registry`

All seven use `monkeypatch` to point `hallways._HALLWAY_FILE` at a `tmp_path` location so the real `~/.mempalace/hallways.json` is never touched.

## Checklist
- [x] Tests pass (`uv run pytest tests/ -v`) — 7 new + 188 in `test_mcp_server.py`
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check .` and `ruff format --check`)

---

Verified against `develop` HEAD (`4ceb880`, 2026-06-08).
