### PR TITLE
fix(repair): patch dim-None pickles after rebuild_index to prevent immediate re-quarantine (#1492)

### DIFF
--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -1366,13 +1366,17 @@ def _repair_dim_none_pickles(palace_path: str, collection_name: str, progress=pr
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as e:
+        progress(f"  WARNING: SQLite error while reading collection dimension: {e}")
         return 0
 
     dim_by_seg: dict[str, int] = {}
     for seg_id, dim in rows:
-        if dim is not None and int(dim) > 0:
-            dim_by_seg[seg_id] = int(dim)
+        try:
+            if dim is not None and int(dim) > 0:
+                dim_by_seg[seg_id] = int(dim)
+        except (ValueError, TypeError):
+            continue
 
     if not dim_by_seg:
         return 0

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -849,6 +849,12 @@ def rebuild_index(
         raise
 
     _close_chroma_handles(palace_path, backend=backend)
+
+    # Patch any dim-None pickles written by chromadb 1.5.8's flush bug
+    # (#1492). Must run after close so mmap handles are released but before
+    # the function returns, so the next open doesn't quarantine the fresh index.
+    _repair_dim_none_pickles(palace_path, collection_name, progress=progress)
+
     _vacuum_and_rebuild_fts5(palace_path, progress=progress)
 
     print(f"\n  Repair complete. {filed} drawers rebuilt.")
@@ -1327,6 +1333,87 @@ def _close_chroma_handles(palace_path: str, backend: "ChromaBackend | None" = No
     except Exception:
         pass
     gc.collect()
+
+
+def _repair_dim_none_pickles(palace_path: str, collection_name: str, progress=print) -> int:
+    """Patch any dim-None index_metadata.pickle files left by the chromadb 1.5.8 flush bug.
+
+    After ``_rebuild_collection_via_temp`` completes, chromadb may have written
+    ``dimensionality: None`` into the segment pickle (chroma-core/chroma#6949).
+    This function reads the true dimension from ``chroma.sqlite3``'s
+    ``collections.dimension`` column and rewrites each affected pickle atomically.
+
+    Returns the number of pickles patched.
+    """
+    import pickle
+
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return 0
+
+    # Collect segment dimensions for this collection from sqlite.
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            rows = conn.execute(
+                """
+                SELECT s.id, c.dimension
+                FROM segments s
+                JOIN collections c ON s.collection = c.id
+                WHERE c.name = ? AND s.scope = 'VECTOR'
+                """,
+                (collection_name,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return 0
+
+    dim_by_seg: dict[str, int] = {}
+    for seg_id, dim in rows:
+        if dim is not None and int(dim) > 0:
+            dim_by_seg[seg_id] = int(dim)
+
+    if not dim_by_seg:
+        return 0
+
+    patched = 0
+    try:
+        entries = os.listdir(palace_path)
+    except OSError:
+        return 0
+
+    for name in entries:
+        if name not in dim_by_seg:
+            continue
+        seg_dir = os.path.join(palace_path, name)
+        meta_path = os.path.join(seg_dir, "index_metadata.pickle")
+        if not os.path.isfile(meta_path):
+            continue
+        try:
+            with open(meta_path, "rb") as f:
+                data = pickle.load(f)  # noqa: S301
+            dim = dim_by_seg[name]
+            if isinstance(data, dict):
+                if data.get("dimensionality") == dim:
+                    continue  # already correct
+                data["dimensionality"] = dim
+            else:
+                if getattr(data, "dimensionality", None) == dim:
+                    continue
+                data.dimensionality = dim
+            tmp = meta_path + ".tmp"
+            with open(tmp, "wb") as f:
+                pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
+            os.replace(tmp, meta_path)
+            patched += 1
+            progress(
+                f"  Patched dim-None pickle in {name}: set dimensionality={dim} "
+                "(chromadb 1.5.8 checkpoint bug)"
+            )
+        except Exception:
+            progress(f"  WARNING: could not patch dim-None pickle in {name}; skipping")
+    return patched
 
 
 class MaxSeqIdVerificationError(RuntimeError):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -361,6 +361,70 @@ def test_rebuild_index_success(mock_backend_cls, mock_shutil, tmp_path):
 
 @patch("mempalace.repair.shutil")
 @patch("mempalace.repair.ChromaBackend")
+def test_rebuild_index_patches_dim_none_pickle(mock_backend_cls, mock_shutil, tmp_path):
+    """After rebuild, dim-None pickles in segments are patched to the correct dimension."""
+    import pickle as pickle_module
+
+    # Create a valid sqlite file with dimension metadata
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    with sqlite3.connect(sqlite_path) as conn:
+        conn.execute(
+            "CREATE TABLE collections(id INTEGER PRIMARY KEY, name TEXT, dimension INTEGER)"
+        )
+        conn.execute("CREATE TABLE segments(id TEXT PRIMARY KEY, collection INTEGER, scope TEXT)")
+        conn.execute(
+            "INSERT INTO collections(id, name, dimension) VALUES(1, 'mempalace_drawers', 1536)"
+        )
+        conn.execute(
+            "INSERT INTO segments(id, collection, scope) VALUES('seg-uuid-1', 1, 'VECTOR')"
+        )
+        conn.commit()
+
+    # Create a segment directory with a dim-None pickle
+    seg_dir = tmp_path / "seg-uuid-1"
+    seg_dir.mkdir()
+    pickle_path = seg_dir / "index_metadata.pickle"
+    with open(pickle_path, "wb") as f:
+        pickle_module.dump({"dimensionality": None, "other_key": "value"}, f)
+
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_col.get.return_value = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"wing": "a"}, {"wing": "b"}],
+    }
+
+    mock_new_col = MagicMock()
+    mock_new_col.count.return_value = 2
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 2
+    mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
+    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+
+    def _fake_copy2(src, dst):
+        with open(dst, "w") as handle:
+            handle.write("backup")
+
+    mock_shutil.copy2.side_effect = _fake_copy2
+
+    repair.rebuild_index(palace_path=str(tmp_path))
+
+    # Verify the pickle was patched
+    with open(pickle_path, "rb") as f:
+        patched_data = pickle_module.load(f)
+    assert patched_data["dimensionality"] == 1536
+    assert patched_data["other_key"] == "value"
+
+
+def test_repair_dim_none_pickles_skips_when_no_sqlite(tmp_path):
+    """When chroma.sqlite3 is absent, _repair_dim_none_pickles returns 0 without error."""
+    result = repair._repair_dim_none_pickles(str(tmp_path), "mempalace_drawers")
+    assert result == 0
+
+
+@patch("mempalace.repair.shutil")
+@patch("mempalace.repair.ChromaBackend")
 def test_rebuild_index_ignores_missing_temp_collection_at_start(
     mock_backend_cls, mock_shutil, tmp_path
 ):


### PR DESCRIPTION
## Summary

`rebuild_index` upserts vectors via chromadb's `new_col.upsert()`, which on chromadb 1.5.8 writes `index_metadata.pickle` with `dimensionality: None` at every sync-threshold flush (chroma-core/chroma#6949). After `_close_chroma_handles` returns, the on-disk pickle is invalid. On the next daemon open, `quarantine_invalid_hnsw_metadata` renames the segment to `*.corrupt-<ts>` — discarding the full rebuild output. The recovery tool was broken by construction: it produced output its own integrity gate immediately rejected.

## Reproduction

1. Run `mempalace repair rebuild` on a palace with >= 2 drawers.
2. Stop the daemon, restart it.
3. Without this fix: the just-rebuilt segment is quarantined; the index is empty again.
4. With this fix: the pickle has a valid `dimensionality`; the segment loads normally.

## Fix

New helper `_repair_dim_none_pickles` (`repair.py`, inserted before `MaxSeqIdVerificationError` at line 1332) walks the palace directory, matches segment UUIDs against `chroma.sqlite3`'s `segments -> collections.dimension` join, and rewrites any pickle whose `dimensionality` is wrong or `None`. Called from `rebuild_index` at line 851 (after `_close_chroma_handles`, before function return) so the repair runs once per rebuild with a clear progress line.

`pickle` import added to `repair.py`'s import block; `sqlite3` was already imported.

## Test plan
- [x] `python -m pytest tests/test_repair.py -v -k "rebuild_index or dim_none"` — 84 passed (2 new)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean