### PR TITLE
fix(ids): use length-prefixed recipe v3

### DIFF
--- a/mempalace/ids.py
+++ b/mempalace/ids.py
@@ -22,7 +22,7 @@ import hashlib
 # as legacy ``v1`` (pre-delimiter recipe), drawers with ``id_recipe="v2"``
 # are guaranteed collision-safe within the v2 generation. The constant is
 # exported so call sites use ``ids.ID_RECIPE`` rather than a magic string.
-ID_RECIPE: str = "v2"
+ID_RECIPE: str = "v3"
 
 # '|' is reserved in Windows filenames and cannot appear in source paths
 # on any supported platform, making it strictly safer than ':' (which
@@ -49,7 +49,7 @@ def _delimited_sha256(parts: tuple[object, ...], truncate: int) -> str:
     e.g. ``valid_from=None`` joins as the literal string ``"None"`` rather
     than crashing.
     """
-    key = _DELIM.join(str(p) for p in parts).encode()
+    key = "".join(f"{len(part)}:{part}" for part in (str(p) for p in parts)).encode()
     return hashlib.sha256(key).hexdigest()[:truncate]
 
 

--- a/mempalace/ids.py
+++ b/mempalace/ids.py
@@ -49,7 +49,7 @@ def _delimited_sha256(parts: tuple[object, ...], truncate: int) -> str:
     e.g. ``valid_from=None`` joins as the literal string ``"None"`` rather
     than crashing.
     """
-    key = "".join(f"{len(part)}:{part}" for part in (str(p) for p in parts)).encode()
+    key = "".join(f"{len(part)}:{part}" for part in map(str, parts)).encode()
     return hashlib.sha256(key).hexdigest()[:truncate]
 
 

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -18,11 +18,11 @@ from mempalace import ids
 # ── ID_RECIPE constant ─────────────────────────────────────────────────
 
 
-def test_id_recipe_constant_is_v2():
+def test_id_recipe_constant_is_v3():
     """Audit code reads ids.ID_RECIPE to tag new drawers. The constant
-    must be the literal "v2" string; a typo here silently re-introduces
+    must be the literal "v3" string; a typo here silently re-introduces
     the ambiguity v2 was meant to fix."""
-    assert ids.ID_RECIPE == "v2"
+    assert ids.ID_RECIPE == "v3"
 
 
 # ── make_drawer_id_from_chunk ─────────────────────────────────────────
@@ -170,14 +170,19 @@ def test_make_triple_id_does_not_collide_across_iso_datetime_boundary():
 # ── _delimited_sha256 (private helper, smoke test only) ───────────────
 
 
-def test_private_delimited_sha256_uses_pipe_delimiter():
-    """Confirms the implementation actually uses '|' and not ':' — a
-    subtle copy-paste from the diary_ingest precedent or a stale
-    ':' precedent from convo_miner could regress the delimiter without
-    breaking the higher-level tests."""
+def test_private_delimited_sha256_uses_length_prefixing():
     result = ids._delimited_sha256(("a", "b"), 64)
-    expected = hashlib.sha256(b"a|b").hexdigest()
+    expected = hashlib.sha256(b"1:a1:b").hexdigest()
     assert result == expected
+
+    # These tuples collapse to the same raw pipe-joined string:
+    # "a|b|c|d". The v3 length-prefixed recipe must keep them distinct.
+    left = ids._delimited_sha256(("a", "b|c", "d"), 64)
+    right = ids._delimited_sha256(("a|b", "c", "d"), 64)
+    assert left != right
+
+
+
 
 
 def test_private_delimited_sha256_truncation_honoured():

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -182,9 +182,6 @@ def test_private_delimited_sha256_uses_length_prefixing():
     assert left != right
 
 
-
-
-
 def test_private_delimited_sha256_truncation_honoured():
     """Truncation argument actually shortens the hex output."""
     result = ids._delimited_sha256(("a", "b"), 8)


### PR DESCRIPTION
## What does this PR do?

Closes #1776.


Switches the centralized ID hash recipe from raw delimiter joining to length-prefixed component encoding.

## Fix

- Bumps `ID_RECIPE` from `v2` to `v3`.
- Changes `_delimited_sha256()` so every component is encoded as `len(value):value`.
- Keeps deterministic IDs and existing truncation lengths.
- Removes ambiguity when any component contains the old `|` delimiter.


- Updates the recipe constant test to expect `v3`.
- Updates the private hash smoke test to expect length-prefixing.
- Adds a regression where inputs that collide under raw pipe joining no longer collide.

## How to test

`ruff format tests/test_ids.py mempalace/ids.py`
`ruff check tests/test_ids.py mempalace/ids.py`
`pytest tests/test_ids.py -v`
`python -m pytest tests/ -v`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
