### PR TITLE
fix(backends): accept zero-byte link_lists.bin for small all-layer-0 HNSW indexes (#1716)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -82,10 +82,14 @@ def _hnsw_link_to_data_ratio(seg_dir: str) -> Optional[float]:
 def _hnsw_link_lists_is_usable_for_payload(seg_dir: str) -> bool:
     """Return False when a non-trivial HNSW payload lacks usable link lists.
 
-    A missing or empty link_lists.bin is acceptable only for a fresh/empty
-    segment. Once data_level0.bin has real payload, a zero-byte link_lists.bin
-    is not a harmless async-flush shape: ChromaDB can later hand the broken
-    graph to hnswlib and crash in native code.
+    A missing or empty link_lists.bin is acceptable for:
+    - a fresh/empty segment (data_level0.bin trivially small), or
+    - a small index where all elements sit on HNSW layer 0 (hnswlib
+      legitimately serializes an empty link_lists.bin in this case).
+
+    For larger segments, a zero-byte link_lists.bin indicates an
+    interrupted persist — ChromaDB can crash in native code if it
+    hands the broken graph to hnswlib.
     """
     data_path = os.path.join(seg_dir, "data_level0.bin")
     link_path = os.path.join(seg_dir, "link_lists.bin")
@@ -98,7 +102,16 @@ def _hnsw_link_lists_is_usable_for_payload(seg_dir: str) -> bool:
         if data_size <= _HNSW_MISSING_METADATA_DATA_FLOOR:
             return True
 
-        return os.path.isfile(link_path) and os.path.getsize(link_path) > 0
+        link_exists = os.path.isfile(link_path)
+        if link_exists and os.path.getsize(link_path) > 0:
+            return True
+
+        # Zero-byte or missing link_lists: acceptable for small indexes
+        # where an all-layer-0 HNSW graph is expected.
+        if data_size <= _HNSW_ZERO_LINK_LISTS_DATA_CEIL:
+            return True
+
+        return False
     except OSError:
         return False
 
@@ -145,6 +158,14 @@ _HNSW_BLOAT_GUARD = {
 # when data is trivially small) and _missing_dimensionality_appears_recoverable
 # (don't attempt recovery on segments with negligible data).
 _HNSW_MISSING_METADATA_DATA_FLOOR = 1024
+
+# Below this data_level0.bin size, a zero-byte link_lists.bin is plausible:
+# all elements landed on HNSW layer 0, which is the expected shape for small
+# indexes (hnswlib only serializes link lists for elements with level > 0).
+# 512 KB covers ~200 elements at 384-dim / M=16, well within the all-layer-0
+# probability envelope.  Above this threshold a zero-byte link_lists.bin is
+# treated as a failed persist and flagged as unusable.
+_HNSW_ZERO_LINK_LISTS_DATA_CEIL = 512 * 1024
 
 
 def _validate_where(where: Optional[dict]) -> None:

--- a/tests/test_hnsw_payload_health.py
+++ b/tests/test_hnsw_payload_health.py
@@ -114,12 +114,16 @@ def test_quarantine_leaves_reasonable_payload_in_place(tmp_path):
 
 
 def test_segment_health_rejects_zero_byte_link_lists_with_payload(tmp_path):
-    """Regression #1457: real HNSW payload with empty link_lists.bin is corrupt."""
+    """Regression #1457: real HNSW payload with empty link_lists.bin is corrupt.
+
+    Uses data_size > _HNSW_ZERO_LINK_LISTS_DATA_CEIL so the segment is large
+    enough that an all-layer-0 HNSW graph is implausible.
+    """
     seg_dir = tmp_path / "11111111-2222-3333-4444-555555555555"
 
     _write_segment(
         seg_dir,
-        data_size=2_000,
+        data_size=1_000_000,  # > 512 KB, so zero-byte link_lists is suspicious
         link_size=0,
         write_metadata=True,
     )
@@ -128,7 +132,11 @@ def test_segment_health_rejects_zero_byte_link_lists_with_payload(tmp_path):
 
 
 def test_quarantine_catches_zero_byte_link_lists_when_stale(tmp_path):
-    """Regression #1457: stale segments with empty link_lists.bin are quarantined."""
+    """Regression #1457: stale segments with empty link_lists.bin are quarantined.
+
+    Uses data_size > _HNSW_ZERO_LINK_LISTS_DATA_CEIL so the segment is large
+    enough that an all-layer-0 HNSW graph is implausible.
+    """
     palace = tmp_path / "palace"
     palace.mkdir()
 
@@ -138,7 +146,7 @@ def test_quarantine_catches_zero_byte_link_lists_when_stale(tmp_path):
     seg_dir = palace / "11111111-2222-3333-4444-555555555555"
     _write_segment(
         seg_dir,
-        data_size=2_000,
+        data_size=1_000_000,  # > 512 KB, so zero-byte link_lists is suspicious
         link_size=0,
         write_metadata=True,
     )
@@ -156,3 +164,53 @@ def test_quarantine_catches_zero_byte_link_lists_when_stale(tmp_path):
     moved_path = Path(moved[0])
     assert moved_path.exists()
     assert moved_path.name.startswith("11111111-2222-3333-4444-555555555555.drift-")
+
+
+def test_segment_health_accepts_zero_byte_link_lists_for_small_index(tmp_path):
+    """Issue #1716: small all-layer-0 HNSW indexes legitimately have zero-byte link_lists.
+
+    When data_size <= _HNSW_ZERO_LINK_LISTS_DATA_CEIL, a zero-byte link_lists.bin
+    is plausible for an index where all elements landed on layer 0.
+    """
+    seg_dir = tmp_path / "11111111-2222-3333-4444-555555555555"
+
+    _write_segment(
+        seg_dir,
+        data_size=300_000,  # < 512 KB, so all-layer-0 is expected
+        link_size=0,
+        write_metadata=True,
+    )
+
+    assert _segment_appears_healthy(str(seg_dir))
+
+
+def test_quarantine_leaves_small_zero_byte_link_lists_in_place(tmp_path):
+    """Issue #1716: small segments with zero-byte link_lists are not quarantined.
+
+    When data_size <= _HNSW_ZERO_LINK_LISTS_DATA_CEIL, the segment is left
+    in place even if mtime drifts and link_lists.bin is zero-byte.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    db_path = palace / "chroma.sqlite3"
+    db_path.write_text("sqlite placeholder")
+
+    seg_dir = palace / "11111111-2222-3333-4444-555555555555"
+    _write_segment(
+        seg_dir,
+        data_size=300_000,  # < 512 KB, so all-layer-0 is expected
+        link_size=0,
+        write_metadata=True,
+    )
+
+    hnsw_time = 1_700_000_000
+    sqlite_time = hnsw_time + 1_000
+    os.utime(seg_dir / "data_level0.bin", (hnsw_time, hnsw_time))
+    os.utime(db_path, (sqlite_time, sqlite_time))
+
+    moved = quarantine_stale_hnsw(str(palace), stale_seconds=300)
+
+    # Segment should not be quarantined.
+    assert moved == []
+    assert seg_dir.exists()


### PR DESCRIPTION
## Summary

Small HNSW indexes where all elements land on layer 0 legitimately produce a 0-byte `link_lists.bin` (hnswlib only serializes link data for elements with level > 0). The health check `_hnsw_link_lists_is_usable_for_payload()` unconditionally treated this as corruption, triggering a quarantine on every cold start. Since self-repair rebuilds the segment in the same shape, the quarantine re-fired each session, accumulating `.drift-*` directories in a self-perpetuating loop.

## Fix

Introduce `_HNSW_ZERO_LINK_LISTS_DATA_CEIL` (512 KB). When `data_level0.bin` is below this ceiling, a zero-byte `link_lists.bin` is accepted as a valid all-layer-0 graph rather than flagged as an interrupted persist. The 512 KB threshold covers ~200 elements at typical embedding dimensions (384-dim, M=16), well within the statistical envelope where all elements on layer 0 is expected. Above the threshold, the existing corruption detection is unchanged.

## Test plan
- [x] `python -m pytest tests/test_hnsw_payload_health.py -v`
- [ ] `python -m pytest tests/ -v`
- [x] Verified: small segment (data < 512 KB) with 0-byte link_lists is not quarantined
- [x] Verified: large segment (data > 512 KB) with 0-byte link_lists is still quarantined when stale