### PR TITLE
fix(mcp): surface Chroma compaction write failures with repair guidance (#1714)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -874,6 +874,32 @@ def _safe_meta(meta):
     return meta if isinstance(meta, dict) else {}
 
 
+def _is_chroma_compaction_corruption(exc_msg: str) -> bool:
+    msg = exc_msg.lower()
+    return (
+        "not compatible" in msg
+        and "sql type blob" in msg
+        and ("mismatched types" in msg or "rust type" in msg)
+    )
+
+
+def _write_error_payload(exc: BaseException) -> dict:
+    message = str(exc)
+    payload = {
+        "success": False,
+        "error": message,
+        "error_class": type(exc).__name__,
+    }
+    if _is_chroma_compaction_corruption(message):
+        payload["repair_guidance"] = (
+            "Detected Chroma compaction corruption. "
+            "Run `mempalace repair --mode from-sqlite --archive-existing` "
+            "to rebuild from chroma.sqlite3."
+        )
+        payload["hint"] = "Run `mempalace repair --mode from-sqlite --archive-existing`."
+    return payload
+
+
 def _fetch_all_metadata(col, where=None):
     """Paginate col.get() to avoid the 10K silent truncation limit."""
     total = col.count()
@@ -1442,7 +1468,9 @@ def tool_add_drawer(
         existing = col.get(ids=idempotency_probe_ids, include=[])
         if existing.ids:
             return {"success": True, "reason": "already_exists", "drawer_id": drawer_id}
-    except Exception:
+    except Exception as exc:
+        if _is_chroma_compaction_corruption(str(exc)):
+            return _write_error_payload(exc)
         logger.debug("Idempotency pre-check failed for %s", idempotency_probe_ids, exc_info=True)
 
     try:
@@ -1504,7 +1532,7 @@ def tool_add_drawer(
             "chunk_ids": chunk_ids,
         }
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        return _write_error_payload(e)
 
 
 def tool_delete_drawer(drawer_id: str):
@@ -1513,31 +1541,31 @@ def tool_delete_drawer(drawer_id: str):
     col = _get_collection()
     if not col:
         return _collection_error_or_no_palace()
-    existing = col.get(ids=[drawer_id])
-    if not existing["ids"]:
-        return {"success": False, "error": f"Drawer not found: {drawer_id}"}
-
-    # Log the deletion with the content being removed for audit trail
-    deleted_content = existing.get("documents", [""])[0] if existing.get("documents") else ""
-    deleted_meta = _safe_meta(
-        existing.get("metadatas", [{}])[0] if existing.get("metadatas") else {}
-    )
-    _wal_log(
-        "delete_drawer",
-        {
-            "drawer_id": drawer_id,
-            "deleted_meta": deleted_meta,
-            "content_preview": deleted_content[:200],
-        },
-    )
-
     try:
+        existing = col.get(ids=[drawer_id])
+        if not existing["ids"]:
+            return {"success": False, "error": f"Drawer not found: {drawer_id}"}
+
+        # Log the deletion with the content being removed for audit trail
+        deleted_content = existing.get("documents", [""])[0] if existing.get("documents") else ""
+        deleted_meta = _safe_meta(
+            existing.get("metadatas", [{}])[0] if existing.get("metadatas") else {}
+        )
+        _wal_log(
+            "delete_drawer",
+            {
+                "drawer_id": drawer_id,
+                "deleted_meta": deleted_meta,
+                "content_preview": deleted_content[:200],
+            },
+        )
+
         col.delete(ids=[drawer_id])
         _metadata_cache = None
         logger.info(f"Deleted drawer: {drawer_id}")
         return {"success": True, "drawer_id": drawer_id}
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        return _write_error_payload(e)
 
 
 def tool_sync(project_dir: str = None, wing: str = None, apply: bool = False):
@@ -1734,7 +1762,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
             "room": new_meta.get("room", ""),
         }
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        return _write_error_payload(e)
 
 
 # ==================== KNOWLEDGE GRAPH ====================
@@ -1990,7 +2018,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
             "chunk_ids": chunk_ids,
         }
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        return _write_error_payload(e)
 
 
 def tool_diary_read(agent_name: str, last_n: int = 10, wing: str = ""):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1212,6 +1212,32 @@ class TestWriteTools:
         assert result["success"] is False
         assert "not readable" in result["error"]
 
+    def test_add_drawer_surfaces_chroma_compaction_corruption(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        error = (
+            "mismatched types; Rust type 'u64' and corresponding SQL type BLOB are not compatible"
+        )
+
+        class _FakeGetResult:
+            ids = []
+
+        class _FakeCol:
+            def get(self, **kwargs):
+                return _FakeGetResult()
+
+            def upsert(self, **kwargs):
+                raise RuntimeError(error)
+
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda create=False: _FakeCol())
+
+        result = mcp_server.tool_add_drawer("w", "r", "content")
+        assert result["success"] is False
+        assert error in result["error"]
+        assert "repair_guidance" in result
+        assert "mempalace repair --mode from-sqlite --archive-existing" in result["repair_guidance"]
+
     def test_add_drawer_shared_header_no_collision(self, monkeypatch, config, palace_path, kg):
         """Documents sharing a >100-char header must get distinct IDs (full-content hash)."""
         _patch_mcp_server(monkeypatch, config, kg)
@@ -1249,6 +1275,55 @@ class TestWriteTools:
 
         result = tool_delete_drawer("nonexistent_drawer")
         assert result["success"] is False
+
+    def test_delete_drawer_surfaces_chroma_compaction_corruption(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        error = (
+            "mismatched types; Rust type 'u64' and corresponding SQL type BLOB are not compatible"
+        )
+
+        class _FakeCol:
+            def get(self, **kwargs):
+                return {"ids": ["drawer_proj_backend_aaa"], "documents": ["old"], "metadatas": [{}]}
+
+            def delete(self, **kwargs):
+                raise RuntimeError(error)
+
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda create=False: _FakeCol())
+
+        result = mcp_server.tool_delete_drawer("drawer_proj_backend_aaa")
+        assert result["success"] is False
+        assert error in result["error"]
+        assert result["error_class"] == "RuntimeError"
+        assert "repair_guidance" in result
+
+    def test_update_drawer_surfaces_chroma_compaction_corruption(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        error = (
+            "mismatched types; Rust type 'u64' and corresponding SQL type BLOB are not compatible"
+        )
+
+        class _FakeCol:
+            def get(self, **kwargs):
+                return {
+                    "ids": ["drawer_proj_backend_aaa"],
+                    "documents": ["original"],
+                    "metadatas": [{"wing": "w", "room": "r"}],
+                }
+
+            def update(self, **kwargs):
+                raise RuntimeError(error)
+
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda create=False: _FakeCol())
+
+        result = mcp_server.tool_update_drawer("drawer_proj_backend_aaa", content="updated")
+        assert result["success"] is False
+        assert error in result["error"]
+        assert "repair_guidance" in result
 
     def test_check_duplicate_handles_none_metadata(self, monkeypatch, config, kg):
         """tool_check_duplicate must tolerate None entries in the result lists
@@ -2215,6 +2290,29 @@ class TestDiaryTools:
         _client2, col = _get_collection(palace_path)
         del _client2
         assert col.count() == 1
+
+    def test_diary_write_surfaces_chroma_compaction_corruption(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        error = (
+            "mismatched types; Rust type 'u64' and corresponding SQL type BLOB are not compatible"
+        )
+
+        class _FakeCol:
+            def add(self, **kwargs):
+                raise RuntimeError(error)
+
+            def get(self, **kwargs):
+                raise AssertionError("insert path should fail before readback")
+
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda create=False: _FakeCol())
+
+        result = mcp_server.tool_diary_write(agent_name="TestAgent", entry="corrupt")
+        assert result["success"] is False
+        assert error in result["error"]
+        assert result["error_class"] == "RuntimeError"
+        assert "repair_guidance" in result
 
     def test_diary_write_oversized_entry_chunked(self, monkeypatch, config, palace_path, kg):
         """Regression for #1539: an entry far above CHUNK_SIZE must be


### PR DESCRIPTION

## Summary

Write-side MCP tools could fail as an opaque disconnect when ChromaDB hit a compaction/corruption error, leaving users with “Connection closed” instead of the underlying storage problem. This PR catches that write failure shape and surfaces the inner Chroma error with actionable repair guidance.

## Fix

- `mempalace/mcp_server.py`: detect the Chroma compaction/corruption failure shape on MCP write tools, preserve the inner error text, and return a structured application error that points users at `mempalace repair --mode from-sqlite --archive-existing`.
- `tests/test_mcp_server.py`: add focused coverage for `mempalace_add_drawer`, `mempalace_delete_drawer`, `mempalace_update_drawer`, and `mempalace_diary_write` so write failures surface as structured tool errors instead of opaque disconnects.

## Why It Matters

Users can distinguish a real storage corruption problem from a network or client issue and are pointed at the existing repair workflow immediately. This saves debugging time without pretending the underlying Chroma corruption has been fixed in-process.

## Test plan

- [x] `D:\Repos\mempalace\.venv\Scripts\python.exe -m pytest tests/test_mcp_server.py -v`
- [x] `D:\Repos\mempalace\.venv\Scripts\python.exe -m ruff check .`
- [x] `D:\Repos\mempalace\.venv\Scripts\python.exe -m ruff format --check .`
- [x] `D:\Repos\mempalace\.venv\Scripts\python.exe -m pytest tests/ -v`
