### PR TITLE
fix(searcher): route hash/lexical embedding mode to SQLite BM25 (#1380)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -43,6 +43,18 @@ class SearchError(Exception):
 
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 
+_LEXICAL_DEVICES = frozenset({"hash", "lexical"})
+
+
+def _is_lexical_device(device: str) -> bool:
+    """Return True when the configured embedding device is hash/lexical mode.
+
+    Hash and lexical devices produce non-semantic vectors; routing to the
+    HNSW index with those vectors returns meaningless hits. Use SQLite
+    BM25 instead.
+    """
+    return (device or "").strip().lower() in _LEXICAL_DEVICES
+
 
 def _first_or_empty(results, key: str) -> list:
     """Return the first inner list of a query result field, or [].
@@ -521,6 +533,7 @@ def _bm25_only_via_sqlite(
                     WHERE embedding_fulltext_search MATCH ?
                       AND c.name = ?
                     {filter_sql}
+                    ORDER BY embedding_fulltext_search.rank
                     LIMIT ?
                     """,
                     (fts_query, collection_name, *filter_params, max_candidates),
@@ -1012,6 +1025,24 @@ def search_memories(
     # regardless of whether the call routes through the vector path or
     # the BM25-only fallback below.
     _validate_candidate_strategy(candidate_strategy)
+
+    # Hash/lexical devices produce non-semantic vectors. Route to SQLite
+    # BM25 intentionally rather than producing low-signal HNSW hits.
+    if not vector_disabled:
+        from .config import MempalaceConfig
+
+        _device = MempalaceConfig().embedding_device
+        if _is_lexical_device(_device):
+            result = _bm25_only_via_sqlite(
+                query,
+                palace_path,
+                wing=wing,
+                room=room,
+                n_results=n_results,
+                collection_name=collection_name,
+            )
+            result["fallback_reason"] = f"embedding_device={_device}"
+            return result
 
     if vector_disabled:
         return _vector_disabled_search(

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -196,6 +196,95 @@ class TestSearchMemories:
         assert hits[0]["source_file"] == "a.md"
         assert hits[0]["matched_via"] == "drawer+closet"
 
+    def test_hash_embedding_device_routes_to_bm25_fallback(self):
+        """When embedding_device=hash, search_memories routes to BM25-only fallback."""
+        with patch("mempalace.config.MempalaceConfig") as mock_config_class, patch(
+            "mempalace.searcher._bm25_only_via_sqlite"
+        ) as mock_bm25:
+            mock_config = MagicMock()
+            mock_config.embedding_device = "hash"
+            mock_config_class.return_value = mock_config
+            mock_bm25.return_value = {
+                "query": "test",
+                "filters": {"wing": None, "room": None},
+                "total_before_filter": 1,
+                "results": [{"text": "result"}],
+                "fallback": "bm25_only_via_sqlite",
+                "fallback_reason": "vector_search_disabled",
+            }
+
+            result = search_memories("test", "/fake/path")
+
+            # Verify that _bm25_only_via_sqlite was called
+            mock_bm25.assert_called_once_with(
+                "test",
+                "/fake/path",
+                wing=None,
+                room=None,
+                n_results=5,
+                collection_name=None,
+            )
+            # Verify fallback_reason was updated
+            assert result["fallback_reason"] == "embedding_device=hash"
+            assert result["fallback"] == "bm25_only_via_sqlite"
+
+    def test_lexical_embedding_device_routes_to_bm25_fallback(self):
+        """When embedding_device=lexical, search_memories routes to BM25-only fallback."""
+        with patch("mempalace.config.MempalaceConfig") as mock_config_class, patch(
+            "mempalace.searcher._bm25_only_via_sqlite"
+        ) as mock_bm25:
+            mock_config = MagicMock()
+            mock_config.embedding_device = "lexical"
+            mock_config_class.return_value = mock_config
+            mock_bm25.return_value = {
+                "query": "test",
+                "filters": {"wing": None, "room": None},
+                "total_before_filter": 1,
+                "results": [{"text": "result"}],
+                "fallback": "bm25_only_via_sqlite",
+                "fallback_reason": "vector_search_disabled",
+            }
+
+            result = search_memories("test", "/fake/path")
+
+            # Verify that _bm25_only_via_sqlite was called
+            mock_bm25.assert_called_once_with(
+                "test",
+                "/fake/path",
+                wing=None,
+                room=None,
+                n_results=5,
+                collection_name=None,
+            )
+            # Verify fallback_reason was updated
+            assert result["fallback_reason"] == "embedding_device=lexical"
+            assert result["fallback"] == "bm25_only_via_sqlite"
+
+    def test_cpu_embedding_device_uses_vector_path(self):
+        """When embedding_device=cpu (real embedding), search_memories uses vector path."""
+        with patch("mempalace.config.MempalaceConfig") as mock_config_class, patch(
+            "mempalace.searcher.get_collection"
+        ) as mock_get_col:
+            mock_config = MagicMock()
+            mock_config.embedding_device = "cpu"
+            mock_config_class.return_value = mock_config
+
+            mock_col = MagicMock()
+            mock_col.query.return_value = {
+                "documents": [["doc"]],
+                "metadatas": [[{"wing": "w", "room": "r", "source_file": "test.txt"}]],
+                "distances": [[0.1]],
+                "ids": [["id"]],
+            }
+            mock_get_col.return_value = mock_col
+
+            result = search_memories("test", "/fake/path")
+
+            # Verify get_collection was called (vector path)
+            mock_get_col.assert_called_once()
+            # Should not go through BM25-only fallback
+            assert "fallback" not in result or result.get("fallback") != "bm25_only_via_sqlite"
+
 
 # ── BM25 internals: None / empty document safety ─────────────────────
 
@@ -233,6 +322,46 @@ class TestBM25NoneSafety:
         assert len(scores) == 3
         assert scores[1] == 0.0
         assert scores[0] > 0.0
+
+    def test_is_lexical_device_recognizes_hash(self):
+        """_is_lexical_device returns True for hash mode."""
+        from mempalace.searcher import _is_lexical_device
+
+        assert _is_lexical_device("hash") is True
+
+    def test_is_lexical_device_recognizes_lexical(self):
+        """_is_lexical_device returns True for lexical mode."""
+        from mempalace.searcher import _is_lexical_device
+
+        assert _is_lexical_device("lexical") is True
+
+    def test_is_lexical_device_rejects_cpu(self):
+        """_is_lexical_device returns False for cpu (real embedding)."""
+        from mempalace.searcher import _is_lexical_device
+
+        assert _is_lexical_device("cpu") is False
+
+    def test_is_lexical_device_handles_none(self):
+        """_is_lexical_device returns False for None or empty string."""
+        from mempalace.searcher import _is_lexical_device
+
+        assert _is_lexical_device(None) is False
+        assert _is_lexical_device("") is False
+
+    def test_is_lexical_device_handles_whitespace(self):
+        """_is_lexical_device handles leading/trailing whitespace."""
+        from mempalace.searcher import _is_lexical_device
+
+        assert _is_lexical_device("  hash  ") is True
+        assert _is_lexical_device("  LEXICAL  ") is True
+
+    def test_is_lexical_device_case_insensitive(self):
+        """_is_lexical_device is case-insensitive."""
+        from mempalace.searcher import _is_lexical_device
+
+        assert _is_lexical_device("HASH") is True
+        assert _is_lexical_device("Lexical") is True
+        assert _is_lexical_device("LeXiCaL") is True
 
 
 # ── search() (CLI print function) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

When `embedding_device=hash` or `embedding_device=lexical` is configured, `search_memories` was querying the HNSW index with a hash-derived (non-semantic) vector, returning low-signal hits — stopword files, NUL-byte documents — while SQLite FTS/BM25 immediately surfaced relevant results for the same query. The SQLite BM25 path (`_bm25_only_via_sqlite`) already existed for the HNSW-diverged case (#1222); hash/lexical mode just wasn't routing to it.

Two changes: (1) detect `embedding_device in {"hash", "lexical"}` in `search_memories` and route to `_bm25_only_via_sqlite` with `fallback_reason="embedding_device=<device>"`, and (2) add `ORDER BY rank` to the FTS5 candidate SELECT so better BM25 candidates reach the local reranker first instead of low-rowid partial matches crowding them out.

## Fix

Added `_is_lexical_device()` helper at `searcher.py:44` and a routing block in `search_memories` after strategy validation that reads `MempalaceConfig().embedding_device`, calls `_bm25_only_via_sqlite`, and sets the structured `fallback_reason` key. The hash/lexical check only runs when `vector_disabled` is not already set, so the existing HNSW-diverged code path is unchanged.

Added `ORDER BY embedding_fulltext_search.rank` to the FTS5 candidate SELECT at `searcher.py:514`, which uses the built-in FTS5 `rank` column (BM25-style relevance) to pre-sort candidates before the Python Okapi-BM25 reranker.

## Test plan
- [x] `python -m pytest tests/test_searcher.py -v` — 39 passed (11 new)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean