### PR TITLE
perf(mcp): cache HNSW divergence probe result with 30s TTL to avoid per-request I/O (#1471)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -406,7 +406,7 @@ def _refresh_vector_disabled_flag(*, force: bool = False) -> None:
     global _vector_disabled, _vector_disabled_reason, _vector_capacity_status
     global _vector_probe_last_run
     now = time.monotonic()
-    if not force and (now - _vector_probe_last_run) < _VECTOR_PROBE_TTL:
+    if not force and _vector_probe_last_run != 0.0 and (now - _vector_probe_last_run) < _VECTOR_PROBE_TTL:
         return
     if not _is_chroma_backend():
         _vector_disabled = False
@@ -418,6 +418,7 @@ def _refresh_vector_disabled_flag(*, force: bool = False) -> None:
         info = hnsw_capacity_status(_config.palace_path, _config.collection_name)
     except Exception:
         logger.debug("HNSW capacity probe raised", exc_info=True)
+        _vector_probe_last_run = now
         return
     _vector_capacity_status = info
     _vector_probe_last_run = now

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -353,7 +353,8 @@ def _force_chroma_cache_reset() -> None:
         _palace_db_inode, \
         _palace_db_mtime, \
         _metadata_cache, \
-        _metadata_cache_time
+        _metadata_cache_time, \
+        _vector_probe_last_run
     _client_cache = None
     _collection_cache = None
     _collection_cache_backend = None
@@ -363,6 +364,7 @@ def _force_chroma_cache_reset() -> None:
     _palace_db_mtime = 0.0
     _metadata_cache = None
     _metadata_cache_time = 0
+    _vector_probe_last_run = 0.0
     try:
         from .palace import get_backend_for_palace
 
@@ -385,21 +387,32 @@ _vector_disabled_reason = ""
 # parsing happy — PEP 604 unions in annotations only became unconditional
 # at module-eval time in 3.10.
 _vector_capacity_status: Optional[dict] = None
+_vector_probe_last_run: float = 0.0
+_VECTOR_PROBE_TTL: float = 30.0
 
 
-def _refresh_vector_disabled_flag() -> None:
+def _refresh_vector_disabled_flag(*, force: bool = False) -> None:
     """Re-run the HNSW capacity probe and update the module-level flag.
 
     Called from :func:`_get_client` whenever the client cache is rebuilt
     (first open or palace replacement). Cheap — pure sqlite + pickle
     read, no chromadb interaction. Never raises: a probe that crashes
     would defeat the point.
+
+    Uses a TTL gate (default 30s) to avoid per-request I/O for the probe.
+    Set ``force=True`` to bypass the TTL and re-run immediately (used
+    during reconnects).
     """
     global _vector_disabled, _vector_disabled_reason, _vector_capacity_status
+    global _vector_probe_last_run
+    now = time.monotonic()
+    if not force and (now - _vector_probe_last_run) < _VECTOR_PROBE_TTL:
+        return
     if not _is_chroma_backend():
         _vector_disabled = False
         _vector_disabled_reason = ""
         _vector_capacity_status = None
+        _vector_probe_last_run = now
         return
     try:
         info = hnsw_capacity_status(_config.palace_path, _config.collection_name)
@@ -407,6 +420,7 @@ def _refresh_vector_disabled_flag() -> None:
         logger.debug("HNSW capacity probe raised", exc_info=True)
         return
     _vector_capacity_status = info
+    _vector_probe_last_run = now
     if info.get("diverged"):
         if not _vector_disabled:
             logger.warning(
@@ -565,7 +579,7 @@ def _get_client():
         # if the index is severely undersized, segment load can segfault
         # the whole MCP server (#1222). The probe is pure sqlite +
         # metadata read; never touches the HNSW binary files.
-        _refresh_vector_disabled_flag()
+        _refresh_vector_disabled_flag(force=True)
         if inode_changed or mtime_changed:
             ChromaBackend._quarantined_paths.discard(_config.palace_path)
         _client_cache = ChromaBackend.make_client(_config.palace_path)
@@ -2393,7 +2407,8 @@ def tool_reconnect():
         _palace_db_inode, \
         _palace_db_mtime, \
         _vector_disabled, \
-        _vector_disabled_reason
+        _vector_disabled_reason, \
+        _vector_probe_last_run
     from . import palace as palace_module
 
     close_errors = []
@@ -2453,6 +2468,7 @@ def tool_reconnect():
     _collection_open_error = None
     _palace_db_inode = 0
     _palace_db_mtime = 0.0
+    _vector_probe_last_run = 0.0
     ChromaBackend._quarantined_paths.discard(_config.palace_path)
     # Force probe re-run on next _get_client by clearing the flag now;
     # _refresh_vector_disabled_flag will re-set it if the divergence

--- a/tests/test_hnsw_capacity.py
+++ b/tests/test_hnsw_capacity.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import pickle
 import sqlite3
+import time
 
 import pytest
 
@@ -640,3 +641,80 @@ def test_tool_status_via_sqlite_returns_breakdown(palace_with_drawers, monkeypat
     # ops×2 (incident + repair runbook), design×1 (metaphor).
     assert out["wings"].get("ops") == 2
     assert out["wings"].get("design") == 1
+
+
+# ── Divergence probe TTL caching (#1471) ─────────────────────────────
+
+
+class TestDivergenceProbeTTL:
+    """Test that the HNSW divergence probe runs once per TTL window, not per-request."""
+
+    def test_probe_not_repeated_within_ttl(self, tmp_path, monkeypatch):
+        """Probe should not run again within the TTL window."""
+        from mempalace import mcp_server
+
+        seg = "seg-ttl-cache"
+        _seed_chroma_db(str(tmp_path), sqlite_count=1000, segment_id=seg)
+        _write_pickle(str(tmp_path), seg, hnsw_count=950)
+
+        class _Cfg:
+            palace_path = str(tmp_path)
+            collection_name = "mempalace_drawers"
+
+        # Track how many times hnsw_capacity_status is called
+        call_count = [0]
+        original_probe = mcp_server.hnsw_capacity_status
+
+        def tracked_probe(palace_path, collection_name):
+            call_count[0] += 1
+            return original_probe(palace_path, collection_name)
+
+        # Mock _is_chroma_backend to return True
+        monkeypatch.setattr(mcp_server, "_config", _Cfg())
+        monkeypatch.setattr(mcp_server, "hnsw_capacity_status", tracked_probe)
+        monkeypatch.setattr(mcp_server, "_is_chroma_backend", lambda: True)
+        # Reset probe timing state
+        monkeypatch.setattr(mcp_server, "_vector_probe_last_run", 0.0)
+
+        # First call should run the probe
+        mcp_server._refresh_vector_disabled_flag()
+        assert call_count[0] == 1
+
+        # Second call within TTL should not run the probe
+        mcp_server._refresh_vector_disabled_flag()
+        assert call_count[0] == 1
+
+    def test_force_bypasses_ttl(self, tmp_path, monkeypatch):
+        """force=True should bypass TTL and re-run the probe immediately."""
+        from mempalace import mcp_server
+
+        seg = "seg-ttl-force"
+        _seed_chroma_db(str(tmp_path), sqlite_count=1000, segment_id=seg)
+        _write_pickle(str(tmp_path), seg, hnsw_count=950)
+
+        class _Cfg:
+            palace_path = str(tmp_path)
+            collection_name = "mempalace_drawers"
+
+        # Track how many times hnsw_capacity_status is called
+        call_count = [0]
+        original_probe = mcp_server.hnsw_capacity_status
+
+        def tracked_probe(palace_path, collection_name):
+            call_count[0] += 1
+            return original_probe(palace_path, collection_name)
+
+        # Mock _is_chroma_backend to return True
+        monkeypatch.setattr(mcp_server, "_config", _Cfg())
+        monkeypatch.setattr(mcp_server, "hnsw_capacity_status", tracked_probe)
+        monkeypatch.setattr(mcp_server, "_is_chroma_backend", lambda: True)
+        # Set probe time to now (within TTL)
+        monkeypatch.setattr(mcp_server, "_vector_probe_last_run", time.monotonic())
+
+        # First call without force should not run (within TTL)
+        mcp_server._refresh_vector_disabled_flag()
+        assert call_count[0] == 0
+
+        # Second call with force=True should run despite being within TTL
+        mcp_server._refresh_vector_disabled_flag(force=True)
+        assert call_count[0] == 1


### PR DESCRIPTION
## Summary
`_refresh_vector_disabled_flag()` is called on every search request with no result caching. Each call runs `hnsw_capacity_status()` — a sqlite `COUNT(*)` plus a pickle file read. On a 173k-drawer palace in a divergence-positive state, this per-request I/O caused 30-60s search latency while non-search endpoints responded in under 20ms.

This PR adds a 30-second TTL guard so the probe re-runs at most once per 30 seconds under normal operation. A `force=True` parameter bypasses the TTL for `_get_client()` (cache rebuild) and `tool_reconnect()` (post-repair).

## Fix
- Add `_vector_probe_last_run` and `_VECTOR_PROBE_TTL = 30.0` module-level constants.
- Guard `_refresh_vector_disabled_flag()` with `time.monotonic()` check; add `force: bool = False` kwarg.
- `_get_client()` and `tool_reconnect()` call with `force=True`.
- Reset `_vector_probe_last_run = 0.0` on palace path change.

## Test plan
- [x] `python -m pytest tests/test_hnsw_capacity.py -v` (29 passed including 2 new TTL tests)
- [x] `python -m pytest tests/test_mcp_server.py -v`
