### PR TITLE
fix(mcp): upgrade stdio UTF-8 reconfigure to errors=strict and cover stderr (#1488)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -3481,10 +3481,19 @@ def main():
     # defaults stdin/stdout to the system codepage (e.g. cp1251), which
     # corrupts non-ASCII payloads and surfaces as generic -32000 errors on
     # Cyrillic/CJK content. See PEP 540.
-    for stream in (sys.stdin, sys.stdout, sys.stderr):
+    # stdin uses surrogateescape so a malformed byte from a redirected file
+    # or misbehaving client survives as a lone surrogate instead of raising
+    # UnicodeDecodeError and killing the read loop. stdout/stderr use strict
+    # because everything written there is server-controlled JSON-RPC; encode
+    # failures are real bugs the operator wants loud. See mempalace/_stdio.py.
+    for stream, errors in (
+        (sys.stdin, "surrogateescape"),
+        (sys.stdout, "strict"),
+        (sys.stderr, "strict"),
+    ):
         if hasattr(stream, "reconfigure"):
             try:
-                stream.reconfigure(encoding="utf-8", errors="strict")
+                stream.reconfigure(encoding="utf-8", errors=errors)
             except (AttributeError, OSError):
                 pass
     logger.info("MemPalace MCP Server starting...")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2135,7 +2135,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
     now = datetime.now()
     entry_id = (
         f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_"
-        f"{hashlib.sha256(entry.encode()).hexdigest()[:12]}"
+        f"{hashlib.sha256(entry.encode('utf-8')).hexdigest()[:12]}"
     )
 
     _wal_log(
@@ -3481,10 +3481,10 @@ def main():
     # defaults stdin/stdout to the system codepage (e.g. cp1251), which
     # corrupts non-ASCII payloads and surfaces as generic -32000 errors on
     # Cyrillic/CJK content. See PEP 540.
-    for stream in (sys.stdin, sys.stdout):
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
         if hasattr(stream, "reconfigure"):
             try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
+                stream.reconfigure(encoding="utf-8", errors="strict")
             except (AttributeError, OSError):
                 pass
     logger.info("MemPalace MCP Server starting...")

--- a/tests/test_mcp_stdio_protection.py
+++ b/tests/test_mcp_stdio_protection.py
@@ -81,3 +81,71 @@ def test_mcp_server_no_stdout_noise_on_clean_exit():
     assert proc.stdout == b"", (
         f"stdout must be empty before the first JSON-RPC response, but got: {proc.stdout!r}"
     )
+
+
+def test_main_reconfigures_all_streams_to_utf8_strict():
+    """Verify that main() reconfigures stdin, stdout, and stderr with
+    encoding='utf-8' and errors='strict' to handle non-ASCII content."""
+    code = textwrap.dedent(
+        """
+        import sys
+        from unittest.mock import Mock, patch, MagicMock
+
+        reconfigure_calls = []
+
+        def make_reconfigure(stream_name):
+            def reconfigure(**kwargs):
+                reconfigure_calls.append((stream_name, kwargs))
+            return reconfigure
+
+        # Create fake stream objects with reconfigure methods
+        fake_stdin = MagicMock()
+        fake_stdout = MagicMock()
+        fake_stderr = MagicMock()
+
+        fake_stdin.reconfigure = make_reconfigure('stdin')
+        fake_stdout.reconfigure = make_reconfigure('stdout')
+        fake_stderr.reconfigure = make_reconfigure('stderr')
+
+        # Mock readline to return empty on first call (which causes main loop to exit)
+        fake_stdin.readline = Mock(return_value='')
+
+        from mempalace import mcp_server
+
+        # Patch _REAL_STDOUT so that _restore_stdout() will restore to our fake
+        with patch.object(mcp_server, '_REAL_STDOUT', fake_stdout), \
+             patch.object(mcp_server.sys, 'stdin', fake_stdin), \
+             patch.object(mcp_server.sys, 'stdout', fake_stdout), \
+             patch.object(mcp_server.sys, 'stderr', fake_stderr), \
+             patch.object(mcp_server, '_start_idle_exit_watchdog', return_value=None), \
+             patch.object(mcp_server, '_maybe_eager_warmup_embedder', return_value=None), \
+             patch.object(mcp_server, '_refresh_vector_disabled_flag', return_value=None):
+            mcp_server.main()
+
+        # Verify reconfigure was called on all three streams with correct args
+        expected_kwargs = {'encoding': 'utf-8', 'errors': 'strict'}
+        assert len(reconfigure_calls) == 3, (
+            f"Expected exactly 3 reconfigure calls, got {len(reconfigure_calls)}: {reconfigure_calls}"
+        )
+
+        stream_names = {call[0] for call in reconfigure_calls}
+        assert stream_names == {'stdin', 'stdout', 'stderr'}, (
+            f"Expected all three streams, got: {stream_names}"
+        )
+
+        for stream_name, kwargs in reconfigure_calls:
+            assert kwargs == expected_kwargs, (
+                f"Stream {stream_name}: expected {expected_kwargs}, got {kwargs}"
+            )
+
+        print("OK", file=sys.stderr)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"Test failed. stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )

--- a/tests/test_mcp_stdio_protection.py
+++ b/tests/test_mcp_stdio_protection.py
@@ -84,8 +84,9 @@ def test_mcp_server_no_stdout_noise_on_clean_exit():
 
 
 def test_main_reconfigures_all_streams_to_utf8_strict():
-    """Verify that main() reconfigures stdin, stdout, and stderr with
-    encoding='utf-8' and errors='strict' to handle non-ASCII content."""
+    """Verify that main() reconfigures stdio with per-stream error policies:
+    stdin uses surrogateescape (malformed bytes survive the read loop);
+    stdout and stderr use strict (server-controlled JSON-RPC, failures are bugs)."""
     code = textwrap.dedent(
         """
         import sys
@@ -123,7 +124,6 @@ def test_main_reconfigures_all_streams_to_utf8_strict():
             mcp_server.main()
 
         # Verify reconfigure was called on all three streams with correct args
-        expected_kwargs = {'encoding': 'utf-8', 'errors': 'strict'}
         assert len(reconfigure_calls) == 3, (
             f"Expected exactly 3 reconfigure calls, got {len(reconfigure_calls)}: {reconfigure_calls}"
         )
@@ -133,9 +133,18 @@ def test_main_reconfigures_all_streams_to_utf8_strict():
             f"Expected all three streams, got: {stream_names}"
         )
 
+        # Per-stream error policies: stdin uses surrogateescape so malformed
+        # bytes survive the read loop; stdout/stderr use strict because
+        # they carry server-controlled JSON-RPC and encode failures are bugs.
+        expected_per_stream = {
+            'stdin':  {'encoding': 'utf-8', 'errors': 'surrogateescape'},
+            'stdout': {'encoding': 'utf-8', 'errors': 'strict'},
+            'stderr': {'encoding': 'utf-8', 'errors': 'strict'},
+        }
         for stream_name, kwargs in reconfigure_calls:
-            assert kwargs == expected_kwargs, (
-                f"Stream {stream_name}: expected {expected_kwargs}, got {kwargs}"
+            expected = expected_per_stream[stream_name]
+            assert kwargs == expected, (
+                f"Stream {stream_name}: expected {expected}, got {kwargs}"
             )
 
         print("OK", file=sys.stderr)


### PR DESCRIPTION
## Summary
On Windows with a non-UTF-8 system locale (cp1252, cp1251, etc.), the MCP server's stdio streams default to the system codepage. Claude Desktop sends JSON-RPC over stdio in UTF-8; non-ASCII bytes (Cyrillic, CJK, accented Latin) arrive as lone surrogates under Python's `surrogateescape` handler. Any downstream `.encode()` call then raises `UnicodeEncodeError`, which the MCP layer wraps as `-32000 Internal tool error`.

The existing `reconfigure` call in `main()` addressed the root cause but used `errors="replace"` and omitted `sys.stderr`. This PR upgrades to `errors="strict"` and extends coverage to stderr, so a bad byte raises at the decode boundary with a clear traceable error rather than silently substituting U+FFFD. A bare `.encode()` at line 2138 (diary ID hash) is also upgraded to `.encode('utf-8')`.

## Fix
- `mcp_server.py:3484`: extend the stream loop to include `sys.stderr`; change `errors="replace"` to `errors="strict"`.
- `mcp_server.py:2138`: `entry.encode()` → `entry.encode('utf-8')`.
- `tests/test_mcp_stdio_protection.py`: add assertion that `main()` reconfigures all three standard streams with `encoding='utf-8'` and `errors='strict'`.

## Test plan
- [x] `python -m pytest tests/test_mcp_stdio_protection.py -v`
- [x] `python -m pytest tests/test_mcp_server.py -v`
