### PR TITLE
fix(mcp): return error on idempotency check failure instead of falling through to upsert (#1712)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1462,8 +1462,13 @@ def tool_add_drawer(
         existing = col.get(ids=idempotency_probe_ids, include=[])
         if existing.ids:
             return {"success": True, "reason": "already_exists", "drawer_id": drawer_id}
-    except Exception:
-        logger.debug("Idempotency pre-check failed for %s", idempotency_probe_ids, exc_info=True)
+    except Exception as e:
+        logger.warning(
+            "Idempotency pre-check failed for %s; refusing write to protect index integrity",
+            idempotency_probe_ids,
+            exc_info=True,
+        )
+        return {"success": False, "error": f"idempotency check failed: {e}"}
 
     try:
         if len(content) <= chunk_size:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1766,6 +1766,36 @@ class TestWriteTools:
         assert deleted_logical["success"] is False
         assert "not found" in deleted_logical["error"].lower()
 
+    def test_add_drawer_returns_error_on_idempotency_check_failure(self, monkeypatch, config, kg):
+        """When idempotency pre-check raises (e.g., corrupt HNSW index),
+        tool_add_drawer must return success: False without calling
+        col.upsert. The index is never written to when the read path is
+        unhealthy, preventing unbounded sparse-file growth from repeated
+        upserts on a stressed or partially-corrupt graph."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        class _FakeGetResult:
+            ids = []
+
+        upsert_called = []
+
+        class _FakeCol:
+            def get(self, ids=None, **kwargs):
+                # Simulate idempotency check failure
+                raise RuntimeError("HNSW index under stress; seek drift in link_lists.bin")
+
+            def upsert(self, **kwargs):
+                upsert_called.append(True)
+                return None
+
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda create=False: _FakeCol())
+
+        result = mcp_server.tool_add_drawer("w", "r", "test content")
+        assert result["success"] is False
+        assert "idempotency check failed" in result["error"]
+        assert len(upsert_called) == 0, "upsert must not be called when idempotency check fails"
+
 
 # ── KG Tools ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`tool_add_drawer()` swallowed exceptions from the idempotency pre-check (`col.get()`) and fell through to `col.upsert()`. When the HNSW index was under stress, each swallowed exception led to a duplicate write that compounded seek drift in `link_lists.bin`, producing unbounded sparse-file growth (reported: 9.6 TB logical / 575 GB real after ~10k sessions).

## Fix

The `except Exception` block at `mcp_server.py:1445` now returns `{"success": False, "error": "idempotency check failed: {e}"}` instead of silently continuing. Log level upgraded from `debug` to `warning`. The caller sees the failure and can retry; the HNSW index is never written to when the read path is unhealthy.

This is a two-line change. The existing `_HNSW_BLOAT_GUARD` (batch/sync thresholds) helps defer flushes but does not protect against the exception-swallow path; both fixes together close the loop.

## Test plan
- [x] `python -m pytest tests/test_mcp_server.py -v -k idempotency`
- [ ] `python -m pytest tests/ -v`
- [x] Verified: when `col.get()` raises, `tool_add_drawer` returns `success: False` without calling `col.upsert`
- [x] Verified: normal add and idempotency-hit paths are unchanged