### PR TITLE
feat(mcp): index KG triples in ChromaDB to make them searchable (#376)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1051,9 +1051,10 @@ def tool_status():
 PALACE_PROTOCOL = """IMPORTANT — MemPalace Memory Protocol:
 1. ON WAKE-UP: Call mempalace_status to load palace overview + AAAK spec.
 2. BEFORE RESPONDING about any person, project, or past event: call mempalace_kg_query or mempalace_search FIRST. Never guess — verify.
-3. IF UNSURE about a fact (name, gender, age, relationship): say "let me check" and query the palace. Wrong is worse than slow.
-4. AFTER EACH SESSION: call mempalace_diary_write to record what happened, what you learned, what matters.
-5. WHEN FACTS CHANGE: call mempalace_kg_invalidate on the old fact, mempalace_kg_add for the new one.
+3. FOR FACTS YOU KNOW EXIST BUT CAN'T RECALL EXACTLY: use mempalace_kg_search to find triples by semantic similarity.
+4. IF UNSURE about a fact (name, gender, age, relationship): say "let me check" and query the palace. Wrong is worse than slow.
+5. AFTER EACH SESSION: call mempalace_diary_write to record what happened, what you learned, what matters.
+6. WHEN FACTS CHANGE: call mempalace_kg_invalidate on the old fact, mempalace_kg_add for the new one.
 
 This protocol ensures the AI KNOWS before it speaks. Storage is not memory — but storage + this protocol = memory."""
 
@@ -1990,6 +1991,27 @@ def tool_kg_query(entity: str, as_of: str = None, direction: str = "both"):
     return {"entity": entity, "as_of": as_of, "facts": results, "count": len(results)}
 
 
+def _kg_synthetic_doc(subject: str, predicate: str, obj: str, triple_id: str) -> tuple[str, dict]:
+    """Create a synthetic document for KG triple indexing in ChromaDB.
+
+    Converts a triple into searchable text + metadata for semantic search.
+    The text is a simple humanized form: 'Subject predicate_name Object'.
+    Metadata preserves the exact KG identifiers for reconstruction.
+    """
+    pred_human = predicate.replace("_", " ")
+    doc = f"{subject} {pred_human} {obj}"
+    meta = {
+        "wing": "kg",
+        "room": "triples",
+        "ingest_mode": "kg",
+        "kg_triple_id": triple_id,
+        "kg_subject": subject,
+        "kg_predicate": predicate,
+        "kg_object": obj,
+    }
+    return doc, meta
+
+
 def tool_kg_add(
     subject: str,
     predicate: str,
@@ -2044,6 +2066,16 @@ def tool_kg_add(
             source_drawer_id=source_drawer_id,
         )
     )
+
+    # Index triple in ChromaDB for semantic search.
+    try:
+        col = _get_collection(create=True)
+        if col:
+            doc, meta = _kg_synthetic_doc(subject, predicate, object, triple_id)
+            col.upsert(documents=[doc], ids=[triple_id], metadatas=[meta])
+    except Exception as _kg_idx_err:
+        logger.warning("kg_add: failed to index triple in ChromaDB: %s", _kg_idx_err)
+
     return {"success": True, "triple_id": triple_id, "fact": f"{subject} → {predicate} → {object}"}
 
 
@@ -2099,6 +2131,60 @@ def tool_kg_timeline(entity: str = None):
 def tool_kg_stats():
     """Knowledge graph overview: entities, triples, relationship types."""
     return _call_kg(lambda kg: kg.stats())
+
+
+def tool_kg_search(query: str, limit: int = 10):
+    """Semantic search over knowledge graph triples.
+
+    Use when you know a fact exists but can't remember the exact entity name
+    or relationship type. Returns matching triples with similarity scores.
+
+    Args:
+        query: Natural language search query (e.g., "who did swimming", "Alice parent")
+        limit: Maximum number of results to return (1-50, default 10)
+
+    Returns:
+        Dict with query, result count, and matched triples with similarity scores.
+    """
+    try:
+        sanitized = sanitize_query(query)
+        clean_query = sanitized.get("clean_query", "")
+        if not clean_query:
+            return {"error": "Query is empty after sanitization"}
+        limit = max(1, min(50, int(limit)))
+    except (ValueError, TypeError) as e:
+        return {"error": f"Invalid limit: {e}"}
+
+    try:
+        results = search_memories(
+            clean_query,
+            palace_path=_config.palace_path,
+            wing="kg",
+            room="triples",
+            n_results=limit,
+        )
+    except Exception as e:
+        return {"error": f"Search failed: {str(e)}", "results": []}
+
+    if "error" in results:
+        return results
+
+    hits = []
+    for result in results.get("results", []):
+        # Each result is a dict with text, wing, room, similarity, distance, etc.
+        # KG triple documents have the format: "subject predicate_human object"
+        # and are tagged with wing="kg", room="triples" in the index.
+        if result.get("wing") == "kg" and result.get("room") == "triples":
+            text = result.get("text", "")
+            hits.append(
+                {
+                    "text": text,
+                    "similarity": result.get("similarity", 0),
+                    "distance": result.get("distance", 0),
+                }
+            )
+
+    return {"query": clean_query, "results": hits, "count": len(hits)}
 
 
 # ==================== AGENT DIARY ====================
@@ -2630,6 +2716,27 @@ TOOLS = {
         "description": "Knowledge graph overview: entities, triples, current vs expired facts, relationship types.",
         "input_schema": {"type": "object", "properties": {}},
         "handler": tool_kg_stats,
+    },
+    "mempalace_kg_search": {
+        "description": "Semantic search over knowledge graph triples. Use when you know a fact exists but can't remember the exact entity name.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Semantic search query",
+                    "maxLength": 250,
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (default 10)",
+                    "minimum": 1,
+                    "maximum": 50,
+                },
+            },
+            "required": ["query"],
+        },
+        "handler": tool_kg_search,
     },
     "mempalace_traverse": {
         "description": "Walk the palace graph from a room. Shows connected ideas across wings — the tunnels. Like following a thread through the palace: start at 'chromadb-setup' in wing_code, discover it connects to wing_myproject (planning) and wing_user (feelings about it).",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2145,6 +2145,8 @@ def tool_kg_search(query: str, limit: int = 10):
 
     Returns:
         Dict with query, result count, and matched triples with similarity scores.
+        Each result includes triple_id, subject, predicate, object, and similarity.
+        Invalidated facts (valid_to IS NOT NULL in SQLite) are excluded.
     """
     try:
         sanitized = sanitize_query(query)
@@ -2155,35 +2157,66 @@ def tool_kg_search(query: str, limit: int = 10):
     except (ValueError, TypeError) as e:
         return {"error": f"Invalid limit: {e}"}
 
+    col = _get_collection()
+    if not col:
+        return _collection_error_or_no_palace()
+
     try:
-        results = search_memories(
-            clean_query,
-            palace_path=_config.palace_path,
-            wing="kg",
-            room="triples",
+        raw = col.query(
+            query_texts=[clean_query],
             n_results=limit,
+            where={"$and": [{"wing": "kg"}, {"room": "triples"}]},
+            include=["metadatas", "documents", "distances"],
         )
     except Exception as e:
         return {"error": f"Search failed: {str(e)}", "results": []}
 
-    if "error" in results:
-        return results
+    ids = raw.get("ids", [[]])[0]
+    if not ids:
+        return {"query": clean_query, "results": [], "count": 0}
 
-    hits = []
-    for result in results.get("results", []):
-        # Each result is a dict with text, wing, room, similarity, distance, etc.
-        # KG triple documents have the format: "subject predicate_human object"
-        # and are tagged with wing="kg", room="triples" in the index.
-        if result.get("wing") == "kg" and result.get("room") == "triples":
-            text = result.get("text", "")
-            hits.append(
-                {
-                    "text": text,
-                    "similarity": result.get("similarity", 0),
-                    "distance": result.get("distance", 0),
-                }
+    metadatas = raw.get("metadatas", [[]])[0]
+    distances = raw.get("distances", [[]])[0]
+    metric = _metric_for_collection(col)
+
+    # Collect triple_ids that appear active in ChromaDB metadata
+    candidates = []
+    for i, _doc_id in enumerate(ids):
+        meta = _safe_meta(metadatas[i] if i < len(metadatas) else None)
+        triple_id = meta.get("kg_triple_id", "")
+        if not triple_id:
+            continue
+        dist = distances[i] if i < len(distances) else 1.0
+        similarity = round(_distance_to_similarity(dist, metric), 3)
+        candidates.append(
+            {
+                "triple_id": triple_id,
+                "subject": meta.get("kg_subject", ""),
+                "predicate": meta.get("kg_predicate", ""),
+                "object": meta.get("kg_object", ""),
+                "similarity": similarity,
+            }
+        )
+
+    if not candidates:
+        return {"query": clean_query, "results": [], "count": 0}
+
+    # Verify each triple is still active (valid_to IS NULL) in SQLite
+    triple_ids = [c["triple_id"] for c in candidates]
+    placeholders = ",".join("?" * len(triple_ids))
+    active_ids = _call_kg(
+        lambda kg: {
+            row["id"]
+            for row in kg._conn()
+            .execute(
+                f"SELECT id FROM triples WHERE id IN ({placeholders}) AND valid_to IS NULL",
+                triple_ids,
             )
+            .fetchall()
+        }
+    )
 
+    hits = [c for c in candidates if c["triple_id"] in active_ids]
     return {"query": clean_query, "results": hits, "count": len(hits)}
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2220,6 +2220,58 @@ class TestKGTools:
             assert "count" in result
             assert isinstance(result["count"], int)
 
+    def test_kg_search_returns_structured_triples(self, monkeypatch, config, palace_path, kg):
+        """tool_kg_search returns structured triple fields, not raw text."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        try:
+            from mempalace.mcp_server import tool_kg_add, tool_kg_search
+
+            result = tool_kg_add(subject="Alice", predicate="does", object="swimming")
+            assert result["success"] is True
+
+            search = tool_kg_search("Alice swimming", limit=5)
+            assert "results" in search
+            assert "count" in search
+            if search["count"] > 0:
+                hit = search["results"][0]
+                assert "triple_id" in hit
+                assert "subject" in hit
+                assert "predicate" in hit
+                assert "object" in hit
+                assert "similarity" in hit
+                # Must not be raw text blob — structured fields must be non-empty strings
+                assert isinstance(hit["subject"], str)
+                assert isinstance(hit["predicate"], str)
+                assert isinstance(hit["object"], str)
+        finally:
+            _client.delete_collection("mempalace_drawers")
+            _client.close()
+
+    def test_kg_search_excludes_invalidated_facts(self, monkeypatch, config, palace_path, kg):
+        """tool_kg_search filters out triples that have been invalidated."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        try:
+            from mempalace.mcp_server import tool_kg_add, tool_kg_invalidate, tool_kg_search
+
+            # Add and then invalidate a triple
+            add_result = tool_kg_add(subject="Bob", predicate="works_at", object="OldCo")
+            assert add_result["success"] is True
+            triple_id = add_result["triple_id"]
+
+            inv_result = tool_kg_invalidate(subject="Bob", predicate="works_at", object="OldCo")
+            assert inv_result["success"] is True
+
+            # The invalidated triple must not appear in search results
+            search = tool_kg_search("Bob works at OldCo", limit=10)
+            assert "results" in search
+            returned_ids = [r["triple_id"] for r in search["results"]]
+            assert triple_id not in returned_ids
+        finally:
+            _client.delete_collection("mempalace_drawers")
+            _client.close()
+
 
 # ── Diary Tools ─────────────────────────────────────────────────────────
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2142,6 +2142,84 @@ class TestKGTools:
         assert "valid_from" in result["error"]
         assert "YYYY-MM-DDTHH:MM:SSZ" in result["error"]
 
+    # --- KG Search (issue #376) ---
+
+    def test_kg_synthetic_doc_creates_humanized_text(self, monkeypatch, config, palace_path, kg):
+        """_kg_synthetic_doc converts predicate underscores to spaces."""
+        from mempalace.mcp_server import _kg_synthetic_doc
+
+        doc, meta = _kg_synthetic_doc("Alice", "child_of", "Bob", "t_alice_child_of_bob_xyz")
+        assert doc == "Alice child of Bob"
+        assert meta["wing"] == "kg"
+        assert meta["room"] == "triples"
+        assert meta["kg_subject"] == "Alice"
+        assert meta["kg_predicate"] == "child_of"
+        assert meta["kg_object"] == "Bob"
+        assert meta["kg_triple_id"] == "t_alice_child_of_bob_xyz"
+
+    def test_kg_add_indexes_triple_in_chromadb(self, monkeypatch, config, palace_path, kg):
+        """tool_kg_add attempts to upsert the triple into ChromaDB."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, col = _get_collection(palace_path, create=True)
+        try:
+            from mempalace.mcp_server import tool_kg_add
+
+            result = tool_kg_add(
+                subject="Max",
+                predicate="does",
+                object="swimming",
+                valid_from="2025-01-01",
+            )
+            assert result["success"] is True
+            triple_id = result["triple_id"]
+
+            # Verify the triple was indexed in ChromaDB
+            docs = col.get(ids=[triple_id], include=["documents", "metadatas"])
+            assert len(docs["ids"]) == 1
+            assert docs["documents"][0] == "Max does swimming"
+            assert docs["metadatas"][0]["kg_subject"] == "Max"
+            assert docs["metadatas"][0]["kg_predicate"] == "does"
+            assert docs["metadatas"][0]["kg_object"] == "swimming"
+        finally:
+            _client.delete_collection("mempalace_drawers")
+            _client.close()
+
+    def test_kg_search_cleans_query_before_search(self, monkeypatch, config, palace_path, kg):
+        """tool_kg_search sanitizes the query input."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_kg_search
+
+        # Search with an empty query should return error
+        result = tool_kg_search("")
+        assert "error" in result
+
+    def test_kg_search_limit_parameter_bounds_results(self, monkeypatch, config, palace_path, kg):
+        """tool_kg_search enforces limit bounds (1-50)."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_kg_search
+
+        # Limit too high is clamped to 50; empty result is ok
+        result = tool_kg_search("nonexistent query", limit=200)
+        assert isinstance(result, dict)
+
+        # Limit too low is raised to 1; empty result is ok
+        result = tool_kg_search("another query", limit=0)
+        assert isinstance(result, dict)
+
+    def test_kg_search_returns_expected_format(self, monkeypatch, config, palace_path, kg):
+        """tool_kg_search returns results in expected format."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_kg_search
+
+        result = tool_kg_search("some query", limit=5)
+        assert "query" in result or "error" in result
+        if "query" in result:
+            assert "results" in result
+            assert "count" in result
+            assert isinstance(result["count"], int)
+
 
 # ── Diary Tools ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
`mempalace_search` and `kg_query` are completely disconnected: KG triples exist only in SQLite and are invisible to semantic search unless you remember the exact entity name. This PR closes the gap by auto-indexing a synthetic natural-language document in ChromaDB whenever a triple is added, and adds a `mempalace_kg_search` tool that queries those synthetic docs semantically — so "swimming lessons" finds `Max loves swimming` without knowing the exact entity names.

## Changes
- `mcp_server.py`: `tool_kg_add` now upserts a synthetic document `"{subject} {predicate_human} {object}"` into ChromaDB after the SQLite write. ChromaDB failures are caught and logged as warnings.
- `mcp_server.py`: adds `tool_kg_search(query, limit)` that calls `search_memories` with `wing="kg"`, `room="triples"` and returns triple-shaped results with similarity scores.
- `mcp_server.py`: registers `mempalace_kg_search` in the TOOLS dict. Updates system prompt guidance.
- `tests/test_mcp_server.py`: 5 new tests for synthetic doc format, ChromaDB indexing, query sanitization, limit bounds, and result format.

## Test plan
- [x] `python -m pytest tests/test_knowledge_graph.py tests/test_mcp_server.py -v` (226 passed, 3 skipped)
- [x] `python -m pytest tests/ -v`
