### PR TITLE
test: stabilize release validation on develop

### DIFF
--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -114,11 +114,13 @@ class TestClosetMetadata:
             palace,
             drawer_id="D1",
             source_file="fixture_D1.md",
-            topics=["JWT authentication", "24h expiry", "auth tokens"],
+            topics=["JWT auth tokens", "session expiry", "authentication service"],
         )
-        result = search_memories("JWT authentication", palace, n_results=2)
+        result = search_memories("JWT auth tokens expiry", palace, n_results=2)
         top = result["results"][0]
         assert top["source_file"] == "fixture_D1.md"
+        assert top["matched_via"] == "drawer+closet"
+        assert top["closet_boost"] > 0
         assert "closet_preview" in top
 
     def test_drawer_only_hits_have_no_closet_preview(self, tmp_path):

--- a/tests/test_miner_fts5_validation.py
+++ b/tests/test_miner_fts5_validation.py
@@ -87,10 +87,18 @@ def _corrupt_fts5_segment(sqlite_path: Path) -> None:
             pytest.skip("FTS5 segments empty: cannot fabricate FTS5-only corruption")
         target = next((r for r in rows if r[0] > 10), rows[0])
         garbage = b"\xde\xad\xbe\xef" * (len(target[1]) // 4)
-        conn.execute(
-            "UPDATE embedding_fulltext_search_data SET block=? WHERE id=?",
-            (garbage, target[0]),
-        )
+        try:
+            conn.execute(
+                "UPDATE embedding_fulltext_search_data SET block=? WHERE id=?",
+                (garbage, target[0]),
+            )
+        except sqlite3.OperationalError as exc:
+            if "may not be modified" in str(exc):
+                pytest.skip(
+                    "this SQLite build refuses direct FTS5 shadow-table writes; "
+                    "cannot fabricate FTS5-only corruption"
+                )
+            raise
         conn.commit()
 
 


### PR DESCRIPTION
## Summary

This is a small release-polish PR for the current `develop` head while preparing v3.4.1.

It addresses two test-harness issues found during local release validation:

- strengthens `test_closet_preview_exposed_when_boosted` so the expected `closet_preview` assertion is tied to an actual closet-boosted result instead of a borderline fixture that failed on Windows
- skips fabricated FTS5 shadow-table corruption tests on SQLite builds that reject direct writes to FTS5 shadow tables, instead of failing before the corruption scenario can be created

## Why

The latest `develop` push at `422edc2` is red only on Windows in `tests/test_hybrid_search.py::TestClosetMetadata::test_closet_preview_exposed_when_boosted`. Linux 3.9/3.11/3.13, macOS, and lint passed. The strengthened fixture keeps the intended coverage but removes the Windows-specific ranking ambiguity.

The FTS5 change came from local Python 3.9/macOS validation, where the SQLite build reports `table embedding_fulltext_search_data may not be modified`. That is a test fabrication limitation, not a product-path failure.

## Verification

Run from a clean worktree based on `origin/develop` (`422edc2`):

```bash
uv run --python 3.13 pytest tests/test_hybrid_search.py tests/test_miner_fts5_validation.py -q
# 22 passed

.venv/bin/ruff check .
.venv/bin/ruff format --check .
git diff --check
# passed

.venv/bin/python -m pytest tests/ -v --ignore=tests/benchmarks --cov=mempalace --cov-report=term-missing --cov-fail-under=80 --durations=10
# 2843 passed, 5 skipped, coverage 82.76%
```

Also previously verified the FTS5 portability path under a separate pip-installed Python 3.9 environment: targeted suite passed with the unsupported direct-shadow-write cases skipped.
