### PR TITLE
fix(hallways): scope hallway-file path to MempalaceConfig.palace_path (#1778)

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -333,6 +333,18 @@ class MempalaceConfig:
         return os.path.join(os.path.dirname(self.palace_path), "tunnels.json")
 
     @property
+    def hallway_file(self):
+        """Path to the hallway file, sibling of palace_path.
+
+        Mirrors ``tunnel_file`` so within-wing hallway state is scoped to the
+        configured palace and survives palace rebuilds (it does not live in
+        ChromaDB which can be recreated). Prior to this property the path was
+        hardcoded under ``~/.mempalace/hallways.json`` and multiple palaces on
+        one host silently shared one file (see ``hallways._legacy_hallway_file``).
+        """
+        return os.path.join(os.path.dirname(self.palace_path), "hallways.json")
+
+    @property
     def collection_name(self):
         """ChromaDB collection name."""
         return self._file_config.get("collection_name", DEFAULT_COLLECTION_NAME)

--- a/mempalace/hallways.py
+++ b/mempalace/hallways.py
@@ -46,13 +46,11 @@ from .dynamics import initialize_dynamics_fields
 
 logger = logging.getLogger("mempalace_hallways")
 
-# Persistence target. Mirrors ``palace_graph._get_tunnel_file`` (the 3.3.6
-# palace-scoped pattern) so the storage layout is uniform across the two
-# related primitives. Prefer the resolver functions below — the module-level
-# constant is kept only for legacy fallback detection and for tests that still
-# monkey-patch it directly via ``monkeypatch.setattr(hallways,
-# "_HALLWAY_FILE", tmp_path/...)``.
-_HALLWAY_FILE = os.path.join(os.path.expanduser("~"), ".mempalace", "hallways.json")
+# Persistence target is resolved through ``_get_hallway_file`` below, which
+# mirrors ``palace_graph._get_tunnel_file`` (the 3.3.6 palace-scoped pattern)
+# so the storage layout is uniform across the two related primitives. Tests
+# should monkey-patch ``_get_hallway_file`` and ``_legacy_hallway_file`` rather
+# than poking a module-level constant.
 
 _SCHEMA_VERSION = 1
 
@@ -97,9 +95,6 @@ def _load_hallways(config=None) -> list[dict]:
     clobbering newer data. Same posture as ``palace_graph._load_tunnels``.
     """
     current_hallway_file = _get_hallway_file(config)
-    # Honor direct monkey-patches of the module constant (used by older tests).
-    if _HALLWAY_FILE != _legacy_hallway_file():
-        current_hallway_file = _HALLWAY_FILE
     if os.path.exists(current_hallway_file):
         try:
             with open(current_hallway_file, encoding="utf-8") as f:
@@ -133,9 +128,6 @@ def _save_hallways(hallways: list[dict], config=None) -> None:
     not want world-readable.
     """
     hallway_file = _get_hallway_file(config)
-    # Honor direct monkey-patches of the module constant (used by older tests).
-    if _HALLWAY_FILE != _legacy_hallway_file():
-        hallway_file = _HALLWAY_FILE
     directory = os.path.dirname(hallway_file)
     os.makedirs(directory, exist_ok=True)
     payload = {

--- a/mempalace/hallways.py
+++ b/mempalace/hallways.py
@@ -46,9 +46,12 @@ from .dynamics import initialize_dynamics_fields
 
 logger = logging.getLogger("mempalace_hallways")
 
-# Persistence target. Mirrors ``palace_graph._TUNNEL_FILE`` so the storage
-# pattern is uniform across the two related primitives. Tests override
-# this via ``monkeypatch.setattr(hallways, "_HALLWAY_FILE", tmp_path/...)``.
+# Persistence target. Mirrors ``palace_graph._get_tunnel_file`` (the 3.3.6
+# palace-scoped pattern) so the storage layout is uniform across the two
+# related primitives. Prefer the resolver functions below — the module-level
+# constant is kept only for legacy fallback detection and for tests that still
+# monkey-patch it directly via ``monkeypatch.setattr(hallways,
+# "_HALLWAY_FILE", tmp_path/...)``.
 _HALLWAY_FILE = os.path.join(os.path.expanduser("~"), ".mempalace", "hallways.json")
 
 _SCHEMA_VERSION = 1
@@ -62,36 +65,78 @@ __all__ = [
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Persistence — JSON file at _HALLWAY_FILE, restricted perms (0600) on POSIX
+# Persistence — JSON file resolved from MempalaceConfig.hallway_file,
+# restricted perms (0600) on POSIX. Pre-3.3.6 behavior (hardcoded
+# ~/.mempalace/hallways.json) is kept only as a one-time orphan detection
+# fallback, matching the palace_graph tunnel-file migration pattern.
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _load_hallways() -> list[dict]:
-    """Read all hallway records. Returns ``[]`` if the file is missing or corrupt."""
-    if not os.path.exists(_HALLWAY_FILE):
+def _get_hallway_file(config=None) -> str:
+    """Return the path to the hallways.json file, derived from MempalaceConfig.palace_path."""
+    from .config import MempalaceConfig
+
+    config = config or MempalaceConfig()
+    return config.hallway_file
+
+
+def _legacy_hallway_file() -> str:
+    """The pre-palace-scoped hardcoded path. Kept only for one-time orphan detection."""
+    return os.path.join(os.path.expanduser("~"), ".mempalace", "hallways.json")
+
+
+def _load_hallways(config=None) -> list[dict]:
+    """Read all hallway records. Returns ``[]`` if the file is missing or corrupt.
+
+    Backwards-compatibility: prior to this migration the hallway file was
+    hardcoded at ``~/.mempalace/hallways.json`` regardless of the configured
+    palace_path. If the configured hallway file is missing but a legacy file
+    exists at a different path, log a one-line warning naming both paths so
+    users can move the file manually. We do NOT auto-migrate — auto-merging
+    hallway state across two locations is too magical for a bugfix and risks
+    clobbering newer data. Same posture as ``palace_graph._load_tunnels``.
+    """
+    current_hallway_file = _get_hallway_file(config)
+    # Honor direct monkey-patches of the module constant (used by older tests).
+    if _HALLWAY_FILE != _legacy_hallway_file():
+        current_hallway_file = _HALLWAY_FILE
+    if os.path.exists(current_hallway_file):
+        try:
+            with open(current_hallway_file, encoding="utf-8") as f:
+                raw = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            logger.debug("hallways: load failed, treating as empty", exc_info=True)
+            return []
+        if isinstance(raw, dict) and "hallways" in raw:
+            return raw.get("hallways") or []
+        if isinstance(raw, list):
+            return raw
         return []
-    try:
-        with open(_HALLWAY_FILE, encoding="utf-8") as f:
-            raw = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        logger.debug("hallways: load failed, treating as empty", exc_info=True)
-        return []
-    if isinstance(raw, dict) and "hallways" in raw:
-        return raw.get("hallways") or []
-    if isinstance(raw, list):
-        return raw
+
+    legacy = _legacy_hallway_file()
+    if legacy != current_hallway_file and os.path.exists(legacy):
+        logger.warning(
+            "Legacy hallways file at '%s' is being ignored; configured location is '%s'. "
+            "Move or copy the legacy file to the configured path to recover its hallways.",
+            legacy,
+            current_hallway_file,
+        )
     return []
 
 
-def _save_hallways(hallways: list[dict]) -> None:
-    """Atomically persist hallway records to _HALLWAY_FILE.
+def _save_hallways(hallways: list[dict], config=None) -> None:
+    """Atomically persist hallway records to the configured hallway file.
 
     Uses an os.replace temp-file dance so a crash mid-write doesn't
     corrupt the file. POSIX permission is restricted to 0600 because
     hallways reveal within-wing entity connections that the user may
     not want world-readable.
     """
-    directory = os.path.dirname(_HALLWAY_FILE)
+    hallway_file = _get_hallway_file(config)
+    # Honor direct monkey-patches of the module constant (used by older tests).
+    if _HALLWAY_FILE != _legacy_hallway_file():
+        hallway_file = _HALLWAY_FILE
+    directory = os.path.dirname(hallway_file)
     os.makedirs(directory, exist_ok=True)
     payload = {
         "schema_version": _SCHEMA_VERSION,
@@ -106,7 +151,7 @@ def _save_hallways(hallways: list[dict]) -> None:
         except OSError:
             # Non-POSIX systems may not support chmod; not fatal.
             pass
-        os.replace(tmp_path, _HALLWAY_FILE)
+        os.replace(tmp_path, hallway_file)
     except Exception:
         try:
             os.unlink(tmp_path)

--- a/tests/test_hallways.py
+++ b/tests/test_hallways.py
@@ -20,9 +20,18 @@ with patch.dict("sys.modules", {"chromadb": MagicMock()}):
 
 
 def _use_tmp_hallway_file(monkeypatch, tmp_path):
-    """Redirect hallway persistence to a per-test JSON file."""
+    """Redirect both the hallway-file resolver and the legacy-file check at the
+    tmp_path so existing tests stay in the configured-path branch and don't
+    accidentally trip the new legacy-file warning branch in _load_hallways.
+    Mirrors the analogous helper in ``tests/test_palace_graph_tunnels.py``.
+    """
     hallway_file = tmp_path / "hallways.json"
-    monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", str(hallway_file))
+    monkeypatch.setattr(hallways_mod, "_get_hallway_file", lambda *a, **kw: str(hallway_file))
+    monkeypatch.setattr(
+        hallways_mod,
+        "_legacy_hallway_file",
+        lambda: str(tmp_path / "legacy-hallways.json"),
+    )
     return hallway_file
 
 

--- a/tests/test_hallways_pagination.py
+++ b/tests/test_hallways_pagination.py
@@ -15,7 +15,13 @@ with patch.dict("sys.modules", {"chromadb": MagicMock()}):
 
 
 def _use_tmp_hallway_file(monkeypatch, tmp_path):
-    monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", str(tmp_path / "hallways.json"))
+    hallway_file = tmp_path / "hallways.json"
+    monkeypatch.setattr(hallways_mod, "_get_hallway_file", lambda *a, **kw: str(hallway_file))
+    monkeypatch.setattr(
+        hallways_mod,
+        "_legacy_hallway_file",
+        lambda: str(tmp_path / "legacy-hallways.json"),
+    )
 
 
 def _collection_that_rejects_where_get(drawers):

--- a/tests/test_hallways_palace_scoped.py
+++ b/tests/test_hallways_palace_scoped.py
@@ -74,7 +74,6 @@ class TestLegacyHallwayFileDetection:
 
         # Point the module constant at the patched-legacy path so the
         # back-compat shim treats it as "legacy, defer to resolver".
-        monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", str(legacy))
         monkeypatch.setattr(hallways_mod, "_get_hallway_file", lambda *a, **kw: str(configured))
         monkeypatch.setattr(hallways_mod, "_legacy_hallway_file", lambda: str(legacy))
 
@@ -90,7 +89,6 @@ class TestLegacyHallwayFileDetection:
         we must not emit a misleading 'legacy file ignored' warning when the
         file simply doesn't exist yet."""
         same = tmp_path / "hallways.json"
-        monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", str(same))
         monkeypatch.setattr(hallways_mod, "_get_hallway_file", lambda *a, **kw: str(same))
         monkeypatch.setattr(hallways_mod, "_legacy_hallway_file", lambda: str(same))
 
@@ -136,7 +134,6 @@ class TestMultiPalaceIsolation:
 
         # Force the module constant to match the (default) legacy path so the
         # back-compat shim doesn't override the resolver.
-        monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", hallways_mod._legacy_hallway_file())
 
         monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace_a))
         hallways_mod._save_hallways(

--- a/tests/test_hallways_palace_scoped.py
+++ b/tests/test_hallways_palace_scoped.py
@@ -1,0 +1,157 @@
+"""Tests for the palace-scoped hallway-file migration.
+
+The pre-3.4 hallway store was hardcoded at ``~/.mempalace/hallways.json``
+regardless of the configured ``palace_path``, so two palaces on one host
+silently shared one file. This file covers the migration: ``hallways.py``
+now resolves the path through ``MempalaceConfig.hallway_file`` (sibling of
+``palace_path``), mirroring the 3.3.6 tunnel-file migration in
+``palace_graph._get_tunnel_file``.
+
+Style and structure mirror ``tests/test_palace_graph_tunnels.py``'s
+analogous coverage for tunnels (orphaned-legacy warning, same-path
+no-warning, palace_path-follows behavior).
+"""
+
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+with patch.dict("sys.modules", {"chromadb": MagicMock()}):
+    from mempalace import hallways as hallways_mod
+    from mempalace.config import DEFAULT_PALACE_PATH, MempalaceConfig
+
+
+# =============================================================================
+# Resolver: MempalaceConfig.hallway_file + _get_hallway_file
+# =============================================================================
+
+
+class TestHallwayFileResolution:
+    def test_default_hallway_file_is_sibling_of_default_palace(self):
+        cfg = MempalaceConfig()
+        expected = os.path.join(os.path.dirname(DEFAULT_PALACE_PATH), "hallways.json")
+        assert cfg.hallway_file == expected
+        assert hallways_mod._get_hallway_file(cfg) == expected
+
+    def test_hallway_file_follows_palace_path(self, tmp_path):
+        """Custom palace_path → hallway sits beside the palace, not at the
+        hardcoded legacy location."""
+        custom_dir = tmp_path / "custom-palace"
+        cfg = MempalaceConfig(config_dir=tmp_path)
+        cfg._file_config["palace_path"] = str(custom_dir)
+        assert cfg.hallway_file == str(tmp_path / "hallways.json")
+        assert hallways_mod._get_hallway_file(cfg) == str(tmp_path / "hallways.json")
+
+    def test_palace_env_var_redirects_hallway_file(self, tmp_path, monkeypatch):
+        """MEMPALACE_PALACE_PATH must redirect the hallway file too."""
+        custom_palace = tmp_path / "envpalace" / "palace"
+        monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(custom_palace))
+        cfg = MempalaceConfig()
+        assert cfg.hallway_file == str(tmp_path / "envpalace" / "hallways.json")
+
+
+# =============================================================================
+# Orphan detection: legacy file present, configured file missing
+# =============================================================================
+
+
+class TestLegacyHallwayFileDetection:
+    def test_load_hallways_warns_on_orphaned_legacy_file(self, tmp_path, monkeypatch, caplog):
+        """When the configured hallway file is missing but a legacy file
+        exists at a different path, _load_hallways logs a one-line warning
+        naming both paths and returns []. Critically, it does NOT
+        auto-migrate — silent merging risks clobbering newer data."""
+        configured = tmp_path / "configured" / "hallways.json"
+        legacy = tmp_path / "legacy" / "hallways.json"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text(
+            '{"schema_version": 1, "hallways": ['
+            '{"id":"orphan","wing":"a","entity_a":"Alice",'
+            '"entity_b":"Bob","co_occurrence_count":2,"rooms":["r"]}'
+            "]}",
+            encoding="utf-8",
+        )
+
+        # Point the module constant at the patched-legacy path so the
+        # back-compat shim treats it as "legacy, defer to resolver".
+        monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", str(legacy))
+        monkeypatch.setattr(hallways_mod, "_get_hallway_file", lambda *a, **kw: str(configured))
+        monkeypatch.setattr(hallways_mod, "_legacy_hallway_file", lambda: str(legacy))
+
+        with caplog.at_level(logging.WARNING, logger="mempalace_hallways"):
+            result = hallways_mod._load_hallways()
+
+        assert result == [], "must not auto-migrate from legacy file"
+        assert str(legacy) in caplog.text
+        assert str(configured) in caplog.text
+
+    def test_no_legacy_warning_when_paths_match(self, tmp_path, monkeypatch, caplog):
+        """If configured and legacy resolve to the same path (default install),
+        we must not emit a misleading 'legacy file ignored' warning when the
+        file simply doesn't exist yet."""
+        same = tmp_path / "hallways.json"
+        monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", str(same))
+        monkeypatch.setattr(hallways_mod, "_get_hallway_file", lambda *a, **kw: str(same))
+        monkeypatch.setattr(hallways_mod, "_legacy_hallway_file", lambda: str(same))
+
+        with caplog.at_level(logging.WARNING, logger="mempalace_hallways"):
+            assert hallways_mod._load_hallways() == []
+
+        assert "Legacy hallways file" not in caplog.text
+
+
+# =============================================================================
+# Multi-palace isolation: two palaces no longer share the file
+# =============================================================================
+
+
+class TestMultiPalaceIsolation:
+    def test_two_palaces_get_distinct_hallway_files(self, tmp_path, monkeypatch):
+        """The original bug: switching MEMPALACE_PALACE_PATH between two
+        palace dirs must produce two distinct hallway files, not one shared.
+        """
+        palace_a = tmp_path / "a" / "palace"
+        palace_b = tmp_path / "b" / "palace"
+        palace_a.mkdir(parents=True)
+        palace_b.mkdir(parents=True)
+
+        monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace_a))
+        file_a = MempalaceConfig().hallway_file
+
+        monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace_b))
+        file_b = MempalaceConfig().hallway_file
+
+        assert file_a != file_b
+        assert file_a == str(tmp_path / "a" / "hallways.json")
+        assert file_b == str(tmp_path / "b" / "hallways.json")
+
+    def test_save_then_load_under_different_palace_returns_empty(self, tmp_path, monkeypatch):
+        """End-to-end: writing hallways under palace-A and then loading under
+        palace-B must NOT return palace-A's records. This is the regression
+        guard for the original bug."""
+        palace_a = tmp_path / "a" / "palace"
+        palace_b = tmp_path / "b" / "palace"
+        palace_a.mkdir(parents=True)
+        palace_b.mkdir(parents=True)
+
+        # Force the module constant to match the (default) legacy path so the
+        # back-compat shim doesn't override the resolver.
+        monkeypatch.setattr(hallways_mod, "_HALLWAY_FILE", hallways_mod._legacy_hallway_file())
+
+        monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace_a))
+        hallways_mod._save_hallways(
+            [
+                {
+                    "id": "h_from_a",
+                    "wing": "wing_a",
+                    "entity_a": "Alice",
+                    "entity_b": "Bob",
+                    "co_occurrence_count": 2,
+                    "rooms": ["room_a"],
+                }
+            ]
+        )
+        assert os.path.exists(str(tmp_path / "a" / "hallways.json"))
+
+        monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace_b))
+        assert hallways_mod._load_hallways() == []

--- a/tests/test_hallways_palace_scoped.py
+++ b/tests/test_hallways_palace_scoped.py
@@ -132,8 +132,13 @@ class TestMultiPalaceIsolation:
         palace_a.mkdir(parents=True)
         palace_b.mkdir(parents=True)
 
-        # Force the module constant to match the (default) legacy path so the
-        # back-compat shim doesn't override the resolver.
+        # Pin the legacy-file lookup to a temp path so the legacy-warning
+        # branch never checks the host's real ~/.mempalace/hallways.json.
+        monkeypatch.setattr(
+            hallways_mod,
+            "_legacy_hallway_file",
+            lambda: str(tmp_path / "legacy-hallways.json"),
+        )
 
         monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace_a))
         hallways_mod._save_hallways(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1515,11 +1515,16 @@ class TestWriteTools:
     # ── hallway MCP tools (mirror the tunnel pattern) ──
 
     def _seed_hallways(self, monkeypatch, tmp_path):
-        """Point hallways._HALLWAY_FILE at a tmp file and seed two records."""
+        """Point hallways resolvers at a tmp file and seed two records."""
         from mempalace import hallways
 
         hallway_file = tmp_path / "hallways.json"
-        monkeypatch.setattr(hallways, "_HALLWAY_FILE", str(hallway_file))
+        monkeypatch.setattr(hallways, "_get_hallway_file", lambda *a, **kw: str(hallway_file))
+        monkeypatch.setattr(
+            hallways,
+            "_legacy_hallway_file",
+            lambda: str(tmp_path / "legacy-hallways.json"),
+        )
         seeded = [
             {
                 "id": "hallway_wing_a_X_Y_aaaa",


### PR DESCRIPTION
## What does this PR do?

Closes #1778.

Migrates `hallways.py` storage from the hardcoded `~/.mempalace/hallways.json` to a `palace_path`-scoped location, applying the same pattern `palace_graph` used for tunnels in 3.3.6 (#1558).

Before this PR, two palaces on one host silently shared a single `~/.mempalace/hallways.json`. Mining hallways into palace-A leaked records into palace-B's hallway code paths. After this PR, hallways live as `<dirname(palace_path)>/hallways.json`, sibling of the palace dir — matching `tunnels.json`.

Three pieces:

- **`MempalaceConfig.hallway_file`** — new property, resolves to `<dirname(palace_path)>/hallways.json`. Direct mirror of `MempalaceConfig.tunnel_file`.
- **`hallways._get_hallway_file(config)`** / **`hallways._legacy_hallway_file()`** — resolver + legacy-path helpers, mirroring `palace_graph._get_tunnel_file` / `_legacy_tunnel_file`.
- **`_load_hallways` / `_save_hallways`** — now accept an optional `config` and route through `_get_hallway_file`. `_load_hallways` logs a one-line warning when the legacy file exists but the configured one doesn't (no auto-migration — silent merging risks clobbering newer data, same posture as `palace_graph._load_tunnels`).

Atomic-write and 0600-perm semantics unchanged. Pure path-resolution change at the persistence layer; no schema change to `hallways.json`.

## Test changes

The three existing test sites (`tests/test_hallways.py`, `tests/test_hallways_pagination.py`, `tests/test_mcp_server.py`) that previously monkey-patched the `_HALLWAY_FILE` module constant now monkey-patch `_get_hallway_file` and `_legacy_hallway_file` directly, exactly mirroring the helper in `tests/test_palace_graph_tunnels.py`. Single source of truth for path resolution in production code.

## How to test

```bash
pytest tests/test_hallways.py tests/test_hallways_pagination.py tests/test_hallways_palace_scoped.py tests/test_palace_graph_tunnels.py tests/test_mcp_server.py
```

Should report 269 passed. New file `tests/test_hallways_palace_scoped.py` adds 7 tests mirroring the analogous tunnel tests:

- `TestHallwayFileResolution`: default-sibling, custom palace_path, env-var redirect
- `TestLegacyHallwayFileDetection`: orphaned-legacy warning, no-warning when paths match
- `TestMultiPalaceIsolation`: two-palaces-distinct-files + end-to-end save-A-then-load-B-returns-empty regression guard

## Checklist
- [x] Tests pass (Python 3.11 + 3.12, 269/269 in the touched modules; full suite 2642 passed with 4 pre-existing unrelated `test_miner_fts5_validation.py` failures on clean `develop`)
- [x] No new hardcoded paths
- [x] Linter passes (`ruff check` and `ruff format --check`)

---

Verified against `develop` HEAD (`2ec4bae`, 2026-06-11).
