### PR TITLE
test: stabilize closet boost fixture on Windows

### DIFF
--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -543,14 +543,21 @@ class TestSearchMemoriesHybrid:
         ``closet_preview`` exposes the hydrated index line."""
         closets = get_closets_collection(palace_path)
         # Seed the closet against the same source_file the drawer uses so
-        # the boost lookup keys align.
-        closets.upsert(
-            ids=["closet_proj_backend_aaa_01"],
-            documents=["JWT auth tokens|;|→drawer_proj_backend_aaa"],
-            metadatas=[{"wing": "project", "room": "backend", "source_file": "auth.py"}],
+        # the boost lookup keys align. Use several high-signal closet lines
+        # instead of one terse pointer so the ranking is stable across Chroma
+        # platform builds.
+        upsert_closet_lines(
+            closets,
+            closet_id_base="closet_proj_backend_aaa",
+            lines=[
+                "JWT auth tokens|;|→drawer_proj_backend_aaa",
+                "session expiry authentication module|;|→drawer_proj_backend_aaa",
+                "HttpOnly refresh cookies|;|→drawer_proj_backend_aaa",
+            ],
+            metadata={"wing": "project", "room": "backend", "source_file": "auth.py"},
         )
 
-        result = search_memories("JWT authentication", palace_path)
+        result = search_memories("JWT auth tokens expiry", palace_path)
         assert result["results"], "hybrid search should still return results"
         # The JWT-bearing drawer should surface with closet agreement.
         boosted = [h for h in result["results"] if h["matched_via"] == "drawer+closet"]


### PR DESCRIPTION
## Summary
- stabilize the closet-boost hybrid search fixture that failed on Windows CI for `develop@7f5bbd8`
- seed the closet with several high-signal pointer lines through `upsert_closet_lines()` instead of one terse raw upsert
- keep the assertion focused on the `drawer+closet`/`closet_preview` contract rather than borderline Chroma ranking differences

## Root Cause
The `test_closet_boost_marks_hit_as_drawer_plus_closet` fixture depended on a single short closet document ranking strongly enough on every Chroma platform build. On Windows, the direct drawer search still returned results, but no hit crossed the closet boost path, leaving `boosted == []`.

## Validation
- `uv run --python 3.13 pytest tests/test_closets.py::TestSearchMemoriesHybrid::test_closet_boost_marks_hit_as_drawer_plus_closet -v`
- `uv run --python 3.13 pytest tests/test_closets.py::TestSearchMemoriesHybrid tests/test_hybrid_search.py -v`
- `git diff --check`
- `uv run --python 3.13 ruff check .`
- `uv run --python 3.13 ruff format --check .`
