### PR TITLE
fix: close blob seq sqlite migration connection

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1073,7 +1073,7 @@ def _fix_blob_seq_ids(palace_path: str) -> None:
     if os.path.isfile(marker):
         return
     try:
-        with sqlite3.connect(db_path) as conn:
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
             try:
                 rows = conn.execute(
                     "SELECT rowid, seq_id FROM embeddings WHERE typeof(seq_id) = 'blob'"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -768,6 +768,33 @@ def test_fix_blob_seq_ids_writes_marker_when_already_integer(tmp_path):
     assert marker.is_file(), "marker must be written even when no BLOBs found"
 
 
+def test_fix_blob_seq_ids_closes_sqlite_connection(tmp_path, monkeypatch):
+    """The migration closes sqlite connections after the pre-open probe."""
+    db_path = tmp_path / "chroma.sqlite3"
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        conn.execute("CREATE TABLE embeddings (rowid INTEGER PRIMARY KEY, seq_id INTEGER)")
+        conn.execute("INSERT INTO embeddings (seq_id) VALUES (42)")
+        conn.commit()
+
+    closed = []
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def close(self):
+            closed.append(True)
+            super().close()
+
+    def tracking_connect(*args, **kwargs):
+        kwargs["factory"] = TrackingConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr("mempalace.backends.chroma.sqlite3.connect", tracking_connect)
+
+    _fix_blob_seq_ids(str(tmp_path))
+
+    assert closed == [True]
+
+
 def test_fix_blob_seq_ids_skips_sqlite_when_marker_present(tmp_path):
     """When the marker exists, ``_fix_blob_seq_ids`` does not open sqlite3.
 


### PR DESCRIPTION
## Summary
- close the sqlite connection used by the blob seq_id pre-open migration after probing/migrating
- add a regression test that tracks the migration connection close path

## Why
Python sqlite3 connection context managers commit or roll back, but they do not close the connection. Under Python 3.13 warning probes, the release candidate stack surfaced ResourceWarning noise from this pre-open migration path.

## Validation
- `uv run --python 3.13 pytest tests/test_backends.py::test_fix_blob_seq_ids_closes_sqlite_connection tests/test_backends.py::test_fix_blob_seq_ids_converts_blobs_to_integers tests/test_backends.py::test_fix_blob_seq_ids_writes_marker_when_already_integer -q`
- `PYTHONTRACEMALLOC=10 uv run --python 3.13 pytest tests/test_sync.py -q -W default::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning`
- `uv run --python 3.13 ruff check mempalace/backends/chroma.py tests/test_backends.py`
- `uv run --python 3.13 ruff format --check mempalace/backends/chroma.py tests/test_backends.py`
- `git diff --check`