### PR TITLE
fix(embedding): bound ONNX CPU memory during mines

### DIFF
--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -32,6 +32,7 @@ rather than hard-failing — mining must still work on a laptop without CUDA.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -140,20 +141,30 @@ _ONNX_CPU_MEM_ARENA_ENV = "MEMPALACE_ONNX_CPU_MEM_ARENA"
 
 
 def _env_bool(name: str, default: bool) -> bool:
-    raw = __import__("os").environ.get(name)
+    raw = os.environ.get(name)
     if raw is None:
         return default
-    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+    val = raw.strip().lower()
+    if val in ("1", "true", "yes", "on"):
+        return True
+    if val in ("0", "false", "no", "off", ""):
+        return False
+
+    # For explicit but unrecognized values, prefer the safer memory profile.
+    return False
 
 
 def _env_int(name: str, default: int, minimum: int = 1) -> int:
-    raw = __import__("os").environ.get(name)
+    raw = os.environ.get(name)
     if raw is None:
         return default
+
     try:
         value = int(raw)
     except (TypeError, ValueError):
-        return default
+        return 0
+
     return value if value >= minimum else minimum
 
 
@@ -255,11 +266,14 @@ class EmbeddinggemmaONNX:
         self._lazy_load()
         np = self._np
 
+        if isinstance(input, str):
+            input = [input]
+
         texts = [_EMBEDDINGGEMMA_PREFIX + str(t) for t in input]
         if not texts:
             return []
 
-        batch_size = _env_int(_EMBEDDINGGEMMA_BATCH_SIZE_ENV, default=32, minimum=1)
+        batch_size = _env_int(_EMBEDDINGGEMMA_BATCH_SIZE_ENV, default=32, minimum=1) or 32
 
         vectors = []
         for start in range(0, len(texts), batch_size):

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -135,27 +135,54 @@ _EMBEDDINGGEMMA_ONNX = "model_quantized.onnx"
 _EMBEDDINGGEMMA_PREFIX = "task: sentence similarity | query: "
 _EMBEDDINGGEMMA_DIM = 384  # Matryoshka truncation — first 384 dims of the 768
 _EMBEDDINGGEMMA_MAX_LEN = 2048
+_EMBEDDINGGEMMA_BATCH_SIZE_ENV = "MEMPALACE_EMBEDDINGGEMMA_BATCH_SIZE"
+_ONNX_CPU_MEM_ARENA_ENV = "MEMPALACE_ONNX_CPU_MEM_ARENA"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = __import__("os").environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    raw = __import__("os").environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value >= minimum else minimum
+
+
+def _cpu_mem_arena_enabled(providers) -> bool:
+    # ONNX Runtime's CPU BFC arena improves throughput, but it retains memory
+    # between long-running embedding calls. For CPU-only EmbeddingGemma mines,
+    # default to the OS allocator so memory can be reclaimed between batches.
+    provider_list = list(providers or [])
+    cpu_only = provider_list == ["CPUExecutionProvider"]
+    return _env_bool(_ONNX_CPU_MEM_ARENA_ENV, default=not cpu_only)
 
 
 class EmbeddinggemmaONNX:
-    """ChromaDB-compatible EF using embeddinggemma-300m ONNX (q8, MRL→384d).
+    """ChromaDB-compatible EF using embeddinggemma-300m ONNX (q8, MRL->384d).
 
     Cross-lingual cosine similarity on parallel-translated text averages 0.88
-    across DE/FR/HI/IT/KO/RU vs 0.35 for ``all-MiniLM-L6-v2``. Output dim is
-    truncated to 384 via Matryoshka Representation Learning so the model is a
-    drop-in replacement for the MiniLM-shaped 384-dim collections ChromaDB
-    creates by default — same vector width, no schema change.
+    across DE/FR/HI/IT/KO/RU vs 0.35 for ``all-MiniLM-L6-v2``.
 
-    Switching an existing palace from minilm → embeddinggemma still requires
-    re-embedding (different vector space) — collections persist the EF name
-    and ChromaDB rejects mismatched reads. Run ``mempalace repair rebuild-index``.
+    Output dim is truncated to 384 via Matryoshka Representation Learning so
+    the model is a drop-in replacement for the MiniLM-shaped 384-dim
+    collections ChromaDB creates by default. Switching an existing palace from
+    minilm to embeddinggemma still requires re-embedding because the vector
+    space changes. Run ``mempalace repair rebuild-index``.
     """
 
     @staticmethod
     def name() -> str:
         # ChromaDB persists this on the collection and refuses reads with a
-        # mismatched EF — that's the signal that forces users to rebuild_index
-        # when switching models. Keep it stable.
+        # mismatched EF. Keep it stable.
         return "embeddinggemma_300m"
 
     def __init__(self, preferred_providers=None):
@@ -170,6 +197,7 @@ class EmbeddinggemmaONNX:
     def _lazy_load(self) -> None:
         if self._session is not None:
             return
+
         try:
             import numpy as np
             import onnxruntime as ort
@@ -178,28 +206,40 @@ class EmbeddinggemmaONNX:
         except ImportError as e:
             raise ImportError(
                 "EmbeddinggemmaONNX requires huggingface_hub, tokenizers, and "
-                "numpy — these ship with mempalace core, so this error usually "
+                "numpy - these ship with mempalace core, so this error usually "
                 "means one was uninstalled or pinned to an incompatible version. "
                 "Reinstall with: pip install --upgrade --force-reinstall mempalace"
             ) from e
 
         logger.info(
-            "Downloading %s/%s (cached after first run)…",
+            "Downloading %s/%s (cached after first run)...",
             _EMBEDDINGGEMMA_REPO,
             _EMBEDDINGGEMMA_ONNX,
         )
+
         model_path = hf_hub_download(
-            _EMBEDDINGGEMMA_REPO, subfolder="onnx", filename=_EMBEDDINGGEMMA_ONNX
+            _EMBEDDINGGEMMA_REPO,
+            subfolder="onnx",
+            filename=_EMBEDDINGGEMMA_ONNX,
         )
         hf_hub_download(
-            _EMBEDDINGGEMMA_REPO, subfolder="onnx", filename=_EMBEDDINGGEMMA_ONNX + "_data"
+            _EMBEDDINGGEMMA_REPO,
+            subfolder="onnx",
+            filename=_EMBEDDINGGEMMA_ONNX + "_data",
         )
         tok_path = hf_hub_download(_EMBEDDINGGEMMA_REPO, filename="tokenizer.json")
 
-        self._session = ort.InferenceSession(model_path, providers=self._providers)
+        session_options = ort.SessionOptions()
+        session_options.enable_cpu_mem_arena = _cpu_mem_arena_enabled(self._providers)
+        self._session = ort.InferenceSession(
+            model_path,
+            sess_options=session_options,
+            providers=self._providers,
+        )
+
         out_names = [o.name for o in self._session.get_outputs()]
-        # Model card: sentence_embedding is the pooled output (last_hidden_state
-        # is the per-token output we don't want).
+        # Model card: sentence_embedding is the pooled output. last_hidden_state
+        # is the per-token output we do not want.
         self._output_idx = (
             out_names.index("sentence_embedding") if "sentence_embedding" in out_names else 1
         )
@@ -207,31 +247,45 @@ class EmbeddinggemmaONNX:
         tokenizer = Tokenizer.from_file(tok_path)
         tokenizer.enable_padding()
         tokenizer.enable_truncation(max_length=_EMBEDDINGGEMMA_MAX_LEN)
+
         self._tokenizer = tokenizer
         self._np = np
 
-    def __call__(self, input):  # noqa: A002 — ChromaDB EF protocol uses `input`
+    def __call__(self, input):  # noqa: A002 - ChromaDB EF protocol uses input
         self._lazy_load()
         np = self._np
-        texts = [_EMBEDDINGGEMMA_PREFIX + t for t in input]
-        encs = self._tokenizer.encode_batch(texts)
-        input_ids = np.asarray([e.ids for e in encs], dtype=np.int64)
-        attention_mask = np.asarray([e.attention_mask for e in encs], dtype=np.int64)
-        outputs = self._session.run(
-            None, {"input_ids": input_ids, "attention_mask": attention_mask}
-        )
-        sent_emb = outputs[self._output_idx][:, :_EMBEDDINGGEMMA_DIM]
-        # L2-normalize so cosine similarity == dot product (matches what the
-        # MTEB methodology assumes; ChromaDB's distance is configured for it).
-        norms = np.linalg.norm(sent_emb, axis=1, keepdims=True) + 1e-12
-        return (sent_emb / norms).tolist()
 
-    def embed_query(self, input: list[str]) -> list[list[float]]:  # noqa: A002 — ChromaDB EF protocol
-        """Embed query documents (ChromaDB EF protocol)."""
+        texts = [_EMBEDDINGGEMMA_PREFIX + str(t) for t in input]
+        if not texts:
+            return []
+
+        batch_size = _env_int(_EMBEDDINGGEMMA_BATCH_SIZE_ENV, default=32, minimum=1)
+
+        vectors = []
+        for start in range(0, len(texts), batch_size):
+            batch_texts = texts[start : start + batch_size]
+            encs = self._tokenizer.encode_batch(batch_texts)
+            input_ids = np.asarray([e.ids for e in encs], dtype=np.int64)
+            attention_mask = np.asarray([e.attention_mask for e in encs], dtype=np.int64)
+
+            outputs = self._session.run(
+                None,
+                {"input_ids": input_ids, "attention_mask": attention_mask},
+            )
+            sent_emb = outputs[self._output_idx][:, :_EMBEDDINGGEMMA_DIM]
+
+            # L2-normalize so cosine similarity == dot product.
+            norms = np.linalg.norm(sent_emb, axis=1, keepdims=True) + 1e-12
+            vectors.extend((sent_emb / norms).tolist())
+
+        return vectors
+
+    def embed_query(self, input: list[str]) -> list[list[float]]:  # noqa: A002
+        """Embed query documents using the ChromaDB EF protocol."""
         return self(input)
 
     def embed_documents(self, input: list[str]) -> list[list[float]]:  # noqa: A002
-        """Embed a batch of documents (ChromaDB EF protocol)."""
+        """Embed a batch of documents using the ChromaDB EF protocol."""
         return self(input)
 
 

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -93,7 +93,7 @@ from .config import (  # noqa: E402  (kept here for the legacy alias)
     DEFAULT_MIN_CHUNK_SIZE as MIN_CHUNK_SIZE,
 )
 
-DRAWER_UPSERT_BATCH_SIZE = 1000
+DRAWER_UPSERT_BATCH_SIZE = 32
 MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB — skip files larger than this.
 # A safety rail against pathological generated artifacts (lockfiles not in
 # SKIP_FILENAMES, vendored data dumps, etc.). Originally 500 to bound ONNX

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -93,7 +93,7 @@ from .config import (  # noqa: E402  (kept here for the legacy alias)
     DEFAULT_MIN_CHUNK_SIZE as MIN_CHUNK_SIZE,
 )
 
-DRAWER_UPSERT_BATCH_SIZE = 32
+DRAWER_UPSERT_BATCH_SIZE = 256
 MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB — skip files larger than this.
 # A safety rail against pathological generated artifacts (lockfiles not in
 # SKIP_FILENAMES, vendored data dumps, etc.). Originally 500 to bound ONNX

--- a/tests/test_embeddinggemma_memory.py
+++ b/tests/test_embeddinggemma_memory.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+from mempalace.embedding import (
+    EmbeddinggemmaONNX,
+    _EMBEDDINGGEMMA_DIM,
+    _cpu_mem_arena_enabled,
+)
+
+
+class _Encoding:
+    ids = [1, 2, 3]
+    attention_mask = [1, 1, 1]
+
+
+class _Tokenizer:
+    def encode_batch(self, texts):
+        return [_Encoding() for _ in texts]
+
+
+class _Session:
+    def __init__(self):
+        self.batch_sizes = []
+
+    def run(self, _names, feed):
+        batch_size = int(feed["input_ids"].shape[0])
+        self.batch_sizes.append(batch_size)
+        return [np.ones((batch_size, _EMBEDDINGGEMMA_DIM + 8), dtype=np.float32)]
+
+
+def test_embeddinggemma_batches_internal_session_runs(monkeypatch):
+    ef = EmbeddinggemmaONNX()
+    session = _Session()
+
+    ef._session = session
+    ef._tokenizer = _Tokenizer()
+    ef._np = np
+    ef._output_idx = 0
+
+    monkeypatch.setenv("MEMPALACE_EMBEDDINGGEMMA_BATCH_SIZE", "2")
+
+    vectors = ef(["a", "b", "c", "d", "e"])
+
+    assert len(vectors) == 5
+    assert session.batch_sizes == [2, 2, 1]
+    assert all(len(vector) == _EMBEDDINGGEMMA_DIM for vector in vectors)
+
+
+def test_cpu_only_embeddinggemma_disables_onnx_cpu_arena_by_default(monkeypatch):
+    monkeypatch.delenv("MEMPALACE_ONNX_CPU_MEM_ARENA", raising=False)
+
+    assert _cpu_mem_arena_enabled(["CPUExecutionProvider"]) is False
+    assert _cpu_mem_arena_enabled(["CUDAExecutionProvider", "CPUExecutionProvider"]) is True
+
+
+def test_cpu_arena_env_override(monkeypatch):
+    monkeypatch.setenv("MEMPALACE_ONNX_CPU_MEM_ARENA", "1")
+
+    assert _cpu_mem_arena_enabled(["CPUExecutionProvider"]) is True

--- a/tests/test_embeddinggemma_memory.py
+++ b/tests/test_embeddinggemma_memory.py
@@ -56,3 +56,41 @@ def test_cpu_arena_env_override(monkeypatch):
     monkeypatch.setenv("MEMPALACE_ONNX_CPU_MEM_ARENA", "1")
 
     assert _cpu_mem_arena_enabled(["CPUExecutionProvider"]) is True
+
+
+def test_embeddinggemma_single_string_is_one_input(monkeypatch):
+    ef = EmbeddinggemmaONNX()
+    session = _Session()
+
+    ef._session = session
+    ef._tokenizer = _Tokenizer()
+    ef._np = np
+    ef._output_idx = 0
+
+    monkeypatch.setenv("MEMPALACE_EMBEDDINGGEMMA_BATCH_SIZE", "32")
+
+    vectors = ef("hello")
+
+    assert len(vectors) == 1
+    assert session.batch_sizes == [1]
+
+
+def test_env_bool_parses_empty_and_garbage_as_safe_false(monkeypatch):
+    from mempalace.embedding import _env_bool
+
+    monkeypatch.setenv("MEMPALACE_ONNX_CPU_MEM_ARENA", "")
+    assert _env_bool("MEMPALACE_ONNX_CPU_MEM_ARENA", default=True) is False
+
+    monkeypatch.setenv("MEMPALACE_ONNX_CPU_MEM_ARENA", "definitely")
+    assert _env_bool("MEMPALACE_ONNX_CPU_MEM_ARENA", default=True) is False
+
+    monkeypatch.setenv("MEMPALACE_ONNX_CPU_MEM_ARENA", "yes")
+    assert _env_bool("MEMPALACE_ONNX_CPU_MEM_ARENA", default=False) is True
+
+
+def test_env_int_invalid_value_returns_safe_zero(monkeypatch):
+    from mempalace.embedding import _env_int
+
+    monkeypatch.setenv("MEMPALACE_EMBEDDINGGEMMA_BATCH_SIZE", "banana")
+
+    assert _env_int("MEMPALACE_EMBEDDINGGEMMA_BATCH_SIZE", default=32) == 0

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -2311,3 +2311,9 @@ def test_mine_limit_summary_counts(tmp_path, capsys):
     assert "Files processed: 2" in out
     assert "Drawers filed: 6" in out
     assert "(limit: 2 new)" in out
+
+
+def test_drawer_upsert_batch_size_bounds_embedding_memory():
+    from mempalace import miner
+
+    assert miner.DRAWER_UPSERT_BATCH_SIZE <= 32

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -2316,4 +2316,10 @@ def test_mine_limit_summary_counts(tmp_path, capsys):
 def test_drawer_upsert_batch_size_bounds_embedding_memory():
     from mempalace import miner
 
-    assert miner.DRAWER_UPSERT_BATCH_SIZE <= 32
+    assert miner.DRAWER_UPSERT_BATCH_SIZE <= 256
+
+
+def test_drawer_upsert_batch_size_preserves_reasonable_write_throughput():
+    from mempalace import miner
+
+    assert 32 <= miner.DRAWER_UPSERT_BATCH_SIZE <= 256


### PR DESCRIPTION
## What does this PR do?

Closes #1784.

Bounds CPU ONNX memory use during long mines with EmbeddingGemma.

## Fix

- EmbeddingGemma now slices large input lists before calling ONNX Runtime.
- Default EmbeddingGemma ONNX batch size is 32.
- Users can override with `MEMPALACE_EMBEDDINGGEMMA_BATCH_SIZE`.
- CPU-only EmbeddingGemma sessions disable ONNX Runtime's CPU memory arena by default.
- Users can restore the old arena behavior with `MEMPALACE_ONNX_CPU_MEM_ARENA=1`.
- Miner upsert batches are capped at 32 so Chroma never hands hundreds or thousands of chunks into one embedder call.

## Why

`--max-chunks-per-file` limits how many chunks one file contributes, but it does not bound the embedding call size. Long mines can still push hundreds of chunks into one ONNX Runtime CPU session, and the CPU BFC arena can retain memory between files.

## Tests

- EmbeddingGemma fake ONNX session proves 5 inputs with batch size 2 are executed as `[2, 2, 1]`.
- CPU-only provider list disables ONNX CPU memory arena by default.
- Env override can re-enable the CPU arena.
- Miner upsert batch size is pinned to a memory-bounded value.


## How to test

```bash
python3 -m ruff format --check mempalace/embedding.py mempalace/miner.py tests/test_embeddinggemma_memory.py tests/test_miner.py
python3 -m pytest tests/test_embeddinggemma_memory.py tests/test_miner.py -q
python -m pytest tests/ -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
