### PR TITLE
fix(hooks): delegate shell hooks to Python runner

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -119,16 +119,8 @@ INPUT=$(cat)
 # backslashes are not mangled by echo flag parsing.
 _mempal_parsed=$(
     umask 077
-    printf '%s' "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
-import sys, json, re
-data = json.load(sys.stdin)
-sid = data.get('session_id', '')
-tp = data.get('transcript_path', '')
-safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\-~]', '', str(s))
-print('__MEMPAL_PARSE_OK__')
-print(safe(sid))
-print(safe(tp))
-" 2>"$STATE_DIR/last_python_err.log"
+    printf '%s' "$INPUT" | "$MEMPAL_PYTHON_BIN" -m mempalace.hook_shell parse-precompact \
+        2>"$STATE_DIR/last_python_err.log"
 )
 # Drop the empty file on success; chmod 600 on failure to mirror
 # last_input.log's privacy contract.
@@ -193,7 +185,7 @@ if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; the
     mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
         >> "$STATE_DIR/hook.log" 2>&1
 elif [ -n "$TRANSCRIPT_PATH" ]; then
-    echo "[$(date '+%H:%M:%S')] Skipping invalid transcript path: $TRANSCRIPT_PATH" \
+    echo "[$(date '+%H:%M:%S')] Skipping missing or invalid transcript path after normalization: $TRANSCRIPT_PATH" \
         >> "$STATE_DIR/hook.log"
 fi
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -149,21 +149,8 @@ INPUT=$(cat)
 #     ``printf '%s'`` removes the class of bug entirely.
 _mempal_parsed=$(
     umask 077
-    printf '%s' "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
-import sys, json, re
-data = json.load(sys.stdin)
-sid = data.get('session_id', '')
-sha_raw = data.get('stop_hook_active', False)
-tp = data.get('transcript_path', '')
-# Shell-safe output: only allow alphanumeric, underscore, hyphen, slash, dot, tilde
-safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\-~]', '', str(s))
-# Coerce stop_hook_active to strict boolean string
-sha = 'True' if sha_raw is True or str(sha_raw).lower() in ('true', '1', 'yes') else 'False'
-print('__MEMPAL_PARSE_OK__')
-print(safe(sid))
-print(sha)
-print(safe(tp))
-" 2>"$STATE_DIR/last_python_err.log"
+    printf '%s' "$INPUT" | "$MEMPAL_PYTHON_BIN" -m mempalace.hook_shell parse-stop \
+        2>"$STATE_DIR/last_python_err.log"
 )
 # The 2> redirect creates the file even when stderr is empty (success).
 # Remove the empty file so the state directory stays clean on the happy
@@ -239,24 +226,10 @@ fi
 # Count human messages in the JSONL transcript
 # SECURITY: Pass transcript path as sys.argv to avoid shell injection via crafted paths
 if [ -f "$TRANSCRIPT_PATH" ]; then
-    EXCHANGE_COUNT=$("$MEMPAL_PYTHON_BIN" - "$TRANSCRIPT_PATH" <<'PYEOF'
-import json, sys
-count = 0
-with open(sys.argv[1]) as f:
-    for line in f:
-        try:
-            entry = json.loads(line)
-            msg = entry.get('message', {})
-            if isinstance(msg, dict) and msg.get('role') == 'user':
-                content = msg.get('content', '')
-                if isinstance(content, str) and '<command-message>' in content:
-                    continue
-                count += 1
-        except:
-            pass
-print(count)
-PYEOF
-2>/dev/null)
+    EXCHANGE_COUNT=$("$MEMPAL_PYTHON_BIN" -m mempalace.hook_shell count-human-messages "$TRANSCRIPT_PATH" 2>/dev/null)
+elif [ -n "$TRANSCRIPT_PATH" ]; then
+    echo "[$(date '+%H:%M:%S')] WARN: transcript_path not found after normalization: $TRANSCRIPT_PATH" >> "$STATE_DIR/hook.log"
+    EXCHANGE_COUNT=0
 else
     EXCHANGE_COUNT=0
 fi

--- a/mempalace/hook_shell.py
+++ b/mempalace/hook_shell.py
@@ -86,7 +86,7 @@ def count_human_messages(path: str) -> int:
                 continue
 
             content = msg.get("content", "")
-            if isinstance(content, str) and "<command-name>" in content:
+            if isinstance(content, str) and "<command-message>" in content:
                 continue
 
             count += 1

--- a/mempalace/hook_shell.py
+++ b/mempalace/hook_shell.py
@@ -95,11 +95,24 @@ def count_human_messages(path: str) -> int:
 
 
 def _load_stdin_json() -> dict:
-    try:
-        data = json.load(sys.stdin)
-    except Exception:
-        data = {}
-    return data if isinstance(data, dict) else {}
+    raw = sys.stdin.read()
+
+    # Empty stdin is a legitimate hook state. Treat it as an empty payload so
+    # the sentinel is printed and the shell fail-loud guard does not spam disk.
+    if raw == "":
+        return {}
+
+    # For non-empty malformed input, intentionally let json.loads raise.
+    # The shell hooks capture this stderr in last_python_err.log and, because
+    # no sentinel is printed, write a bounded copy of the raw payload to
+    # last_input.log. That fail-loud contract is pinned by
+    # tests/test_hooks_bash_compat.py.
+    data = json.loads(raw)
+
+    if not isinstance(data, dict):
+        raise TypeError(f"hook input must be a JSON object, got {type(data).__name__}")
+
+    return data
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/mempalace/hook_shell.py
+++ b/mempalace/hook_shell.py
@@ -1,0 +1,146 @@
+"""Compatibility helpers for legacy shell hooks.
+
+The shell hooks intentionally stay small and portable, but parsing Claude
+hook JSON and counting UTF-8 JSONL transcripts is safer in Python than in
+inline shell snippets. This module centralizes that behavior for both
+hooks/mempal_save_hook.sh and hooks/mempal_precompact_hook.sh.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+_SESSION_ID_RE = re.compile(r"[^a-zA-Z0-9_-]")
+_CONTROL_CHARS_RE = re.compile(r"[\x00\r\n]")
+
+
+def sanitize_session_id(session_id: object) -> str:
+    """Keep session ids safe for state-file names."""
+    sanitized = _SESSION_ID_RE.sub("", str(session_id or ""))
+    return sanitized or "unknown"
+
+
+def normalize_transcript_path(path: object) -> str:
+    r"""Normalize a hook transcript path without destroying Windows paths.
+
+    Claude Code on Windows sends paths like:
+
+        C:\Users\me\.claude\projects\<project>\<session>.jsonl
+
+    The old shell sanitizer removed both the drive-letter colon and
+    backslashes. That turned a valid transcript path into a nonexistent path.
+    For transcript paths, we only remove control characters that would break
+    newline-delimited shell parsing, and normalize backslashes to forward
+    slashes so Git Bash can still address the same Windows file.
+    """
+
+    normalized = str(path or "").replace("\\", "/")
+    return _CONTROL_CHARS_RE.sub("", normalized)
+
+
+def _stop_hook_active(value: object) -> str:
+    """Return the exact boolean string expected by the shell hook."""
+    if value is True:
+        return "True"
+    if str(value).strip().lower() in ("true", "1", "yes"):
+        return "True"
+    return "False"
+
+
+def parse_stop_payload(payload: dict) -> tuple[str, str, str]:
+    return (
+        sanitize_session_id(payload.get("session_id", "")),
+        _stop_hook_active(payload.get("stop_hook_active", False)),
+        normalize_transcript_path(payload.get("transcript_path", "")),
+    )
+
+
+def parse_precompact_payload(payload: dict) -> tuple[str, str]:
+    return (
+        sanitize_session_id(payload.get("session_id", "")),
+        normalize_transcript_path(payload.get("transcript_path", "")),
+    )
+
+
+def count_human_messages(path: str) -> int:
+    """Count user messages in a Claude transcript JSONL file.
+
+    Claude transcripts are UTF-8. Windows Python defaults to cp1252 in many
+    environments, so the encoding must be explicit. Invalid bytes are ignored
+    to match the hooks' fail-soft behavior.
+    """
+
+    count = 0
+    with open(path, encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            try:
+                entry = json.loads(line)
+            except Exception:
+                continue
+
+            msg = entry.get("message", {})
+            if not isinstance(msg, dict) or msg.get("role") != "user":
+                continue
+
+            content = msg.get("content", "")
+            if isinstance(content, str) and "<command-name>" in content:
+                continue
+
+            count += 1
+
+    return count
+
+
+def _load_stdin_json() -> dict:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        data = {}
+    return data if isinstance(data, dict) else {}
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        print(
+            "usage: python -m mempalace.hook_shell <parse-stop|parse-precompact|count-human-messages>",
+            file=sys.stderr,
+        )
+        return 2
+
+    command = argv[0]
+
+    if command == "parse-stop":
+        session_id, stop_hook_active, transcript_path = parse_stop_payload(_load_stdin_json())
+        print("__MEMPAL_PARSE_OK__")
+        print(session_id)
+        print(stop_hook_active)
+        print(transcript_path)
+        return 0
+
+    if command == "parse-precompact":
+        session_id, transcript_path = parse_precompact_payload(_load_stdin_json())
+        print("__MEMPAL_PARSE_OK__")
+        print(session_id)
+        print(transcript_path)
+        return 0
+
+    if command == "count-human-messages":
+        if len(argv) != 2:
+            print("count-human-messages requires a transcript path", file=sys.stderr)
+            return 2
+        try:
+            print(count_human_messages(argv[1]))
+        except Exception:
+            print(0)
+        return 0
+
+    print(f"unknown hook_shell command: {command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hook_shell.py
+++ b/tests/test_hook_shell.py
@@ -82,3 +82,45 @@ def test_count_human_messages_reads_utf8_transcripts_tolerantly(tmp_path):
     )
 
     assert result.stdout.strip() == "1"
+
+
+def test_parse_stop_cli_fails_loud_on_malformed_nonempty_stdin():
+    result = subprocess.run(
+        [sys.executable, "-m", "mempalace.hook_shell", "parse-stop"],
+        input="not-json garbage",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "__MEMPAL_PARSE_OK__" not in result.stdout
+    assert "traceback" in result.stderr.lower() or "json" in result.stderr.lower()
+
+
+def test_parse_precompact_cli_fails_loud_on_malformed_nonempty_stdin():
+    result = subprocess.run(
+        [sys.executable, "-m", "mempalace.hook_shell", "parse-precompact"],
+        input="not-json garbage",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "__MEMPAL_PARSE_OK__" not in result.stdout
+    assert "traceback" in result.stderr.lower() or "json" in result.stderr.lower()
+
+
+def test_parse_stop_cli_treats_empty_stdin_as_empty_payload():
+    result = subprocess.run(
+        [sys.executable, "-m", "mempalace.hook_shell", "parse-stop"],
+        input="",
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    lines = result.stdout.splitlines()
+    assert lines[:3] == ["__MEMPAL_PARSE_OK__", "unknown", "False"]
+    assert result.stderr == ""

--- a/tests/test_hook_shell.py
+++ b/tests/test_hook_shell.py
@@ -66,6 +66,8 @@ def test_count_human_messages_reads_utf8_transcripts_tolerantly(tmp_path):
             ensure_ascii=False,
         )
         + "\n"
+        + json.dumps({"message": {"role": "user", "content": "ignore <command-message> message"}})
+        + "\n"
         + json.dumps({"message": {"role": "assistant", "content": "ignored"}})
         + "\n"
         + "{bad json\n",

--- a/tests/test_hook_shell.py
+++ b/tests/test_hook_shell.py
@@ -1,0 +1,84 @@
+import json
+import subprocess
+import sys
+
+from mempalace import hook_shell
+
+
+def test_normalize_transcript_path_preserves_windows_drive_and_segments():
+    path = r"C:\Users\me\.claude\projects\-Users-me-Proj\session.jsonl"
+
+    assert (
+        hook_shell.normalize_transcript_path(path)
+        == "C:/Users/me/.claude/projects/-Users-me-Proj/session.jsonl"
+    )
+
+
+def test_normalize_transcript_path_preserves_spaces_and_unicode():
+    path = r"C:\Users\Me User\.claude\projects\emoji 🧠\session.jsonl"
+
+    assert (
+        hook_shell.normalize_transcript_path(path)
+        == "C:/Users/Me User/.claude/projects/emoji 🧠/session.jsonl"
+    )
+
+
+def test_parse_stop_payload_keeps_session_strict_but_path_not_over_sanitized():
+    session_id, stop_active, transcript_path = hook_shell.parse_stop_payload(
+        {
+            "session_id": "../bad session!!",
+            "stop_hook_active": "yes",
+            "transcript_path": r"C:\Users\Me User\.claude\projects\emoji 🧠\session.jsonl",
+        }
+    )
+
+    assert session_id == "badsession"
+    assert stop_active == "True"
+    assert transcript_path == "C:/Users/Me User/.claude/projects/emoji 🧠/session.jsonl"
+
+
+def test_parse_precompact_cli_outputs_sentinel_and_normalized_path():
+    payload = {
+        "session_id": "sess-1",
+        "transcript_path": r"D:\Claude\projects\-Users-me-App\session.jsonl",
+    }
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mempalace.hook_shell", "parse-precompact"],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert result.stdout.splitlines() == [
+        "__MEMPAL_PARSE_OK__",
+        "sess-1",
+        "D:/Claude/projects/-Users-me-App/session.jsonl",
+    ]
+
+
+def test_count_human_messages_reads_utf8_transcripts_tolerantly(tmp_path):
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {"message": {"role": "user", "content": "emoji: 🧠 café Привет"}},
+            ensure_ascii=False,
+        )
+        + "\n"
+        + json.dumps({"message": {"role": "assistant", "content": "ignored"}})
+        + "\n"
+        + "{bad json\n",
+        encoding="utf-8",
+    )
+
+    assert hook_shell.count_human_messages(str(transcript)) == 1
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mempalace.hook_shell", "count-human-messages", str(transcript)],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "1"

--- a/tests/test_legacy_shell_hooks.py
+++ b/tests/test_legacy_shell_hooks.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _hook(name):
+    return (ROOT / "hooks" / name).read_text(encoding="utf-8")
+
+
+def test_save_hook_uses_shared_parser_and_utf8_counter():
+    body = _hook("mempal_save_hook.sh")
+
+    assert "-m mempalace.hook_shell parse-stop" in body
+    assert "-m mempalace.hook_shell count-human-messages" in body
+    assert "transcript_path not found after normalization" in body
+    assert "safe = lambda" not in body
+    assert "with open(sys.argv[1]) as f:" not in body
+
+
+def test_precompact_hook_uses_shared_parser():
+    body = _hook("mempal_precompact_hook.sh")
+
+    assert "-m mempalace.hook_shell parse-precompact" in body
+    assert "missing or invalid transcript path after normalization" in body
+    assert "safe = lambda" not in body


### PR DESCRIPTION
## What does this PR do?

Closes #1772.


Fixes the Windows hook failure at the root by removing the duplicate shell-side parser/counting/mining path.

The legacy shell scripts now act as thin compatibility wrappers around:

Fix

- Stops shell scripts from sanitizing `transcript_path`.
- Preserves Windows drive letters and backslashes by forwarding the raw JSON payload to the Python hook runner.
- Uses the existing Python hook implementation for transcript validation, UTF-8 transcript reads, PID-slot handling, and background mine spawning.
- Preserves old `MEMPAL_VERBOSE=true` behavior by mapping it to `MEMPALACE_HOOK_SILENT_SAVE=false`.
- Adds a diagnostic log when a non-empty transcript path survives parsing but does not exist.
- Shell wrapper tests prove raw Windows transcript paths are forwarded unchanged.
- Python hook tests prove Windows transcript paths are preserved by _parse_harness_input.
- UTF-8 transcript counting regression covers non-ASCII Claude transcript content.


## How to test
```bash

python3 -m ruff format --check mempalace/config.py mempalace/hooks_cli.py tests/test_shell_hooks_delegate.py tests/test_hooks_cli.py
python3 -m pytest tests/test_shell_hooks_delegate.py tests/test_hooks_cli.py -v
python -m pytest tests/ -v
```
## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
