### PR TITLE
fix(searcher): use filter-fallback in CLI search path for HNSW drift (#1665)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -376,7 +376,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         if where:
             kwargs["where"] = where
 
-        results = col.query(**kwargs)
+        results = _query_drawers_with_filter_fallback(col, kwargs, query, n_results, wing, room)
 
     except Exception as e:
         print(f"\n  Search error: {e}")

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -413,3 +413,45 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         assert "[1]" in captured.out
         assert "[2]" in captured.out
+
+    def test_search_wing_filter_fallback_on_hnsw_drift(self, fake_palace_path, capsys):
+        """search() gracefully falls back to unfiltered + post-filter when
+        a filtered query fails due to HNSW/SQLite mismatch (orphan IDs).
+
+        Simulates: a filtered query raises "Error finding id", but an
+        unfiltered query succeeds. The fallback retries unfiltered,
+        post-filters in Python by wing, and returns results without
+        raising SearchError.
+        """
+        mock_col = MagicMock()
+        mock_col.metadata = {"hnsw:space": "cosine"}
+
+        # First call (filtered): raises, simulating orphan ID drift
+        # Second call (unfiltered fallback): succeeds
+        mock_col.query.side_effect = [
+            RuntimeError("Error finding id"),
+            {
+                "documents": [["doc in project wing", "doc in notes wing"]],
+                "metadatas": [
+                    [
+                        {"source_file": "a.md", "wing": "project", "room": "frontend"},
+                        {"source_file": "b.md", "wing": "notes", "room": "general"},
+                    ]
+                ],
+                "distances": [[0.1, 0.2]],
+            },
+        ]
+
+        with patch("mempalace.searcher.get_collection", return_value=mock_col):
+            search("test query", fake_palace_path, wing="project")
+
+        captured = capsys.readouterr()
+        # Should print results (no SearchError raised)
+        assert "Results for" in captured.out
+        assert "[1]" in captured.out
+        # Should contain the filtered result (wing matches)
+        assert "project" in captured.out or "a.md" in captured.out
+        # Fallback was applied: only the project wing result is shown (post-filtered)
+        assert "a.md" in captured.out  # project wing result
+        # notes wing result should NOT be shown (filtered out in Python)
+        assert "b.md" not in captured.out


### PR DESCRIPTION
## Summary

`search()` (CLI path) and `search_memories()` (MCP/API path) diverged in their handling of filtered HNSW failures. `search_memories` already routes through `_query_drawers_with_filter_fallback` (added for #1245/#1035), which retries unfiltered and post-filters in Python when ChromaDB raises `Error finding id` on a `where=`-scoped query. `search()` did not — its `except Exception` block at `searcher.py:381` caught the error and re-raised as `SearchError`, so wing-filtered CLI searches failed with a cryptic message while the equivalent MCP call recovered cleanly.

The fix routes `search()` through the same helper, making CLI and MCP behavior consistent. No new infrastructure: the helper already handles the unfiltered-retry, Python post-filter, and warning log.

## Fix

Replace the inline `col.query(**kwargs)` call in `search()` (`searcher.py:379`) with `_query_drawers_with_filter_fallback(col, kwargs, query, n_results, wing, room)`. The helper signature accepts the same kwargs dict and the existing wing/room locals, so no refactoring is needed around the call site.

Add a regression in `tests/test_searcher.py`: mock a collection whose `query` raises only when `where=` is present, call `search()` with a wing filter, assert no `SearchError` is raised and results are returned.


## Related work

Open PRs #951, #1005, #1463, and #1598 address overlapping search-fallback surfaces. This PR is the narrowest fix: it routes the CLI `search()` path through the existing `_query_drawers_with_filter_fallback` helper that `search_memories()` already uses. #1005 and #1598 both subsume this change as part of broader scope; if either lands first, this PR is redundant.

## Test plan
- [x] `python -m pytest tests/test_searcher.py -v` — 31 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
