### PR TITLE
fix(backends): serialize first connect in sqlite_exact and pgvector (#1774, #1775)

### DIFF
--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -465,11 +465,10 @@ class _PgVectorClient:
     def __init__(self, config: _PgVectorConfig):
         self._config = config
         self._conn = None
+        self._closed = False
         self._lock = threading.RLock()
 
     def _connect(self):
-        if self._conn is not None and not getattr(self._conn, "closed", False):
-            return self._conn
         try:
             import psycopg
         except ImportError as exc:  # pragma: no cover - exercised only without the extra
@@ -477,15 +476,27 @@ class _PgVectorClient:
                 "pgvector backend requires the optional 'psycopg' dependency; "
                 "install mempalace[pgvector]"
             ) from exc
-        try:
-            self._conn = psycopg.connect(self._config.dsn)
-        except Exception as exc:  # noqa: BLE001 - surface any driver failure uniformly
-            raise BackendError(f"pgvector connection failed: {exc}") from exc
-        return self._conn
+        # One client is shared across threads (PgVectorBackend caches a
+        # single instance per config), so the read-create-store on self._conn
+        # must hold the same lock _execute serializes on; unlocked, two
+        # first-connect threads each opened a connection and the loser leaked
+        # unclosed. The RLock makes the _execute -> _connect nesting safe. A
+        # stalled connect blocks peers under the lock the same way any
+        # in-flight query on this single shared connection already does.
+        with self._lock:
+            if self._closed:
+                raise BackendError("pgvector client has been closed")
+            if self._conn is not None and not getattr(self._conn, "closed", False):
+                return self._conn
+            try:
+                self._conn = psycopg.connect(self._config.dsn)
+            except Exception as exc:  # noqa: BLE001 - surface any driver failure uniformly
+                raise BackendError(f"pgvector connection failed: {exc}") from exc
+            return self._conn
 
     def _execute(self, sql: str, params=None, *, fetch: bool = False, many: bool = False):
-        conn = self._connect()
         with self._lock:
+            conn = self._connect()
             try:
                 with conn.cursor() as cur:
                     if many:
@@ -684,7 +695,12 @@ class _PgVectorClient:
         self._execute(f"ANALYZE {_quote_identifier(table)}")
 
     def close(self) -> None:
+        # Terminal: the only caller is PgVectorBackend.close(), after which
+        # the backend refuses to hand the client out again. Without the flag a
+        # stale reference would silently reconnect and leak a session nobody
+        # can ever close.
         with self._lock:
+            self._closed = True
             if self._conn is not None:
                 try:
                     self._conn.close()
@@ -1285,9 +1301,12 @@ class PgVectorBackend(BaseBackend):
 
     # ------------------------------------------------------------------
     def _client(self, config: _PgVectorConfig) -> _PgVectorClient:
-        if self._closed:
-            raise BackendClosedError("PgVectorBackend has been closed")
         with self._lock:
+            # Checked under the lock so a client cannot be created and stored
+            # concurrently with close() clearing the registry (mirrors
+            # SQLiteExactBackend._connect).
+            if self._closed:
+                raise BackendClosedError("PgVectorBackend has been closed")
             client = self._clients.get(config)
             if client is None:
                 client = _PgVectorClient(config)

--- a/mempalace/backends/sqlite_exact.py
+++ b/mempalace/backends/sqlite_exact.py
@@ -836,19 +836,31 @@ class SQLiteExactBackend(BaseBackend):
                 os.chmod(palace_path, 0o700)
             except (OSError, NotImplementedError):
                 pass
+        # Hold the registry lock across cache-check + connect + schema init:
+        # two threads first-opening the same palace must not each create a
+        # connection (the loser leaked unclosed and outlived close()) nor run
+        # _init_schema concurrently on a fresh file, which surfaces transient
+        # "database is locked" errors before WAL mode is established. Only
+        # first-open pays for the I/O under the lock; cache hits are a dict
+        # probe.
         with self._clients_lock:
+            if self._closed:
+                raise BackendClosedError("SQLiteExactBackend has been closed")
             cached = self._clients.get(palace_path)
             if cached is not None and not cached.closed:
                 return cached
-        conn = sqlite3.connect(db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        lock = threading.RLock()
-        handle = _SQLiteExactHandle(conn, lock)
-        with handle.lock:
-            self._init_schema(conn)
-        with self._clients_lock:
+            conn = sqlite3.connect(db_path, check_same_thread=False)
+            try:
+                conn.row_factory = sqlite3.Row
+                lock = threading.RLock()
+                handle = _SQLiteExactHandle(conn, lock)
+                with handle.lock:
+                    self._init_schema(conn)
+            except BaseException:
+                conn.close()
+                raise
             self._clients[palace_path] = handle
-        return handle
+            return handle
 
     def _init_schema(self, conn: sqlite3.Connection) -> None:
         conn.executescript(
@@ -979,14 +991,19 @@ class SQLiteExactBackend(BaseBackend):
                 cached.conn.close()
 
     def close(self) -> None:
+        # Flip _closed under the registry lock so a concurrent _connect either
+        # sees the flag or finishes before the handle snapshot is taken; a
+        # connection can no longer slip into the registry after close().
+        # Unlocked readers of _closed elsewhere are advisory fast-fails; the
+        # locked recheck in _connect is the authoritative gate.
         with self._clients_lock:
             handles = list(self._clients.values())
             self._clients.clear()
+            self._closed = True
         for handle in handles:
             with handle.lock:
                 handle.closed = True
                 handle.conn.close()
-        self._closed = True
 
     def health(self, palace: Optional[PalaceRef] = None) -> HealthStatus:
         if self._closed:

--- a/tests/test_pgvector_backend.py
+++ b/tests/test_pgvector_backend.py
@@ -1,4 +1,7 @@
 import os
+import sys
+import threading
+import types
 
 import pytest
 
@@ -14,6 +17,8 @@ from mempalace.backends import (
 )
 from mempalace.backends.pgvector import (
     PgVectorBackend,
+    _PgVectorClient,
+    _PgVectorConfig,
     _matches_where,
     _vector_distance,
     _as_vector_array,
@@ -509,3 +514,140 @@ def test_pgvector_live_roundtrip_when_enabled(tmp_path):
         except Exception:
             pass
         backend.close()
+
+
+def test_client_concurrent_first_connect_single_connection(monkeypatch):
+    """Two threads racing ``_execute`` through the first ``_connect`` must end
+    up on one shared connection.
+
+    The barrier inside the fake ``psycopg.connect`` releases immediately only
+    when both threads pass the ``self._conn is None`` check together: the
+    broken interleaving, which created two connections, leaked the loser, and
+    ran the threads on different connections. With ``_connect`` under
+    ``self._lock`` the second thread blocks on the lock, the winner's barrier
+    times out, and the loser reuses the winner's connection.
+    """
+    created = []
+    barrier = threading.Barrier(2)
+
+    class _FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def execute(self, sql, params=None):
+            return None
+
+        def executemany(self, sql, params=None):
+            return None
+
+        def fetchall(self):
+            return [(1,)]
+
+    class _FakeConn:
+        def __init__(self):
+            self.closed = False
+
+        def cursor(self):
+            return _FakeCursor()
+
+        def commit(self):
+            return None
+
+        def rollback(self):
+            return None
+
+        def close(self):
+            self.closed = True
+
+    fake_psycopg = types.ModuleType("psycopg")
+
+    def racing_connect(dsn):
+        try:
+            barrier.wait(timeout=1.0)
+        except threading.BrokenBarrierError:
+            pass
+        conn = _FakeConn()
+        created.append(conn)
+        return conn
+
+    fake_psycopg.connect = racing_connect
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    errors = []
+
+    def run_query():
+        try:
+            client.ping()
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run_query, daemon=True) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not any(t.is_alive() for t in threads)
+    assert errors == []
+    assert len(created) == 1
+    assert client._conn is created[0]
+
+    client.close()
+    assert created[0].closed
+
+
+def test_client_execute_after_close_raises(monkeypatch):
+    """``close()`` is terminal: a stale client reference must get an error
+    instead of silently reconnecting and leaking a session nobody closes."""
+    created = []
+
+    class _FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def execute(self, sql, params=None):
+            return None
+
+        def fetchall(self):
+            return [(1,)]
+
+    class _FakeConn:
+        def __init__(self):
+            self.closed = False
+
+        def cursor(self):
+            return _FakeCursor()
+
+        def commit(self):
+            return None
+
+        def close(self):
+            self.closed = True
+
+    fake_psycopg = types.ModuleType("psycopg")
+
+    def fake_connect(dsn):
+        conn = _FakeConn()
+        created.append(conn)
+        return conn
+
+    fake_psycopg.connect = fake_connect
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    client.ping()
+    assert len(created) == 1
+
+    client.close()
+    assert created[0].closed
+
+    with pytest.raises(BackendError, match="closed"):
+        client.ping()
+    assert len(created) == 1

--- a/tests/test_sqlite_exact_backend.py
+++ b/tests/test_sqlite_exact_backend.py
@@ -1,7 +1,10 @@
 import math
+import sqlite3
+import threading
 
 import pytest
 
+import mempalace.backends.sqlite_exact as sqlite_exact_module
 from mempalace.backends import (
     BackendMismatchError,
     CollectionNotInitializedError,
@@ -375,3 +378,58 @@ def test_search_vector_disabled_fallback_is_chroma_only(tmp_path, monkeypatch):
 
     assert result["unsupported_capability"] == "chroma_hnsw_fallback"
     assert result["backend"] == "sqlite_exact"
+
+
+def test_concurrent_first_open_single_connection_no_leak(tmp_path, monkeypatch):
+    """Two threads first-opening the same palace concurrently must share one
+    handle and one sqlite connection.
+
+    The barrier inside the patched ``sqlite3.connect`` releases immediately
+    only when both threads pass the cache-miss check together: the broken
+    interleaving, which also ran ``_init_schema`` concurrently on a fresh
+    file and surfaced "database is locked". With creation serialized under
+    ``_clients_lock`` the second thread waits on the lock instead, the
+    winner's barrier times out, and exactly one connection is ever created.
+    """
+    created = []
+    barrier = threading.Barrier(2)
+    real_connect = sqlite3.connect
+
+    def racing_connect(*args, **kwargs):
+        try:
+            barrier.wait(timeout=1.0)
+        except threading.BrokenBarrierError:
+            pass
+        conn = real_connect(*args, **kwargs)
+        created.append(conn)
+        return conn
+
+    monkeypatch.setattr(sqlite_exact_module.sqlite3, "connect", racing_connect)
+
+    backend = SQLiteExactBackend()
+    palace = PalaceRef(id=str(tmp_path), local_path=str(tmp_path))
+    results = [None, None]
+    errors = []
+
+    def open_collection(i):
+        try:
+            results[i] = backend.get_collection(
+                palace=palace, collection_name="drawers", create=True
+            )
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=open_collection, args=(i,), daemon=True) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not any(t.is_alive() for t in threads)
+    assert errors == []
+    assert len(created) == 1
+    assert results[0]._handle is results[1]._handle
+
+    backend.close()
+    with pytest.raises(sqlite3.ProgrammingError):
+        created[0].execute("SELECT 1")


### PR DESCRIPTION
## What does this PR do?

Fixes #1774. Fixes #1775.

Both backends race their first connect when one backend instance is shared across threads, which is the contract `backends.registry.get_backend` advertises ("repeated calls return the same object").

**sqlite_exact (#1774).** `_connect` checked the per-palace cache under `_clients_lock`, then created the connection and ran `_init_schema` outside it, then re-acquired the lock to store. Two threads first-opening the same palace both missed the cache. Reproduced on develop with a deterministic 2-thread barrier probe: both connections got created, the loser leaked unclosed, and the racing `executescript` on the fresh file failed one thread with `sqlite3.OperationalError: database is locked` before WAL mode was established. The leaked connection also survived `backend.close()`, because `close()` only closes what the registry holds.

The fix holds `_clients_lock` across cache-check + connect + `_init_schema` + store (the per-palace creation lock shape suggested in the issue). Only first-open pays the I/O under the lock; cache hits stay a dict probe. Two adjacent windows of the same shape are closed too: `close()` now flips `_closed` inside the lock, so a concurrent `_connect` cannot store a fresh handle into a just-cleared registry, and a failure inside `_init_schema` now closes the connection instead of leaking it.

**pgvector (#1775).** `_execute` called `_connect()` before taking `self._lock`, and `_connect` read/wrote `self._conn` with no synchronization. Reproduced the same way: two racing threads each opened a connection, the loser leaked (against a real server, a dangling session), and the threads kept cursoring on different connections. The fix moves the `_connect` body under `self._lock` (the RLock `_execute` already serializes on, so the nesting is reentrant) and makes `_execute` acquire the lock before resolving the connection. `import psycopg` stays before the lock so the one-time import cost is not serialized. Two adjacent windows of the same shape are closed too: `PgVectorBackend._client` now checks `_closed` under the registry lock, and `_PgVectorClient.close()` is terminal, so an `_execute` on a stale client reference raises instead of silently reconnecting to a session nobody can ever close.

**Same-shape audit across the tree.** `QdrantBackend._client` and `PgVectorBackend._client` factories already create under their lock. `KnowledgeGraph._conn` is eagerly initialized in `__init__` before the instance can be shared, and its methods lock around `_conn()` calls (#884). `ChromaBackend._client` shares the check-then-act shape with no lock at all, but it is the default production backend with its own inode/mtime invalidation logic, and chromadb's in-process client cache changes the failure mode; touching it deserves its own issue rather than a ride-along here.

Known residual, deliberately not taken: `get_collection`/`delete_collection` can still hit a raw `sqlite3.ProgrammingError` when racing `close()` on an already-obtained handle. That window predates this PR and is byte-identical on develop.

## How to test

```bash
python -m pytest tests/test_sqlite_exact_backend.py tests/test_pgvector_backend.py -v
python -m pytest tests/ -v
```

The two new tests are deterministic on both sides of the fix: a 2-party barrier inside the patched `connect` releases immediately only when both threads pass the cache-miss check together (the broken interleaving, red before this change); on the fixed code the second thread blocks on the lock, the winner's barrier times out, and the assertions pin exactly one created connection, one shared handle, and no connection surviving `close()`.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
