### PR TITLE
chore(release): 3.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [3.4.1] — 2026-06-14
+
 ### Features
 
 - **Cursor IDE plugin (`.cursor-plugin/`).** Drops into `~/.cursor/plugins/local/mempalace` (or installs from the Cursor marketplace once published) and auto-registers the `mempalace-mcp` server, five slash commands (`/mempalace-help`, `/mempalace-init`, `/mempalace-mine`, `/mempalace-search`, `/mempalace-status`), and the model-invocable [`mempalace` skill](.cursor-plugin/skills/mempalace/SKILL.md) — no manual `~/.cursor/mcp.json` edit required. The plugin manifest deliberately omits a hardcoded `version` field — `mempalace/version.py` is the single source of truth, so there is nothing to drift on the next release (a contract test enforces the field stays absent). The canonical plugin components (`commands/`, `skills/`, `mcp.json`) are real files at the plugin root; no symlinks are committed (committed symlinks materialise as broken text files on Windows clones with `core.symlinks=false`). Mirrors the surface of [`.claude-plugin/`](.claude-plugin/) and [`.codex-plugin/`](.codex-plugin/) without duplicating their hook scripts: the Cursor hook scripts under [`hooks/cursor/`](hooks/cursor/) (shipped in the same release) remain the canonical install path for `stop` / `preCompact` / `sessionStart`, wired separately by [`hooks/cursor/install.sh`](hooks/cursor/install.sh). Contract tests in [`tests/test_cursor_plugin_manifest.py`](tests/test_cursor_plugin_manifest.py) cover manifest JSON validity, kebab-case naming, `..`-free relative paths, on-disk path resolution, marketplace alignment, MCP config shape (`mcpServers` wrapper required by Cursor, unlike Claude's flat `.mcp.json`), the version-field-absent guard, the no-symlink guard, and every skill/command frontmatter — all pure file inspection so they run on any CI platform without Cursor itself.
@@ -512,7 +516,16 @@ Initial public release.
 
 ---
 
-[Unreleased]: https://github.com/MemPalace/mempalace/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/MemPalace/mempalace/compare/v3.4.1...HEAD
+[3.4.1]: https://github.com/MemPalace/mempalace/compare/v3.4.0...v3.4.1
+[3.4.0]: https://github.com/MemPalace/mempalace/compare/v3.3.6...v3.4.0
+[3.3.6]: https://github.com/MemPalace/mempalace/compare/v3.3.5...v3.3.6
+[3.3.5]: https://github.com/MemPalace/mempalace/compare/v3.3.4...v3.3.5
+[3.3.4]: https://github.com/MemPalace/mempalace/compare/v3.3.3...v3.3.4
+[3.3.3]: https://github.com/MemPalace/mempalace/compare/v3.3.2...v3.3.3
+[3.3.2]: https://github.com/MemPalace/mempalace/compare/v3.3.1...v3.3.2
+[3.3.1]: https://github.com/MemPalace/mempalace/compare/v3.3.0...v3.3.1
+[3.3.0]: https://github.com/MemPalace/mempalace/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/MemPalace/mempalace/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/MemPalace/mempalace/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/MemPalace/mempalace/releases/tag/v3.0.0

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 MIT — see [LICENSE](LICENSE).
 
 <!-- Link Definitions -->
-[version-shield]: https://img.shields.io/badge/version-3.4.0-4dc9f6?style=flat-square&labelColor=0a0e14
+[version-shield]: https://img.shields.io/badge/version-3.4.1-4dc9f6?style=flat-square&labelColor=0a0e14
 [release-link]: https://github.com/MemPalace/mempalace/releases
 [python-shield]: https://img.shields.io/badge/python-3.9+-7dd8f8?style=flat-square&labelColor=0a0e14&logo=python&logoColor=7dd8f8
 [python-link]: https://www.python.org/

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.4.0"
+version = "3.4.1"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1951,7 +1951,7 @@ wheels = [
 
 [[package]]
 name = "mempalace"
-version = "3.4.0"
+version = "3.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Release 3.4.1

Bumps the version across **all six** version sources (the five `version-guard.yml` checks plus the README badge that `tests/test_readme_claims.py` enforces) and promotes the `[Unreleased]` changelog to `## [3.4.1]`.

> Supersedes #1808, which was opened on a `release/*` branch. That name matches a repository ruleset (`pull_request` + `non_fast_forward`) that blocks follow-up commits, so the branch couldn't take review fixes. This PR is on an unprotected branch and folds in the review feedback.

### Version sources bumped 3.4.0 → 3.4.1
- `mempalace/version.py` (source of truth)
- `pyproject.toml`
- `.claude-plugin/marketplace.json`
- `.claude-plugin/plugin.json`
- `.codex-plugin/plugin.json`
- `README.md` version badge
- `uv.lock` (editable package entry)

### Shipping in 3.4.1
**Features**
- Cursor IDE plugin (`.cursor-plugin/`)
- Cursor IDE hook support (`stop` / `preCompact` / `sessionStart`)
- First-class Antigravity IDE support (+ zero-config interpreter resolution)

**Bug fixes**
- `embeddinggemma` bulk re-embed OOM fix
- Backup-retention pruning (`max_backups`)

### CHANGELOG link block — fully rebuilt
The compare-link reference block had been abandoned at `v3.2.0`, leaving the `[3.3.0]`–`[3.3.6]` and `[3.4.0]` headers as broken/unclickable links (flagged in review on #1808). This PR rebuilds the full chain: every version header from `[3.0.0]` to `[3.4.1]` now resolves to a compare link, and `[Unreleased]` points at `v3.4.1...HEAD`.

### Pre-existing issue still open (out of scope)
**3.4.0 never got its own CHANGELOG section body** — only its compare-link is restored here. The section text remains undocumented; worth a follow-up if you want the history complete.

### Validation
- All six version sources agree (replicated `version-guard.yml` locally — green)
- Entry-point alignment check (RELEASING.md) — `mempalace-mcp` consistent across manifests
- `ruff check` + `ruff format --check` — clean
- Full suite: **2853 passed, 5 skipped**

### After merge (manual, per docs/RELEASING.md)
Merge `develop → main`, then draft a GitHub Release targeting `main` with tag `v3.4.1` to trigger `publish.yml` (PyPI Trusted Publishing, manual approval on the `pypi` environment).