### PR TITLE
feat(antigravity): add recall skill, optional rule, shared protocol

### DIFF
--- a/.antigravity-plugin/README.md
+++ b/.antigravity-plugin/README.md
@@ -13,8 +13,12 @@ This directory is the source of truth for what gets installed at
 ├── mcp_config.json        # auto-registers the mempalace-mcp stdio server
 ├── hooks.json.tmpl        # template — installer renders to hooks.json
 ├── skills/
-│   └── mempalace/
-│       └── SKILL.md       # the in-plugin skill discovered by Antigravity
+│   ├── mempalace/
+│   │   └── SKILL.md       # ops skill: setup, mine, status, CLI delegation
+│   └── mempalace-recall/
+│       └── SKILL.md       # recall-only skill: search-before-answer protocol
+├── rules/
+│   └── mempalace-recall.md # optional recall rule (complements the skill)
 └── README.md              # this file
 ```
 
@@ -22,6 +26,35 @@ The hook scripts themselves live at `hooks/antigravity/`. The installer
 copies them into `<install-dir>/hooks/` and renders `hooks.json.tmpl`
 into a `hooks.json` whose `command` paths point at the absolute install
 location.
+
+## Three recall layers
+
+MemPalace can store everything, but it only helps if the agent actually
+*reads* the palace before answering. Three layers wire that in, from
+eager to on-demand:
+
+1. **Wake hook** (`hooks/antigravity/mempal_wake_hook_antigravity.sh`,
+   `PreInvocation` event, gated to `invocationNum == 1`). On the first
+   model call of a conversation it runs `mempalace wake-up` and injects
+   the **actual palace content verbatim** via Antigravity's
+   `injectSteps[].ephemeralMessage` output. This is Antigravity's native
+   equivalent of Cursor's `sessionStart` `additional_context`, except it
+   delivers the memory itself rather than a directive to go fetch it.
+2. **Recall skill** (`skills/mempalace-recall/SKILL.md`). The
+   search-before-answer protocol the agent follows when a turn is
+   recall-relevant — tool selection, unhappy paths, anti-patterns. It
+   covers recall only; the `mempalace` skill covers setup / mine /
+   status.
+3. **Optional recall rule** (`rules/mempalace-recall.md`). A lightweight
+   markdown rule that nudges the agent to search before answering when
+   Antigravity's matcher decides the turn is recall-relevant. It is
+   deliberately recall-scoped (not an always-on global rule) so it never
+   adds latency to greenfield work, honouring MemPalace's "memory should
+   feel instant" budget.
+
+All three point to the single canonical protocol in
+[`integrations/shared/recall-protocol.md`](../integrations/shared/recall-protocol.md)
+so the skill and rule never drift.
 
 ## Install
 

--- a/.antigravity-plugin/rules/mempalace-recall.md
+++ b/.antigravity-plugin/rules/mempalace-recall.md
@@ -1,0 +1,18 @@
+# MemPalace recall
+
+Before answering anything that may already be in the user's memory
+palace — past work, prior decisions, a person, a project, or "what did
+we do / decide / discuss last time?" — search the palace first:
+
+1. Call `mempalace_search` with a short keyword query. Use
+   `mempalace_kg_query` for relational or time-bound facts.
+2. Quote the drawer's **verbatim** text. Never summarize or paraphrase
+   stored content.
+3. If results are empty, say so — do not invent an answer. If the MCP
+   server is unavailable, surface the error; do not fall back to guessing.
+
+Skip recall for pure greenfield work with no memory relevance (renaming
+a variable, fixing a typo). Recall is question-driven, not reflexive.
+
+Full protocol: <https://github.com/MemPalace/mempalace/blob/main/integrations/shared/recall-protocol.md>. Deeper guidance:
+the `mempalace-recall` skill.

--- a/.antigravity-plugin/skills/mempalace-recall/SKILL.md
+++ b/.antigravity-plugin/skills/mempalace-recall/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: mempalace-recall
+description: "Recall protocol for MemPalace — search the palace before answering about past work, people, projects, or prior decisions. Apply when the user asks what was decided, what happened before, who someone is, what was discussed last time, or anything that may already be filed in their memory palace; or when mempalace-recall is invoked. Complements the mempalace setup skill and requires the mempalace-mcp server."
+---
+
+# MemPalace Recall
+
+Search-before-answer protocol for MemPalace. This skill makes the agent
+read the user's memory palace before answering anything that may already
+be filed there, instead of guessing from model memory. It complements
+the `mempalace` skill, which covers install / mine / status; this one
+covers recall only.
+
+## Step 0 — Verify MemPalace is available
+
+Before relying on recall, confirm MemPalace is installed and reachable:
+
+- Official release page: <https://github.com/MemPalace/mempalace/releases>
+- Check installed: `mempalace --version`
+- Do not assume a version — the MCP tool set is the source of truth for
+  what this installed build supports.
+
+If the `mempalace_*` MCP tools are not available, tell the user the
+server is not connected and point them at the `mempalace` skill to set
+it up. Do not silently fall back to answering from model memory.
+
+## Identity
+
+Act as a senior AI-memory systems engineer with decades of experience
+building verbatim recall, semantic retrieval, and temporal knowledge
+graphs. Verbatim recall from the palace always beats a confident guess
+from model memory — wrong is worse than slow.
+
+## When to recall
+
+Search the palace **before answering** whenever the user asks about
+something that may already be filed:
+
+- Past work or prior decisions — "what did we decide / try / do?"
+- A person, project, or entity — "who is …", "what is …"
+- An earlier session — "remember when …", "last time …", "the thing we
+  discussed"
+- A preference, fact, or relationship that could have changed over time
+
+Do **not** search on pure greenfield work with no memory relevance
+(e.g. "rename this variable", "fix this typo"). Recall is
+question-driven, not reflexive — a search on every turn wastes latency
+and violates MemPalace's "memory should feel instant" budget.
+
+## Protocol
+
+1. On wake-up, the MemPalace PreInvocation hook injects verbatim palace
+   content via `injectSteps[].ephemeralMessage` on the first model call
+   of a conversation. If memory was injected, start from it before
+   searching further.
+2. Before responding about people / projects / past events / prior
+   decisions: call `mempalace_search` first. Use `mempalace_kg_query`
+   for relational or time-bound facts.
+3. If unsure about a fact: say "let me check the palace" and query.
+4. Return the drawer's **verbatim** text. Never summarize or paraphrase
+   stored content — quoting the exact words is the point of the system.
+5. After a substantive session, record continuity with
+   `mempalace_diary_write` (skip if a background hook already saved).
+6. When a fact changes: `mempalace_kg_invalidate` the old fact, then
+   `mempalace_kg_add` the new one.
+
+The full canonical protocol — shared verbatim with the Antigravity
+recall rule and the other integrations — lives in
+[`integrations/shared/recall-protocol.md`](https://github.com/MemPalace/mempalace/blob/main/integrations/shared/recall-protocol.md).
+
+## Tool selection
+
+| You need | Tool |
+|---|---|
+| Find any memory by meaning | `mempalace_search` (start here) |
+| Relational / time-bound facts about an entity | `mempalace_kg_query` |
+| The chronological story of an entity | `mempalace_kg_timeline` |
+| Recent session continuity | `mempalace_diary_read` |
+| Which wings / rooms exist (scope unknown) | `mempalace_list_wings`, `mempalace_list_rooms` |
+| Record this session | `mempalace_diary_write` |
+
+`mempalace_search` takes a short natural-language `query` (keywords or a
+question — not a system prompt or pasted conversation) plus optional
+`wing` / `room` filters and `limit` (default 5).
+
+## Unhappy paths
+
+- **Empty results.** Say the palace has nothing on this; do not invent an
+  answer. Offer to widen the search (drop the `wing` filter) or to file
+  the new information.
+- **MCP error / server down.** Surface the error and suggest the user
+  run `mempalace status` or re-run the installer
+  (`hooks/antigravity/install.sh`). Never fall back to guessing.
+- **Conflicting facts.** Trust the knowledge graph's time-valid answer;
+  invalidate-then-add rather than overwriting silently.
+
+## Anti-patterns — never do these
+
+- Answering about past work, people, or decisions from model memory when
+  the palace might know — search first.
+- Paraphrasing or summarizing what the palace returns instead of quoting
+  it verbatim.
+- Searching on every turn, including greenfield tasks with no memory
+  relevance.
+- Pasting the whole conversation or a system prompt into the `query`
+  argument — keep queries short and keyword-driven.
+
+## Official References
+
+- MemPalace: <https://github.com/MemPalace/mempalace>
+- MemPalace releases: <https://github.com/MemPalace/mempalace/releases>
+- Antigravity documentation: <https://antigravity.google/docs>
+- Agent Skills specification: <https://agentskills.io/specification>

--- a/.antigravity-plugin/skills/mempalace-recall/SKILL.md
+++ b/.antigravity-plugin/skills/mempalace-recall/SKILL.md
@@ -53,16 +53,20 @@ and violates MemPalace's "memory should feel instant" budget.
    content via `injectSteps[].ephemeralMessage` on the first model call
    of a conversation. If memory was injected, start from it before
    searching further.
-2. Before responding about people / projects / past events / prior
-   decisions: call `mempalace_search` first. Use `mempalace_kg_query`
-   for relational or time-bound facts.
-3. If unsure about a fact: say "let me check the palace" and query.
-4. Return the drawer's **verbatim** text. Never summarize or paraphrase
-   stored content — quoting the exact words is the point of the system.
-5. After a substantive session, record continuity with
-   `mempalace_diary_write` (skip if a background hook already saved).
-6. When a fact changes: `mempalace_kg_invalidate` the old fact, then
-   `mempalace_kg_add` the new one.
+2. **Before responding** about people, projects, past events, or prior
+   decisions: call `mempalace_search` first. For relational or temporal
+   facts ("who reported to whom in March", "what was true then"), call
+   `mempalace_kg_query` instead or as well.
+3. **If unsure** about a fact (name, age, relationship, preference): say
+   "let me check the palace" and query. Wrong is worse than slow.
+4. **Return verbatim.** Quote the drawer's exact stored words. Never
+   summarize, paraphrase, or lossy-compress what the palace returns —
+   that is the whole point of the system.
+5. **After a substantive session**, record continuity with
+   `mempalace_diary_write` (background hooks may already do this — do not
+   double-file).
+6. **When a fact changes**, call `mempalace_kg_invalidate` on the old
+   fact, then `mempalace_kg_add` for the new one.
 
 The full canonical protocol — shared verbatim with the Antigravity
 recall rule and the other integrations — lives in
@@ -86,23 +90,25 @@ question — not a system prompt or pasted conversation) plus optional
 ## Unhappy paths
 
 - **Empty results.** Say the palace has nothing on this; do not invent an
-  answer. Offer to widen the search (drop the `wing` filter) or to file
-  the new information.
-- **MCP error / server down.** Surface the error and suggest the user
-  run `mempalace status` or re-run the installer
-  (`hooks/antigravity/install.sh`). Never fall back to guessing.
-- **Conflicting facts.** Trust the knowledge graph's time-valid answer;
-  invalidate-then-add rather than overwriting silently.
+  answer to fill the gap. Offer to widen the search (drop the wing
+  filter) or to file the new information.
+- **MCP unavailable / tool error.** Surface the error plainly and suggest
+  the user verify the server (`mempalace status`, or re-run the
+  installer `hooks/antigravity/install.sh`). Do not silently fall back
+  to guessing from model memory.
+- **Stale or conflicting facts.** Prefer the knowledge graph's
+  time-valid answer; if a fact has changed, invalidate the old one and
+  add the new one rather than overwriting context silently.
 
 ## Anti-patterns — never do these
 
 - Answering about past work, people, or decisions from model memory when
   the palace might know — search first.
-- Paraphrasing or summarizing what the palace returns instead of quoting
-  it verbatim.
-- Searching on every turn, including greenfield tasks with no memory
-  relevance.
-- Pasting the whole conversation or a system prompt into the `query`
+- Paraphrasing or summarizing stored content instead of quoting it
+  verbatim.
+- Searching reflexively on every turn, including pure greenfield coding
+  with no memory relevance.
+- Pasting the full conversation or a system prompt into the `query`
   argument — keep queries short and keyword-driven.
 
 ## Official References

--- a/hooks/antigravity/install.sh
+++ b/hooks/antigravity/install.sh
@@ -305,6 +305,8 @@ log info "install dir: $INSTALL_DIR"
 # ── Install: directories ─────────────────────────────────────────────
 run mkdir -p "$INSTALL_DIR" \
     "$INSTALL_DIR/skills/mempalace" \
+    "$INSTALL_DIR/skills/mempalace-recall" \
+    "$INSTALL_DIR/rules" \
     "$INSTALL_DIR/hooks" \
     "$INSTALL_DIR/hooks/lib"
 
@@ -313,9 +315,22 @@ copy_file "$PLUGIN_SRC/plugin.json"     "$INSTALL_DIR/plugin.json"
 copy_file "$PLUGIN_SRC/mcp_config.json" "$INSTALL_DIR/mcp_config.json"
 copy_file "$PLUGIN_SRC/README.md"       "$INSTALL_DIR/README.md"
 
-# ── Install: skill (real file, no symlinks at the discovery path) ────
+# ── Install: skills (real files, no symlinks at the discovery path) ──
 copy_file "$PLUGIN_SRC/skills/mempalace/SKILL.md" \
     "$INSTALL_DIR/skills/mempalace/SKILL.md"
+copy_file "$PLUGIN_SRC/skills/mempalace-recall/SKILL.md" \
+    "$INSTALL_DIR/skills/mempalace-recall/SKILL.md"
+
+# ── Install: optional recall rule ────────────────────────────────────
+#
+# Antigravity discovers markdown rules under the plugin's rules/
+# directory. This one is recall-only and intentionally lightweight —
+# it complements the mempalace-recall skill. Shipping it as a plugin
+# rule (not an always-on global rule) keeps it scoped to recall-
+# relevant turns, honouring MemPalace's "memory should feel instant"
+# budget.
+copy_file "$PLUGIN_SRC/rules/mempalace-recall.md" \
+    "$INSTALL_DIR/rules/mempalace-recall.md"
 
 # ── Install: hooks ───────────────────────────────────────────────────
 copy_file "$HOOKS_SRC/lib/common.sh"                    "$INSTALL_DIR/hooks/lib/common.sh"

--- a/integrations/shared/recall-protocol.md
+++ b/integrations/shared/recall-protocol.md
@@ -1,0 +1,92 @@
+# MemPalace Recall Protocol
+
+The canonical "search before answering" protocol shared across every
+MemPalace integration (Cursor, Antigravity, Claude Code, Codex,
+OpenClaw). This file is the single source of truth — skills and rules
+should link here rather than restating the protocol, so the rule never
+drifts from the skill.
+
+The protocol exists to honour MemPalace's foundational promise:
+**100% recall, verbatim, never guess.** When the palace might hold the
+answer, the agent must read the palace before answering from model
+memory.
+
+## When to recall
+
+Search the palace **before answering** whenever the user asks about
+anything that may already be filed:
+
+- Past work, prior decisions, or "what did we do / decide / try?"
+- A person, project, or entity ("who is …", "what is …")
+- Something that happened in an earlier session ("remember when …",
+  "last time …", "the thing we discussed")
+- A preference, fact, or relationship that could have changed over time
+
+If the question is pure greenfield work with no memory relevance (e.g.
+"rename this variable", "fix this typo"), do not search — recall is
+question-driven, not reflexive.
+
+## The protocol
+
+1. **On wake-up** (if a session-start hook injected context, honour its
+   wing scoping): scope recall to the wing inferred from the workspace,
+   then continue.
+2. **Before responding** about people, projects, past events, or prior
+   decisions: call `mempalace_search` first. For relational or temporal
+   facts ("who reported to whom in March", "what was true then"), call
+   `mempalace_kg_query` instead or as well.
+3. **If unsure** about a fact (name, age, relationship, preference): say
+   "let me check the palace" and query. Wrong is worse than slow.
+4. **Return verbatim.** Quote the drawer's exact stored words. Never
+   summarize, paraphrase, or lossy-compress what the palace returns —
+   that is the whole point of the system.
+5. **After a substantive session**, record continuity with
+   `mempalace_diary_write` (background hooks may already do this — do not
+   double-file).
+6. **When a fact changes**, call `mempalace_kg_invalidate` on the old
+   fact, then `mempalace_kg_add` for the new one.
+
+## Tool selection
+
+| You need | Tool |
+|---|---|
+| Find any memory by meaning | `mempalace_search` (start here) |
+| Relational / time-bound facts about an entity | `mempalace_kg_query` |
+| The chronological story of an entity | `mempalace_kg_timeline` |
+| Recent session continuity | `mempalace_diary_read` |
+| Which wings / rooms exist (when scope unknown) | `mempalace_list_wings`, `mempalace_list_rooms` |
+| Record this session | `mempalace_diary_write` |
+
+`mempalace_search` takes a short natural-language `query` (keywords or a
+question — not a system prompt or pasted conversation) plus optional
+`wing` / `room` filters and `limit` (default 5).
+
+## Unhappy paths
+
+- **Empty results.** Say the palace has nothing on this; do not invent an
+  answer to fill the gap. Offer to widen the search (drop the wing
+  filter) or to file the new information.
+- **MCP unavailable / tool error.** Surface the error plainly and suggest
+  the user verify the server (`mempalace status`, or re-run install).
+  Do not silently fall back to guessing from model memory.
+- **Stale or conflicting facts.** Prefer the knowledge graph's
+  time-valid answer; if a fact has changed, invalidate the old one and
+  add the new one rather than overwriting context silently.
+
+## Anti-patterns
+
+- Answering about past work, people, or decisions from model memory when
+  the palace might know — search first.
+- Paraphrasing or summarizing stored content instead of quoting it
+  verbatim.
+- Searching reflexively on every turn, including pure greenfield coding
+  with no memory relevance.
+- Pasting the full conversation or a system prompt into the `query`
+  argument — keep queries short and keyword-driven.
+
+## See also
+
+- [`integrations/openclaw/SKILL.md`](../openclaw/SKILL.md) — the original
+  full-protocol skill this is distilled from.
+- MemPalace design principles (verbatim, local-first, never summarize):
+  <https://github.com/MemPalace/mempalace>

--- a/tests/test_antigravity_plugin_manifest.py
+++ b/tests/test_antigravity_plugin_manifest.py
@@ -34,6 +34,15 @@ HOOKS_TMPL = PLUGIN_DIR / "hooks.json.tmpl"
 SKILL_MD = PLUGIN_DIR / "skills" / "mempalace" / "SKILL.md"
 PLUGIN_README = PLUGIN_DIR / "README.md"
 
+# Recall layer (mirrors the Cursor branch's recall skill + rule + shared protocol)
+RECALL_SKILL_MD = PLUGIN_DIR / "skills" / "mempalace-recall" / "SKILL.md"
+RECALL_RULE_MD = PLUGIN_DIR / "rules" / "mempalace-recall.md"
+SHARED_PROTOCOL = REPO_ROOT / "integrations" / "shared" / "recall-protocol.md"
+INSTALL_SH = REPO_ROOT / "hooks" / "antigravity" / "install.sh"
+SHARED_PROTOCOL_REF = (
+    "https://github.com/MemPalace/mempalace/blob/main/integrations/shared/recall-protocol.md"
+)
+
 EXPECTED_HOOKS = {
     "Stop": {
         "script_basename": "mempal_save_hook_antigravity.sh",
@@ -226,3 +235,124 @@ def test_plugin_readme_present_and_substantive() -> None:
     # that drops the operational links.
     for needle in ("plugin.json", "mcp_config.json", "hooks.json"):
         assert needle in body, f"README.md must mention {needle}"
+
+
+# ── Recall layer: skill, rule, shared protocol ───────────────────────
+#
+# Mirrors the three-layer recall wiring added for Cursor on
+# feat/cursor-hooks-support, adapted for Antigravity's plugin surface.
+# The wake hook (PreInvocation) is the eager layer; these files are the
+# on-demand layers (skill + optional rule), both anchored to the single
+# canonical protocol so they can never drift.
+
+
+def test_shared_protocol_exists() -> None:
+    """The canonical recall protocol is the single source of truth.
+
+    The recall skill and rule both link here rather than restating the
+    protocol, so the rule can never drift from the skill.
+    """
+    assert SHARED_PROTOCOL.is_file(), f"missing: {SHARED_PROTOCOL}"
+    body = SHARED_PROTOCOL.read_text(encoding="utf-8")
+    assert "MemPalace Recall Protocol" in body, "shared protocol must carry its canonical title"
+
+
+def test_recall_skill_exists() -> None:
+    """The recall-only skill must be a real file at the discovery path."""
+    assert RECALL_SKILL_MD.is_file(), f"missing: {RECALL_SKILL_MD}"
+    assert not RECALL_SKILL_MD.is_symlink(), (
+        f"{RECALL_SKILL_MD} must be a real file, not a symlink — installers "
+        "that cp without -L would otherwise carry the symlink into the install."
+    )
+
+
+def test_recall_skill_has_required_frontmatter() -> None:
+    """The recall skill must carry YAML frontmatter with a non-empty description.
+
+    Antigravity's skill loader uses `description` for progressive
+    disclosure, exactly like the ops `mempalace` skill.
+    """
+    body = RECALL_SKILL_MD.read_text(encoding="utf-8")
+    assert body.startswith("---\n"), "recall SKILL.md must begin with YAML frontmatter"
+    end = body.find("\n---\n", 4)
+    assert end > 0, "recall SKILL.md frontmatter is missing the closing fence"
+    front = body[4:end]
+    desc_match = re.search(r"^description:\s*(.+)$", front, re.MULTILINE)
+    assert desc_match is not None, "recall SKILL.md frontmatter missing `description` key"
+    assert desc_match.group(1).strip(), "recall SKILL.md `description` is empty"
+
+
+def test_recall_skill_has_required_sections() -> None:
+    """The recall skill must carry the load-bearing protocol sections."""
+    body = RECALL_SKILL_MD.read_text(encoding="utf-8")
+    for section in (
+        "When to recall",
+        "Protocol",
+        "Tool selection",
+        "Unhappy paths",
+        "Anti-patterns",
+    ):
+        assert section in body, f"recall SKILL.md must contain a '{section}' section"
+
+
+def test_recall_skill_links_to_shared_protocol() -> None:
+    """The recall skill must defer to the canonical protocol, not restate it."""
+    body = RECALL_SKILL_MD.read_text(encoding="utf-8")
+    assert SHARED_PROTOCOL_REF in body, (
+        f"recall SKILL.md must reference {SHARED_PROTOCOL_REF} so the protocol stays single-sourced"
+    )
+
+
+def test_recall_rule_exists() -> None:
+    """The optional recall rule must be a real file under the plugin rules dir."""
+    assert RECALL_RULE_MD.is_file(), f"missing: {RECALL_RULE_MD}"
+    assert not RECALL_RULE_MD.is_symlink(), f"{RECALL_RULE_MD} must be a real file"
+
+
+def test_recall_rule_is_plain_markdown_not_mdc() -> None:
+    """Antigravity rules are plain `.md` with no YAML frontmatter.
+
+    Per https://antigravity.google/docs plugins use `rules/<name>.md`
+    (no `.mdc`, no Cursor-style `alwaysApply` frontmatter). Pin the
+    plain-markdown shape so nobody copies the Cursor `.mdc` verbatim.
+    """
+    assert RECALL_RULE_MD.suffix == ".md", "Antigravity rule must use the .md extension"
+    assert not (RECALL_RULE_MD.parent / "mempalace-recall.mdc").exists(), (
+        "an .mdc rule leaked in; Antigravity rules are plain .md"
+    )
+    body = RECALL_RULE_MD.read_text(encoding="utf-8")
+    assert not body.startswith("---"), (
+        "Antigravity rule must NOT carry YAML frontmatter (no Cursor-style "
+        "`alwaysApply`); it is plain markdown"
+    )
+
+
+def test_recall_rule_references_shared_protocol() -> None:
+    """The rule must point at the canonical protocol and the deeper skill."""
+    body = RECALL_RULE_MD.read_text(encoding="utf-8")
+    assert SHARED_PROTOCOL_REF in body, f"recall rule must reference {SHARED_PROTOCOL_REF}"
+
+
+def test_installer_creates_rules_dir() -> None:
+    """install.sh must create the skills/mempalace-recall and rules dirs."""
+    body = INSTALL_SH.read_text(encoding="utf-8")
+    assert '"$INSTALL_DIR/rules"' in body, "install.sh mkdir block must create the rules/ directory"
+    assert '"$INSTALL_DIR/skills/mempalace-recall"' in body, (
+        "install.sh mkdir block must create the skills/mempalace-recall/ directory"
+    )
+
+
+def test_installer_copies_recall_skill() -> None:
+    """install.sh must copy the recall skill into the install dir."""
+    body = INSTALL_SH.read_text(encoding="utf-8")
+    assert "skills/mempalace-recall/SKILL.md" in body, (
+        "install.sh must copy_file the mempalace-recall skill"
+    )
+
+
+def test_installer_copies_recall_rule() -> None:
+    """install.sh must copy the recall rule into the install dir."""
+    body = INSTALL_SH.read_text(encoding="utf-8")
+    assert "rules/mempalace-recall.md" in body, (
+        "install.sh must copy_file the mempalace-recall rule"
+    )


### PR DESCRIPTION
## Summary

Adds the recall layer to the Antigravity plugin, mirroring the three-layer wiring from `feat/cursor-hooks-support`, adapted for Antigravity's native plugin and hook surfaces. Follows on from #1633.

- **`integrations/shared/recall-protocol.md`** — canonical "search before answering" protocol, single source of truth shared across Cursor, Antigravity, Claude Code, Codex, OpenClaw. Skills and rules link here rather than restating the protocol, so they can never drift from each other.
- **`.antigravity-plugin/skills/mempalace-recall/SKILL.md`** — recall-only skill (Protocol, Tool selection, Unhappy paths, Anti-patterns). Complements the ops `mempalace` skill. Protocol cross-reference uses a GitHub URL rather than a relative file path, so the link works in the installed copy at `~/.gemini/config/plugins/mempalace/` as well as in the repo.
- **`.antigravity-plugin/rules/mempalace-recall.md`** — plain `.md` recall rule (no `.mdc`, no YAML frontmatter per Antigravity's `rules/<name>.md` format). Body mirrors the Cursor rule.
- **`hooks/antigravity/install.sh`** — creates `skills/mempalace-recall/` and `rules/` in the install directory; copies both new files (cmp-gated, idempotent). Verified: first run writes, second run is silent.
- **`.antigravity-plugin/README.md`** — updated layout tree + "Three recall layers" section (wake hook eager layer → recall skill on-demand layer → optional rule).
- **11 new tests** in `tests/test_antigravity_plugin_manifest.py` covering: shared protocol presence, recall skill structure (YAML frontmatter, required sections, GitHub URL reference), rule format (plain `.md`, no frontmatter), and installer lines.

## Why the wake hook is unchanged

The Antigravity wake hook (`PreInvocation`, `invocationNum==1`) already injects **actual palace content** via `injectSteps[].ephemeralMessage`. This is strictly better than Cursor's `sessionStart` approach of emitting a static "please call these tools" directive — it delivers the memory itself rather than asking the agent to go fetch it. No change needed.

## Test plan

- `uv run pytest tests/test_antigravity_plugin_manifest.py` — 22 tests (11 new), all pass
- `uv run pytest tests/ --ignore=tests/benchmarks` — 2349 passed, 3 skipped
- `bash hooks/antigravity/install.sh --dry-run` — shows correct `mkdir` + `copy_file` entries for recall skill and rule
- `bash hooks/antigravity/install.sh` then re-run — idempotent (no second-run writes)
- `uv run ruff check .` — clean

Made with [Cursor](https://cursor.com)