### PR TITLE
fix(repair): run post-rebuild FTS5 cleanup on legacy cmd_repair path (#1747)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -889,7 +889,12 @@ def cmd_repair_status(args):
 
 
 def cmd_repair(args):
-    """Rebuild palace vector index from SQLite metadata."""
+    """Rebuild palace vector index from SQLite metadata.
+
+    On success the palace SQLite file is VACUUMed and the FTS5 index is
+    rebuilt, so the next repair's integrity preflight reads a consistent
+    database (#1747).
+    """
     config = MempalaceConfig()
     collection_name = config.collection_name
     palace_path = os.path.abspath(
@@ -906,6 +911,7 @@ def cmd_repair(args):
         TruncationDetected,
         _close_chroma_handles,
         _extract_drawers,
+        _post_rebuild_cleanup,
         _rebuild_collection_via_temp,
         check_extraction_safety,
         maybe_repair_poisoned_max_seq_id_before_rebuild,
@@ -1098,6 +1104,10 @@ def cmd_repair(args):
                 print(f"    2. Restore the backup directory to: {palace_path}")
                 print(f"       Backup location: {backup_path}")
         sys.exit(1)
+
+    # The bulk delete + re-upsert cycle above leaves the FTS5 inverted index
+    # inconsistent, which fails the next repair's integrity preflight (#1747).
+    _post_rebuild_cleanup(palace_path, backend=backend, progress=print)
 
     print(f"\n  Repair complete. {filed} drawers rebuilt.")
     print(f"  Backup saved at {backup_path}")

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -715,6 +715,19 @@ def _vacuum_and_rebuild_fts5(palace_path: str, progress=print) -> None:
         progress(f"  Warning: post-repair cleanup failed (non-fatal): {exc}")
 
 
+def _post_rebuild_cleanup(palace_path: str, backend: "ChromaBackend", progress=print) -> None:
+    """Close cached chroma handles, then VACUUM and rebuild the FTS5 index.
+
+    Shared epilogue for the two full-rebuild paths (``rebuild_index`` and the
+    CLI legacy ``cmd_repair``), so neither can drift out of the post-run
+    cleanup again (issues #1517, #1747). ChromaDB's PersistentClient keeps
+    chroma.sqlite3 open and VACUUM needs exclusive access, so the handles
+    are released first.
+    """
+    _close_chroma_handles(palace_path, backend=backend)
+    _vacuum_and_rebuild_fts5(palace_path, progress=progress)
+
+
 def rebuild_index(
     palace_path=None,
     confirm_truncation_ok: bool = False,
@@ -848,8 +861,7 @@ def rebuild_index(
             print("  Live collection was not replaced; leaving the original palace untouched.")
         raise
 
-    _close_chroma_handles(palace_path, backend=backend)
-    _vacuum_and_rebuild_fts5(palace_path, progress=progress)
+    _post_rebuild_cleanup(palace_path, backend=backend, progress=progress)
 
     print(f"\n  Repair complete. {filed} drawers rebuilt.")
     print("  HNSW index is now clean with cosine distance metric.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import shlex
 import sqlite3
 import subprocess
 import sys
+from contextlib import closing
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -1080,6 +1081,131 @@ def test_cmd_repair_restores_backup_on_live_rebuild_failure(mock_config_cls, tmp
         call(str(palace_dir), "mempalace_drawers"),
         call(str(palace_dir), "mempalace_drawers__repair_tmp"),
     ]
+
+
+def _repair_backend_mocks(mock_config_cls, palace_dir, create_collection_results=None):
+    """Config + backend mocks for a 2-drawer legacy repair run.
+
+    ``create_collection_results`` overrides the ``create_collection``
+    side_effect sequence; the default is a temp + live collection pair
+    that succeeds.
+    """
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_col.get.return_value = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"wing": "a"}, {"wing": "b"}],
+    }
+    if create_collection_results is None:
+        mock_temp_col = MagicMock()
+        mock_temp_col.count.return_value = 2
+        mock_new_col = MagicMock()
+        mock_new_col.count.return_value = 2
+        create_collection_results = [mock_temp_col, mock_new_col]
+    mock_backend = _mock_backend_for(col=mock_col)
+    mock_backend.create_collection.side_effect = create_collection_results
+    return mock_backend
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_closes_handles_then_rebuilds_fts5(mock_config_cls, tmp_path):
+    """cmd_repair must close chroma handles, then run _vacuum_and_rebuild_fts5.
+
+    Mirrors test_rebuild_index_calls_vacuum in test_repair.py: ChromaDB's
+    PersistentClient holds an open connection to chroma.sqlite3 and VACUUM
+    requires exclusive access, so the handles must be released first. See
+    #1747: the legacy path skipped this cleanup entirely.
+    """
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    args = argparse.Namespace(palace=None, yes=True)
+    mock_backend = _repair_backend_mocks(mock_config_cls, palace_dir)
+
+    call_order = []
+    with (
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+        patch(
+            "mempalace.repair._close_chroma_handles",
+            side_effect=lambda *a, **kw: call_order.append("close"),
+        ) as mock_close,
+        patch(
+            "mempalace.repair._vacuum_and_rebuild_fts5",
+            side_effect=lambda *a, **kw: call_order.append("vacuum"),
+        ) as mock_vacuum,
+    ):
+        cmd_repair(args)
+
+    mock_close.assert_called_once()
+    mock_vacuum.assert_called_once()
+    assert call_order == ["close", "vacuum"], "handles must be closed before VACUUM"
+    vacuum_args, _ = mock_vacuum.call_args
+    assert vacuum_args[0] == str(palace_dir)
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_success_rebuilds_fts5_and_vacuums(mock_config_cls, tmp_path, capsys):
+    """A clean legacy repair leaves the FTS5 index rebuilt and the file vacuumed.
+
+    Regression test for #1747: cmd_repair printed "Repair complete" without
+    ever running _vacuum_and_rebuild_fts5, so the bulk delete + re-upsert
+    cycle left the FTS5 inverted index inconsistent and the next repair run
+    aborted at the integrity preflight. The two banners are the user-visible
+    contract that the cleanup ran.
+    """
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    with closing(sqlite3.connect(str(palace_dir / "chroma.sqlite3"))) as conn:
+        conn.execute(
+            "CREATE VIRTUAL TABLE embedding_fulltext_search"
+            " USING fts5(string_value, tokenize='unicode61')"
+        )
+        conn.execute("INSERT INTO embedding_fulltext_search(string_value) VALUES('hello world')")
+        conn.commit()
+    args = argparse.Namespace(palace=None, yes=True)
+    mock_backend = _repair_backend_mocks(mock_config_cls, palace_dir)
+
+    with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
+        cmd_repair(args)
+
+    out = capsys.readouterr().out
+    assert "Repair complete" in out
+    assert "FTS5 index rebuilt." in out
+    assert "SQLite VACUUM complete." in out
+    assert "post-repair cleanup failed" not in out
+    with closing(sqlite3.connect(str(palace_dir / "chroma.sqlite3"))) as conn:
+        result = conn.execute("PRAGMA quick_check").fetchall()
+    assert result == [("ok",)]
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_does_not_vacuum_when_rebuild_fails(mock_config_cls, tmp_path, capsys):
+    """Post-run FTS5 cleanup must not fire when the rebuild itself failed."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    args = argparse.Namespace(palace=None, yes=True)
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 2
+    mock_backend = _repair_backend_mocks(
+        mock_config_cls,
+        palace_dir,
+        create_collection_results=[mock_temp_col, RuntimeError("live build failed")],
+    )
+
+    with (
+        patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend),
+        patch("mempalace.repair._vacuum_and_rebuild_fts5") as mock_vacuum,
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            cmd_repair(args)
+
+    assert "Repair failed" in capsys.readouterr().out
+    assert excinfo.value.code == 1
+    mock_vacuum.assert_not_called()
 
 
 @patch("mempalace.cli.MempalaceConfig")


### PR DESCRIPTION
## What does this PR do?

Fixes #1747: a clean `mempalace repair --yes` (legacy path) finished without running `_vacuum_and_rebuild_fts5`, so the bulk delete + re-upsert rebuild left the FTS5 inverted index (`embedding_fulltext_search`) inconsistent. `PRAGMA quick_check` then reports `malformed inverted index` and the next repair aborts at the integrity preflight. `rebuild_index()` got exactly this post-run cleanup when #1517 was fixed (#1523); `cmd_repair` in cli.py never did.

- Extracts the shared epilogue `_post_rebuild_cleanup()` in `repair.py` (close chroma handles, then VACUUM + FTS5 rebuild; VACUUM needs exclusive access to chroma.sqlite3) and calls it from both full-rebuild paths, so they cannot drift apart again.
- `cmd_repair` now runs it on the legacy success path only; failure/restore paths are unchanged.
- This also makes existing recovery guidance true: the `MineValidationError` handler in `cmd_mine` (cli.py:607) already tells users that `mempalace repair --yes` rebuilds the FTS5 virtual table automatically, which the legacy path did not actually do until now.

The preflight end (auto-rebuild before aborting on an already-corrupt index) is #1606, with open PR #1607; this PR is the post-run complement the issue describes. Both add one line to the same defer-import block in `cmd_repair`, so whichever lands second needs a trivial rebase there.

## How to test

- `python -m pytest tests/test_cli.py tests/test_repair.py -v`: 152 pass. New tests: `test_cmd_repair_closes_handles_then_rebuilds_fts5` (handles closed before VACUUM, mirroring `test_rebuild_index_calls_vacuum`), `test_cmd_repair_success_rebuilds_fts5_and_vacuums` (real sqlite file with an FTS5 table: both cleanup banners printed, no non-fatal warning, `PRAGMA quick_check` ok), `test_cmd_repair_does_not_vacuum_when_rebuild_fails` (cleanup must not fire when the rebuild failed; exit code 1). The first two fail on develop without the fix.
- End-to-end (1000-drawer palace, chromadb 1.5.7, SQLite 3.51.2, Linux): on develop, `mempalace --palace PALACE_DIR repair --yes` exits 0 and prints neither "FTS5 index rebuilt." nor "SQLite VACUUM complete.", confirming the cleanup never ran; with this patch the same run prints both banners, `PRAGMA quick_check` returns ok, and `sqlite_integrity_errors()` (the exact preflight gate) returns no errors for the next run. The tests assert that the cleanup runs; the malformed-index state itself (3/3 at 56k drawers on chromadb 1.5.8/Windows per the issue) is scale- and environment-dependent and is not synthetically reproduced here, same as when #1523 added this cleanup to `rebuild_index`.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
