### PR TITLE
fix(hooks): gate _mine_sync behind the per-target PID slot to prevent double-ingest race (#1253)

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -566,10 +566,6 @@ def _mine_sync():
                     env=child_env,
                     timeout=60,
                 )
-                try:
-                    pid_file.write_text(f"{os.getpid()} {int(time.time())}")
-                except OSError:
-                    pass
         except (OSError, subprocess.TimeoutExpired):
             pass
         finally:

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -517,10 +517,11 @@ def _maybe_auto_ingest():
     asymmetric interpreter handling and PID-file overwrite when both
     targets fire from a single hook call (#1231 review).
 
-    Per-target dedup is done by ``_spawn_mine`` itself: each (dir, mode)
-    target gets its own PID slot, so distinct targets never block each
-    other but a re-fire of the same target while the previous one is
-    still running is silently skipped.
+    Per-target dedup is done by ``_spawn_mine`` itself (and by
+    ``_mine_sync``, which uses the same PID-slot mechanism): each
+    (dir, mode) target gets its own PID slot, so distinct targets never
+    block each other but a re-fire of the same target while the previous
+    one is still running is silently skipped (#1253).
     """
     targets = _get_mine_targets()
     if not targets:
@@ -538,6 +539,10 @@ def _mine_sync():
     Transcript convos are ingested separately via ``_ingest_transcript``
     in ``hook_precompact`` — keeping them out of this function avoids
     timeout stacking against the harness 30s ceiling (#1231 review).
+
+    Uses the same per-target PID-slot guard as ``_spawn_mine`` so a
+    concurrent ``Stop``/``PreCompact`` double-fire cannot launch two HNSW
+    writers against the same palace (#1253).
     """
     targets = _get_mine_targets()
     if not targets:
@@ -545,24 +550,33 @@ def _mine_sync():
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     log_path = STATE_DIR / "hook.log"
     for mine_dir, mode in targets:
+        cmd = [_mempalace_python(), "-m", "mempalace", "mine", mine_dir, "--mode", mode]
+        pid_file = _claim_mine_slot(cmd)
+        if pid_file is None:
+            _log(f"Skipping sync mine: target already running ({mine_dir!r} {mode!r})")
+            continue
+        child_env = os.environ.copy()
+        child_env[_MINE_PID_FILE_ENV] = str(pid_file)
         try:
             with open(log_path, "a") as log_f:
                 subprocess.run(
-                    [
-                        _mempalace_python(),
-                        "-m",
-                        "mempalace",
-                        "mine",
-                        mine_dir,
-                        "--mode",
-                        mode,
-                    ],
+                    cmd,
                     stdout=log_f,
                     stderr=log_f,
+                    env=child_env,
                     timeout=60,
                 )
+                try:
+                    pid_file.write_text(f"{os.getpid()} {int(time.time())}")
+                except OSError:
+                    pass
         except (OSError, subprocess.TimeoutExpired):
             pass
+        finally:
+            try:
+                pid_file.unlink()
+            except OSError:
+                pass
 
 
 def _desktop_toast(body: str, title: str = "MemPalace"):

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -1098,6 +1098,39 @@ def test_spawn_mine_passes_pid_file_env_var(tmp_path):
                 assert child_env.get("MEMPALACE_MINE_PID_FILE") == expected
 
 
+def test_mine_sync_skips_when_target_running(tmp_path):
+    """_mine_sync skips if the per-target PID slot is already claimed (#1253)."""
+    import time as _time
+
+    mempal_dir = tmp_path / "project"
+    mempal_dir.mkdir()
+    pid_dir = tmp_path / "mine_pids"
+    with patch.dict("os.environ", {"MEMPAL_DIR": str(mempal_dir)}):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli._MINE_PID_DIR", pid_dir):
+                from mempalace.hooks_cli import _pid_file_for_cmd, _mine_sync
+
+                cmd = [
+                    sys.executable,
+                    "-m",
+                    "mempalace",
+                    "mine",
+                    str(mempal_dir.resolve()),
+                    "--mode",
+                    "projects",
+                ]
+                # Pre-populate the per-target slot with a live PID (our own).
+                pid_file = _pid_file_for_cmd(cmd)
+                pid_file.parent.mkdir(parents=True, exist_ok=True)
+                pid_file.write_text(f"{os.getpid()} {int(_time.time())}")
+
+                with patch("mempalace.hooks_cli._mempalace_python", return_value=sys.executable):
+                    with patch("mempalace.hooks_cli.subprocess.run") as mock_run:
+                        _mine_sync()
+                        # subprocess.run should NOT be called when the slot is taken
+                        mock_run.assert_not_called()
+
+
 def test_ingest_transcript_uses_detached_kwargs(tmp_path):
     """_ingest_transcript spawns the convos mine with detach kwargs."""
     transcript = tmp_path / "session.jsonl"


### PR DESCRIPTION
## Summary

`_mine_sync()` in `hooks_cli.py` called `subprocess.run` directly, bypassing the per-target PID-slot guard that `_spawn_mine` and `_maybe_auto_ingest` use. When a `Stop`/`SessionEnd` hook fired concurrently with `PreCompact`, two sync-mine subprocesses could launch for the same `(mine_dir, mode)` pair. Each subprocess acquired `mine_palace_lock` internally, but opening the ChromaDB HNSW segment from two processes simultaneously (even transiently) was sufficient to corrupt `link_lists.bin` — observed as 210GB apparent sparse-file expansion.

The fix routes `_mine_sync` through `_claim_mine_slot` (the same atomic `O_CREAT | O_EXCL` mechanism `_spawn_mine` uses) before calling `subprocess.run`. If the slot is taken, the sync mine is skipped with a log line — matching the behavior of the async paths. The synchronous guarantee (mine completes before the hook returns) is preserved because we still call `subprocess.run`; we just skip when a concurrent writer already holds the slot.

## Reproduction

1. Enable both `PreCompact` and `SessionEnd` hooks.
2. Have a long session so both hooks fire close together (context compaction boundary).
3. `hook.log` shows `chromadb.errors.InternalError: Failed to apply logs to the hnsw segment writer`; `du` shows palace growing with sparse-file inflation.

## Fix

`_mine_sync` (`hooks_cli.py:535`) is rewritten to: build the mine command identically to `_spawn_mine`, call `_claim_mine_slot(cmd)` (returns `None` if a live mine already holds the slot, skipping silently), pass `MEMPALACE_MINE_PID_FILE` in the child env so the subprocess cleanup hook can release the slot on exit, and release the slot in a `finally` block if `subprocess.run` raises or times out.

No changes to `hook_precompact`, `hook_stop`, `_ingest_transcript`, or `_spawn_mine` — all other write paths already use the PID guard.

## Test plan
- [x] `python -m pytest tests/test_hooks_cli.py -v` — 121 passed (1 new), 1 skipped
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean