### PR TITLE
fix(searcher): scope _expand_with_neighbors by parent_drawer_id (#1580)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -270,18 +270,32 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     """
     src = matched_meta.get("source_file")
     chunk_idx = matched_meta.get("chunk_index")
-    if not src or not isinstance(chunk_idx, int):
+    parent_id = matched_meta.get("parent_drawer_id")
+    if not isinstance(chunk_idx, int):
         return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
+    # Issue #1580: chunks filed via ``tool_add_drawer`` with no ``source_file``
+    # all share ``source_file=""`` and a per-call ``parent_drawer_id``. Without
+    # the parent scope, ``_expand_with_neighbors`` would happily stitch chunk 1
+    # of an unrelated drawer onto chunk 0 of the matched drawer. When the
+    # matched chunk carries a ``parent_drawer_id``, narrow the neighbor query
+    # to that logical drawer so cross-drawer leakage cannot happen. Diary /
+    # file-backed chunks have no ``parent_drawer_id`` and rely on the
+    # ``source_file`` filter, which is unambiguous because every chunk in that
+    # path shares one real, non-empty ``source_file``. If neither scope key is
+    # available, neighbor expansion would be unbounded — fall back to the
+    # matched drawer alone.
+    if not src and not parent_id:
+        return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
+    base_filters: list[dict] = []
+    if src:
+        base_filters.append({"source_file": src})
+    if parent_id:
+        base_filters.append({"parent_drawer_id": parent_id})
 
     target_indexes = [chunk_idx + offset for offset in range(-radius, radius + 1)]
     try:
         neighbors = drawers_col.get(
-            where={
-                "$and": [
-                    {"source_file": src},
-                    {"chunk_index": {"$in": target_indexes}},
-                ]
-            },
+            where={"$and": base_filters + [{"chunk_index": {"$in": target_indexes}}]},
             include=["documents", "metadatas"],
         )
     except Exception:
@@ -299,10 +313,12 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     else:
         combined_text = "\n\n".join(doc for _, doc in indexed_docs)
 
-    # Cheap total_drawers lookup: metadata-only scan of the source file.
+    # Cheap total_drawers lookup: metadata-only scan within the same scope
+    # used for neighbor lookup (source_file, optionally parent_drawer_id).
     total_drawers = None
     try:
-        all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
+        scope_filter = base_filters[0] if len(base_filters) == 1 else {"$and": base_filters}
+        all_meta = drawers_col.get(where=scope_filter, include=["metadatas"])
         total_drawers = len(all_meta.ids) if all_meta.ids else None
     except Exception:
         logger.debug("total_drawers lookup failed for %s", src, exc_info=True)

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1477,6 +1477,71 @@ class TestDrawerGrepExpansion:
         assert out["drawer_index"] is None
         assert out["total_drawers"] is None
 
+    def test_expand_scopes_by_parent_drawer_id_when_present(self, palace_path):
+        """Regression for #1580: ``tool_add_drawer`` chunks created with no
+        ``source_file`` all land with ``source_file=""`` and share a
+        per-call ``parent_drawer_id``. Neighbor expansion must use
+        ``parent_drawer_id`` to scope the query so chunk 1 of drawer A
+        cannot be stitched onto chunk 0 of drawer B."""
+        col = get_collection(palace_path)
+        # Seed two logical drawers, both with source_file="" but distinct
+        # parent_drawer_id values — exactly the MCP oversized-content shape.
+        for parent, marker in (
+            ("drawer_repro_paste_AAA", "AAA"),
+            ("drawer_repro_paste_BBB", "BBB"),
+        ):
+            for ci in range(3):
+                col.upsert(
+                    ids=[f"{parent}_chunk_{ci:06d}"],
+                    documents=[f"{marker} chunk_{ci} body content"],
+                    metadatas=[
+                        {
+                            "wing": "repro",
+                            "room": "paste",
+                            "source_file": "",
+                            "chunk_index": ci,
+                            "parent_drawer_id": parent,
+                            "filed_at": "2026-04-13T00:00:00",
+                        }
+                    ],
+                )
+
+        # Expand around chunk_0 of drawer A. Without the parent_drawer_id
+        # scope, chunks of drawer B would bleed in because both share
+        # source_file="" and chunk_index=1 collides across drawers.
+        matched_meta = {
+            "source_file": "",
+            "chunk_index": 0,
+            "parent_drawer_id": "drawer_repro_paste_AAA",
+        }
+        out = _expand_with_neighbors(col, "AAA chunk_0 body content", matched_meta, radius=1)
+
+        assert out["drawer_index"] == 0
+        assert out["total_drawers"] == 3, (
+            f"total_drawers must be scoped to parent_drawer_id; got {out['total_drawers']}"
+        )
+        assert "AAA chunk_0" in out["text"]
+        assert "AAA chunk_1" in out["text"]
+        assert "BBB" not in out["text"], (
+            "chunks from sibling drawer leaked into neighbor expansion — #1580"
+        )
+
+    def test_expand_without_parent_drawer_id_keeps_source_file_scope(self, palace_path):
+        """Diary / file-backed chunks have no ``parent_drawer_id`` and rely
+        on a real ``source_file`` for scoping. The fix for #1580 must not
+        regress that path: when ``parent_drawer_id`` is absent, expansion
+        still uses the source_file-only filter."""
+        col, _ = self._seed_source_file(palace_path, "/proj/legacy.md", n_chunks=4)
+        matched_meta = {"source_file": "/proj/legacy.md", "chunk_index": 1}
+        out = _expand_with_neighbors(
+            col, "chunk_1 content about topic alpha", matched_meta, radius=1
+        )
+        assert out["drawer_index"] == 1
+        assert out["total_drawers"] == 4
+        assert "chunk_0" in out["text"]
+        assert "chunk_1" in out["text"]
+        assert "chunk_2" in out["text"]
+
     def test_hybrid_search_enrichment_populates_drawer_index_and_total(self, palace_path):
         """End-to-end: when a closet boosts a source with many drawers, the
         enrichment step runs drawer-grep across all chunks of that source


### PR DESCRIPTION
Fixes #1580.

## Summary

Implements **Option B** from the issue: scope `_expand_with_neighbors`
by `parent_drawer_id` (in addition to `source_file`) when the matched
chunk carries one.

## Why this is bigger than the one-line guard relaxation

Pre-fix, the helper bailed early when `source_file` was empty:

```python
if not src or not isinstance(chunk_idx, int):
    return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
```

That guard *masked* the bug on the MCP-chunked path (where every chunk
has `source_file=""`) by silently disabling neighbor expansion for it.
So the user-visible symptom on `develop` today is "neighbor expansion
quietly doesn't work for `tool_add_drawer` oversized content"; the
*real* leak only surfaces if two drawers ever share a non-empty
`source_file`.

This PR:

1. Relaxes the early-return: bail only when *both* `source_file` and
   `parent_drawer_id` are missing.
2. Adds `parent_drawer_id` to the `$and` filter (neighbor query *and*
   the `total_drawers` count query) when it's present on the matched
   chunk.
3. Net effect: neighbor expansion is restored for the MCP-chunked path
   *and* hardened so cross-drawer leakage is impossible even if
   `source_file` collides.

## Live verification

Beyond unit tests, I built three harnesses:

**1. Adversarial collision** (two drawers, shared non-empty
`source_file`, distinct `parent_drawer_id`):

| | DEVELOP | BRANCH |
|---|---|---|
| Expansion contains ALPHA-MARKER | ✅ | ✅ |
| Expansion contains BETA-MARKER | ❌ leak | ✅ scoped out |
| `total_drawers` reported | 6 (combined) | 3 (correct) |

**2. Natural MCP path** (oversized `tool_add_drawer`, no
`source_file` — Igor's exact repro):

| | DEVELOP | BRANCH |
|---|---|---|
| Neighbor expansion runs | ❌ short-circuits | ✅ runs, scoped |
| `total_drawers` reported | None | 2 (correct) |

**3. Regression fingerprint** (diary chunks + small drawers + closet
hits + MCP chunked drawers, 3 query patterns):

`diff develop.json branch.json` — *zero diff*. Existing file-backed
and closet-boosted paths are byte-identical pre/post.

## Test coverage

`tests/test_closets.py::TestDrawerGrepExpansion`:
- `test_expand_scopes_by_parent_drawer_id_when_present` — pins the
  #1580 repro (two drawers, shared empty `source_file`, scoped result).
- `test_expand_without_parent_drawer_id_keeps_source_file_scope` —
  pins the legacy diary path keeps source_file-only scope.

Full suite: 259/259 in `tests/test_closets.py` + `tests/test_mcp_server.py`.
Ruff clean.

## Out of scope

- Whether `source_file` should default to a per-drawer synthetic key
  on the MCP path (the issue calls this out explicitly).
- Whether to invalidate / repair palaces that already accumulated
  leak-prone metadata (no migration needed; the fix is purely at the
  query layer).
